### PR TITLE
feat(installer): Linux/macOS multi-source mirror with latency probing

### DIFF
--- a/tools/other/quick_install.sh
+++ b/tools/other/quick_install.sh
@@ -16,7 +16,11 @@ log_error() { echo -e "${RED}[xlings]:${RESET} $1"; }
 
 trap 'log_error "Interrupted"; exit 1' INT TERM
 
+# Official GitHub repo + GitCode resource mirror (low-latency source for users
+# who have trouble reaching GitHub, e.g. mainland China).
 GITHUB_REPO="openxlings/xlings"
+GITCODE_REPO="xlings-res/xlings"
+GITCODE_API="https://api.gitcode.com/api/v5"
 GITHUB_MIRROR="${XLINGS_GITHUB_MIRROR:-}"
 
 # Specify version: curl ... | bash -s -- v0.5.0
@@ -77,7 +81,7 @@ forum: https://forum.d2learn.org
 
 EOF
 
-# --------------- resolve download URL ---------------
+# --------------- prerequisites ---------------
 
 ensure_cmd() {
     if ! command -v "$1" &>/dev/null; then
@@ -89,42 +93,7 @@ ensure_cmd() {
 ensure_cmd curl
 ensure_cmd tar
 
-resolve_latest_version() {
-    local base_url="${GITHUB_MIRROR:-https://github.com}"
-    local url="${base_url}/${GITHUB_REPO}/releases/latest"
-    local final_url
-    final_url=$(curl -fsSIL -o /dev/null -w '%{url_effective}' "$url")
-    echo "${final_url##*/}"
-}
-
-if [[ -n "$XLINGS_VERSION" ]]; then
-    LATEST_VERSION="$XLINGS_VERSION"
-    log_info "Using specified version: ${CYAN}${LATEST_VERSION}${RESET}"
-else
-    log_info "Querying latest release..."
-    LATEST_VERSION=$(resolve_latest_version)
-fi
-
-if [[ -z "$LATEST_VERSION" ]]; then
-    log_error "Failed to resolve release version."
-    exit 1
-fi
-
-[[ "$LATEST_VERSION" == v* ]] || LATEST_VERSION="v${LATEST_VERSION}"
-VERSION_NUM="${LATEST_VERSION#v}"
-TARBALL="xlings-${VERSION_NUM}-${PLATFORM}-${ARCH_TYPE}.tar.gz"
-
-if [[ -n "$GITHUB_MIRROR" ]]; then
-    DOWNLOAD_URL="${GITHUB_MIRROR}/${GITHUB_REPO}/releases/download/${LATEST_VERSION}/${TARBALL}"
-else
-    DOWNLOAD_URL="https://github.com/${GITHUB_REPO}/releases/download/${LATEST_VERSION}/${TARBALL}"
-fi
-
-log_info "Latest version: ${CYAN}${LATEST_VERSION}${RESET}"
-log_info "Package:        ${CYAN}${TARBALL}${RESET}"
-log_info "Download URL:   ${CYAN}${DOWNLOAD_URL}${RESET}"
-
-# --------------- download & extract ---------------
+# --------------- workspace ---------------
 
 TMPDIR_ROOT="${TMPDIR:-/tmp}"
 WORK_DIR=$(mktemp -d "${TMPDIR_ROOT}/xlings-install.XXXXXX")
@@ -136,12 +105,169 @@ cleanup() {
 trap 'cleanup; log_error "Interrupted"; exit 1' INT TERM
 trap cleanup EXIT
 
-log_info "Downloading..."
-if ! curl -fSL --progress-bar -o "${WORK_DIR}/${TARBALL}" "$DOWNLOAD_URL"; then
-    log_error "Download failed. Please check your network or try setting XLINGS_GITHUB_MIRROR."
+# --------------- resolve release sources ---------------
+#
+# Mirror parity with quick_install.ps1: probe both supported sources, measure
+# their latency, then prefer the highest version and, among equal versions, the
+# lowest-latency source. Download falls back to the next source on failure.
+#
+# Each resolver echoes a single line "<version>|<download_url>|<probe_seconds>"
+# on success, or returns non-zero on failure.
+
+ASSET_NAME() { echo "xlings-$1-${PLATFORM}-${ARCH_TYPE}.tar.gz"; }
+
+# GitHub: discover the tag via the /releases/latest redirect (no API token, no
+# rate limit). The same request doubles as the latency probe. Honors
+# XLINGS_GITHUB_MIRROR for the web base.
+resolve_github() {
+    local web_base="${GITHUB_MIRROR:-https://github.com}"
+    web_base="${web_base%/}"
+
+    local version_num tag probe effective
+    if [[ -n "$XLINGS_VERSION" ]]; then
+        version_num="${XLINGS_VERSION#v}"
+        tag="v${version_num}"
+        # HEAD the tag page to confirm existence and measure latency.
+        probe=$(curl -fsSIL -o /dev/null -w '%{time_total}' \
+            "${web_base}/${GITHUB_REPO}/releases/tag/${tag}") || return 1
+    else
+        effective=$(curl -fsSIL -o /dev/null -w '%{time_total} %{url_effective}' \
+            "${web_base}/${GITHUB_REPO}/releases/latest") || return 1
+        probe="${effective%% *}"
+        tag="${effective##*/}"
+        version_num="${tag#v}"
+    fi
+    [[ -n "$version_num" ]] || return 1
+
+    local url="${web_base}/${GITHUB_REPO}/releases/download/${tag}/$(ASSET_NAME "$version_num")"
+    echo "${version_num}|${url}|${probe}"
+}
+
+# GitCode: read release metadata from the v5 API (also the latency probe), then
+# pull the matching asset's browser_download_url out of the JSON with grep so we
+# don't need python/jq. The reported api.gitcode.com download host 404s on direct
+# hits; the same path on gitcode.com redirects to file-cdn.gitcode.com, so rewrite.
+resolve_gitcode() {
+    local meta_file="${WORK_DIR}/gitcode-meta.json"
+    local probe version_num tag
+
+    if [[ -n "$XLINGS_VERSION" ]]; then
+        version_num="${XLINGS_VERSION#v}"
+        # GitCode tags carry no leading "v"; try the bare number first, then "v".
+        local resolved=1 t
+        for t in "${version_num}" "v${version_num}"; do
+            if probe=$(curl -fsS -o "$meta_file" -w '%{time_total}' \
+                "${GITCODE_API}/repos/${GITCODE_REPO}/releases/tags/${t}"); then
+                resolved=0; break
+            fi
+        done
+        [[ $resolved -eq 0 ]] || return 1
+    else
+        probe=$(curl -fsS -o "$meta_file" -w '%{time_total}' \
+            "${GITCODE_API}/repos/${GITCODE_REPO}/releases/latest") || return 1
+        tag=$(grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' "$meta_file" \
+            | head -1 | grep -oE '"[^"]*"$' | tr -d '"')
+        version_num="${tag#v}"
+    fi
+    [[ -n "$version_num" ]] || return 1
+
+    # Escape dots so the asset filename is matched literally inside the JSON blob.
+    local asset_re
+    asset_re=$(ASSET_NAME "$version_num" | sed 's/\./\\./g')
+    local asset_url
+    asset_url=$(grep -oE "\"browser_download_url\"[[:space:]]*:[[:space:]]*\"[^\"]*${asset_re}\"" "$meta_file" \
+        | head -1 | grep -oE "https?://[^\"]*${asset_re}")
+    [[ -n "$asset_url" ]] || return 1
+
+    asset_url="${asset_url/https:\/\/api.gitcode.com\//https://gitcode.com/}"
+    echo "${version_num}|${asset_url}|${probe}"
+}
+
+# Probe a source and append it to the candidate arrays.
+CAND_SRC=(); CAND_VER=(); CAND_URL=(); CAND_PROBE=()
+probe_source() {
+    local name="$1" resolver="$2" out
+    log_info "Probing ${name}..."
+    if out=$("$resolver"); then
+        local ver="${out%%|*}" rest="${out#*|}"
+        local url="${rest%|*}" probe="${rest##*|}"
+        CAND_SRC+=("$name"); CAND_VER+=("$ver"); CAND_URL+=("$url"); CAND_PROBE+=("$probe")
+        log_info "  ${name}: ${CYAN}v${ver}${RESET} (${probe}s)"
+    else
+        log_warn "  ${name} unavailable"
+    fi
+}
+
+if [[ -n "$XLINGS_VERSION" ]]; then
+    log_info "Using specified version: ${CYAN}${XLINGS_VERSION#v}${RESET}"
+else
+    log_info "Resolving latest release across sources..."
+fi
+
+probe_source "GitHub"  resolve_github
+probe_source "GitCode" resolve_gitcode
+
+if [[ ${#CAND_SRC[@]} -eq 0 ]]; then
+    log_error "All release sources failed. Check your network or set XLINGS_GITHUB_MIRROR."
     exit 1
 fi
 
+# When no exact version was requested, keep only candidates at the highest
+# version (dotted numeric sort works on both GNU and BSD sort, unlike -V).
+MAX_VER=""
+if [[ -z "$XLINGS_VERSION" ]]; then
+    MAX_VER=$(printf '%s\n' "${CAND_VER[@]}" | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
+fi
+
+# Order surviving candidates by ascending latency: "<probe> <index>" | sort -n.
+ORDER=()
+for i in "${!CAND_SRC[@]}"; do
+    if [[ -n "$MAX_VER" && "${CAND_VER[$i]}" != "$MAX_VER" ]]; then
+        continue
+    fi
+    ORDER+=("${CAND_PROBE[$i]} ${i}")
+done
+SORTED_IDX=$(printf '%s\n' "${ORDER[@]}" | sort -n | cut -d' ' -f2)
+
+# --------------- download & extract ---------------
+
+is_gzip() {
+    local f="$1" sig
+    [[ -s "$f" ]] || return 1
+    sig=$(od -An -tx1 -N2 "$f" 2>/dev/null | tr -d ' \n')
+    [[ "$sig" == "1f8b" ]]
+}
+
+TARBALL=""
+SELECTED_SRC=""
+download_ok=0
+for i in $SORTED_IDX; do
+    src="${CAND_SRC[$i]}"
+    url="${CAND_URL[$i]}"
+    ver="${CAND_VER[$i]}"
+    TARBALL=$(ASSET_NAME "$ver")
+
+    log_info "Source:       ${CYAN}${src}${RESET} (v${ver}, ${CAND_PROBE[$i]}s)"
+    log_info "Package:      ${CYAN}${TARBALL}${RESET}"
+    log_info "Download URL: ${CYAN}${url}${RESET}"
+    log_info "Downloading..."
+
+    if curl -fSL --progress-bar -o "${WORK_DIR}/${TARBALL}" "$url" && is_gzip "${WORK_DIR}/${TARBALL}"; then
+        download_ok=1
+        SELECTED_SRC="$src"
+        break
+    fi
+
+    log_warn "${src} download failed; trying next source..."
+    rm -f "${WORK_DIR}/${TARBALL}"
+done
+
+if [[ $download_ok -ne 1 ]]; then
+    log_error "All download sources failed. Check your network or set XLINGS_GITHUB_MIRROR."
+    exit 1
+fi
+
+log_info "Downloaded from: ${CYAN}${SELECTED_SRC}${RESET}"
 log_info "Extracting..."
 tar -xzf "${WORK_DIR}/${TARBALL}" -C "$WORK_DIR"
 


### PR DESCRIPTION
## Why

The one-line installer's mirror adaptation was **Windows-only**. `quick_install.ps1` already probes both GitHub and GitCode, picks the lowest-latency source, and falls back automatically. `quick_install.sh` (Linux/macOS), by contrast, only ever direct-downloaded from `github.com` and offered a single **manual** `XLINGS_GITHUB_MIRROR` env var as a fallback — so users who can't reach GitHub (e.g. mainland China) got a noticeably worse out-of-box experience.

GitCode (`xlings-res/xlings`) already hosts the Linux/macOS tarballs (`xlings-<ver>-linux-x86_64.tar.gz`, `xlings-<ver>-macosx-arm64.tar.gz`), so source parity is achievable today.

## What

Bring `quick_install.sh` to parity with the Windows script:

- **Probe both sources** — GitHub `openxlings/xlings` + GitCode `xlings-res/xlings` — measuring latency with curl's `%{time_total}` (portable; avoids macOS `date` lacking `%N` and BSD `sort -V`).
- **Prefer highest version, then lowest latency**, with **automatic fallback** to the next source if a download fails.
- **Parse GitCode JSON with `grep` only** — no new `python`/`jq` dependency.
- **Rewrite `api.gitcode.com` → `gitcode.com`** download URLs (the api host 404s on direct asset hits; `gitcode.com` redirects to `file-cdn.gitcode.com`), matching the ps1 behavior.
- **Validate gzip magic** before extracting.
- Backward compatible: `XLINGS_GITHUB_MIRROR` still overrides the GitHub web base; `XLINGS_VERSION` / positional version arg still honored; platforms GitCode lacks (e.g. `linux-arm64`) transparently fall back to GitHub.

## Testing

Verified on Linux x86_64 (resolution + download isolated from `self install`):

| Scenario | Result |
|---|---|
| Auto (no version) | Both resolve v0.4.51; **GitCode chosen** (0.39s vs 1.54s); valid gzip |
| Specified `v0.4.50` | Both resolve; GitCode chosen; valid gzip |
| GitCode resolver fails | Falls back to **GitHub**; valid gzip |
| Invalid `XLINGS_GITHUB_MIRROR` | GitHub marked unavailable; GitCode serves; valid gzip |

> Note: GitCode currently publishes only `linux-x86_64` / `macosx-arm64` / `windows-x86_64`. Other platforms automatically fall back to GitHub.