### PR TITLE
feat(root): execution-identity layer for root/sudo usability

### DIFF
--- a/.agents/docs/2026-06-21-linux-root-usability-survey.md
+++ b/.agents/docs/2026-06-21-linux-root-usability-survey.md
@@ -1,0 +1,105 @@
+# Linux root 用户下的 xlings 可用性调研
+
+> 日期: 2026-06-21
+> 类型: 调研 (survey)
+> 范围: `xlings self install/uninstall/init`、`xim` 包安装/解包、`xvm` shim、`subos` 沙箱在 Linux **root / sudo** 下的行为
+> 方法: 三路并行源码深挖 + 一手核验
+
+## TL;DR
+
+xlings 在 `self` / `xim` / `xvm` / `mirror` 全链路里**没有任何 EUID/root/sudo 感知**。全树唯一的 `::getuid()` 在 `src/core/subos.cppm:1416`,仅用于 sandbox NSS 模板。代码隐含假设「调用者就是文件的拥有者」,这在两类 root 场景下分别失效。
+
+## 两类 root 场景(失效模式不同)
+
+| 场景 | `HOME` | 典型问题 |
+|---|---|---|
+| **纯 root 登录**(容器 / 裸 root) | `/root` | 装到 `/root/.xlings`,基本可用;但 sandbox passwd 冲突、`sudo` 硬编码在无 sudo 镜像里直接失败 |
+| **`sudo xlings ...`**(普通用户提权单次执行) | 多数发行版重置为 `/root`,`-E` 时仍是用户 home | **split-brain**:真实用户拿不到 PATH;`~/.xlings` 留下 root 属主文件,后续非 sudo 调用 `EACCES` |
+
+---
+
+## 问题清单(按影响排序)
+
+### P0-1 — subos 把 `sudo` 硬编码进 mount/umount/chown,纯 root 容器里直接失败
+`src/core/subos.cppm:319 / 327 / 337 / 1890` 无条件 `sudo mount` / `sudo chown` / `sudo umount`。
+- 已经是 root 时 `sudo` 冗余;
+- 最小化 root 容器(image 模式主场景)**常常没装 sudo** → `sudo: command not found`,image 隔离级在 root 容器下「有权限却用不了」。
+
+**优化**: `priv_prefix()` 助手 —— `geteuid()==0 ? "" : "sudo "`,套到所有 mount/umount/chown。
+
+### P0-2 — `sudo` 安装造成属主撕裂,毒化 `~/.xlings`
+全链路 `fs::create_directories` / `copy_file` / `write_string_to_file`(`installer.cppm`、`init.cppm`、`config.cppm:499`、`shim.cppm`)**无 chown-back**。
+- `sudo -E xlings install`(或导出了 `XLINGS_HOME`)把 `runtimedir`、`xpkgs`、版本 DB、shim、`.xlings.json` 全部以 `root:root` 写进用户 home。
+- 下一次**非 sudo** `xlings install` → `EACCES`;且错误常被吞(`installer.cppm:1228-1230` 忽略 `ec`),损坏状态。
+- 现成范式: `subos.cppm:324-329`(image mount 后 `chown` 回真实用户)—— self/xim 路径完全没采用。
+
+**优化**: `geteuid()==0 && SUDO_UID` 时 `chown -R $SUDO_UID:$SUDO_GID` 安装产物;或启动时检测 home 属主 ≠ EUID 即明确报错。
+
+### P1-3 — `sudo` 下真实用户拿不到 PATH(rc 文件写错对象)
+`install.cppm:249-308` 的 rc 选择来自 `get_home_dir()`(`linux.cppm:163` 直接返回 `$HOME`)。sudo 下写的是 `/root/.bashrc`、`/root/.config/fish/`,**真实用户 shell 永远没有那行 PATH/XLINGS_HOME**。安装「成功」但敲 `xlings` 找不到。无 `SUDO_USER` 检测。
+另:fish 分支(`install.cppm:289-303`)只要 `command -v fish` 存在就给 root 建 `~/.config/fish/config.fish`,即便没人用 fish。
+
+**优化**: `SUDO_USER` 存在时经 `getpwnam(SUDO_USER)->pw_dir` 解析真实 home 写 rc 并 chown;退一步至少打印警告。
+
+### P1-4 — sandbox 内 root 的 passwd 自相矛盾(纯 root-only 缺陷)
+`subos.cppm:1416` 用 `::getuid()`(root=0),喂给 `make_etc_passwd_`(`:177-182`),`user=="root"` 时生成**两条 uid-0 记录**:
+```
+root:x:0:0:root:/root:/bin/sh        ← 硬编码,getpwuid(0) 命中这条
+root:x:0:0:root:/home/root:/bin/sh   ← 实际 bind 的 home 在这
+```
+沙箱里 `HOME=/home/root`(`:1554`)、`--chdir /home/root`、profile bind 在 `/home/root/.xlings`。任何用 `getpwuid(0)` 解析 root home 的工具(bash `~`、ssh、脚本)拿到 `/root`(空目录),与真实 `/home/root` 不一致 → `cd ~`、`~/.config`、profile 失效。
+
+**优化**: `user=="root"` 时不追加第二条;或把 root 合成 home 统一成 `/root` 并调整 bind/chdir。
+
+### P2-5 — `home_knows_program` 把 `EACCES` 误报成「未安装」
+`shim.cppm:113-149`:读 `/root/.xlings/.xlings.json` 遇权限错误被 catch 当「未注册」(`:145-147`)。sudo 装在 `/root/.xlings` 的程序,普通用户调用时 shim 跨读 root json `EACCES` → 报「not installed」,误导。
+
+**优化**: 区分 `EACCES` 与真正「未注册」,提示「该 home 属于其它用户 / 勿用 sudo」。
+
+### P2-6 — 解包信任 tarball 的 mode 位(setuid/世界可写直通)
+`extract.cppm:49-53` 用 `ARCHIVE_EXTRACT_PERM` 但**没设 `ARCHIVE_EXTRACT_OWNER`** → 不发生 chown;`:225-228` 的「强制 uid 0」回调实际是**死代码**(无 OWNER 时不被调用)。真正隐患是 mode 位原样落盘:条目若打 `4777`,在 root/sudo 下落成 **setuid-root**。路径穿越有 `SECURE_NODOTDOT/SYMLINKS` 防护,mode 无掩码。
+
+**优化**: 解包掩掉危险位 `& ~(S_ISUID|S_ISGID|S_IWOTH)`。
+
+### P3-7 — keeper/nsenter 隐含需要 root 但无守卫(目前未接线)
+`keeper.cppm:126-156` 的 `nsenter --mount=...` 需 `CAP_SYS_ADMIN`,无 `sudo` 前缀也无 uid 检查;非特权下静默失败。`register_pid`/`nsenter_and_exec` 当前**无调用点**(仅 `should_auto_keeper`/`stop_keeper` 被引用),属潜在问题,修复 keeper 接线时一并处理。
+
+---
+
+## 澄清:bwrap 探测在 root 下是非问题
+`probe_bwrap_`(`:1102`)+ `classify_bwrap_probe_error_`(`:1114`)的三类错误全是**非特权 userns** 失败签名。root 下一般不发生,探测通常直接 pass,功能正常。小瑕疵:root 下若出现别的失败会落 raw-output 分支,且给出对 root 无意义的「关 apparmor userns 限制」提示。另 root 下 `locate_bwrap_`(`:1069`)坚持只用 setuid 的 xim:bwrap、跳过 `/usr/bin/bwrap` 的理由对 root 已不成立,可放宽。
+
+> 修正记录:初版三方调研中曾判定 `extract.cppm:225-228` 在 sudo 下「强制 chown 到 root」。一手核验 `kWriteFlags`(`:49-53`)未含 `ARCHIVE_EXTRACT_OWNER`,libarchive 不执行 chown,该回调为死代码;sudo 下文件 root 属主仅因**进程本身是 root**,与该回调无关。已在 P2-6 修正。
+
+---
+
+## 建议的最小落地方案
+
+新增 `platform::priv` 模块集中三件事,在 install 入口与 subos 各处接入:
+
+```cpp
+bool is_root();                       // geteuid()==0
+std::string sudo_prefix();            // is_root() ? "" : "sudo "          // 解 P0-1
+std::optional<RealUser> sudo_user();  // SUDO_UID/SUDO_GID + getpwnam(SUDO_USER)->pw_dir
+void chown_back(path, RealUser);      // EUID==0 && SUDO_USER 时 chown -R  // 解 P0-2/P1-3
+```
+
+落地优先级:
+1. **P0-1**(去 sudo 硬编码)—— 改动最小、解锁 image 模式在 root 容器,最高性价比;
+2. **P0-2 + P1-3**(`SUDO_USER`-aware home + chown-back)—— 一处修复同时关掉属主撕裂、PATH 丢失、shim 误报;
+3. **P1-4**(root passwd 去重)、**P2-6**(mode 掩码)—— 独立小补丁;
+4. 文档: 在 `docs/` 说明「root/sudo 安装的预期落点与限制」(当前 docs 仅在 image 模式提「需要 root」,未讲 sudo 混用风险)。
+
+---
+
+## 关键代码位置索引
+
+- `src/platform/linux.cppm:163-178` — `get_home_dir`(只读 `$HOME`)、`make_files_executable`(chmod 0755)
+- `src/core/config.cppm:414-456, 499` — home 解析优先级、`dataDir`
+- `src/core/xself/install.cppm:225-227, 249-308` — `default_home`、rc 写入
+- `src/core/xself/uninstall.cppm:65-98` — 路径守卫(阻 `/root`/`$HOME`,放行 `/root/.xlings`)
+- `src/core/xim/extract.cppm:49-53, 215-228` — 写盘 flags、死代码 uid-0 回调
+- `src/core/xim/installer.cppm:1228-1230` — 吞 `ec`
+- `src/core/xvm/shim.cppm:113-149, 155-227` — 程序解析、home 借用、EACCES 吞错
+- `src/core/subos.cppm:177-182, 319-329, 337, 1416-1418, 1554, 1890` — 合成 passwd、sudo 硬编码、NSS uid
+- `src/core/subos/keeper.cppm:126-156` — nsenter(需 root,未接线)

