### PR TITLE
ci: refresh stale mcpp + pkgindex pins (fix linux unit tests + windows E2E-07)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,8 @@ env:
   # Pinned bootstrap xlings used to install mcpp. Bump together with
   # XIM_PKGINDEX_REF so release uses a known-good xlings + package index pair.
   BOOTSTRAP_XLINGS_VERSION: v0.4.49
-  # Must contain the mcpp version pinned in .xlings.json (0.0.56).
-  XIM_PKGINDEX_REF: e692575099151d1f2c12c288d17aaa50f97e4e5d
+  # Must contain the mcpp version pinned in .xlings.json (0.0.57).
+  XIM_PKGINDEX_REF: fbcad0320fbf84271b710650402ac7ed1a8fa64f
 
 jobs:
   build-linux:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,8 @@ env:
   # Pinned bootstrap xlings used to install mcpp. Bump together with
   # XIM_PKGINDEX_REF so release uses a known-good xlings + package index pair.
   BOOTSTRAP_XLINGS_VERSION: v0.4.49
-  # Includes mcpp 0.0.36 for all release builds.
-  XIM_PKGINDEX_REF: 34e32a0fe234d0677b6200e824bad7dcd24dd78c
+  # Must contain the mcpp version pinned in .xlings.json (0.0.56).
+  XIM_PKGINDEX_REF: e692575099151d1f2c12c288d17aaa50f97e4e5d
 
 jobs:
   build-linux:

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -83,30 +83,6 @@ jobs:
 
       # ── Phase 1.5: Unit Tests ────────────────────────────────────
 
-      - name: "DIAG: compat.zlib actual source file (temporary)"
-        run: |
-          # Trigger index materialization (fails at compat.zlib; expected).
-          mcpp build || true
-          cache="$HOME/.mcpp/registry/data/mcpplibs/.xlings-index-cache.json"
-          echo "::group::cache 'path' field for compat.zlib"
-          grep -oE '"path":"[^"]*compat\.zlib\.lua"' "$cache" 2>/dev/null || echo "(cache or compat.zlib entry missing: $cache)"
-          echo "::endgroup::"
-          echo "::group::every compat.zlib.lua under .mcpp roots — block / generated_files / [[ long-bracket"
-          while IFS= read -r f; do
-            echo "=== $f ($(wc -l < "$f" 2>/dev/null) lines) ==="
-            grep -nE 'mcpp = \{|generated_files|\[\[' "$f" 2>/dev/null || echo "  (no mcpp/generated_files/[[ markers)"
-          done < <(find "$HOME/.mcpp" "$GITHUB_WORKSPACE/.mcpp" -name 'compat.zlib.lua' 2>/dev/null | sort -u)
-          echo "::endgroup::"
-          echo "::group::mcpp-region dump + hash of the path-field file"
-          pf=$(grep -oE '"path":"[^"]*compat\.zlib\.lua"' "$cache" 2>/dev/null | head -1 | sed -E 's/.*"path":"//; s/"$//')
-          if [[ -n "$pf" && -f "$pf" ]]; then
-            echo "size=$(wc -c < "$pf")  lines=$(wc -l < "$pf")"
-            echo "sha256=$(sha256sum "$pf" | awk '{print $1}')"
-            echo "EXPECTED upstream HEAD sha256=cfb31c61785e6f8e95093bc8253b811b50c0d653a81411cafacd183e81d1c889"
-            sed -n '38,72p' "$pf"
-          else echo "(path-field file not found: '$pf')"; fi
-          echo "::endgroup::"
-
       - name: Build and run unit tests
         run: |
           mcpp build

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -14,8 +14,8 @@ env:
   # Pinned bootstrap xlings used to install mcpp. Bump together with
   # XIM_PKGINDEX_REF so CI uses a known-good xlings + package index pair.
   BOOTSTRAP_XLINGS_VERSION: v0.4.49
-  # Must contain the mcpp version pinned in .xlings.json (0.0.56).
-  XIM_PKGINDEX_REF: e692575099151d1f2c12c288d17aaa50f97e4e5d
+  # Must contain the mcpp version pinned in .xlings.json (0.0.57).
+  XIM_PKGINDEX_REF: fbcad0320fbf84271b710650402ac7ed1a8fa64f
 
 jobs:
   build-and-test:

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -85,24 +85,6 @@ jobs:
 
       - name: Build and run unit tests
         run: |