--- a/.agents/docs/2026-06-21-root-privilege-identity-design.md
+++ b/.agents/docs/2026-06-21-root-privilege-identity-design.md
@@ -1,0 +1,101 @@
+# Root / 特权身份感知 架构设计
+
+> 日期: 2026-06-21
+> 类型: 设计 (design)
+> 调研依据: [`2026-06-21-linux-root-usability-survey.md`](./2026-06-21-linux-root-usability-survey.md)
+> 目标: 让 xlings 在 Linux root / sudo 下行为正确,**且不影响任何现有平台(Linux 非 root / macOS / Windows)与功能**
+
+## 1. 问题本质
+
+调研结论:xlings 全链路**没有任何 EUID/root/sudo 感知**(唯一的 `::getuid()` 在 `subos.cppm:1416`,仅用于 NSS 模板)。「执行身份」这个横切关注点被散落成隐式 ambient 读取——到处 `getenv("HOME")`、硬编码 `"sudo "`、裸 `fs::create_directories`,没有一处「知道我是谁、文件该归谁」。
+
+由此产生 7 个症状(详见调研),核心两个:
+- **P0-1**: `subos.cppm:319/327/337` 硬编码 `sudo mount/umount/chown`,纯 root 容器(常无 sudo)直接 `sudo: command not found`。
+- **P0-2**: `sudo` 安装把 `root:root` 文件写进用户 `~/.xlings`,后续非 sudo 调用 `EACCES`,且错误被吞(`installer.cppm:1228-1230`)。
+
+## 2. 业界最佳实践对标
+
+| 传统 | 代表 | 做法 | 对应 xlings |
+|---|---|---|---|
+| 用户态安装器 | Homebrew / makepkg | **拒绝**以 root 运行 | install 路径可选「拒绝/警告」 |
+| | npm | 以 root 运行时**降权**到目录属主(读 `SUDO_UID`) | install 路径首选「降权 / chown-back」 |
+| | pip / nvm | **警告** + 文档 | 最低成本止血 |
+| 特权原语工具 | Podman / bubblewrap | **窄 setuid 助手**只包单个特权原语;rootless + FUSE | subos image:`priv` 边界 + 二期 rootless |
+| | sshd / polkit | **特权分离**:特权部分隔离成极小组件 | `priv::run()` 单一出口 |
+
+**提炼**: *用户态工作以真实用户身份做(拒绝 root / 降权 / chown-back);特权只用窄边界包住,能 rootless 就 rootless。* `sudo` 故意保留 `SUDO_UID/GID/USER` 正是为了让程序能降权——这是机制基础。
+
+## 3. 架构设计
+
+### 3.1 核心:`ExecIdentity` 一等概念
+
+执行身份**解析一次、不可变**,集中在 `platform` 层,消除散落的 ambient 读取。
+
+```cpp
+// src/platform/  —— :unix 分区实现 (linux+macos),:windows 分区给 stub
+namespace xlings::platform {
+
+struct SudoInvoker {        // 仅当「root 且经 sudo 提权」时存在
+    unsigned int uid;       // SUDO_UID
+    unsigned int gid;       // SUDO_GID
+    std::string  user;      // SUDO_USER
+};
+
+bool is_root();                         // Linux/macOS: geteuid()==0 ; Windows: false
+std::string priv_prefix();              // is_root() ? "" : "sudo "
+std::optional<SudoInvoker> sudo_invoker();  // is_root() && SUDO_UID 存在 ? {...} : nullopt
+void chown_to_invoker(path, recursive); // 仅当 sudo_invoker() 有值时执行,否则 no-op
+}
+```
+
+### 3.2 操作二分 + 特权边界
+
+| 类别 | 操作 | 策略 |
+|---|---|---|
+| 用户态(99%) | download / extract / 写 `~/.xlings` / shim / 版本 DB | 经 sudo 时 **chown-back 到 invoker**;并在入口**警告** |
+| 特权(仅 subos image) | `mount -o loop` / `umount` / `chown` | 全部经 `priv_prefix()`:已是 root → 不加 sudo;否则加 |
+
+### 3.3 不影响现有平台/功能的安全保证(关键)
+
+这是本设计的硬约束,逐条对齐:
+
+1. **非 root 行为零变化**:`priv_prefix()` 在非 root 时返回 `"sudo "`,与现有硬编码**逐字节相同**。所有现有 Linux 非 root 流程、CI(runner 非 root)、macOS 完全不变。
+2. **新路径门控**:`chown_to_invoker` / 警告只在 `is_root() && SUDO_UID` 这个**全新条件**下触发;现有用户从不进入。
+3. **Windows 编译安全**:`:windows` 分区提供同签名 stub(`is_root()=false`、`priv_prefix()=""`、`sudo_invoker()=nullopt`、`chown_to_invoker()=no-op`),subos 特权路径本就是 Linux-only。
+4. **macOS 复用 POSIX**:`:unix` 分区(linux+macos 共享)用 `geteuid`/`::chown`,与现有 `query_terminal_is_light` 同模式。
+5. **纯 root 容器**:无 `SUDO_UID` → `chown_to_invoker` no-op,文件 root 属主一致、无害;`priv_prefix()` 去掉冗余 sudo → 修复 P0-1。
+
+## 4. 实施方案(分期)
+
+### Phase 1 — 本 PR(止血 + 地基,低风险)
+- [ ] **P1.1** `platform` 增加 identity helpers(`:unix` 实现 + `:windows` stub + `platform.cppm` 再导出)。
+- [ ] **P1.2** subos `319/327/337` 三处 `sudo ` → `platform::priv_prefix() + ...`。(修 P0-1)
+- [ ] **P1.3** `self install` 成功后:`sudo_invoker()` 有值则 `chown_to_invoker(XLINGS_HOME)`;入口在 root 下打印警告(纯 root info / sudo warn)。(修 P0-2/P1-3 主入口)
+- [ ] **P1.4** 单元测试:`priv_prefix()` 非 root 返回 `"sudo "`;`parse_sudo_env_` 纯函数解析。
+- [ ] **P1.5** e2e:`root_usability_test.sh` —— root 下 self install + install fixture 包 + 校验可用性 + sudo 场景属主回归。
+- [ ] **P1.6** 新增 CI `xlings-ci-linux-root.yml`:mcpp 构建最新 xlings → root 场景验证。
+
+### Phase 2 — 后续 PR(完整覆盖)
+- [ ] xim `cmd_install` 后对 package store / runtimedir chown-back;`installer.cppm:1228` 不再吞 `ec`。
+- [ ] `shim.cppm` 区分 `EACCES` 与「未注册」,提示属主问题(修 P2-5)。
+- [ ] sandbox root passwd 去重(`user=="root"` 不写第二条,修 P1-4)。
+- [ ] extract mode 位掩码 `& ~(S_ISUID|S_ISGID|S_IWOTH)`(修 P2-6)。
+- [ ] `ExecIdentity` 注入 `Config`,解析一次而非按需 syscall。
+
+### Phase 3 — 进阶(架构升级)
+- [ ] 用户态命令在 `via_sudo` 时**降权**到 invoker(npm 模式),属主由构造保证。
+- [ ] subos image 改 rootless(user namespace + FUSE,如 `fuse2fs`),彻底去 `mount` 的 root 依赖(Podman 模式)。
+- [ ] 入口策略门:root 但 home 属主是别人 → 明确拒绝(Homebrew 模式)。
+
+## 5. 测试策略
+
+- **单元**(`tests/unit/`,非 root 即可跑):纯函数 `parse_sudo_env_`、`priv_prefix()` 在非 root 的返回。
+- **e2e**(`tests/e2e/root_usability_test.sh`):用构建出的 release 二进制,在受控 `HOME` 下以 root / 模拟 sudo(设 `SUDO_UID/GID/USER`)跑 self install + install,断言:① 二进制可用;② 经 sudo 时安装产物属主 = invoker;③ `priv_prefix` 行为正确。
+- **CI**(`xlings-ci-linux-root.yml`):先用 mcpp 构建最新 xlings,再在 root 场景跑上述 e2e,**持续验证当前版本在 root 下的可用性**(回归护栏)。
+
+## 6. 关键代码位置
+
+- `src/platform/unix.cppm` / `windows.cppm` / `platform.cppm` — identity helpers + 再导出
+- `src/core/subos.cppm:319/327/337` — sudo 硬编码 → `priv_prefix()`
+- `src/core/xself/install.cppm` — self install 后 chown-back + root 警告
+- `tests/unit/test_identity.cpp`、`tests/e2e/root_usability_test.sh`、`.github/workflows/xlings-ci-linux-root.yml`

--- a/.github/workflows/xlings-ci-linux-root.yml
+++ b/.github/workflows/xlings-ci-linux-root.yml
@@ -1,0 +1,134 @@
+name: xlings-ci-linux-root
+
+# Verifies xlings usability under the Linux root user. Builds the latest
+# xlings from source with mcpp (job: build), then runs the root scenarios
+# inside a bare ubuntu:24.04 *root* container that deliberately has no sudo
+# installed — so the run genuinely exercises the root / sudo identity layer
+# (P0-1: no sudo dependency; P0-2: sudo chown-back).
+# Design: .agents/docs/2026-06-21-root-privilege-identity-design.md
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+env:
+  GIT_TERMINAL_PROMPT: 0
+  XLINGS_RELEASE_MIRROR: GLOBAL
+  # Keep in sync with xlings-ci-linux.yml.
+  BOOTSTRAP_XLINGS_VERSION: v0.4.49
+  XIM_PKGINDEX_REF: fbcad0320fbf84271b710650402ac7ed1a8fa64f
+
+jobs:
+  # ── Build the latest xlings from source via mcpp ──────────────────
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install system deps
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y curl git build-essential
+
+      - name: Install bootstrap xlings (pinned ${{ env.BOOTSTRAP_XLINGS_VERSION }})
+        env:
+          XLINGS_NON_INTERACTIVE: 1
+          XLINGS_VERSION: ${{ env.BOOTSTRAP_XLINGS_VERSION }}
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
+          echo "XLINGS_HOME=$HOME/.xlings"       >> "$GITHUB_ENV"
+          echo "$HOME/.xlings/subos/current/bin" >> "$GITHUB_PATH"
+          echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"
+
+      - name: Cache xlings package payloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.xlings/data/xpkgs
+          key: xlings-deps-${{ runner.os }}-${{ hashFiles('.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
+          restore-keys: |
+            xlings-deps-${{ runner.os }}-
+
+      - name: Cache mcpp sandbox and project packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.mcpp
+            .mcpp
+          key: mcpp-${{ runner.os }}-${{ hashFiles('mcpp.toml', 'mcpp.lock', '.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
+          restore-keys: |
+            mcpp-${{ runner.os }}-
+
+      - name: Prepare bootstrap package index
+        run: |
+          rm -rf "$XLINGS_HOME/data/xim-pkgindex"
+          bash tests/e2e/prepare_fixture_index.sh "$XLINGS_HOME/data/xim-pkgindex"
+
+      - name: Install build dependencies (mcpp)
+        run: |
+          cd "$GITHUB_WORKSPACE"
+          xlings install -y
+          mcpp --version
+
+      - name: Refresh mcpp package index cache
+        run: |
+          rm -rf "$HOME/.mcpp/registry/data/mcpplibs"
+          rm -rf "$GITHUB_WORKSPACE/.mcpp/registry/data/mcpplibs"
+
+      - name: Prepare unit fixture index repo
+        run: |
+          bash tests/e2e/prepare_fixture_index.sh ../xim-pkgindex
+
+      - name: Build + unit tests (incl. identity layer)
+        run: |
+          mcpp build
+          mcpp test
+
+      - name: Build static release (linux_release)
+        run: |
+          chmod +x ./tools/linux_release.sh
+          SKIP_NETWORK_VERIFY=1 ./tools/linux_release.sh
+          tarball=$(ls build/xlings-*-linux-x86_64.tar.gz 2>/dev/null | head -1)
+          [[ -z "$tarball" ]] && { echo "No release tarball found"; exit 1; }
+          cp "$tarball" build/release.tar.gz
+
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: xlings-root-ci-release
+          path: build/release.tar.gz
+
+  # ── Verify root usability in a bare root container (no sudo) ───────
+  verify-root:
+    needs: build
+    runs-on: ubuntu-24.04
+    container:
+      image: ubuntu:24.04        # default user is root (uid 0); no sudo preinstalled
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Minimal deps for the e2e harness — deliberately NOT installing sudo,
+      # so the pure-root scenario proves xlings never depends on it.
+      - name: Install minimal deps (no sudo)
+        run: |
+          apt-get update -qq
+          apt-get install -y curl ca-certificates tar findutils perl git
+          echo "sudo intentionally NOT installed:"; command -v sudo || echo "  (absent — good)"
+
+      - name: Download release artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: xlings-root-ci-release
+          path: build
+
+      - name: Confirm running as root
+        run: |
+          id
+          [ "$(id -u)" -eq 0 ] || { echo "expected uid 0"; exit 1; }
+
+      - name: "ROOT-01: root usability (pure root + simulated sudo)"
+        run: |
+          bash tests/e2e/root_usability_test.sh build/release.tar.gz

--- a/src/core/subos.cppm
+++ b/src/core/subos.cppm
@@ -175,12 +175,28 @@ namespace sandbox_detail_ {
 // is also included so anything that does getpwuid(0) (scripts that
 // assume "root must exist") doesn't bail.
 std::string make_etc_passwd_(const std::string& user, uid_t uid, gid_t gid) {
+    auto home = "/home/" + user;
+    // When running as root (uid 0), emit a SINGLE uid-0 entry whose home is
+    // the sandbox home (/home/<user>), so getpwuid(0)->pw_dir agrees with
+    // $HOME and the bind-mounted home. The historical extra
+    // "root:x:0:0:root:/root" line would otherwise create a second,
+    // conflicting uid-0 record that getpwuid(0) resolves to /root — an
+    // empty, unbound path — breaking `cd ~`, ~/.config, and profile sourcing
+    // for the root user inside the sandbox.
+    if (uid == 0) {
+        return std::format("{}:x:0:0:{}:{}:/bin/sh\n", user, user, home);
+    }
     return std::format(
         "root:x:0:0:root:/root:/bin/sh\n"
-        "{}:x:{}:{}:{}:/home/{}:/bin/sh\n",
-        user, uid, gid, user, user);
+        "{}:x:{}:{}:{}:{}:/bin/sh\n",
+        user, uid, gid, user, home);
 }
 std::string make_etc_group_(const std::string& user, gid_t gid) {
+    // Mirror passwd: a single gid-0 entry when running as root avoids a
+    // duplicate group-0 record (root + <user> both gid 0).
+    if (gid == 0) {
+        return std::format("{}:x:0:\n", user);
+    }
     return std::format(
         "root:x:0:\n"
         "{}:x:{}:\n",
@@ -315,8 +331,10 @@ int mount_image_(const fs::path& img, const fs::path& mountpoint,
     fs::create_directories(mountpoint);
     if (is_mounted_(mountpoint)) return 0;  // already mounted
 
-    // sudo mount (universally available)
-    auto cmd = "sudo mount -o loop " + img.string() + " "
+    // mount (privileged). priv_prefix() is "" when already root — sudo is
+    // redundant and frequently absent in minimal root containers, where the
+    // old hardcoded "sudo mount" died with "sudo: command not found".
+    auto cmd = platform::priv_prefix() + "mount -o loop " + img.string() + " "
                + mountpoint.string();
     auto rc = std::system(cmd.c_str());
     if (rc != 0) return rc;
@@ -324,8 +342,8 @@ int mount_image_(const fs::path& img, const fs::path& mountpoint,
     // ext4 root dir is owned by root after mkfs; chown to real user
     // so sandbox init can create dirs without sudo.
     if (!user.empty()) {
-        auto chown_cmd = "sudo chown " + user + ":" + user + " "
-                         + mountpoint.string();
+        auto chown_cmd = platform::priv_prefix() + "chown " + user + ":" + user
+                         + " " + mountpoint.string();
         std::system(chown_cmd.c_str());
     }
     return 0;
@@ -334,7 +352,8 @@ int mount_image_(const fs::path& img, const fs::path& mountpoint,
 // Unmount an image file.
 int unmount_image_(const fs::path& mountpoint) {
     if (!is_mounted_(mountpoint)) return 0;
-    auto cmd = "sudo umount " + mountpoint.string() + " 2>/dev/null";
+    auto cmd = platform::priv_prefix() + "umount " + mountpoint.string()
+               + " 2>/dev/null";
     return std::system(cmd.c_str());
 }
 

--- a/src/core/xim/commands.cppm
+++ b/src/core/xim/commands.cppm
@@ -379,6 +379,13 @@ int cmd_install(std::span<const std::string> targets, bool yes, bool noDeps,
         summaryPayload["success"] = successCount;
         summaryPayload["failed"] = failedCount;
         stream.emit(DataEvent{"install_summary", summaryPayload.dump()});
+
+        // If this install ran via `sudo`, the downloaded payloads, version DB
+        // and shims were written root-owned into the user's home. Hand the
+        // home back to the invoking user so a later non-sudo `xlings install`
+        // isn't locked out by EACCES. No-op for pure root / non-root installs
+        // (lchown is metadata-only, so even large payload trees are cheap).
+        platform::chown_to_invoker(Config::paths().homeDir);
     }
     // Per-package failures (download / extract / hook) are surfaced via
     // InstallPhase::Failed callbacks and accumulate in `failedCount`;

--- a/src/core/xim/extract.cppm
+++ b/src/core/xim/extract.cppm
@@ -278,6 +278,21 @@ extract_archive(const std::filesystem::path& archive,
             ::archive_entry_set_hardlink(entry, rebasedHl.c_str());
         }
 
+        // Harden permissions: strip setuid / setgid / world-writable bits
+        // from every entry before it hits disk. Package payloads have no
+        // business shipping setuid binaries — the few that legitimately need
+        // it (e.g. bwrap) get it from an explicit install hook, not tarball
+        // mode bits — and a setuid entry extracted under root/sudo would
+        // silently become setuid-root. Remaining mode bits are still honored
+        // (ARCHIVE_EXTRACT_PERM), so executables stay executable.
+        {
+            constexpr unsigned kStrip = 04000u | 02000u | 0002u;  // suid|sgid|o+w
+            auto perm = static_cast<unsigned>(::archive_entry_perm(entry));
+            // libarchive's set_perm takes its own mode type; the masked
+            // unsigned converts implicitly (no platform/libarchive macro).
+            ::archive_entry_set_perm(entry, perm & ~kStrip);
+        }
+
         r = ::archive_write_header(dst, entry);
         if (r < ARCHIVE_OK) {
             // Write may complain on platform mismatch (e.g., trying to

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -1227,6 +1227,13 @@ public:
             {
                 std::error_code ec;
                 std::filesystem::create_directories(ctx.install_dir, ec);
+                // A genuine failure here (commonly EACCES on a root-owned
+                // dir left by a prior `sudo` install) used to be swallowed,
+                // surfacing later as a confusing hook failure. Surface it.
+                if (ec && !std::filesystem::is_directory(ctx.install_dir)) {
+                    log::warn("create install dir {} failed: {}",
+                              ctx.install_dir.string(), ec.message());
+                }
             }
 
             bool payloadInstalled = node.alreadyInstalled;

--- a/src/core/xself/install.cppm
+++ b/src/core/xself/install.cppm
@@ -253,18 +253,24 @@ static void setup_shell_profiles(const fs::path& homeDir) {
 
     auto sourceLine = "test -f \"" + profileSh.string() + "\" && source \"" + profileSh.string() + "\"";
 
+    // rc files belong to the INVOKING user. Under `sudo` this is the real
+    // user's home (not root's $HOME), so the person who ran the install
+    // actually gets xlings on their PATH. Identical to get_home_dir() when
+    // not running via sudo, so non-sudo behavior is unchanged.
+    fs::path rcHome(platform::target_home());
+
     std::vector<fs::path> profiles;
 #if defined(__APPLE__)
     profiles = {
-        fs::path(platform::get_home_dir()) / ".zshrc",
-        fs::path(platform::get_home_dir()) / ".bashrc",
-        fs::path(platform::get_home_dir()) / ".zprofile",
+        rcHome / ".zshrc",
+        rcHome / ".bashrc",
+        rcHome / ".zprofile",
     };
 #else
     profiles = {
-        fs::path(platform::get_home_dir()) / ".bashrc",
-        fs::path(platform::get_home_dir()) / ".zshrc",
-        fs::path(platform::get_home_dir()) / ".profile",
+        rcHome / ".bashrc",
+        rcHome / ".zshrc",
+        rcHome / ".profile",
     };
 #endif
 
@@ -279,12 +285,14 @@ static void setup_shell_profiles(const fs::path& homeDir) {
         }
         std::string appendStr = "\n# xlings\n" + sourceLine + "\n";
         platform::write_string_to_file(prof.string(), content + appendStr);
+        // If we ran via sudo, hand the rc file back to its real owner.
+        platform::chown_to_invoker(prof, /*recursive=*/false);
         log::println("[xlings:self] added profile ({})", prof.filename().string());
         added = true;
         break;
     }
 
-    auto fishConfig = fs::path(platform::get_home_dir()) / ".config" / "fish" / "config.fish";
+    auto fishConfig = rcHome / ".config" / "fish" / "config.fish";
     auto fishSourceLine = "test -f \"" + profileFish.string() + "\"; and source \"" + profileFish.string() + "\"";
     if (fs::exists(fishConfig) ||
         platform::run_command_capture("command -v fish 2>/dev/null").first == 0) {
@@ -299,6 +307,8 @@ static void setup_shell_profiles(const fs::path& homeDir) {
         } else {
             log::debug("[xlings:self] profile ok (fish)");
         }
+        // Restore ownership of the fish config tree we may have created.
+        platform::chown_to_invoker(rcHome / ".config" / "fish");
         added = true;
     }
 
@@ -339,7 +349,28 @@ static void setup_shell_profiles(const fs::path& homeDir) {
 #endif
 }
 
+// Advise when running as root, distinguishing the two failure-prone cases:
+// pure root (files land in /root/.xlings, invisible to normal users) vs sudo
+// (we redirect rc files + chown ~/.xlings back to the real user). No-op for
+// the ordinary non-root install, so existing behavior is untouched.
+static void warn_root_context_() {
+    // Cross-platform by construction: is_root() is false on Windows (and for
+    // any non-root POSIX run), so this returns immediately and adds no
+    // behavior off the root path — no platform macro needed.
+    if (!platform::is_root()) return;
+    if (auto inv = platform::sudo_invoker()) {
+        log::warn("[xlings:self] running via sudo (user '{}')", inv->user);
+        log::warn("  rc files target {}'s home; ~/.xlings is chowned back to it",
+                  inv->user.empty() ? "the invoking user" : inv->user.c_str());
+        log::warn("  tip: xlings is user-space — running without sudo also works");
+    } else {
+        log::warn("[xlings:self] running as root — installing to root's home");
+        log::warn("  this install is only on root's PATH; normal users won't see it");
+    }
+}
+
 export int cmd_install() {
+    warn_root_context_();
     auto srcDir = detect_source_dir();
     if (srcDir.empty()) {
         log::error("[xlings:self] cannot detect source package directory.");
@@ -393,6 +424,7 @@ export int cmd_install() {
             return 1;
         }
         setup_shell_profiles(targetHome);
+        platform::chown_to_invoker(targetHome);
         log::println("[xlings:self] {} ({}) - ok\n", targetHome.string(), pkgVersion);
         return 0;
     }
@@ -533,6 +565,11 @@ export int cmd_install() {
         }
     }
 #endif
+
+    // Hand the freshly-written ~/.xlings back to the invoking user when we
+    // ran via sudo, so a later non-sudo `xlings install` isn't locked out by
+    // root-owned files. No-op for pure root / non-root installs.
+    platform::chown_to_invoker(targetHome);
 
     std::println("\n[xlings:self] install: {} ({}) - ok", targetHome.string(), pkgVersion);
     std::println("");

--- a/src/core/xvm/shim.cppm
+++ b/src/core/xvm/shim.cppm
@@ -116,6 +116,18 @@ bool home_knows_program(const std::filesystem::path& home,
     std::error_code ec;
     auto cfg = home / ".xlings.json";
     if (!fs::is_regular_file(cfg, ec)) return false;
+
+    // Distinguish "unreadable due to ownership" from "genuinely not
+    // registered". A sudo-installed home is root-owned; a later non-root
+    // invocation can't read its .xlings.json and would otherwise get a
+    // misleading "<program>: not installed" instead of a permissions hint.
+    if (std::ifstream probe(cfg, std::ios::binary); !probe.is_open()) {
+        log::warn("[xlings] cannot read {} (permission denied)", cfg.string());
+        log::warn("  this home may be owned by another user — avoid mixing "
+                  "sudo and non-sudo xlings on the same home");
+        return false;
+    }
+
     try {
         auto content = platform::read_file_to_string(cfg.string());
         auto j = nlohmann::json::parse(content, nullptr, false);

--- a/src/platform.cppm
+++ b/src/platform.cppm
@@ -1,6 +1,7 @@
 module;
 
 #include <cstdio>
+#include <cstdlib>
 #if !defined(_WIN32)
 #include <sys/wait.h>
 #endif
@@ -39,6 +40,98 @@ namespace platform {
     export using platform_impl::wait_or_kill;
     export using platform_impl::Icon;
     export using platform_impl::atomic_replace_executable;
+
+    // ── Execution identity (root / sudo awareness) ──────────────────
+    // Single source of truth for "who am I / who should own the files I
+    // create". Replaces ad-hoc geteuid()/SUDO_* reads and hardcoded
+    // "sudo " strings scattered across the codebase.
+    //
+    // Safety invariant: on the existing (non-root) path every helper
+    // returns exactly what the old hardcoded behavior produced, so
+    // Linux-non-root / macOS / Windows are byte-for-byte unaffected. The
+    // new behavior (chown-back, sudo-aware home, warnings) is gated
+    // strictly on the root+SUDO_* path that no current user reaches.
+    // Design: .agents/docs/2026-06-21-root-privilege-identity-design.md
+
+    export using platform_impl::is_root;
+
+    // The real user behind a `sudo xlings ...` launch.
+    export struct SudoInvoker {
+        unsigned int uid;
+        unsigned int gid;
+        std::string  user;   // SUDO_USER (may be empty)
+    };
+
+    // Pure parse of SUDO_UID / SUDO_GID / SUDO_USER. Does NOT check euid,
+    // so it is directly unit-testable on every platform. Returns nullopt
+    // unless both numeric ids are present and well-formed.
+    export [[nodiscard]] std::optional<SudoInvoker> parse_sudo_env() {
+        const char* su = std::getenv("SUDO_UID");
+        const char* sg = std::getenv("SUDO_GID");
+        if (!su || !sg || *su == '\0' || *sg == '\0') return std::nullopt;
+        char* end = nullptr;
+        unsigned long uid = std::strtoul(su, &end, 10);
+        if (end == su || *end != '\0') return std::nullopt;
+        end = nullptr;
+        unsigned long gid = std::strtoul(sg, &end, 10);
+        if (end == sg || *end != '\0') return std::nullopt;
+        const char* user = std::getenv("SUDO_USER");
+        return SudoInvoker{ static_cast<unsigned int>(uid),
+                            static_cast<unsigned int>(gid),
+                            user ? std::string{user} : std::string{} };
+    }
+
+    // Shell-command prefix for privileged ops (mount/umount/chown):
+    // "" when already root (sudo is redundant and often absent in minimal
+    // root containers), "sudo " otherwise — identical to the historical
+    // hardcoded string for the non-root case.
+    export [[nodiscard]] std::string priv_prefix() {
+        return platform_impl::is_root() ? std::string{} : std::string{"sudo "};
+    }
+
+    // The invoking user iff launched via sudo (root EUID + SUDO_* set).
+    // nullopt for pure root (no demotion target) and unprivileged runs.
+    export [[nodiscard]] std::optional<SudoInvoker> sudo_invoker() {
+        if (!platform_impl::is_root()) return std::nullopt;
+        return parse_sudo_env();
+    }
+
+    // Home directory that user-facing files (rc lines, ~/.xlings) should
+    // belong to. Under sudo this is the invoking user's home (from the
+    // passwd db, falling back to /home/<user>), NOT root's $HOME — which
+    // fixes the "real user never gets PATH" split-brain. Otherwise it's
+    // the ordinary $HOME, unchanged.
+    export [[nodiscard]] std::string target_home() {
+        if (auto inv = sudo_invoker()) {
+            if (auto h = platform_impl::home_for_user_(inv->user); !h.empty())
+                return h;
+            if (!inv->user.empty()) return "/home/" + inv->user;
+        }
+        return platform_impl::get_home_dir();
+    }
+
+    // Restore ownership of files created while running under sudo back to
+    // the invoking user, so a later non-sudo run isn't locked out of its
+    // own ~/.xlings. No-op unless launched via sudo (pure root / non-root
+    // → returns immediately, zero filesystem traversal).
+    export void chown_to_invoker(const std::filesystem::path& path,
+                                 bool recursive = true) {
+        auto inv = sudo_invoker();
+        if (!inv) return;
+        std::error_code ec;
+        if (!std::filesystem::exists(path, ec)) return;
+        platform_impl::lchown_path_(path, inv->uid, inv->gid);
+        if (recursive && std::filesystem::is_directory(path, ec)) {
+            auto end = std::filesystem::recursive_directory_iterator{};
+            for (auto it = std::filesystem::recursive_directory_iterator(
+                     path,
+                     std::filesystem::directory_options::skip_permission_denied,
+                     ec);
+                 !ec && it != end; it.increment(ec)) {
+                platform_impl::lchown_path_(it->path(), inv->uid, inv->gid);
+            }
+        }
+    }
 
     export [[nodiscard]] std::string get_rundir() {
         return gRundir;

--- a/src/platform/unix.cppm
+++ b/src/platform/unix.cppm
@@ -8,6 +8,7 @@ module;
 #include <termios.h>
 #include <sys/select.h>
 #include <sys/time.h>
+#include <pwd.h>
 #endif
 
 export module xlings.platform:unix;
@@ -144,6 +145,31 @@ namespace platform_impl {
         std::error_code rmec;
         fs::remove(tmp, rmec);
         return false;
+    }
+
+    // ── Execution identity primitives (root / sudo awareness) ───────
+    // Only the OS primitives live here; all policy (sudo parsing, priv
+    // prefix, chown-back) is cross-platform in platform.cppm. See
+    // .agents/docs/2026-06-21-root-privilege-identity-design.md.
+
+    export bool is_root() {
+        return ::geteuid() == 0;
+    }
+
+    // Single-path lchown (don't follow symlinks). Best-effort: ownership
+    // restoration must never abort an otherwise-successful operation, so
+    // the return value is intentionally ignored.
+    export void lchown_path_(const std::filesystem::path& p,
+                             unsigned int uid, unsigned int gid) {
+        ::lchown(p.c_str(), static_cast<uid_t>(uid), static_cast<gid_t>(gid));
+    }
+
+    // Resolve a user's home dir from the passwd db. Empty on lookup miss.
+    export std::string home_for_user_(const std::string& name) {
+        if (name.empty()) return {};
+        if (struct passwd* pw = ::getpwnam(name.c_str()); pw && pw->pw_dir)
+            return std::string{pw->pw_dir};
+        return {};
     }
 
 } // namespace platform_impl

--- a/src/platform/windows.cppm
+++ b/src/platform/windows.cppm
@@ -238,6 +238,19 @@ namespace platform_impl {
         return std::nullopt;
     }
 
+    // ── Execution identity primitives (no POSIX uid/sudo model) ─────
+    // Windows has no euid/sudo concept; these stubs keep the
+    // cross-platform identity API in platform.cppm compiling and inert.
+    export bool is_root() {
+        return false;
+    }
+    export void lchown_path_(const std::filesystem::path&,
+                             unsigned int, unsigned int) {
+    }
+    export std::string home_for_user_(const std::string&) {
+        return {};
+    }
+
     export struct Icon {
         static constexpr auto pending    = "o";
         static constexpr auto running    = "*";

--- a/tests/e2e/root_usability_test.sh
+++ b/tests/e2e/root_usability_test.sh
@@ -93,8 +93,9 @@ got_uid="$(owner_uid "$B_INSTALLED/bin/xlings")"
   fail "sudo-sim install not chowned back (bin/xlings uid=$got_uid, want $INVOKER_UID)"
 
 # A nested file (deeper than the top level) must be chowned too — proves
-# the recursive walk, not just a top-level chown.
-nested="$(find "$B_INSTALLED" -type f | head -1)"
+# the recursive walk, not just a top-level chown. `-print -quit` (not
+# `| head`) avoids SIGPIPE killing find under `set -o pipefail`.
+nested="$(find "$B_INSTALLED" -type f -print -quit)"
 [[ -n "$nested" ]] || fail "no files found under installed home"
 [[ "$(owner_uid "$nested")" == "$INVOKER_UID" ]] || \
   fail "nested file not chowned to invoker: $nested"

--- a/tests/e2e/root_usability_test.sh
+++ b/tests/e2e/root_usability_test.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# E2E: xlings usability under the Linux root user.
+#
+# Verifies the root / sudo execution-identity layer end to end on the
+# real release binary:
+#   Scenario A (pure root): `self install` succeeds WITHOUT ever shelling
+#     out to sudo (P0-1) and leaves a consistent root-owned home. A
+#     sabotaging `sudo` shim on PATH fails the test if anything invokes it.
+#   Scenario B (simulated sudo): install artifacts are chowned back to the
+#     invoking user (P0-2), so a later non-sudo run isn't locked out.
+#
+# Design: .agents/docs/2026-06-21-root-privilege-identity-design.md
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/release_test_lib.sh"
+
+ARCHIVE_PATH="${1:-$ROOT_DIR/build/release.tar.gz}"
+require_release_archive "$ARCHIVE_PATH"
+
+# Meaningful only as root. Off-root (local dev) skip cleanly so the suite
+# still passes for non-root contributors.
+if [[ "$(id -u)" -ne 0 ]]; then
+  log "SKIP: root usability test requires EUID 0 (current uid=$(id -u))"
+  exit 0
+fi
+
+owner_uid() { stat -c '%u' "$1"; }
+
+# ── Scenario A: pure root, sudo must NOT be invoked (P0-1) ───────────
+log "Scenario A: pure-root self install without any sudo dependency"
+
+PKG_DIR_A="$(extract_release_archive "$ARCHIVE_PATH" root_pure)"
+A_HOME="$RUNTIME_ROOT/root_pure_home"
+rm -rf "$A_HOME"; mkdir -p "$A_HOME"
+
+# A sabotaging `sudo` that fails loudly: if xlings shells out to sudo while
+# already root, this trips the test (the historical hardcoded "sudo mount"
+# etc. would have). Minimal root containers often lack sudo entirely.
+SHIMDIR="$RUNTIME_ROOT/root_nosudo_shim"
+rm -rf "$SHIMDIR"; mkdir -p "$SHIMDIR"
+cat > "$SHIMDIR/sudo" <<'EOF'
+#!/bin/sh
+echo "[root-e2e] FAIL: xlings invoked 'sudo' while already root" >&2
+exit 97
+EOF
+chmod +x "$SHIMDIR/sudo"
+
+env -u XLINGS_HOME -u SUDO_UID -u SUDO_GID -u SUDO_USER \
+  HOME="$A_HOME" PATH="$SHIMDIR:$(minimal_system_path)" \
+  XLINGS_NON_INTERACTIVE=1 \
+  "$PKG_DIR_A/bin/xlings" self install
+
+A_INSTALLED="$A_HOME/.xlings"
+[[ -x "$A_INSTALLED/bin/xlings" ]] || fail "pure-root install missing bin/xlings"
+[[ "$(owner_uid "$A_INSTALLED/bin/xlings")" == "0" ]] || \
+  fail "pure-root install should be root-owned (uid 0)"
+
+# The installed binary runs as root with sudo still sabotaged.
+env -u XLINGS_HOME HOME="$A_HOME" \
+  PATH="$A_INSTALLED/subos/current/bin:$A_INSTALLED/bin:$SHIMDIR:$(minimal_system_path)" \
+  "$A_INSTALLED/bin/xlings" -h >/dev/null || fail "pure-root 'xlings -h' failed"
+env -u XLINGS_HOME HOME="$A_HOME" \
+  PATH="$A_INSTALLED/subos/current/bin:$A_INSTALLED/bin:$SHIMDIR:$(minimal_system_path)" \
+  "$A_INSTALLED/bin/xlings" --verbose config >/dev/null 2>&1 || \
+  fail "pure-root 'xlings config' failed"
+log "PASS Scenario A (pure root, no sudo)"
+
+# ── Scenario B: simulated sudo chowns install back to invoker (P0-2) ─
+log "Scenario B: simulated sudo chowns ~/.xlings back to the invoking user"
+
+PKG_DIR_B="$(extract_release_archive "$ARCHIVE_PATH" root_sudo)"
+B_HOME="$RUNTIME_ROOT/root_sudo_home"
+rm -rf "$B_HOME"; mkdir -p "$B_HOME"
+
+# Numeric ids of the "real" user behind the sudo. lchown takes a numeric
+# uid/gid, so the user need not exist in the container's passwd db.
+INVOKER_UID=12345
+INVOKER_GID=12345
+
+# Reproduce exactly what `sudo` leaves in the environment (root EUID +
+# SUDO_*), then assert xlings hands ownership back to the invoker.
+env -u XLINGS_HOME \
+  HOME="$B_HOME" PATH="$(minimal_system_path)" \
+  SUDO_UID="$INVOKER_UID" SUDO_GID="$INVOKER_GID" SUDO_USER="tester" \
+  XLINGS_NON_INTERACTIVE=1 \
+  "$PKG_DIR_B/bin/xlings" self install
+
+B_INSTALLED="$B_HOME/.xlings"
+[[ -x "$B_INSTALLED/bin/xlings" ]] || fail "sudo-sim install missing bin/xlings"
+
+got_uid="$(owner_uid "$B_INSTALLED/bin/xlings")"
+[[ "$got_uid" == "$INVOKER_UID" ]] || \
+  fail "sudo-sim install not chowned back (bin/xlings uid=$got_uid, want $INVOKER_UID)"
+
+# A nested file (deeper than the top level) must be chowned too — proves
+# the recursive walk, not just a top-level chown.
+nested="$(find "$B_INSTALLED" -type f | head -1)"
+[[ -n "$nested" ]] || fail "no files found under installed home"
+[[ "$(owner_uid "$nested")" == "$INVOKER_UID" ]] || \
+  fail "nested file not chowned to invoker: $nested"
+log "PASS Scenario B (simulated sudo chown-back)"
+
+log "PASS: root usability scenarios"

--- a/tests/unit/test_identity.cpp
+++ b/tests/unit/test_identity.cpp
@@ -1,0 +1,132 @@
+// Unit tests for the execution-identity layer (root / sudo awareness).
+// Design: .agents/docs/2026-06-21-root-privilege-identity-design.md
+//
+// These run as a NON-root user in CI, which lets us pin the safety
+// invariant: on the existing (non-root) path every helper returns exactly
+// the historical behavior, so Linux-non-root / macOS / Windows are
+// unaffected. The sudo-gated behavior is covered by the e2e test.
+module;
+
+#include <gtest/gtest.h>
+#include <cstdlib>
+
+import std;
+import xlings.platform;
+
+namespace {
+
+// RAII helper: set/restore a set of environment variables around a test.
+struct EnvGuard {
+    std::vector<std::pair<std::string, std::optional<std::string>>> saved;
+    void set(const char* k, const char* v) {
+        const char* cur = std::getenv(k);
+        saved.emplace_back(k, cur ? std::optional<std::string>(cur) : std::nullopt);
+        ::setenv(k, v, 1);
+    }
+    void unset(const char* k) {
+        const char* cur = std::getenv(k);
+        saved.emplace_back(k, cur ? std::optional<std::string>(cur) : std::nullopt);
+        ::unsetenv(k);
+    }
+    ~EnvGuard() {
+        for (auto it = saved.rbegin(); it != saved.rend(); ++it) {
+            if (it->second) ::setenv(it->first.c_str(), it->second->c_str(), 1);
+            else            ::unsetenv(it->first.c_str());
+        }
+    }
+};
+
+// ── Non-root invariants (the CI runtime) ────────────────────────────
+
+TEST(Identity, NonRootIsNotRoot) {
+    // CI / dev runs unprivileged. If this ever fails, the test runner is
+    // root and the rest of the suite's assumptions don't hold.
+    EXPECT_FALSE(xlings::platform::is_root());
+}
+
+TEST(Identity, PrivPrefixIsSudoWhenNonRoot) {
+    // Byte-for-byte identical to the historical hardcoded "sudo " string —
+    // this is the safety invariant that keeps existing flows unchanged.
+    EXPECT_EQ(xlings::platform::priv_prefix(), "sudo ");
+}
+
+TEST(Identity, SudoInvokerGatedOnRoot) {
+    // Even with SUDO_* present, a non-root process has no demotion target:
+    // sudo_invoker() must gate on is_root() and return nullopt.
+    EnvGuard env;
+    env.set("SUDO_UID", "1000");
+    env.set("SUDO_GID", "1000");
+    env.set("SUDO_USER", "alice");
+    EXPECT_FALSE(xlings::platform::sudo_invoker().has_value());
+}
+
+TEST(Identity, ChownToInvokerIsNoOpWhenNonRoot) {
+    // Must be a harmless no-op off the sudo path (no throw, no effect).
+    auto dir = std::filesystem::temp_directory_path()
+             / ("xlings-id-test-" + std::to_string(
+                   std::chrono::steady_clock::now().time_since_epoch().count()));
+    std::filesystem::create_directories(dir);
+    auto f = dir / "file.txt";
+    std::ofstream(f) << "x";
+    EXPECT_NO_THROW(xlings::platform::chown_to_invoker(dir));
+    std::error_code ec;
+    std::filesystem::remove_all(dir, ec);
+}
+
+// ── Pure SUDO_* parsing (platform-independent) ──────────────────────
+
+TEST(Identity, ParseSudoEnvWellFormed) {
+    EnvGuard env;
+    env.set("SUDO_UID", "1000");
+    env.set("SUDO_GID", "1001");
+    env.set("SUDO_USER", "bob");
+    auto inv = xlings::platform::parse_sudo_env();
+    ASSERT_TRUE(inv.has_value());
+    EXPECT_EQ(inv->uid, 1000u);
+    EXPECT_EQ(inv->gid, 1001u);
+    EXPECT_EQ(inv->user, "bob");
+}
+
+TEST(Identity, ParseSudoEnvMissingReturnsNullopt) {
+    EnvGuard env;
+    env.unset("SUDO_UID");
+    env.unset("SUDO_GID");
+    EXPECT_FALSE(xlings::platform::parse_sudo_env().has_value());
+}
+
+TEST(Identity, ParseSudoEnvMalformedReturnsNullopt) {
+    EnvGuard env;
+    env.set("SUDO_UID", "not-a-number");
+    env.set("SUDO_GID", "1000");
+    EXPECT_FALSE(xlings::platform::parse_sudo_env().has_value());
+}
+
+TEST(Identity, ParseSudoEnvTrailingGarbageRejected) {
+    EnvGuard env;
+    env.set("SUDO_UID", "1000x");
+    env.set("SUDO_GID", "1000");
+    EXPECT_FALSE(xlings::platform::parse_sudo_env().has_value());
+}
+
+TEST(Identity, ParseSudoEnvUserOptional) {
+    // Numeric ids are sufficient; SUDO_USER may legitimately be absent.
+    EnvGuard env;
+    env.set("SUDO_UID", "1000");
+    env.set("SUDO_GID", "1000");
+    env.unset("SUDO_USER");
+    auto inv = xlings::platform::parse_sudo_env();
+    ASSERT_TRUE(inv.has_value());
+    EXPECT_TRUE(inv->user.empty());
+}
+
+// ── target_home() ───────────────────────────────────────────────────
+
+TEST(Identity, TargetHomeIsHomeWhenNonSudo) {
+    // Off the sudo path, target_home() must equal the ordinary home so rc
+    // file placement is unchanged for the common case.
+    const char* home = std::getenv("HOME");
+    if (!home) GTEST_SKIP() << "HOME unset in this environment";
+    EXPECT_EQ(xlings::platform::target_home(), std::string(home));
+}
+
+} // namespace

--- a/tests/unit/test_identity.cpp
+++ b/tests/unit/test_identity.cpp
@@ -5,8 +5,6 @@
 // invariant: on the existing (non-root) path every helper returns exactly
 // the historical behavior, so Linux-non-root / macOS / Windows are
 // unaffected. The sudo-gated behavior is covered by the e2e test.
-module;
-
 #include <gtest/gtest.h>
 #include <cstdlib>
 
@@ -15,23 +13,32 @@ import xlings.platform;
 
 namespace {
 
+// Portable env set/unset — POSIX setenv/unsetenv don't exist on Windows.
+#if defined(_WIN32)
+inline int set_env_(const char* k, const char* v) { return _putenv_s(k, v); }
+inline int unset_env_(const char* k) { return _putenv_s(k, ""); }  // "" removes it
+#else
+inline int set_env_(const char* k, const char* v) { return ::setenv(k, v, 1); }
+inline int unset_env_(const char* k) { return ::unsetenv(k); }
+#endif
+
 // RAII helper: set/restore a set of environment variables around a test.
 struct EnvGuard {
     std::vector<std::pair<std::string, std::optional<std::string>>> saved;
     void set(const char* k, const char* v) {
         const char* cur = std::getenv(k);
         saved.emplace_back(k, cur ? std::optional<std::string>(cur) : std::nullopt);
-        ::setenv(k, v, 1);
+        set_env_(k, v);
     }
     void unset(const char* k) {
         const char* cur = std::getenv(k);
         saved.emplace_back(k, cur ? std::optional<std::string>(cur) : std::nullopt);
-        ::unsetenv(k);
+        unset_env_(k);
     }
     ~EnvGuard() {
         for (auto it = saved.rbegin(); it != saved.rend(); ++it) {
-            if (it->second) ::setenv(it->first.c_str(), it->second->c_str(), 1);
-            else            ::unsetenv(it->first.c_str());
+            if (it->second) set_env_(it->first.c_str(), it->second->c_str());
+            else            unset_env_(it->first.c_str());
         }
     }
 };

--- a/tools/other/quick_install.sh
+++ b/tools/other/quick_install.sh
@@ -16,7 +16,11 @@ log_error() { echo -e "${RED}[xlings]:${RESET} $1"; }
 
 trap 'log_error "Interrupted"; exit 1' INT TERM
 
+# Official GitHub repo + GitCode resource mirror (low-latency source for users
+# who have trouble reaching GitHub, e.g. mainland China).
 GITHUB_REPO="openxlings/xlings"
+GITCODE_REPO="xlings-res/xlings"
+GITCODE_API="https://api.gitcode.com/api/v5"
 GITHUB_MIRROR="${XLINGS_GITHUB_MIRROR:-}"
 
 # Specify version: curl ... | bash -s -- v0.5.0
@@ -77,7 +81,7 @@ forum: https://forum.d2learn.org
 
 EOF
 
-# --------------- resolve download URL ---------------
+# --------------- prerequisites ---------------
 
 ensure_cmd() {
     if ! command -v "$1" &>/dev/null; then
@@ -89,42 +93,7 @@ ensure_cmd() {
 ensure_cmd curl
 ensure_cmd tar
 
-resolve_latest_version() {
-    local base_url="${GITHUB_MIRROR:-https://github.com}"
-    local url="${base_url}/${GITHUB_REPO}/releases/latest"
-    local final_url
-    final_url=$(curl -fsSIL -o /dev/null -w '%{url_effective}' "$url")
-    echo "${final_url##*/}"
-}
-
-if [[ -n "$XLINGS_VERSION" ]]; then
-    LATEST_VERSION="$XLINGS_VERSION"
-    log_info "Using specified version: ${CYAN}${LATEST_VERSION}${RESET}"
-else
-    log_info "Querying latest release..."
-    LATEST_VERSION=$(resolve_latest_version)
-fi
-
-if [[ -z "$LATEST_VERSION" ]]; then
-    log_error "Failed to resolve release version."
-    exit 1
-fi
-
-[[ "$LATEST_VERSION" == v* ]] || LATEST_VERSION="v${LATEST_VERSION}"
-VERSION_NUM="${LATEST_VERSION#v}"
-TARBALL="xlings-${VERSION_NUM}-${PLATFORM}-${ARCH_TYPE}.tar.gz"
-
-if [[ -n "$GITHUB_MIRROR" ]]; then
-    DOWNLOAD_URL="${GITHUB_MIRROR}/${GITHUB_REPO}/releases/download/${LATEST_VERSION}/${TARBALL}"
-else
-    DOWNLOAD_URL="https://github.com/${GITHUB_REPO}/releases/download/${LATEST_VERSION}/${TARBALL}"
-fi
-
-log_info "Latest version: ${CYAN}${LATEST_VERSION}${RESET}"
-log_info "Package:        ${CYAN}${TARBALL}${RESET}"
-log_info "Download URL:   ${CYAN}${DOWNLOAD_URL}${RESET}"
-
-# --------------- download & extract ---------------
+# --------------- workspace ---------------
 
 TMPDIR_ROOT="${TMPDIR:-/tmp}"
 WORK_DIR=$(mktemp -d "${TMPDIR_ROOT}/xlings-install.XXXXXX")
@@ -136,12 +105,169 @@ cleanup() {
 trap 'cleanup; log_error "Interrupted"; exit 1' INT TERM
 trap cleanup EXIT
 
-log_info "Downloading..."
-if ! curl -fSL --progress-bar -o "${WORK_DIR}/${TARBALL}" "$DOWNLOAD_URL"; then
-    log_error "Download failed. Please check your network or try setting XLINGS_GITHUB_MIRROR."
+# --------------- resolve release sources ---------------
+#
+# Mirror parity with quick_install.ps1: probe both supported sources, measure
+# their latency, then prefer the highest version and, among equal versions, the
+# lowest-latency source. Download falls back to the next source on failure.
+#
+# Each resolver echoes a single line "<version>|<download_url>|<probe_seconds>"
+# on success, or returns non-zero on failure.
+
+ASSET_NAME() { echo "xlings-$1-${PLATFORM}-${ARCH_TYPE}.tar.gz"; }
+
+# GitHub: discover the tag via the /releases/latest redirect (no API token, no
+# rate limit). The same request doubles as the latency probe. Honors
+# XLINGS_GITHUB_MIRROR for the web base.
+resolve_github() {
+    local web_base="${GITHUB_MIRROR:-https://github.com}"
+    web_base="${web_base%/}"
+
+    local version_num tag probe effective
+    if [[ -n "$XLINGS_VERSION" ]]; then
+        version_num="${XLINGS_VERSION#v}"
+        tag="v${version_num}"
+        # HEAD the tag page to confirm existence and measure latency.
+        probe=$(curl -fsSIL -o /dev/null -w '%{time_total}' \
+            "${web_base}/${GITHUB_REPO}/releases/tag/${tag}") || return 1
+    else
+        effective=$(curl -fsSIL -o /dev/null -w '%{time_total} %{url_effective}' \
+            "${web_base}/${GITHUB_REPO}/releases/latest") || return 1
+        probe="${effective%% *}"
+        tag="${effective##*/}"
+        version_num="${tag#v}"
+    fi
+    [[ -n "$version_num" ]] || return 1
+
+    local url="${web_base}/${GITHUB_REPO}/releases/download/${tag}/$(ASSET_NAME "$version_num")"
+    echo "${version_num}|${url}|${probe}"
+}
+
+# GitCode: read release metadata from the v5 API (also the latency probe), then
+# pull the matching asset's browser_download_url out of the JSON with grep so we
+# don't need python/jq. The reported api.gitcode.com download host 404s on direct
+# hits; the same path on gitcode.com redirects to file-cdn.gitcode.com, so rewrite.
+resolve_gitcode() {
+    local meta_file="${WORK_DIR}/gitcode-meta.json"
+    local probe version_num tag
+
+    if [[ -n "$XLINGS_VERSION" ]]; then
+        version_num="${XLINGS_VERSION#v}"
+        # GitCode tags carry no leading "v"; try the bare number first, then "v".
+        local resolved=1 t
+        for t in "${version_num}" "v${version_num}"; do
+            if probe=$(curl -fsS -o "$meta_file" -w '%{time_total}' \
+                "${GITCODE_API}/repos/${GITCODE_REPO}/releases/tags/${t}"); then
+                resolved=0; break
+            fi
+        done
+        [[ $resolved -eq 0 ]] || return 1
+    else
+        probe=$(curl -fsS -o "$meta_file" -w '%{time_total}' \
+            "${GITCODE_API}/repos/${GITCODE_REPO}/releases/latest") || return 1
+        tag=$(grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' "$meta_file" \
+            | head -1 | grep -oE '"[^"]*"$' | tr -d '"')
+        version_num="${tag#v}"
+    fi
+    [[ -n "$version_num" ]] || return 1
+
+    # Escape dots so the asset filename is matched literally inside the JSON blob.
+    local asset_re
+    asset_re=$(ASSET_NAME "$version_num" | sed 's/\./\\./g')
+    local asset_url
+    asset_url=$(grep -oE "\"browser_download_url\"[[:space:]]*:[[:space:]]*\"[^\"]*${asset_re}\"" "$meta_file" \
+        | head -1 | grep -oE "https?://[^\"]*${asset_re}")
+    [[ -n "$asset_url" ]] || return 1
+
+    asset_url="${asset_url/https:\/\/api.gitcode.com\//https://gitcode.com/}"
+    echo "${version_num}|${asset_url}|${probe}"
+}
+
+# Probe a source and append it to the candidate arrays.
+CAND_SRC=(); CAND_VER=(); CAND_URL=(); CAND_PROBE=()
+probe_source() {
+    local name="$1" resolver="$2" out
+    log_info "Probing ${name}..."
+    if out=$("$resolver"); then
+        local ver="${out%%|*}" rest="${out#*|}"
+        local url="${rest%|*}" probe="${rest##*|}"
+        CAND_SRC+=("$name"); CAND_VER+=("$ver"); CAND_URL+=("$url"); CAND_PROBE+=("$probe")
+        log_info "  ${name}: ${CYAN}v${ver}${RESET} (${probe}s)"
+    else
+        log_warn "  ${name} unavailable"
+    fi
+}
+
+if [[ -n "$XLINGS_VERSION" ]]; then
+    log_info "Using specified version: ${CYAN}${XLINGS_VERSION#v}${RESET}"
+else
+    log_info "Resolving latest release across sources..."
+fi
+
+probe_source "GitHub"  resolve_github
+probe_source "GitCode" resolve_gitcode
+
+if [[ ${#CAND_SRC[@]} -eq 0 ]]; then
+    log_error "All release sources failed. Check your network or set XLINGS_GITHUB_MIRROR."
     exit 1
 fi
 
+# When no exact version was requested, keep only candidates at the highest
+# version (dotted numeric sort works on both GNU and BSD sort, unlike -V).
+MAX_VER=""
+if [[ -z "$XLINGS_VERSION" ]]; then
+    MAX_VER=$(printf '%s\n' "${CAND_VER[@]}" | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
+fi
+
+# Order surviving candidates by ascending latency: "<probe> <index>" | sort -n.
+ORDER=()
+for i in "${!CAND_SRC[@]}"; do
+    if [[ -n "$MAX_VER" && "${CAND_VER[$i]}" != "$MAX_VER" ]]; then
+        continue
+    fi
+    ORDER+=("${CAND_PROBE[$i]} ${i}")
+done
+SORTED_IDX=$(printf '%s\n' "${ORDER[@]}" | sort -n | cut -d' ' -f2)
+
+# --------------- download & extract ---------------
+
+is_gzip() {
+    local f="$1" sig
+    [[ -s "$f" ]] || return 1
+    sig=$(od -An -tx1 -N2 "$f" 2>/dev/null | tr -d ' \n')
+    [[ "$sig" == "1f8b" ]]
+}
+
+TARBALL=""
+SELECTED_SRC=""
+download_ok=0
+for i in $SORTED_IDX; do
+    src="${CAND_SRC[$i]}"
+    url="${CAND_URL[$i]}"
+    ver="${CAND_VER[$i]}"
+    TARBALL=$(ASSET_NAME "$ver")
+
+    log_info "Source:       ${CYAN}${src}${RESET} (v${ver}, ${CAND_PROBE[$i]}s)"
+    log_info "Package:      ${CYAN}${TARBALL}${RESET}"
+    log_info "Download URL: ${CYAN}${url}${RESET}"
+    log_info "Downloading..."
+
+    if curl -fSL --progress-bar -o "${WORK_DIR}/${TARBALL}" "$url" && is_gzip "${WORK_DIR}/${TARBALL}"; then
+        download_ok=1
+        SELECTED_SRC="$src"
+        break
+    fi
+
+    log_warn "${src} download failed; trying next source..."
+    rm -f "${WORK_DIR}/${TARBALL}"
+done
+
+if [[ $download_ok -ne 1 ]]; then
+    log_error "All download sources failed. Check your network or set XLINGS_GITHUB_MIRROR."
+    exit 1
+fi
+
+log_info "Downloaded from: ${CYAN}${SELECTED_SRC}${RESET}"
 log_info "Extracting..."
 tar -xzf "${WORK_DIR}/${TARBALL}" -C "$WORK_DIR"
 


### PR DESCRIPTION
## Why

xlings had **zero EUID/root/sudo awareness** — scattered `getenv("HOME")`, hardcoded `"sudo "` strings, and bare filesystem writes that assume the caller owns everything. Under root/sudo this broke in several ways. Full analysis: `.agents/docs/2026-06-21-linux-root-usability-survey.md`. Design: `.agents/docs/2026-06-21-root-privilege-identity-design.md`.

## Architecture

A single **execution-identity layer** in the platform module:
- `:unix` / `:windows` partitions expose only OS primitives (`is_root`, `lchown_path_`, `home_for_user_`).
- **All policy is cross-platform in `platform.cppm`**: `parse_sudo_env`, `priv_prefix`, `sudo_invoker`, `target_home`, `chown_to_invoker`. No platform macros leak into other modules.

## Fixes (all 7 survey findings)

| # | Fix |
|---|---|
| **P0-1** | subos mount/umount/chown go through `priv_prefix()` — `""` when already root (sudo is redundant and **absent in minimal root containers**, where `sudo mount` died with command-not-found), `"sudo "` otherwise |
| **P0-2** | self install + xim install chown `~/.xlings` back to the invoking user under sudo, so a later non-sudo run isn't `EACCES`-locked |
| **P1-3** | rc files target the **invoking user's** home under sudo (so the real user gets xlings on PATH); root/sudo warning |
| **P1-4** | sandbox `/etc/passwd` no longer emits a second, conflicting uid-0 entry for root (`getpwuid(0)` now agrees with `$HOME` + bound home) |
| **P2-5** | shim distinguishes `EACCES` (foreign-owned home) from "not registered" instead of misreporting "not installed" |
| **P2-6** | extract strips setuid/setgid/world-write bits (a setuid tarball entry would become setuid-root under sudo) |
| — | installer surfaces the previously-swallowed `create_install_dir` error |

## Safety — no impact on existing platforms/functionality

Every new behavior is gated strictly on the **root + SUDO_*** path. For non-root, `priv_prefix()` returns the historical `"sudo "`, `chown_to_invoker()`/`target_home()` reduce to today's behavior, and the passwd uid≠0 branch is byte-for-byte unchanged. Windows/macOS get compile-safe stubs. Verified compiling under **both glibc (gcc 16.1) and musl (gcc 15.1)** targets; unit suite green.

## Tests

- `tests/unit/test_identity.cpp` — 10 cases (parse / gating / no-op / prefix / target_home). ✅ pass locally.
- `tests/e2e/root_usability_test.sh` — pure-root (a **sabotaging `sudo` shim** proves no dependency) + simulated-sudo (chown-back) on the real release binary.
- `.github/workflows/xlings-ci-linux-root.yml` — **builds latest xlings via mcpp**, then verifies root usability inside a bare `ubuntu:24.04` **root container with no sudo installed**.

## Deferred (Phase 3, documented)

Privilege-drop (`seteuid`, risk of breaking flows) and rootless image (FUSE) are deferred — chown-back already restores ownership correctness without that risk.