-          # WORKAROUND (mcpp read_xpkg_lua cross-index ambiguity):
-          # mcpp resolves (ns=compat, name=compat.zlib) by scanning
-          # ~/.mcpp/registry/data/* via directory_iterator (unspecified
-          # order) with candidates [compat.zlib.lua, zlib.lua]. The bare
-          # `zlib.lua` fallback collides with xim-pkgindex/pkgs/z/zlib.lua
-          # (upstream xim:zlib, no mcpp block). On ubuntu-24.04 runners
-          # xim-pkgindex is scanned before mcpplibs, so the wrong file wins
-          # → "compat.zlib: index entry has no mcpp field". (Only zlib
-          # collides; bzip2/lz4/xz have no bare-name pkg in a direct child
-          # index.) Drop the colliding bare zlib.lua so the namespaced
-          # compat.zlib.lua in mcpplibs is selected deterministically.
-          # TODO: remove once mcpp read_xpkg_lua prefers the exact
-          # namespaced match over the bare-name fallback.
-          mcpp build || true   # first pass materializes ~/.mcpp data indexes
-          for root in "$HOME/.mcpp" "$GITHUB_WORKSPACE/.mcpp"; do
-            find "$root/registry/data" -mindepth 1 -maxdepth 1 -type d \
-              ! -name mcpplibs -exec rm -f {}/pkgs/z/zlib.lua \; 2>/dev/null || true
-          done
           mcpp build
           mcpp test || {
             status=$?

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -85,6 +85,24 @@ jobs:
 
       - name: Build and run unit tests
         run: |
+          # WORKAROUND (mcpp read_xpkg_lua cross-index ambiguity):
+          # mcpp resolves (ns=compat, name=compat.zlib) by scanning
+          # ~/.mcpp/registry/data/* via directory_iterator (unspecified
+          # order) with candidates [compat.zlib.lua, zlib.lua]. The bare
+          # `zlib.lua` fallback collides with xim-pkgindex/pkgs/z/zlib.lua
+          # (upstream xim:zlib, no mcpp block). On ubuntu-24.04 runners
+          # xim-pkgindex is scanned before mcpplibs, so the wrong file wins
+          # → "compat.zlib: index entry has no mcpp field". (Only zlib
+          # collides; bzip2/lz4/xz have no bare-name pkg in a direct child
+          # index.) Drop the colliding bare zlib.lua so the namespaced
+          # compat.zlib.lua in mcpplibs is selected deterministically.
+          # TODO: remove once mcpp read_xpkg_lua prefers the exact
+          # namespaced match over the bare-name fallback.
+          mcpp build || true   # first pass materializes ~/.mcpp data indexes
+          for root in "$HOME/.mcpp" "$GITHUB_WORKSPACE/.mcpp"; do
+            find "$root/registry/data" -mindepth 1 -maxdepth 1 -type d \
+              ! -name mcpplibs -exec rm -f {}/pkgs/z/zlib.lua \; 2>/dev/null || true
+          done
           mcpp build
           mcpp test || {
             status=$?

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -56,9 +56,14 @@ jobs:
           path: |
             ~/.mcpp
             .mcpp
-          key: mcpp-${{ runner.os }}-${{ hashFiles('mcpp.toml', 'mcpp.lock', '.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
+          # idxfmt2 salt: abandon pre-2026-06-08 caches whose materialized
+          # compat xpkgs predate the mcpp-index GLOBAL/CN url schema (#41).
+          # The "Refresh mcpp package index cache" step re-fetches the index
+          # but not the materialized xpkgs, so a stale cache here resurfaces
+          # the old format and fails compat.zlib resolution.
+          key: mcpp-${{ runner.os }}-idxfmt2-${{ hashFiles('mcpp.toml', 'mcpp.lock', '.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
           restore-keys: |
-            mcpp-${{ runner.os }}-
+            mcpp-${{ runner.os }}-idxfmt2-
 
       - name: Prepare bootstrap package index
         run: |

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -16,11 +16,6 @@ env:
   BOOTSTRAP_XLINGS_VERSION: v0.4.49
   # Must contain the mcpp version pinned in .xlings.json (0.0.56).
   XIM_PKGINDEX_REF: e692575099151d1f2c12c288d17aaa50f97e4e5d
-  # mcpp's own lib index (compat.*, mcpplibs.*). Pinned and cloned raw so
-  # the unit-test build doesn't depend on mcpp's lazy index fetch, which
-  # drops compat.zlib's multiline `generated_files` mcpp block.
-  MCPP_INDEX_URL: https://github.com/mcpp-community/mcpp-index.git
-  MCPP_INDEX_REF: d7191f431210731e025319a1a8ea91c24ac7d4ee
 
 jobs:
   build-and-test:
@@ -61,13 +56,9 @@ jobs:
           path: |
             ~/.mcpp
             .mcpp
-          # idxfmt2 salt: abandon pre-2026-06-08 caches whose materialized
-          # compat xpkgs predate the mcpp-index GLOBAL/CN url schema (#41).
-          # The unit-test build re-provisions mcpplibs from a pinned raw
-          # clone, so the cached index copy is not relied upon for it.
-          key: mcpp-${{ runner.os }}-idxfmt2-${{ hashFiles('mcpp.toml', 'mcpp.lock', '.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
+          key: mcpp-${{ runner.os }}-${{ hashFiles('mcpp.toml', 'mcpp.lock', '.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
           restore-keys: |
-            mcpp-${{ runner.os }}-idxfmt2-
+            mcpp-${{ runner.os }}-
 
       - name: Prepare bootstrap package index
         run: |
@@ -81,6 +72,11 @@ jobs:
           mcpp --version
           mcpp self version
 
+      - name: Refresh mcpp package index cache
+        run: |
+          rm -rf "$HOME/.mcpp/registry/data/mcpplibs"
+          rm -rf "$GITHUB_WORKSPACE/.mcpp/registry/data/mcpplibs"
+
       - name: Prepare unit fixture index repo
         run: |
           bash tests/e2e/prepare_fixture_index.sh ../xim-pkgindex
@@ -89,28 +85,6 @@ jobs:
 
       - name: Build and run unit tests
         run: |
-          # First pass initializes the mcpp sandbox and materializes the
-          # toolchain. It also lazily fetches mcpp-index, which corrupts
-          # compat.zlib (its multiline `generated_files` mcpp block is
-          # dropped → "index entry has no mcpp field"); that makes this
-          # pass fail, which is expected — we repair the index next.
-          mcpp build || true
-          # Repair: replace mcpplibs with a raw clone of mcpp-index pinned
-          # to MCPP_INDEX_REF. A raw clone preserves compat.zlib's mcpp
-          # block (matches a working local checkout); the marker file stops
-          # mcpp from re-fetching it on the next build.
-          mcpplibs="$HOME/.mcpp/registry/data/mcpplibs"
-          rm -rf "$mcpplibs"
-          mkdir -p "$(dirname "$mcpplibs")"
-          git clone --quiet "$MCPP_INDEX_URL" "$mcpplibs"
-          git -C "$mcpplibs" checkout --quiet "$MCPP_INDEX_REF"
-          printf 'ok\n' > "$mcpplibs/.mcpp-index-updated"
-          zlib_entry="$mcpplibs/pkgs/c/compat.zlib.lua"
-          if ! grep -q 'mcpp = {' "$zlib_entry"; then
-            echo "::error::compat.zlib index entry missing mcpp block: $zlib_entry"
-            exit 1
-          fi
-          # Real build + tests against the repaired index.
           mcpp build
           mcpp test || {
             status=$?

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -97,9 +97,14 @@ jobs:
             grep -nE 'mcpp = \{|generated_files|\[\[' "$f" 2>/dev/null || echo "  (no mcpp/generated_files/[[ markers)"
           done < <(find "$HOME/.mcpp" "$GITHUB_WORKSPACE/.mcpp" -name 'compat.zlib.lua' 2>/dev/null | sort -u)
           echo "::endgroup::"
-          echo "::group::mcpp-region dump of the path-field file"
+          echo "::group::mcpp-region dump + hash of the path-field file"
           pf=$(grep -oE '"path":"[^"]*compat\.zlib\.lua"' "$cache" 2>/dev/null | head -1 | sed -E 's/.*"path":"//; s/"$//')
-          if [[ -n "$pf" && -f "$pf" ]]; then sed -n '38,72p' "$pf"; else echo "(path-field file not found: '$pf')"; fi
+          if [[ -n "$pf" && -f "$pf" ]]; then
+            echo "size=$(wc -c < "$pf")  lines=$(wc -l < "$pf")"
+            echo "sha256=$(sha256sum "$pf" | awk '{print $1}')"
+            echo "EXPECTED upstream HEAD sha256=cfb31c61785e6f8e95093bc8253b811b50c0d653a81411cafacd183e81d1c889"
+            sed -n '38,72p' "$pf"
+          else echo "(path-field file not found: '$pf')"; fi
           echo "::endgroup::"
 
       - name: Build and run unit tests

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -81,6 +81,24 @@ jobs:
         run: |
           rm -rf "$HOME/.mcpp/registry/data/mcpplibs"
           rm -rf "$GITHUB_WORKSPACE/.mcpp/registry/data/mcpplibs"
+          # Rebuild the index explicitly. Deleting mcpplibs and letting
+          # `mcpp build` repopulate it lazily yields a compat.zlib entry
+          # whose multiline `generated_files` mcpp block is dropped (post
+          # mcpp-index #41 GLOBAL/CN reformat) → "index entry has no mcpp
+          # field". `xlings update` rebuilds the index correctly.
+          xlings update
+
+      - name: "Diagnose: compat.zlib index entries"
+        run: |
+          echo "::group::all compat.zlib*.lua under ~/.mcpp (mcpp-block status)"
+          while IFS= read -r f; do
+            if grep -q 'mcpp = {' "$f"; then s="HAS mcpp block"; else s="MISSING mcpp block"; fi
+            echo "[$s] $f"
+          done < <(find "$HOME/.mcpp" -name 'compat.zlib*.lua' 2>/dev/null | sort)
+          echo "::endgroup::"
+          echo "::group::index entry content (mcpplibs)"
+          cat "$HOME/.mcpp/registry/data/mcpplibs/pkgs/c/compat.zlib.lua" 2>/dev/null || echo "(no mcpplibs compat.zlib.lua)"
+          echo "::endgroup::"
 
       - name: Prepare unit fixture index repo
         run: |

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -14,8 +14,8 @@ env:
   # Pinned bootstrap xlings used to install mcpp. Bump together with
   # XIM_PKGINDEX_REF so CI uses a known-good xlings + package index pair.
   BOOTSTRAP_XLINGS_VERSION: v0.4.49
-  # Includes mcpp 0.0.36 for all CI/release mcpp builds.
-  XIM_PKGINDEX_REF: 34e32a0fe234d0677b6200e824bad7dcd24dd78c
+  # Must contain the mcpp version pinned in .xlings.json (0.0.56).
+  XIM_PKGINDEX_REF: e692575099151d1f2c12c288d17aaa50f97e4e5d
 
 jobs:
   build-and-test:

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -63,9 +63,8 @@ jobs:
             .mcpp
           # idxfmt2 salt: abandon pre-2026-06-08 caches whose materialized
           # compat xpkgs predate the mcpp-index GLOBAL/CN url schema (#41).
-          # The "Refresh mcpp package index cache" step re-fetches the index
-          # but not the materialized xpkgs, so a stale cache here resurfaces
-          # the old format and fails compat.zlib resolution.
+          # The unit-test build re-provisions mcpplibs from a pinned raw
+          # clone, so the cached index copy is not relied upon for it.
           key: mcpp-${{ runner.os }}-idxfmt2-${{ hashFiles('mcpp.toml', 'mcpp.lock', '.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
           restore-keys: |
             mcpp-${{ runner.os }}-idxfmt2-
@@ -82,31 +81,6 @@ jobs:
           mcpp --version
           mcpp self version
 
-      - name: Refresh mcpp package index (pinned raw clone)
-        run: |
-          # mcpp resolves compat.* / mcpplibs.* from mcpp-community/mcpp-index.
-          # A fresh CI runner has no copy, so `mcpp build` would fetch it
-          # lazily — and that fetch drops compat.zlib's multiline
-          # `generated_files` mcpp block, failing with "index entry has no
-          # mcpp field" (only zlib has that field; bzip2/lz4/xz are fine).
-          # Provision it deterministically as a raw clone at MCPP_INDEX_REF,
-          # which preserves the block (matches a working local checkout).
-          for root in "$HOME/.mcpp" "$GITHUB_WORKSPACE/.mcpp"; do
-            mcpplibs="$root/registry/data/mcpplibs"
-            [[ -d "$root" ]] || continue
-            rm -rf "$mcpplibs"
-            mkdir -p "$(dirname "$mcpplibs")"
-            git clone --quiet "$MCPP_INDEX_URL" "$mcpplibs"
-            git -C "$mcpplibs" checkout --quiet "$MCPP_INDEX_REF"
-            printf 'ok\n' > "$mcpplibs/.mcpp-index-updated"
-          done
-          # Fail fast (with the offending file) if the entry lacks its block.
-          zlib_entry="$HOME/.mcpp/registry/data/mcpplibs/pkgs/c/compat.zlib.lua"
-          if ! grep -q 'mcpp = {' "$zlib_entry"; then
-            echo "::error::compat.zlib index entry missing mcpp block: $zlib_entry"
-            exit 1
-          fi
-
       - name: Prepare unit fixture index repo
         run: |
           bash tests/e2e/prepare_fixture_index.sh ../xim-pkgindex
@@ -115,6 +89,28 @@ jobs:
 
       - name: Build and run unit tests
         run: |
+          # First pass initializes the mcpp sandbox and materializes the
+          # toolchain. It also lazily fetches mcpp-index, which corrupts
+          # compat.zlib (its multiline `generated_files` mcpp block is
+          # dropped → "index entry has no mcpp field"); that makes this
+          # pass fail, which is expected — we repair the index next.
+          mcpp build || true
+          # Repair: replace mcpplibs with a raw clone of mcpp-index pinned
+          # to MCPP_INDEX_REF. A raw clone preserves compat.zlib's mcpp
+          # block (matches a working local checkout); the marker file stops
+          # mcpp from re-fetching it on the next build.
+          mcpplibs="$HOME/.mcpp/registry/data/mcpplibs"
+          rm -rf "$mcpplibs"
+          mkdir -p "$(dirname "$mcpplibs")"
+          git clone --quiet "$MCPP_INDEX_URL" "$mcpplibs"
+          git -C "$mcpplibs" checkout --quiet "$MCPP_INDEX_REF"
+          printf 'ok\n' > "$mcpplibs/.mcpp-index-updated"
+          zlib_entry="$mcpplibs/pkgs/c/compat.zlib.lua"
+          if ! grep -q 'mcpp = {' "$zlib_entry"; then
+            echo "::error::compat.zlib index entry missing mcpp block: $zlib_entry"
+            exit 1
+          fi
+          # Real build + tests against the repaired index.
           mcpp build
           mcpp test || {
             status=$?

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -83,6 +83,25 @@ jobs:
 
       # ── Phase 1.5: Unit Tests ────────────────────────────────────
 
+      - name: "DIAG: compat.zlib actual source file (temporary)"
+        run: |
+          # Trigger index materialization (fails at compat.zlib; expected).
+          mcpp build || true
+          cache="$HOME/.mcpp/registry/data/mcpplibs/.xlings-index-cache.json"
+          echo "::group::cache 'path' field for compat.zlib"
+          grep -oE '"path":"[^"]*compat\.zlib\.lua"' "$cache" 2>/dev/null || echo "(cache or compat.zlib entry missing: $cache)"
+          echo "::endgroup::"
+          echo "::group::every compat.zlib.lua under .mcpp roots — block / generated_files / [[ long-bracket"
+          while IFS= read -r f; do
+            echo "=== $f ($(wc -l < "$f" 2>/dev/null) lines) ==="
+            grep -nE 'mcpp = \{|generated_files|\[\[' "$f" 2>/dev/null || echo "  (no mcpp/generated_files/[[ markers)"
+          done < <(find "$HOME/.mcpp" "$GITHUB_WORKSPACE/.mcpp" -name 'compat.zlib.lua' 2>/dev/null | sort -u)
+          echo "::endgroup::"
+          echo "::group::mcpp-region dump of the path-field file"
+          pf=$(grep -oE '"path":"[^"]*compat\.zlib\.lua"' "$cache" 2>/dev/null | head -1 | sed -E 's/.*"path":"//; s/"$//')
+          if [[ -n "$pf" && -f "$pf" ]]; then sed -n '38,72p' "$pf"; else echo "(path-field file not found: '$pf')"; fi
+          echo "::endgroup::"
+
       - name: Build and run unit tests
         run: |
           mcpp build

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -16,6 +16,11 @@ env:
   BOOTSTRAP_XLINGS_VERSION: v0.4.49
   # Must contain the mcpp version pinned in .xlings.json (0.0.56).
   XIM_PKGINDEX_REF: e692575099151d1f2c12c288d17aaa50f97e4e5d
+  # mcpp's own lib index (compat.*, mcpplibs.*). Pinned and cloned raw so
+  # the unit-test build doesn't depend on mcpp's lazy index fetch, which
+  # drops compat.zlib's multiline `generated_files` mcpp block.
+  MCPP_INDEX_URL: https://github.com/mcpp-community/mcpp-index.git
+  MCPP_INDEX_REF: d7191f431210731e025319a1a8ea91c24ac7d4ee
 
 jobs:
   build-and-test:
@@ -77,28 +82,30 @@ jobs:
           mcpp --version
           mcpp self version
 
-      - name: Refresh mcpp package index cache
+      - name: Refresh mcpp package index (pinned raw clone)
         run: |
-          rm -rf "$HOME/.mcpp/registry/data/mcpplibs"
-          rm -rf "$GITHUB_WORKSPACE/.mcpp/registry/data/mcpplibs"
-          # Rebuild the index explicitly. Deleting mcpplibs and letting
-          # `mcpp build` repopulate it lazily yields a compat.zlib entry
-          # whose multiline `generated_files` mcpp block is dropped (post
-          # mcpp-index #41 GLOBAL/CN reformat) → "index entry has no mcpp
-          # field". `xlings update` rebuilds the index correctly.
-          xlings update
-
-      - name: "Diagnose: compat.zlib index entries"
-        run: |
-          echo "::group::all compat.zlib*.lua under ~/.mcpp (mcpp-block status)"
-          while IFS= read -r f; do
-            if grep -q 'mcpp = {' "$f"; then s="HAS mcpp block"; else s="MISSING mcpp block"; fi
-            echo "[$s] $f"
-          done < <(find "$HOME/.mcpp" -name 'compat.zlib*.lua' 2>/dev/null | sort)
-          echo "::endgroup::"
-          echo "::group::index entry content (mcpplibs)"
-          cat "$HOME/.mcpp/registry/data/mcpplibs/pkgs/c/compat.zlib.lua" 2>/dev/null || echo "(no mcpplibs compat.zlib.lua)"
-          echo "::endgroup::"
+          # mcpp resolves compat.* / mcpplibs.* from mcpp-community/mcpp-index.
+          # A fresh CI runner has no copy, so `mcpp build` would fetch it
+          # lazily — and that fetch drops compat.zlib's multiline
+          # `generated_files` mcpp block, failing with "index entry has no
+          # mcpp field" (only zlib has that field; bzip2/lz4/xz are fine).
+          # Provision it deterministically as a raw clone at MCPP_INDEX_REF,
+          # which preserves the block (matches a working local checkout).
+          for root in "$HOME/.mcpp" "$GITHUB_WORKSPACE/.mcpp"; do
+            mcpplibs="$root/registry/data/mcpplibs"
+            [[ -d "$root" ]] || continue
+            rm -rf "$mcpplibs"
+            mkdir -p "$(dirname "$mcpplibs")"
+            git clone --quiet "$MCPP_INDEX_URL" "$mcpplibs"
+            git -C "$mcpplibs" checkout --quiet "$MCPP_INDEX_REF"
+            printf 'ok\n' > "$mcpplibs/.mcpp-index-updated"
+          done
+          # Fail fast (with the offending file) if the entry lacks its block.
+          zlib_entry="$HOME/.mcpp/registry/data/mcpplibs/pkgs/c/compat.zlib.lua"
+          if ! grep -q 'mcpp = {' "$zlib_entry"; then
+            echo "::error::compat.zlib index entry missing mcpp block: $zlib_entry"
+            exit 1
+          fi
 
       - name: Prepare unit fixture index repo
         run: |

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -15,8 +15,8 @@ env:
   # Pinned bootstrap xlings used to install mcpp. Bump together with
   # XIM_PKGINDEX_REF so CI uses a known-good xlings + package index pair.
   BOOTSTRAP_XLINGS_VERSION: v0.4.49
-  # Must contain the mcpp version pinned in .xlings.json (0.0.56).
-  XIM_PKGINDEX_REF: e692575099151d1f2c12c288d17aaa50f97e4e5d
+  # Must contain the mcpp version pinned in .xlings.json (0.0.57).
+  XIM_PKGINDEX_REF: fbcad0320fbf84271b710650402ac7ed1a8fa64f
 
 jobs:
   build-and-test:

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -15,8 +15,8 @@ env:
   # Pinned bootstrap xlings used to install mcpp. Bump together with
   # XIM_PKGINDEX_REF so CI uses a known-good xlings + package index pair.
   BOOTSTRAP_XLINGS_VERSION: v0.4.49
-  # Includes mcpp 0.0.36 for all CI/release mcpp builds.
-  XIM_PKGINDEX_REF: 34e32a0fe234d0677b6200e824bad7dcd24dd78c
+  # Must contain the mcpp version pinned in .xlings.json (0.0.56).
+  XIM_PKGINDEX_REF: e692575099151d1f2c12c288d17aaa50f97e4e5d
 
 jobs:
   build-and-test:

--- a/.github/workflows/xlings-ci-windows.yml
+++ b/.github/workflows/xlings-ci-windows.yml
@@ -14,8 +14,8 @@ env:
   # Pinned bootstrap xlings used to install mcpp. Bump together with
   # XIM_PKGINDEX_REF so CI uses a known-good xlings + package index pair.
   BOOTSTRAP_XLINGS_VERSION: v0.4.49
-  # Must contain the mcpp version pinned in .xlings.json (0.0.56).
-  XIM_PKGINDEX_REF: e692575099151d1f2c12c288d17aaa50f97e4e5d
+  # Must contain the mcpp version pinned in .xlings.json (0.0.57).
+  XIM_PKGINDEX_REF: fbcad0320fbf84271b710650402ac7ed1a8fa64f
 
 jobs:
   build-and-test:

--- a/.github/workflows/xlings-ci-windows.yml
+++ b/.github/workflows/xlings-ci-windows.yml
@@ -14,8 +14,8 @@ env:
   # Pinned bootstrap xlings used to install mcpp. Bump together with
   # XIM_PKGINDEX_REF so CI uses a known-good xlings + package index pair.
   BOOTSTRAP_XLINGS_VERSION: v0.4.49
-  # Includes mcpp 0.0.36 for all CI/release mcpp builds.
-  XIM_PKGINDEX_REF: 34e32a0fe234d0677b6200e824bad7dcd24dd78c
+  # Must contain the mcpp version pinned in .xlings.json (0.0.56).
+  XIM_PKGINDEX_REF: e692575099151d1f2c12c288d17aaa50f97e4e5d
 
 jobs:
   build-and-test:

--- a/.xlings.json
+++ b/.xlings.json
@@ -3,6 +3,6 @@
   "projectScope": false,
   "mirror": "GLOBAL",
   "workspace": {
-    "mcpp": "0.0.50"
+    "mcpp": "0.0.56"
   }
 }

--- a/.xlings.json
+++ b/.xlings.json
@@ -3,6 +3,6 @@
   "projectScope": false,
   "mirror": "GLOBAL",
   "workspace": {
-    "mcpp": "0.0.56"
+    "mcpp": "0.0.57"
   }
 }

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ One tool to install any version of anything, run it rootless, and isolate it OS-
 2. **Multi-version coexistence** — N versions side-by-side; version-view + ref-counting (N envs ≈ 1× storage)
 3. **3-level SubOS isolation** — shell (env switch) / FS (bwrap/proot, rootless) / image (ext4, root)
 4. **Decentralized package index** — official + 3rd-party + self-hosted; resource servers for binary mirrors
-5. 🤖 **JSON event interface** — `xlings interface` (NDJSON) for AI agents, CI, and 3rd-party tooling
+5. **JSON event interface** — `xlings interface` (NDJSON) for AI agents, CI, and 3rd-party tooling
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ One tool to install any version of anything, run it rootless, and isolate it OS-
 
 ## Core capabilities
 
-1. 📦 **Universal package infrastructure** — binary / script / config / subos / tutorial, all as xpkg
-2. 🔀 **Multi-version coexistence** — N versions side-by-side; version-view + ref-counting (N envs ≈ 1× storage)
-3. 🏗️ **3-level SubOS isolation** — shell (env switch) / FS (bwrap/proot, rootless) / image (ext4, root)
-4. 🌐 **Decentralized package index** — official + 3rd-party + self-hosted; resource servers for binary mirrors
+1. **Universal package infrastructure** — binary / script / config / subos / tutorial, all as xpkg
+2. **Multi-version coexistence** — N versions side-by-side; version-view + ref-counting (N envs ≈ 1× storage)
+3. **3-level SubOS isolation** — shell (env switch) / FS (bwrap/proot, rootless) / image (ext4, root)
+4. **Decentralized package index** — official + 3rd-party + self-hosted; resource servers for binary mirrors
 5. 🤖 **JSON event interface** — `xlings interface` (NDJSON) for AI agents, CI, and 3rd-party tooling
 
 ## Quick Start

--- a/README.zh.md
+++ b/README.zh.md
@@ -28,10 +28,10 @@
 
 ## 核心能力
 
-1. 📦 **通用包管理基础设施** —— binary / script / config / subos / tutorial 统统是 xpkg
-2. 🔀 **多版本共存** —— 同一工具 N 个版本并存;版本视图 + 引用计数(N 个环境 ≈ 1 份存储)
-3. 🏗️ **三级 SubOS 隔离** —— shell(env 切换)/ FS(bwrap/proot,无需 root)/ image(ext4,需 root)
-4. 🌐 **去中心化包索引** —— 官方 + 第三方 + 自建仓库;资源服务器做二进制镜像分发
+1. **通用包管理基础设施** —— binary / script / config / subos / tutorial 统统是 xpkg
+2. **多版本共存** —— 同一工具 N 个版本并存;版本视图 + 引用计数(N 个环境 ≈ 1 份存储)
+3. **三级 SubOS 隔离** —— shell(env 切换)/ FS(bwrap/proot,无需 root)/ image(ext4,需 root)
+4. **去中心化包索引** —— 官方 + 第三方 + 自建仓库;资源服务器做二进制镜像分发
 5. 🤖 **JSON 事件接口** —— `xlings interface`(NDJSON 协议)面向 AI Agent、CI 和第三方工具
 
 ## 快速开始

--- a/README.zh.md
+++ b/README.zh.md
@@ -32,7 +32,7 @@
 2. **多版本共存** —— 同一工具 N 个版本并存;版本视图 + 引用计数(N 个环境 ≈ 1 份存储)
 3. **三级 SubOS 隔离** —— shell(env 切换)/ FS(bwrap/proot,无需 root)/ image(ext4,需 root)
 4. **去中心化包索引** —— 官方 + 第三方 + 自建仓库;资源服务器做二进制镜像分发
-5. 🤖 **JSON 事件接口** —— `xlings interface`(NDJSON 协议)面向 AI Agent、CI 和第三方工具
+5. **JSON 事件接口** —— `xlings interface`(NDJSON 协议)面向 AI Agent、CI 和第三方工具
 
 ## 快速开始
 


### PR DESCRIPTION
## Why

Both `xlings-ci-linux` and `xlings-ci-windows` went red on the 2026-06-19 `main` push (#323), a **docs-only** change. The break correlates with *time*, not the diff: the exact same commit `d6f1e7e` was green on **2026-06-05**, and nothing in `main` changed but README.

Root cause is **upstream drift that landed 2026-06-08** (after the last green run) against pins that hadn't moved.

### Linux — unit tests (`mcpp build`)
```
error: dependency 'compat.zlib': index entry has no `mcpp = ...` field ...
```
`compat.zlib` is an **unlocked transitive dep** (pulled in by `compat.libarchive`, which *is* in `mcpp.lock`; zlib is not). It resolves from the floating `mcpp-community/mcpp-index`. PR #41 there (06-08T18:47) reformatted url entries to `GLOBAL/CN` tables — a schema the pinned **mcpp 0.0.50** (06-05, pre-#41) can't parse, so it reports the `mcpp` block as missing. → **bump mcpp `0.0.50` → `0.0.56`**.

### Windows — E2E-07 (Sub-Index Search)
```
[error] package 'd2x@0.1.5' not found
[error] [d2mcpp] failed: config hook failed
```
`d2mcpp`'s config hook installs `d2x`, which resolves to latest = **0.1.5** (released 06-08). The pinned index `34e32a0f` predates that and only knows `d2x ≤ 0.1.4`. → **bump `XIM_PKGINDEX_REF` → `e692575`** (carries `d2x 0.1.5`).

The index bump is required for **both**: the old index only offered mcpp `0.0.50`; the new one offers up to `0.0.56`.

## Changes
- `.xlings.json`: mcpp `0.0.50` → `0.0.56`
- `XIM_PKGINDEX_REF`: `34e32a0f` → `e692575` (linux/windows/macos/release workflows)
- Fix stale `# Includes mcpp 0.0.36` comments

## Not a product change
No xlings binary/behavior change — shipped releases are unaffected. This is **CI pin maintenance**; no new xlings release is required.

## Follow-up (not in this PR)
`mcpp-index` and sub-indexes are fetched at floating HEAD, escaping `XIM_PKGINDEX_REF`. A nightly canary build would surface this drift the day it happens instead of on the next unrelated push.