### PR TITLE
feat(xim): index as a resource artifact — v0.4.52 (Y-asset)

### DIFF
--- a/.agents/docs/2026-06-21-pkgindex-mirror-analysis.md
+++ b/.agents/docs/2026-06-21-pkgindex-mirror-analysis.md
@@ -1,0 +1,216 @@
+# xlings 包索引与镜像机制 — 深度分析与优化方向
+
+> 日期: 2026-06-21
+> 类型: 分析报告 (analysis)
+> 范围: `xim-pkgindex` 主索引 + 子索引仓库 (awesome/scode/d2x) 的网络获取链路
+> 关联: `2026-05-01-mirror-fallback-step1.md`、`2026-06-04-github-asset-adaptive-mirror.md`、
+>       `2026-05-29-compact-git-bootstrap-plan.md`
+
+## TL;DR — 一句话结论
+
+xlings 已经做对了大方向（域内 origin + 多镜像回退 + 延迟探测），但**用户痛点恰好落在被这套机制覆盖最弱的那条路径上**：
+
+1. **子索引仓库 (`awesome`/`scode`/`d2x`) 根本没有国内镜像** —
+   `xim-indexrepos.lua` 里这三个仓库的 `CN` 与 `GLOBAL` 都指向同一个
+   `github.com/d2learn/...`。CN 用户主索引能走 Gitee，子仓库却必然回到 GitHub。
+2. **索引的 `git clone` 路径只享受了"静态顺序镜像回退"，没有享受 0.4.49 的延迟重排和卡顿看门狗** —
+   后两者只在 HTTP 下载器 (`tinyhttps`) 里，`git clone` 走的是 `compact::git` CLI，
+   GitHub 永远被第一个尝试，劣化网络下会先卡满超时再轮代理。
+3. **编译进二进制的代理列表会"腐烂"** — `kkgithub` 已死、`jsdelivr` 在国内已无 ICP、
+   `ghproxy` 系免费代理整体脆弱；而"远程热更新代理表"被显式推迟了。
+
+行业共识（Homebrew/Cargo/Go/apt 全部走过同一条路）：**索引应当以"静态文件 + CDN +
+传输无关的签名/哈希完整性"分发，而不是对 GitHub 做 live git clone**。下文给出分级优化路线。
+
+---
+
+## 1. 现状：xlings 到底怎么取索引的
+
+### 1.1 两个都叫 "mirror" 的东西（务必区分）
+
+代码里 "mirror" 一词被重载，是理解全局的前提：
+
+| 概念 | 取值 | 作用 | 代码 |
+| --- | --- | --- | --- |
+| **区域键** `Config::mirror()` | `GLOBAL` / `CN` | 选择**上游主机**（github vs gitee/gitcode） | `config.cppm:90-103` |
+| **代理改写** `mirror::` 命名空间 | jsdelivr/ghfast/ghproxy.net/kkgithub | 把 `github.com` URL **改写成第三方代理**，并做延迟重排 | `src/core/mirror/*.cppm` |
+
+二者正交：区域键决定"原始 URL 指向哪个站"，代理改写决定"GitHub URL 失败后换哪些代理"。
+
+### 1.2 主索引 `xim-pkgindex`
+
+- `GLOBAL`: `https://github.com/openxlings/xim-pkgindex.git`
+- `CN`: `https://gitee.com/sunrisepeak/xim-pkgindex.git` ✅ **有真实国内镜像**
+- 机制：`git clone --depth 1` 到 `XLINGS_HOME/data/xim-pkgindex/`，更新用 `git pull --ff-only`
+  →（失败）`git fetch + reset --hard`。非强制时 **7 天节流**（`.xlings-sync-stamp`）。
+  代码：`repo.cppm:164-249`、`config.cppm:90-96`。
+- 解析后的索引缓存：`.xlings-index-cache.json`，以 **git HEAD 哈希**做有效性校验
+  （HEAD 变了才全量重建）。`index.cppm:167-198`。
+
+### 1.3 子索引仓库（用户口中的"子仓库索引"）
+
+- 在主索引根目录的 `xim-indexrepos.lua` 中声明，按区域键取 URL，缺省回退 `GLOBAL`：
+  解析器 `repo.cppm:72-143`（手写状态机，不依赖 Lua 解释器/regex）。
+- **现状（问题根因）**：
+  ```lua
+  ["awesome"] = { ["GLOBAL"] = ".../xim-pkgindex-awesome.git",
+                  ["CN"]     = ".../xim-pkgindex-awesome.git" },  -- ⚠ CN == GLOBAL == github
+  ["scode"]   = { ... 同上 ... },
+  ["d2x"]     = { ... 同上 ... },
+  ```
+  → **CN 用户取子仓库时，区域键这层完全失效，必然落到 github.com。**
+- 克隆位置：`XLINGS_HOME/data/xim-index-repos/<name>/`，成功后写回
+  `xim-indexrepos.json`。同样走 `sync_repo()`（同一条 git clone 链路）。
+
+### 1.4 三层网络韧性机制（关键在于谁覆盖谁）
+
+| 机制 | 在哪条路径 | 谁享受了 |
+| --- | --- | --- |
+| **区域键 origin 切换**（github↔gitee/gitcode） | 主索引、`XLINGS_RES` 资源服务器 | 主索引 ✅ / **子仓库 ❌** |
+| **代理改写 `mirror::expand`**（静态优先级顺序） | HTTP 下载 + **所有 git clone**（含索引） | 索引/子仓库 ✅（但仅静态顺序） |
+| **延迟重排 `adaptive::reorder` + 卡顿看门狗**（0.4.49） | **仅 HTTP 下载器 `tinyhttps`** | 资源下载 ✅ / **索引 git clone ❌** |
+
+**这张表就是结论**：用户最常失败的"取子索引"恰好在每一层都拿到的是最弱档：
+没有 origin 镜像、只有静态顺序代理、没有延迟重排、没有卡顿检测。
+
+证据：
+- HTTP 下载器：`downloader.cppm` 先 `expand`（:362）再 `adaptive::reorder`（:374）再
+  `tinyhttps::download_file`（:414，带卡顿看门狗 + sha256 校验 + `penalize_host`）。
+- 索引 clone：`repo.cppm:177` 只调 `mirror::expand(url,{Git})`，然后
+  `repo.cppm:184-209` **按静态顺序**逐个 `compact::git::clone_shallow` —
+  **无 `adaptive::reorder`、无卡顿看门狗**（git CLI 子进程，也没设超时，依赖 git 默认值）。
+
+### 1.5 劣化网络下的真实体验（为什么"很卡"）
+
+引用 `2026-06-04` 设计文档自述的 tier-3 缺陷，在 git clone 路径上原样成立：
+
+> 一个**握手成功但只有 KB/s** 的连接，既不触发 `connectTimeoutSec=30`，也不触发
+> `maxTimeSec=600` 之外的任何东西；最坏情况要 `600s × (1+retry)` 才会尝试第一个镜像。
+
+而卡顿看门狗（`StallDetector`，10KB/s × 15s 触发）只接到了 HTTP 下载器上，
+**git clone 收不到**。于是子索引获取 = GitHub 优先 + 可能长时间假死 + 才轮到一串脆弱免费代理。
+
+### 1.6 bootstrap 安装器（独立的一套，已较完善）
+
+`tools/other/quick_install.sh`（commit `06fd09f`）与 `.ps1`：GitHub + GitCode 双源，
+用 `curl -w '%{time_total}'` 做延迟探测，按"版本优先 → 延迟次之"排序，下载校验 gzip 魔数后回退。
+这套逻辑**独立于运行时 C++ 链路**，不共享代码。它证明团队已认可"多源+探测+回退"范式 —
+只是运行时索引路径还没补齐。
+
+---
+
+## 2. 行业最佳实践（索引分发，非二进制分发）
+
+跨生态系统的结论高度一致，且**没有一个**是"对 GitHub 做 live git clone"。
+
+### 2.1 索引分发形态的演进：git → 静态 HTTP
+
+| 系统 | 旧 | 新 | 启示 |
+| --- | --- | --- | --- |
+| **Homebrew** | tap 全量 git clone，`brew update` = `git pull` | **4.0 (2023.02) 改为 JSON-over-CDN**：`formulae.brew.sh/api/formula.jws.json`（JWS 签名），自动更新频率 5min→24h | 单一巨型 blob（~31MB）在弱网下"全有或全无"反而易失败（issue #15443/#21622）→ **不要用单体索引** |
+| **Cargo** | `crates.io-index` 全量 clone | **稀疏 HTTP 索引（1.70 默认）**：`sparse+https://index.crates.io/`，按名分片一包一文件，`ETag`+`If-None-Match`→`304` | 纯静态文件、可放 CDN、只取依赖树涉及的包；国内 `rsproxy.cn` 提供 `sparse+https://rsproxy.cn/index/` |
+| **Go modules** | — | **GOPROXY 协议**（不可变静态文件 `/@v/*`）+ **GOSUMDB** 传输无关校验；`GOPROXY=https://goproxy.cn,direct` | "完整性独立于谁送的字节"——恶意镜像无法投毒。**金标准** |
+| **npm/pip** | — | 逐包元数据 + 内容协商精简格式；国内 `npmmirror.com` / 清华 PyPI（bandersnatch 全量同步） | 纯主机名替换 + 保留原始哈希 = 镜像安全 |
+| **Debian/apt** | — | **签名 `InRelease` 哈希所有子索引，子索引哈希所有 .deb**；一个签名验证整库 | 镜像可完全不可信；`by-hash` 让同步原子化 |
+
+### 2.2 镜像选择：服务端 CDN vs 客户端探测
+
+- **Debian `deb.debian.org`**：Fastly/CloudFront CDN 前置 + DNS SRV 就近，**客户端零配置**。
+- **Ubuntu `mirror://`**：GeoIP 列表 + 故障转移（只看地理，不测速）。
+- **Arch `reflector`**：主动排名，`--sort rate`（真实下载测速）vs `--sort age`（新鲜度）。
+  **关键洞察：延迟 ≠ 新鲜度**——快但陈旧的镜像会过哈希/`Valid-Until` 校验失败。
+- **Happy Eyeballs (RFC 8305)**：先连第一个，~250ms 后并行连下一个，先连上者胜。
+  与探测互补：**探测排序 + 竞速前 N 个**。
+
+### 2.3 中国 GitHub 绕行方案：每一个免费的都死过
+
+> 规律：免费服务 → 流量/滥用爆炸 → 成本/政策压力 → 关停或封禁大仓。**不要硬编码任何单一免费代理。**
+
+| 方案 | 状态/权衡 |
+| --- | --- |
+| **ghproxy 系**（`ghproxy.net`/`gh-proxy.com`…） | 原 `ghproxy.com` 已死；2022 起封禁 top 仓库（曾 ~1TB/天）；整体高churn |
+| **gh-proxy 自建**（Cloudflare Worker） | **可持续的答案**：自己控制，免费层 ~10万请求/天；无不可信中间人 |
+| **jsDelivr** | 全球优秀且可锁版本，**但 ~2021-12 失去中国 ICP** → 国内 DNS 污染/TCP reset，**国内不可依赖** |
+| **FastGit** | **已关停**（注意：最终告别公告是 **2024-07-06**，非 2022） |
+| **Gitee 镜像** | ICP 备案、域内稳定；但强制覆盖、**最小 5min 同步间隔/30min 超时/无 LFS**、自动同步实践中不稳、Pages 需人工审核 |
+| **TUNA/USTC/阿里/腾讯 镜像站** | 最持久（机构、ICP、rsync）；**但只镜像策展过的发行版/语言上游，不是任意 GitHub 仓库**。可申请收录，但偏好成熟项目 |
+
+xlings 现用 **Gitee + GitCode**（都是 ICP 备案的域内 git 站）作为 CN origin —— 这是**正确**的
+"稳定域内 origin"选择，优于脆弱的免费代理。
+
+### 2.4 完整性：让所有镜像都可以不被信任（最缺的一层）
+
+一旦从不受控的镜像/代理取内容，**TLS 不够**，需要端到端签名/哈希元数据：
+
+- **校验清单 + minisign**（Ed25519，极简，仅签名）→ 最低门槛、最契合
+- **sigstore/cosign**（无长期密钥，OIDC 身份 + Rekor 透明日志）→ 中等
+- **完整 TUF**（root/targets/snapshot/timestamp，防回滚/冻结/混搭）→ 最复杂
+- **内容寻址**（用哈希命名索引文件）→ 完整性内生、缓存天然安全；只需对一个小的"根指针"签名
+
+xlings 通过不受信代理拉取的是**可执行的 Lua `install()` 配方** —— 完整性缺失的安全敞口比一般索引更大。
+
+---
+
+## 3. xlings 的具体差距（按研究映射）
+
+| # | 差距 | 证据 | 对应行业实践 |
+| --- | --- | --- | --- |
+| **G1** | **子索引仓库无国内镜像**（CN==GLOBAL==github） | `xim-indexrepos.lua` | 主机名替换镜像（npm/pip/apt 国内站） |
+| **G2** | **索引 git clone 不做延迟重排、无卡顿看门狗** | `repo.cppm:177-209` 只 `expand` 无 `reorder`；watchdog 仅在 `tinyhttps` | Arch reflector `--sort rate` / Happy Eyeballs |
+| **G3** | **代理列表编译进二进制会腐烂**（kkgithub 已死/jsdelivr 国内失效） | `registry.cppm:36-69`；热更新被推迟 | 数据驱动 + 远程可更新镜像表 |
+| **G4** | **git clone 不可断点续传**，弱网下断 = 从零重来 | `compact::git::clone_shallow` | tarball Range / Cargo 稀疏文件 |
+| **G5** | **索引未签名/未内容寻址**（配方是可执行 Lua） | 无对应代码 | apt InRelease / Go GOSUMDB / minisign |
+| **G6** | 7 天节流 + HEAD 哈希缓存，无 ETag 条件请求 | `repo.cppm:215-227`、`index.cppm:177` | Cargo `If-None-Match`→304 |
+
+---
+
+## 4. 优化方向（分级，按"性价比/侵入性"排序）
+
+### 第 0 级：运维即可修，零代码，立即见效
+- **O1（最高优先）给子索引仓库配置真实 CN 镜像**：把 `xim-indexrepos.lua` 中三个子仓库的
+  `CN` 改为 Gitee/GitCode 镜像（与主索引同源策略），并建立 GitHub→Gitee 的自动同步
+  （GitHub Action 推送，规避 Gitee 自动同步的 5min/不稳问题）。
+  —— 这一步直接消除 G1，是覆盖面最大、改动最小的修复。
+
+### 第 1 级：小改动，把已有能力补到索引路径（消除"最弱档")
+- **O2 让索引 clone 享受延迟重排 + 卡顿检测**：
+  - 在 `repo.cppm` clone 循环前调用 `mirror::adaptive::reorder(urls, /*has_sha256=*/false)`，
+    失败时 `penalize_host()`（`reorder` 已是通用函数，几乎零新代码）。消除 G2 的"静态顺序"。
+  - git CLI 无法接 `StallDetector`，但可给 clone 子进程加**总超时 + 低速放弃**
+    （`git -c http.lowSpeedLimit=… -c http.lowSpeedTime=…`，或外层 watchdog 杀进程后换下一个候选），
+    把"600s 假死"压到秒级。消除 G2 的"无卡顿检测"。
+- **O3 代理表数据驱动 + 可远程更新**：把 `registry.cppm` 默认表标注"易腐烂"，
+  并允许从已成功取到的索引仓库里附带一份 `github-mirrors.json` 做热更新（先有 origin 才更新代理表，
+  规避鸡生蛋）。清掉已死的 kkgithub，国内场景下调 jsdelivr 优先级。消除 G3。
+
+### 第 2 级：中等架构改动，对齐 Cargo/Go 范式（弱网根治）
+- **O4 索引改为可断点续传的传输**：对"一次性、克隆完即可丢历史"的索引，用
+  **commit 锁定的 tarball**（`/archive/<commit>.tar.gz`，HTTP Range 可续传、可走 CDN）替代
+  非续传的 git clone；用 commit ID（而非 tarball 哈希，后者不稳定）锁定完整性。消除 G4。
+- **O5 引入 ETag/`If-None-Match` 条件请求**：索引/资源的 HTTP 路径加条件请求，命中 304 零体积，
+  比 7 天节流更精准且实时。补强 G6。
+
+### 第 3 级：长期，安全与可扩展性
+- **O6 索引签名/内容寻址**：对索引（或一份校验清单）做 **minisign** 签名（最低门槛），
+  使任意镜像/CDN/代理都可不被信任；这是把整个镜像生态"安全地"放开的前提。消除 G5。
+- **O7（远期）稀疏索引化**：若包数量持续增长，参考 Cargo 稀疏 HTTP 索引/Homebrew 逐包 JSON，
+  按需取元数据 + 静态 CDN，彻底摆脱"整库 clone"。
+
+### 推荐落地顺序
+**O1 → O2 → O3**（覆盖绝大多数当前抱怨，改动小、风险低）→ 再评估 O4/O5 → O6 长期排期。
+
+---
+
+## 5. 诚实标注的核查注意点
+- **FastGit** 最终关停为 **2024-07-06**（非 2022，早期有 2021–22 中断）。
+- **Gitee** "全局禁用自动更新"无法证实；可证实的是限速（最小 5min）+ 自动同步不稳 + Pages 人工审核。
+- **jsDelivr** 国内失效（ICP ~2021-12 吊销）证据充分；全球仍稳健。
+
+## 关键文件索引
+- 索引/子仓库同步：`src/core/xim/repo.cppm`（`sync_repo` :164、子仓库解析 :72-143、clone 循环 :177-209）
+- 区域键 origin / 资源服务器：`src/core/config.cppm:90-103,346-380`
+- 代理改写：`src/core/mirror/{registry,forms,expand,adaptive,types}.cppm`
+- HTTP 下载器（已含 reorder+watchdog）：`src/core/xim/downloader.cppm:362,374,414`
+- 解析索引缓存：`src/core/xim/index.cppm:167-198`
+- 子索引配置：`<index>/xim-indexrepos.lua`
+- bootstrap 安装器多源探测：`tools/other/quick_install.{sh,ps1}`

--- a/.agents/docs/2026-06-21-pkgindex-redesign-proposal.md
+++ b/.agents/docs/2026-06-21-pkgindex-redesign-proposal.md
@@ -1,0 +1,513 @@
+# xlings 索引与更新机制 — 重设计方案(深度分析 + 前沿调研)
+
+> 日期: 2026-06-21
+> 类型: 架构提案 (design proposal)
+> 前置: `2026-06-21-pkgindex-mirror-analysis.md`(现状/问题/行业实践)
+> 关联: mcpp 索引模型分析、前沿调研(OCI/Sigstore/TUF/Nix/边缘代理)
+> 一句话: **要重设计,但是"靶向重设计"** —— 换掉索引的*获取与传输方式*(live git clone → 静态签名目录 + CDN + 多镜像),
+>          保留 git 作为*事实源*,补上*内容寻址 + minisign 签名 + 锁文件*。**不做** OCI/TUF/IPFS 的大改。
+
+---
+
+## 0. 先回答那个问题:要不要重设计?
+
+**要,但范围必须精确。** 把"重设计"拆成三个正交的轴,逐一给结论:
+
+| 轴 | 现状 | 是否重设计 | 结论依据 |
+| --- | --- | --- | --- |
+| **A. 索引的获取与传输** | 对 GitHub 做 live `git clone`(1.7MB 仓库 + 全量历史 + 不可续传)只为读 13KB 目录 | ✅ **是,这是核心** | 行业无一例外:没有主流 PM 对 GitHub live-clone 取索引;且这正是用户卡顿的根 |
+| **B. 索引的完整性与可复现** | 无锁文件、无内容寻址、仅 ~8% 配方有 sha256 | ✅ **是,中优先级** | mcpp 已 PoC(`mcpp.lock`+`fnv1a`);Nix/Go/apt 都做传输无关完整性 |
+| **C. 索引的存储/分发协议范式** | git 仓库 of `pkgs/*.lua`(xpkg V1) | ❌ **不大改**(git 留作事实源) | **67 个包、13KB 目录** —— Cargo 稀疏/OCI/TUF 都是为 10万级+ 设计,对此体量是过度设计 |
+
+**最关键的单一事实(决定一切):** xlings 整个索引 = **67 个配方、工作树 1.7MB、解析后目录仅 13KB**。
+前沿调研结论一致:"git-as-index 只在**大规模**才崩"(Cargo/Homebrew/CocoaPods/Go 的迁移全发生在十万级)。
+所以 xlings 不需要稀疏索引,更不需要 OCI/TUF —— 它需要的只是**别再 clone 一个仓库去读一个 13KB 文件**。
+前沿正确解(content-addressed + 静态 CDN)和最简解(一个签名 JSON)在这个体量上**罕见地重合**。
+
+---
+
+## 1. 为什么 live-git-clone 是错的范式(而非实现细节)
+
+1. **不可断点续传**:git-over-HTTPS 是单条 packfile 流,弱网断 = 从零重来(前沿调研 A3)。
+2. **拿不到 CDN**:GitHub git 协议不可被 jsdelivr/CDN 缓存;只能整库代理(脆弱免费代理)。
+3. **拿不到 0.4.49 的韧性**:延迟重排 + 卡顿看门狗只在 HTTP 下载器,git clone 收不到(见现状文档 G2)。
+4. **为 13KB 付 1.7MB + 全量历史的代价**,且子仓库还没有国内 origin(G1)。
+
+行业反证(全部从 git-index 迁走或从不用):
+- **Homebrew 4.0**:tap git clone → `formula.jws.json`(JWS 签名)over CDN,更新频率 5min→24h。
+- **Cargo 1.70**:`crates.io-index` git clone → 稀疏 HTTP 索引 + ETag/304。
+- **Go**:GOPROXY 不可变静态文件 + GOSUMDB 传输无关校验。
+- **mise/aqua/vfox**(与 xlings 最像的小型工具):索引**烘焙进二进制** / 单个 ref 锁定的静态文件 / GitHub Pages 静态索引。
+
+---
+
+## 2. 前沿调研:哪些是真前沿,哪些是陷阱
+
+前沿调研的最大价值是**划清"该抄"与"别碰"的边界**:
+
+### 值得采纳(便宜且对路)
+- **内容寻址 = 配方里每个下载项带 sha256**(Nix/Zig 思路)。这是 OCI 真正有价值的部分(verify-by-digest),
+  但**零协议成本**:任意镜像/代理/CDN 都能送字节,无需信任关系。mcpp 配方已经这么做了,xim-pkgindex 只有 ~8%。
+- **条件请求**(ETag / If-Modified-Since)的静态索引:刷新近乎零成本。
+- **可脚本化的镜像改写层**(xmake `mirror(url)` 钩子,2.5.4 起):xlings 配方本就是 Lua,天然契合。
+- **Nix 二进制缓存模型(借思路不借机器)**:静态 HTTP + 按内容哈希命名 + 每缓存固定公钥 + 多 substituter 有序回退。
+- **minisign 签名**(单 Ed25519 密钥、单静态二进制、纯离线):小团队的完整性最优解。
+
+### 明确不做(对 xlings 是过度设计 / 对中国用户有害)
+- **OCI-registry-as-index**:连 Homebrew 都无法让镜像代理其 OCI 路径(镜像一律回退到 flat-file);
+  **中国 2024-07 后已无可靠的 ghcr.io 公共拉取缓存**(阿里公共加速器 2024-07-02 起仅限阿里云内网)。
+  强行用 OCI = 强迫客户端讲 token-auth manifest/blob 协议,且国内更慢。
+- **TUF**:PyPI 的 PEP 458 接受多年仍未部署;RustSec 仍在 RFC 阶段。对 67 个包是纯负担。
+- **Sigstore keyless**:依赖在线 Fulcio/Rekor + OIDC,适合"只从 CI 发布"的项目;签名事件公开、离线尴尬。
+  aqua 实测:"支持 Cosign,但几乎没人发布签名"。**除非 xlings 改为纯 CI 发布,否则用 minisign。**
+- **IPFS**:npm/pacman/Nix 全部弃用,实测 DHT 取记录平均 ~6s(最坏 ~1.5h),且最终仍走中心化网关。**不要重访。**
+
+---
+
+## 3. 目标架构
+
+分层设计,每层可独立演进:
+
+```
+┌─ L0 事实源 (Source of Truth) ────────────────────────────────────────┐
+│  git 仓库 xim-pkgindex (+ awesome/scode/d2x):pkgs/*.lua, xpkg V1     │
+│  贡献者 PR / review 仍走 git —— 不变                                   │
+└──────────────────────────────┬───────────────────────────────────────┘
+                               │ CI on push to main
+┌─ L1 构建&发布 (Publish) ──────▼───────────────────────────────────────┐
+│  CI 跑 xpkg::build_index → 产出 catalog.json(≈13KB,压缩后 ~3KB)      │
+│  + minisign 签名 catalog.json.minisig + 版本号/commit 戳              │
+│  发布到多个静态分发面(L2),内容按 commit/hash 不可变                  │
+└──────────────────────────────┬───────────────────────────────────────┘
+┌─ L2 分发面 (Distribution surfaces,全部静态/可 CDN/可续传) ───────────┐
+│  GLOBAL: GitHub Release asset / GitHub Pages / jsdelivr(全球)        │
+│  CN:     Gitee Pages / GitCode / Cloudflare R2(零出口费,含中国 PoP) │
+│  可选:   烘焙进 xlings 二进制(mise 模式)作为离线/首启兜底           │
+└──────────────────────────────┬───────────────────────────────────────┘
+┌─ L3 客户端获取 (Client fetch) ▼───────────────────────────────────────┐
+│  HTTP GET catalog.json(走 tinyhttps:已有 续传/卡顿看门狗/延迟重排)   │
+│  → minisign 验签 → 写入本地 cache + ETag                               │
+│  多镜像按延迟探测排序(adaptive::reorder,已存在)+ 失败 penalize     │
+│  条件请求 If-None-Match → 304 则零体积                                 │
+│  git clone 降级为 *兜底*(静态面全挂)和 *贡献者* 路径                 │
+└──────────────────────────────┬───────────────────────────────────────┘
+┌─ L4 完整性&可复现 ────────────▼───────────────────────────────────────┐
+│  catalog 级:minisign 签名(传输无关,任意镜像可不可信)               │
+│  包级:配方强制 sha256(verify-by-digest,逐候选校验,已有机制)       │
+│  可选 xlings.lock(借 mcpp.lock 模型):项目级固定 commit + 解析哈希   │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+### 3.1 关键设计决策
+
+1. **索引 = 预构建的单个静态 `catalog.json`,不是被 clone 的 git 工作树。**
+   `xpkg::build_index` 已存在(现在客户端本地跑);把它**移到 CI 发布期**跑一次,产物供所有人下载。
+   13KB 目录 → 一次 HTTP GET,可 CDN、可续传、可 ETag。clone 假死问题从根消失。
+2. **子索引(awesome/scode/d2x)同等对待**:各自发布自己的 `catalog.json`,主索引的
+   `xim-indexrepos.json` 改为指向"各子索引 catalog 的多分发面 URL 列表",而非 git 仓库。**直接消除 G1**。
+3. **git 仍是 L0 事实源**:贡献、review、历史不变;只是客户端**默认不再 clone**。
+   "想要完整配方源码/本地改"的用户仍可 `xlings index clone`(显式)。
+4. **完整性双层**:catalog 用 minisign 签名(替代"信任 git origin");包下载用 sha256
+   (推动 xim-pkgindex 把 sha256 覆盖率从 8% 拉到接近 100%,可加 index lint 在 CI 拦截无 sha256 的配方)。
+5. **中国策略是真正该投入工程的地方**(前沿调研明确:客户端延迟探测在别处已被 CDN anycast 淘汰,
+   但在中国"异构、各自为政、随时挂的镜像"场景下**仍然正当**,只要保持便宜——周期探测/竞速一小撮,而非每次下载):
+   - L2 把 catalog 同时放在 Gitee Pages / GitCode / R2(含中国可达面),CN 区域键直接选域内面。
+   - 保留 `mirror::expand` + `adaptive::reorder`,但现在作用在**可被 CDN 缓存的 HTTP URL** 上(比代理 git 强得多)。
+   - 代理表数据驱动 + 可热更新(随 catalog 一起下发 `github-mirrors.json`);清掉已死的 kkgithub。
+   - 大学镜像(`ghcr.nju.edu.cn`/USTC 类)是最持久的一档;所有社区 ghproxy 视为随时失效。
+
+---
+
+## 4. 与 mcpp 的关系:复用而非重造
+
+调研确认:**mcpp 的索引存储和 xlings 完全相同(都是 xpkg V1 的 git 仓库),mcpp 的 registry 就是个嵌套的 xlings home。**
+mcpp 真正多出来的是**可复现/锁定层**,而这层正是 xlings 运行时文档早已列为"待办"的 `xlings.lock`:
+
+- `mcpp.lock`(`version=2`):每依赖 `source = index+ns@version` + `hash = fnv1a:...`(解析级)+ 配方里 `sha256`(字节级)。
+- mcpp 配方**每个包都带 `GLOBAL`/`CN` 双 URL + sha256**(如 ftxui CN→`gitcode.com/mcpp-res/...`)——
+  这正是 xim-pkgindex 该补的(当前仅 8% 有 sha256,且子仓库无 CN URL)。
+
+**结论:L4 的可复现层直接照搬 mcpp 模型(`xlings.lock` + `index+ns@version` + 解析哈希),不必另起炉灶。**
+两者共享同一索引引擎,统一是加一层 lock,而非换引擎。旧文档 `2026-05-01-ci-self-host-via-xlings-json.md:254`
+已明确预留了这个 `xlings.lock`。
+
+---
+
+## 5. 迁移路线(分阶段,低风险优先,与现状文档的 O1–O7 对齐)
+
+| 阶段 | 内容 | 风险 | 对应问题 | 价值 |
+| --- | --- | --- | --- | --- |
+| **P0 运维** | 给子索引配 CN 镜像 + GitHub→Gitee 自动同步(Action 推送) | 极低 | G1 | 立刻止血,覆盖最大 |
+| **P1 补韧性到 git 路径** | 索引 clone 前加 `adaptive::reorder`+`penalize_host`;给 git 子进程加低速放弃/总超时;代理表去死链 | 低 | G2/G3 | 在不改范式前先把"假死"压到秒级 |
+| **P2 静态 catalog(核心重设计)** | CI 发布 `catalog.json`+minisign;客户端改 HTTP 拉取+验签+ETag;git 降级为兜底/贡献者路径;子索引同构 | 中 | A/G1/G4 | 从根上消除 clone 假死;拿到 CDN/续传 |
+| **P3 完整性收口** | 配方 sha256 覆盖率→~100%(CI lint 拦截);catalog 内嵌包级 digest | 中 | B/G5 | 任意镜像可不可信 |
+| **P4 可复现(借 mcpp)** | 引入 `xlings.lock`(`index+ns@version`+解析哈希) | 中 | B | 与 mcpp 统一,CI 可复现 |
+| **P5 可选** | catalog 烘焙进二进制(离线首启);R2 自建边缘面 | 低-中 | A(离线) | mise 式零网络查找 |
+
+**推荐:P0→P1 先上(止血,几乎纯收益),再做 P2(真正的范式切换),P3/P4 随后,P5 按需。**
+
+---
+
+## 6. 权衡与取舍(决策矩阵)
+
+| 维度 | 现状 git-clone | 静态 catalog+CDN(本提案) | OCI-registry(否决) |
+| --- | --- | --- | --- |
+| 弱网/中国可靠性 | 差(假死、无续传、无 CDN) | **好**(续传、CDN、多域内面) | 差(国内无 ghcr 缓存) |
+| 实现复杂度 | 低(已存在) | **中**(CI 发布 + 验签) | 高(token-auth 协议) |
+| 完整性 | 弱(信 origin,8% sha256) | **强**(minisign + sha256) | 强(digest,但协议重) |
+| 离线/首启 | 差(必须联网 clone) | **好**(可烘焙进二进制) | 差 |
+| 贡献者体验 | 好(就是 git) | 好(L0 仍是 git) | 差(要推 registry) |
+| 适配 67 包体量 | 杀鸡用牛刀(整库历史) | **正好** | 牛刀杀蚊子 |
+
+---
+
+## 7. 开放问题 / 风险
+
+1. **catalog 的"最新指针"如何更新**:不可变内容(按 commit/hash)+ 一个短 TTL 的小 `latest.json` 指针;
+   指针也要可验签,避免 CDN 缓存导致新包不可见。
+2. **minisign 密钥保管**:单长期密钥的离线保管/备份/分发是 minisign 唯一的硬成本;公钥需随 xlings 二进制内置。
+   若未来改纯 CI 发布,可再评估 Sigstore(届时才划算)。
+3. **Gitee Pages 需人工审核、5min 同步间隔**:用 Action 主动推送 + R2 兜底,降低对 Gitee 自动同步的依赖。
+4. **向后兼容**:老版本 xlings 仍 clone git;L0 保留即可继续工作,L2 是增量增强。
+5. **catalog schema 版本化**:`.xlings-index-cache.json` 已有 `version:1`,沿用并加签名包裹。
+6. **子索引发现的鸡生蛋**:主 catalog 内嵌子索引 catalog 的多面 URL 列表,客户端先取主 catalog 再并行取子。
+
+---
+
+## 7.5 索引更新机制(核心实现细节)
+
+一旦索引从 git 仓库变为 CDN 静态文件,更新就不是 `git pull`,而要自己解决 5 件事:
+**①便宜地发现变化 ②不可变负载与可变指针共存 ③验签防回滚 ④原子落盘 ⑤失败兜底**。
+
+### 7.5.1 两文件模型(指针 + 内容寻址负载)
+
+借 apt `InRelease`(签名清单哈希所有子索引)+ Go GOSUMDB(传输无关完整性)的思路:
+
+```
+index.json            ← 指针/清单:小、可变、短 TTL、必签名
+  ├ schema_version: 1
+  ├ index_version: 1234            # 单调递增整数(CI run / commit count)
+  ├ commit: "<git sha>"            # 可追溯回 L0 事实源
+  ├ generated_at: "<RFC3339>"      # 防冻结攻击(陈旧指针告警)
+  ├ catalog: { hash: "sha256:ab…", size: 3012,
+  │            urls: ["<面1>/catalog-ab….json.zst", "<面2>/…"] }
+  ├ subindex: {                    # 一个指针覆盖主索引 + 全部子索引
+  │   awesome: { hash, size, urls },
+  │   scode:   { … }, d2x: { … } }
+  ├ mirrors: { … }                 # 可选:热更新 github-mirrors.json(去死链)
+  └ (detached) index.json.minisig  # minisign 签名
+
+catalog-<hash>.json.zst  ← 负载:不可变、按内容哈希命名、Cache-Control: immutable
+                            任意 CDN 永久缓存,无需单独签名(指针已为其哈希背书)
+```
+
+**关键点**:负载按 hash 命名 → 永不失效、可被任意 CDN/镜像缓存、无需逐个签名;
+只有那个**小指针**是可变的、需短 TTL + 验签。这把"CDN 缓存导致新包不可见"的经典坑,
+收敛成"只需正确管理一个 3KB 指针的缓存"。
+
+### 7.5.2 客户端更新流程(替代 `git pull --ff-only`)
+
+```
+1. 按区域键解析指针的多分发面 URL 列表(CN→gitee/gitcode/R2,GLOBAL→pages/jsdelivr)
+   → mirror::adaptive::reorder() 按延迟排序(已有)
+2. 条件请求 GET index.json,带 If-None-Match: <本地ETag>
+   ├ 304 Not Modified → 结束(零体积,这就是新的"freshness check")
+   └ 200 → 继续
+3. minisign 验签(公钥内置于 xlings 二进制)。失败 → 拒绝,换下一个面
+4. 防回滚:if index_version <= 本地版本 → 忽略(除非 --force)
+   防冻结:if now - generated_at > 阈值 → 告警(某个面在喂陈旧指针)
+5. 比对 catalog.hash 与本地缓存 hash
+   ├ 相同 → 仅指针变了(如 mirror 列表)→ 更新本地指针即可,不下负载
+   └ 不同 → 从 catalog.urls(内容寻址,CDN 命中)下载 catalog-<hash>.json.zst
+            走 tinyhttps(已有:续传 + 卡顿看门狗 + 逐候选回退)
+6. 校验 sha256(下载内容) == catalog.hash。不符 → 弃用,换下一个 URL
+7. 子索引:对 subindex 中 hash 变化的项,并行重复 5–6(只取变化的)
+8. 原子落盘:写临时文件 → fsync → rename 覆盖;记录 {index_version, etag, hash}
+   到状态文件。任何步骤失败 → 保留 last-good,降级继续可用
+9. 全部静态面失败 → 回退到现有 git clone 路径(永不比今天更差)
+```
+
+### 7.5.3 为什么"不做增量/delta"是正确的
+
+负载压缩后 ~3KB。**整文件重下比算/应用 delta 更便宜**——这是小体量带来的简化红利,
+**刻意的非目标**。若未来涨到 MB 级再考虑 Cargo 式按包稀疏拉取(`subindex` 结构已为此预留)。
+
+### 7.5.4 freshness / 节流(替代 7 天 git stamp)
+
+- `xlings update`:总是走第 2 步条件请求(304 极廉价,可以频繁)。
+- `xlings install`:最多每 N 小时查一次指针(stamp 节流);因为是 304 条件请求而非整库 clone,
+  N 可远小于现在的 7 天(参考 Homebrew 24h,可设 6–24h,`--refresh` 强制)。
+- 命中 304 = 几十字节;指针真变了才下 3KB 负载;负载没变只是指针动了则零负载。
+
+### 7.5.5 发布侧(CI,merge 到 main 触发)
+
+```
+1. xpkg::build_index 产出 catalog.json(已有逻辑,从客户端移到此处)→ zstd 压缩
+2. hash = sha256(catalog.json.zst);命名 catalog-<hash>.json.zst
+3. 生成新 index.json:index_version+1、commit、各 subindex 的 hash/size/urls
+4. minisign 签 index.json(私钥在 CI secret;或人工离线签更稳)
+5. 上传到所有分发面:
+   - 负载:Cache-Control: public, max-age=31536000, immutable
+   - 指针:Cache-Control: public, max-age=300, must-revalidate(短 TTL)
+6. 保留旧负载(不可变、便宜)→ 支持回滚 / xlings.lock 复现
+```
+
+### 7.5.6 与本地缓存 / xlings.lock 的衔接
+
+- 现有 `.xlings-index-cache.json`(`version:1`,以 git HEAD 为缓存键)→ 缓存键改为
+  **指针里的 catalog.hash**;HEAD 概念不再需要(已无本地 git 工作树)。
+- `xlings.lock`(借 mcpp 模型)记录 `index_version` + `catalog.hash` + 各 `subindex.hash`
+  → `xlings install --locked` / CI 可**精确复现**当时的索引状态(因负载不可变、永久保留)。
+
+### 7.5.7 这套设计对应的攻击/故障防护
+
+| 威胁/故障 | 防护 | 出处范式 |
+| --- | --- | --- |
+| 镜像/代理篡改内容 | minisign 签指针 + sha256 校负载 | apt InRelease / Go GOSUMDB |
+| 回滚到旧索引(降级攻击) | `index_version` 单调 + 拒绝更低 | TUF rollback 防护(最小版) |
+| 冻结/喂陈旧指针 | `generated_at` + 过期告警 | TUF timestamp 角色(最小版) |
+| CDN 缓存致新包不可见 | 负载内容寻址不可变 + 指针短 TTL | jsdelivr 不可变 URL + 短 TTL 指针 |
+| 半更新/损坏 | 临时文件 + fsync + rename 原子替换 | 通用 |
+| 全网失败/离线 | 保留 last-good + git 兜底 + 可烘焙进二进制 | Nix 多 substituter 回退 |
+
+---
+
+## 7.6 落地所需的全部工作(不止"合入代码发版本")
+
+**结论先行:仅"合入 xlings 代码 + 发新版本"不够。** 那只覆盖下表 D 类(二进制改造)。
+方案要真正生效,还依赖 A 密钥/信任根、B 分发面基础设施、C 索引仓库的发布管线、E 索引内容,
+其中相当一部分是**密钥/账号/运维/内容**工作,写代码无法替代。涉及 **2 类共 5 个仓库**:
+xlings 二进制仓(openxlings/xlings)+ 索引内容仓(xim-pkgindex 主仓 + awesome/scode/d2x 三个子仓)。
+
+### 7.6.1 全部工作清单
+
+| 类 | 事项 | 是代码? | 一次性/持续 | 所在仓库/位置 | 前置依赖 |
+| --- | --- | --- | --- | --- | --- |
+| **A 密钥/信任根** | 生成 minisign 长期密钥对(离线) | 否(运维) | 一次性 | 离线/安全环境 | 无 — 最先做 |
+| A | 私钥保管/备份/轮换流程 | 否(运维) | 一次性+持续 | CI secret 或离线签名机 | A 密钥 |
+| A | **公钥内置进 xlings 二进制** | 是 | 一次性 | xlings 源码 | A 密钥 |
+| A | 定签名策略:CI 自动签 vs 人工离线签 | 否(决策) | 一次性 | — | A 密钥 |
+| **B 分发面/基础设施** | 选定并开通静态面(GitHub Pages/Release、Gitee Pages、GitCode、Cloudflare R2) | 否(运维/账号) | 一次性+持续(托管) | 各平台账号 | 无(可并行) |
+| B | 配置 Cache-Control(负载 immutable / 指针短 TTL) | 否(配置) | 一次性 | R2/CF 可配;**Gitee Pages 缓存不可控需评估** | B 开通 |
+| B | (可选)自定义域名 + 中国 PoP CDN + DNS | 否(运维) | 一次性+持续 | DNS/CDN 商 | B 开通 |
+| **C 发布管线** | 主索引 CI:build catalog→zstd→hash→签→上传所有面 | 是 | 一次性 | **xim-pkgindex 仓**(非 xlings 仓!) | A 私钥、B 面、D `build_index` 可独立运行 |
+| C | 子索引 CI:同上 ×3 | 是 | 一次性 | awesome/scode/d2x 三仓 | 同上 |
+| C | index_version 来源 + 旧负载保留策略 | 是 | 一次性 | 索引仓 CI | C 管线 |
+| **D xlings 二进制** | 新增 `sync_via_catalog()`(指针拉取+验签+原子落盘),与 git 兜底并存 | 是 | 一次性 | xlings 源码 | A 公钥 |
+| D | minisign 验签模块 | 是 | 一次性 | xlings 源码 | A 公钥 |
+| D | 缓存键 HEAD→catalog.hash;状态文件;freshness 节流改造 | 是 | 一次性 | xlings 源码 | — |
+| D | 区域键解析指针多面 URL(复用 config.cppm GLOBAL/CN) | 是 | 一次性 | xlings 源码 | B 面 URL 定稿 |
+| D | (可选)`xlings.lock`、catalog 烘焙进二进制 | 是 | 一次性 | xlings 源码 | D 主体 |
+| **E 索引内容** | 配方 sha256 覆盖率 8%→~100% | 否(内容) | 一次性+持续 | xim-pkgindex + 三子仓 | 无(可并行) |
+| E | 子索引 `xim-indexrepos.lua` 的 CN 改域内镜像 + 自动同步(=P0) | 否(内容/运维) | 一次性+持续 | xim-pkgindex | 无 — 可立即做 |
+| E | index lint:CI 拦截无 sha256 的配方 | 是 | 一次性 | 索引仓 CI | E sha256 补齐后 |
+| **F 协调/发布顺序** | 灰度开关(默认 git,逐步切 catalog) | 是 | 一次性 | xlings 源码 | D |
+| F | L0 git 永久保留(老客户端兼容) | 否(策略) | 持续 | 索引仓 | — |
+| F | 回滚预案(指针/版本回退) | 否(运维) | 一次性 | 索引仓 CI + 文档 | C |
+| **G 文档** | 镜像配置文档、贡献者 sha256 要求、密钥轮换文档 | 否(文档) | 一次性 | docs | — |
+
+### 7.6.2 强制发布顺序(鸡生蛋问题)
+
+这是最容易踩坑的地方——**信任根必须先于被签名的内容存在**:
+
+```
+① A 生成密钥 + 公钥进二进制 + B 开通分发面            ← 基础设施,可并行
+② 发一版 xlings:带验签能力,但默认仍走 git(F 灰度=off)  ← 公钥先铺到用户手里
+③ C 在索引仓建管线,发布"首个"签名 catalog + 指针到各面
+④ E 把 sha256 补齐(否则包级完整性形同虚设)
+⑤ 灰度:F 开关切到 catalog 优先(git 兜底);观察各面命中/失败
+⑥ 默认 catalog 优先;git 降级为兜底/贡献者路径
+   E 的 P0(子索引 CN 镜像)可在 ①–⑥ 任意时刻独立先上(纯收益)
+```
+
+要点:
+- **步骤②先于③**:若先发签名 catalog 再发带公钥的二进制,老客户端无法验签;反之公钥先铺开,
+  老客户端忽略 catalog 继续走 git,新 catalog 出现时已有验签能力。
+- **发布管线在索引仓(C),不在 xlings 二进制仓(D)**——这是"只发 xlings 版本不够"的根本原因:
+  catalog 的产出与上传由 xim-pkgindex / 子仓的 CI 负责。
+- **B 的分发面 URL 必须在 D 编译期可知**(区域键里写死或可配),否则二进制不知道去哪取指针。
+
+### 7.6.3 "纯代码即可" vs "需额外工作"一句话区分
+
+| 如果只… | 结果 |
+| --- | --- |
+| 合入 D 代码 + 发 xlings 版本 | 客户端**有了验签和 catalog 拉取能力,但无 catalog 可拉** → 仍走 git 兜底,用户无感 |
+| 再做 A 密钥 + B 面 + C 管线 | 首个签名 catalog 上线 → 客户端可切 catalog,**clone 假死问题消失** |
+| 再做 E sha256 + P0 子索引镜像 | 包级完整性闭环 + 子仓库国内可达 → 方案完整生效 |
+
+---
+
+## 7.7 替代方案 Y:索引随发布捆绑(复用安装器渠道,大幅省步骤)
+
+**问题:既然索引才 13KB,能不能不建独立的 catalog 更新机制,直接让"更新索引 = 重装/取最新发布"?**
+**答案:能,而且省掉一整类基础设施工作。** 关键依据:
+
+1. bootstrap 安装器(`quick_install.{sh,ps1}`,commit 06fd09f)**已有**在中国跑通的
+   多源(GitHub+GitCode)+ 延迟探测 + 回退 + gzip/zip 魔数校验——这条路**已验证可用**。
+2. xlings release **本就同时发在** `github.com/openxlings/xlings` 与 `gitcode.com/xlings-res/xlings`。
+3. 索引体量极小 → 不需要 304 增量、不需要稀疏拉取;"整取一个小资源"已经最优。
+4. mise 已用此模式(索引烘焙进二进制),aqua 用 ref 锁定的单文件。
+
+### 7.7.1 三档形态
+
+| 档 | 机制 | 更新方式 | 新鲜度 |
+| --- | --- | --- | --- |
+| **Y-min** | 索引**烘焙进二进制** | 重装 xlings(`self update`) | = 发布节奏;首启/离线零网络 |
+| **Y-asset**(推荐) | 索引烘焙进二进制 **+** 同一 release 附带一个独立小资源 `xim-index-<ver>.tar.zst` | `xlings update` 只取那个小资源(走安装器式多源探测),验签后原子替换 | 可独立于二进制发布(见下) |
+| **X-full**(§7.5) | catalog + 签名指针 + ETag/304 + 独立 CDN 面 | 指针轮询 | 轮询最省字节,但 13KB 体量收益甚微 |
+
+**推荐 Y-asset**:把索引同时(a)烘焙进二进制做离线/首启兜底,(b)作为一个独立小资源发在
+**已有的 GitHub/GitCode Releases 渠道**上。`xlings update` 内部 = "用安装器那套探测逻辑取最新
+索引资源 → 校验 → 原子替换本地索引",用户仍只敲 `xlings update`,**无需真的手动重装二进制**,
+也**不会**为 13KB 索引去重下整个二进制。
+
+### 7.7.2 新鲜度解耦(Y-asset 的关键)
+
+索引资源在哪发,决定新鲜度是否绑死二进制版本:
+- **绑定**:xlings release 管线拉取 pin 的 xim-pkgindex commit,构建 catalog,作为 release 资源附上 →
+  新包要等下次 xlings 发版。简单,但索引和二进制版本耦合。
+- **解耦(推荐)**:xim-pkgindex / 子仓各自发"索引 release"(把构建好的 `xim-index-<ver>.tar.zst`
+  作为 release 资源,镜像到 gitcode `xlings-res`)。`xlings update` 取**最新索引 release**,与二进制版本无关。
+  —— 这本质就是把 §7.5 的"分发面"换成**已有的 Releases 渠道**,把"签名指针"换成 **release tag**
+  (release 资源天然不可变、安装器探测已会处理),省掉自建 CDN/Pages 与指针机制。
+
+### 7.7.3 Y-asset 相对 X-full(§7.6 清单)省掉/简化了什么
+
+| §7.6 类 | X-full | **Y-asset** |
+| --- | --- | --- |
+| **B 分发面/CDN/Pages** | 需开通 Gitee Pages/R2/自定义域名 + 配 Cache-Control | **整类省掉** —— 复用已有 GitHub/GitCode **Releases** 渠道 |
+| **C 发布管线** | 每个索引仓建 catalog+签名+上传多面 CI | **简化** —— 在已有 release 流程加一步"构建索引资源";无独立 CDN 上传 |
+| **D 客户端更新逻辑** | 指针拉取/ETag-304/防回滚/防冻结/比对 hash | **大幅简化** —— "取资源→校验→原子替换";新鲜度=看有无更新 release |
+| **A 密钥/签名** | 需对指针单独 minisign 签名层 | **简化/可缓** —— 索引随 release,被 release 的签名/sha256 一并覆盖(本就该签 release) |
+| **F 发布顺序(鸡生蛋)** | 公钥必须先于签名 catalog | **缓解** —— 索引与验证它的二进制原子同发,无跨工件时序坑 |
+| **E sha256(包级)** | 需要 | **仍需要**(这是包*内容*下载的完整性,与索引分发正交) |
+| **E P0 子索引 CN 镜像** | 需要 | **仍建议**;但若子索引也走 release 资源,CN 镜像即 gitcode release,问题一并解决 |
+
+### 7.7.4 唯一真正的代价 + 取舍
+
+- **代价:新鲜度**。捆绑式下索引的"实时性"弱于指针轮询。但:① 13KB,`xlings update` 整取毫无压力;
+  ② 用 Y-asset 解耦发布后,新鲜度回到"有没有发新索引 release",与二进制版本无关,代价基本消除;
+  ③ 唯一残留:从不 `xlings update` 的用户索引会旧 —— 加一句"索引已 N 天未更新"的提示即可。
+- **不解决的(本就正交,两方案都要做)**:包*内容*下载仍走运行时下载器 + 镜像(那条路已有
+  延迟重排 + 卡顿看门狗,已 OK);配方 sha256 覆盖率(E)仍要补。
+- **子索引(awesome/scode/d2x)**:默认主索引可捆绑;用户*显式*添加的第三方子索引仍需某种取回路径,
+  但走同样的 release-资源模式即可,不必为它单独建 CDN。
+
+### 7.7.5 结论:省步骤,且更稳
+
+**Y-asset 用"复用已验证可用的 Releases + 安装器探测"换掉了"自建 CDN 面 + 指针/304/签名"整套机制**,
+省掉 §7.6 的 B 类、简化 C/D/A/F,只保留与方案无关的 E。对 13KB、67 包、用户重度在中国的现状,
+这是**性价比最高**的形态:工程量小、复用已跑通的中国可达渠道、首启/离线还能零网络。
+X-full(§7.5)只在"索引涨到 MB 级 + 需要分钟级实时新鲜度"时才值得回头采用——目前是过度设计。
+
+> 落地顺序相应简化:P0(子索引 CN,可立即)→ 给 release 加"构建索引资源"一步 →
+> 客户端 `xlings update` 改为"取索引资源 + 校验 + 原子替换",git 留作兜底 → 补 sha256(E)。
+> 不再需要独立 CDN 面、指针轮询、跨工件签名时序。
+
+---
+
+## 7.8 本质:把索引当作"包资源"来分发(统一管线)
+
+**Y-asset 的本质,就是把索引从"一个被 clone 的 live git 仓库"重新定义为"一个有版本、带 sha256、
+走镜像分发的可下载工件"——即用和包资源完全相同的方式分发索引。** 这不只是省步骤,而是一次概念统一。
+
+### 7.8.1 一套管线服务两类东西
+
+| 维度 | 包资源(现状已有) | 索引(本方案) |
+| --- | --- | --- |
+| 分发渠道 | GitHub Release / `xlings-res`(gitcode) | **同上** |
+| 版本 | 多版本管理("everything is a package") | **同上**(`xim-index-<ver>`) |
+| 完整性 | 配方里 sha256,下载后校验 | **同上** |
+| 镜像/容错 | HTTP 下载器 + `adaptive::reorder` + 卡顿看门狗 | **同上** |
+| 更新语义 | 安装/升级一个包 | `xlings update` = 取最新索引工件 |
+
+→ **一条分发+完整性+镜像管线同时服务"包"和"索引",概念更少、代码更省。**
+这与 xlings 自身哲学("everything is a package")、以及 xim/mcpp 既有实践一致:
+`xim:git`、`xim:mcpp@0.0.36` 这些 bootstrap 工具链本就是当作**包**来交付的;`xlings-res` 本就在
+当作资源分发 xlings 自己的二进制。把索引也归入这套,是顺理成章的延伸。
+
+### 7.8.2 这恰好治好了根因 G2(优雅闭环)
+
+回顾现状文档:索引走 `git clone`,**收不到** HTTP 下载器上的延迟重排 + 卡顿看门狗(G2),
+所以它是韧性最弱的一条路。**而"把索引当包资源下载"会自动把它挪到那条已经具备韧性的 HTTP 路径上**——
+G2 不是"再补一遍机制"解决的,而是"换条路走"顺带消失的。这正是 Y-asset 比给 git-clone 打补丁更优的深层原因。
+
+### 7.8.3 唯一不可消除的差异:bootstrap 悖论
+
+索引是**发现一切的根**,所以它和普通包有一处本质不同:**它不能"通过索引来发现自己"**。
+因此它需要一个**约定俗成的固定地址**(固定的 release 渠道 URL)或**烘焙进二进制**作为信任/发现锚点——
+正如 apt 内置 keyring、cargo 硬编码 crates.io、minisign 公钥内置二进制。
+换言之:索引"作为工件"与包资源同构,但"作为发现根"必须有一个不依赖索引的入口。这是唯一的特例。
+
+> 准确边界:这里说的是"索引用包资源的**分发/完整性/镜像管线**来发布",
+> 不是"把索引建模成索引里的一条配方"(那会循环)。发现根仍需固定入口。
+
+---
+
+## 7.9 发现锚点:需要固定地址吗?——复用已有的 resource-server,基本不用新建
+
+§7.8.3 的 bootstrap 悖论意味着:索引工件**需要一个不依赖索引、编译期可知的固定地址**。
+**但 xlings 已经有这个锚点了** —— 就是现成的 `xlings-res` 资源服务器,因此**不必新发明一套**。
+
+### 7.9.1 现状已存在的固定锚点
+
+`src/core/config.cppm:98-103` 里已经硬编码了一个区域化的资源服务器表:
+
+```cpp
+{ "GLOBAL", { "https://github.com/xlings-res" } },
+{ "CN",     { "https://gitcode.com/xlings-res" } },
+```
+
+而且这套机制(`selected_resource_server_for_`, `config.cppm:346-380`)**已经**:
+- 按区域键(GLOBAL/CN)选不同主机 —— **索引的国内镜像免费拿到**;
+- 支持**每区多个服务器的 fallback 列表**(`lookup_resource_servers_` 返回列表);
+- 对候选服务器做**延迟探测选最快**(≤100ms 早退,memoized)。
+
+它现在已经在干的事:分发 xlings **自己的二进制 release**。把索引工件也放进来,就是同构延伸。
+
+### 7.9.2 所以三个"地址"要分清
+
+| 角色 | 是什么 | 状态 |
+| --- | --- | --- |
+| **L0 内容事实源** | `d2learn/xim-pkgindex` 等 git 仓(配方源码、PR/review) | 已存在,**不变** |
+| **工件分发地址** | 把构建好的 `xim-index-<ver>.tar.zst` 发布到的固定位置 | **复用 `xlings-res`**(github + gitcode 双区) |
+| **二进制内的发现锚点** | 编译期写死的 resource-server 表(可被 env/config 覆盖) | `config.cppm:98-103` **已存在** |
+
+### 7.9.3 真正"新建"的极少
+
+- **不需要**:新发现锚点 / 新约定 / 新 CDN 面 —— 锚点、区域化、fallback、延迟探测都已具备。
+- **需要**:在 `xlings-res`(github + gitcode 两边)下,给索引工件开一个**固定的发布位**
+  —— 一个 `xim-index` 仓库或一条 release 轨道,放 `xim-index-<ver>.tar.zst`;
+- **需要**:CI 把构建好的索引工件推到这个发布位(两区同步,gitcode 即 CN 镜像);
+- **需要**:在 `config.cppm` 加一个"索引工件 URL 模板"(基于 resource-server 拼出
+  `{server}/xim-index/.../xim-index-<ver>.tar.zst`),并允许 env 覆盖做镜像/测试。
+
+### 7.9.4 顺带又一个"免费"收益
+
+因为索引工件走 resource-server 路径,它**自动继承**了 `config.cppm` 那套
+"GLOBAL/CN 区域选择 + 多服务器 fallback + 延迟探测"。也就是说:**索引的"固定地址"问题和
+"多镜像/国内镜像/择优"问题,被同一套既有机制一次性解决**——这与 §7.8.2(索引挪到 HTTP 路径顺带
+拿到卡顿看门狗/延迟重排)是同一种"复用既有能力"的红利。
+
+> 一句话:要固定地址,但 xlings 已经有了(`xlings-res` + `config.cppm` 锚点);
+> 新建的只是"在该地址下给索引工件开一个发布位 + CI 推送 + 一个 URL 模板",不是一套新基础设施。
+
+---
+
+## 7.10 已选定方案与实施
+
+**决策(2026-06-22):采用 Y-asset(§7.7),完全覆盖、不考虑老用户。** 索引作为版本化资源工件
+发布到 `xlings-res/xim-index`(GitHub + GitCode),运行时经 resource-server 路径获取。
+具体实施步骤见 **`2026-06-22-index-as-resource-impl-plan.md`**。目标版本 **v0.4.52**。
+X-full(§7.5,指针+签名+CDN)作为未来演进保留余地(manifest 已预留 `format_version`/`signature`)。
+
+---
+
+## 8. 结论
+
+- **要重设计的是"获取与传输范式"(A 轴)**:live git clone → 预构建静态签名 catalog + CDN + 多域内分发面 +
+  已有的延迟探测/续传/卡顿看门狗。这是用户痛点的根治,也是行业一致方向,且在 67 包体量上恰好也是最简方案。
+- **配套补"完整性与可复现"(B 轴)**:minisign 签 catalog + 配方 sha256 全覆盖 + 借 mcpp 的 `xlings.lock`。
+- **明确不做(C 轴大改)**:OCI-registry-as-index、TUF、IPFS、Sigstore(纯 CI 发布前)——对此体量是过度设计,
+  且 OCI/ghcr 对中国用户反而更差。git 留作事实源。
+- **落地**:P0/P1 先止血(纯收益),P2 切范式,P3/P4 收口完整性与可复现。

--- a/.agents/docs/2026-06-22-index-as-resource-impl-plan.md
+++ b/.agents/docs/2026-06-22-index-as-resource-impl-plan.md
@@ -72,8 +72,15 @@ P3 阶段接入,主索引先行。
 | CN 鲁棒性修复(404 穿透 + GLOBAL 兜底) | ✅ `95018d8`(实测 mirror=CN update 成功,112 包) |
 | PR 开启 | ✅ #327 |
 | release.yml 自动发布工件 job | ✅ `c56beff`(guarded,缺 secret 则跳过) |
-| 三平台 CI 全绿 | ⏳ 运行中(HEAD c56beff) |
+| 三平台 CI 全绿 | ✅ HEAD `49efb58`:linux / linux-root / macos / windows 全 pass(`gh pr checks 327`) |
 | 子索引工件化(awesome/scode/d2x) | ⏳ Phase 3(暂 git 同步,已验证可用) |
+
+### CI 修复记录(测试驱动)
+首轮 CI 暴露 linux `E2E-06`(sub_index_search)、macos `E2E-07`(remove_multi_version)失败:
+二者都把 `index_repos` 指到**本地 fixture 路径**,但旧的 auto gate 仍抓取官方工件、覆盖了本地索引。
+修复(`49efb58`):auto 模式仅当主索引是**官方远端 xim-pkgindex** 时才抓工件;本地/自定义源
+(file://、绝对路径、fork URL)一律走原 git/local。本地验证两测试通过、默认配置仍走工件(112 包)。
+最终 CI(reopen 触发的 `49efb58` 全新一轮)四平台全绿。
 
 ### 发现并修复的两个 CN 关键 bug(测试驱动)
 1. `tinyhttps::download_file` 把 HTTP 404 当致命错误、不穿透到下一候选 → GitCode 资产 404

--- a/.agents/docs/2026-06-22-index-as-resource-impl-plan.md
+++ b/.agents/docs/2026-06-22-index-as-resource-impl-plan.md
@@ -68,11 +68,19 @@ P3 阶段接入,主索引先行。
 | 安全 auto gate + 工件化 bundle + 跨平台测试更新 | ✅ `b3d6507` |
 | xlings-res/xim-index 仓库(gh + gtc)创建 | ✅ 两端已建 |
 | 发布 v0.4.52 工件(gh latest+v0.4.52) | ✅ URL 200,实测 `xlings update` 走工件成功(112 包) |
-| 发布 v0.4.52 工件(gtc) | ⚠️ 资产已上传;GitCode 资产下载 URL 平台 quirk → CN 暂经 GitHub+代理回退(鲁棒) |
+| 发布 v0.4.52 工件(gtc) | ⚠️ 资产已上传;GitCode 资产下载 URL 平台 quirk → CN 经 GitHub+代理回退(已实测鲁棒) |
+| CN 鲁棒性修复(404 穿透 + GLOBAL 兜底) | ✅ `95018d8`(实测 mirror=CN update 成功,112 包) |
 | PR 开启 | ✅ #327 |
-| 三平台 CI 全绿 | ⏳ 运行中 |
-| 子索引工件化(awesome/scode/d2x) | ⏳ Phase 3(暂 git 同步) |
-| release.yml 自动发布工件 | ⏳ Phase 3(当前手动已发) |
+| release.yml 自动发布工件 job | ✅ `c56beff`(guarded,缺 secret 则跳过) |
+| 三平台 CI 全绿 | ⏳ 运行中(HEAD c56beff) |
+| 子索引工件化(awesome/scode/d2x) | ⏳ Phase 3(暂 git 同步,已验证可用) |
+
+### 发现并修复的两个 CN 关键 bug(测试驱动)
+1. `tinyhttps::download_file` 把 HTTP 404 当致命错误、不穿透到下一候选 → GitCode 资产 404
+   导致 CN 直接失败、从不尝试 GitHub。修复:`indexfetch` 显式逐候选循环,任何失败(含 404)都穿透。
+2. `Config::resource_servers("CN")` 只返回 GitCode(对二进制包是对的)→ 索引候选里没有 GitHub。
+   修复:`index_asset_urls` 对索引始终追加 GLOBAL/GitHub(+代理)兜底。
+   结果:CN = gitcode(404)→ github(200)→ github 代理。
 
 已验证:全新隔离 HOME `xlings update`(`XLINGS_INDEX_SOURCE=artifact`)从**线上 GitHub 工件**
 拉取主索引,无 `.git`,版本标记 `0.4.52`,112 个包;篡改工件 → sha256 拒绝且保留旧索引。

--- a/.agents/docs/2026-06-22-index-as-resource-impl-plan.md
+++ b/.agents/docs/2026-06-22-index-as-resource-impl-plan.md
@@ -1,0 +1,179 @@
+# Index-as-Resource 实施计划(Y-asset 落地)
+
+> **For agentic workers:** 配合 superpowers:executing-plans 逐任务实现。步骤用 `- [ ]` 跟踪。
+> 设计依据:`2026-06-21-pkgindex-redesign-proposal.md` §7.7–7.9。
+
+**Goal:** 把 xim 包索引从"运行时 git clone GitHub"改为"作为版本化资源工件从 `xlings-res` 下载"
+(Y-asset),`xlings update` 走 HTTP 资源路径(自动获得延迟重排+卡顿看门狗,根治 G2),git 仅作兜底。
+
+**Architecture:** 索引在 CI 构建为 `xim-index-<ver>.tar.gz` + `manifest.json`,发布到
+`xlings-res/xim-index` 的 GitHub Release(`gh`)并镜像到 GitCode(`gtc`)。运行时用既有
+`Config::resource_server()`(GLOBAL/CN + 延迟探测 + fallback)拼出工件 URL,经 tinyhttps 下载、
+校验 sha256、原子解压到 `data/xim-pkgindex`。
+
+**Tech Stack:** C++23 modules(mcpp/gcc16 构建)、tinyhttps、nlohmann::json、bash/gh/gtc、GitHub Actions。
+
+## Global Constraints
+
+- 版本号:`0.4.51` → **`0.4.52`**(`src/core/config.cppm` VERSION + `mcpp.toml` version,二者必须一致)。
+- **不考虑老用户 / 完全覆盖**:无需向后兼容旧 update 行为;但**保留 git 兜底**以保鲁棒性(非破坏)。
+- **为 X-full 留余地**:`manifest.json` 带 `format_version` + 预留 `signature` 字段(现填 null);
+  fetch 路径结构上允许将来加"指针 + ETag/304 + 签名校验"而不重写。
+- 构建验证用隔离 HOME:`export XLINGS_HOME=$(mktemp -d)`、`export MCPP_HOME=$(mktemp -d)`,
+  不得污染真实 `~/.xlings`(见 AGENTS.md)。
+- 本地构建工具链:`xlings use gcc@16.1.0`(避免 glibc/musl 链接错误)。
+- `xlings-res` 可用 `gh`(github)与 `gtc`(gitcode)操作。
+
+---
+
+## 架构总览(顶层设计)
+
+```
+事实源 (不变)            构建/发布 (新)                分发 (复用 xlings-res)        运行时 (改 update)
+─────────────          ──────────────               ────────────────────        ──────────────────
+d2learn/xim-pkgindex   CI: build_index →            xlings-res/xim-index         Config::resource_server()
+  pkgs/*.lua (git)       catalog + tar.gz +           ├ GitHub Release (gh)        → {server}/xim-index/
+  + awesome/scode/d2x    manifest.json (sha256,       └ GitCode  mirror  (gtc)        releases/download/<tag>/
+                         format_version,                                            → tinyhttps 下载+校验
+                         signature:null)                                           → 原子解压 data/xim-pkgindex
+                                                                                   → 失败回退 git (兜底)
+```
+
+**工件契约(format_version=1):**
+```
+xim-index-<ver>.tar.gz        # 内含: pkgs/  .xpkgindex.json  xim-indexrepos.lua  .xlings-index-cache.json
+manifest.json                 # 指针/清单, 与工件同发布, 也内嵌一份于工件
+  { "format_version": 1,
+    "index_version": "0.4.52",          # 现用 release ver; 未来可换单调整数
+    "generated_at": "<iso8601>",
+    "source_commit": "<xim-pkgindex sha>",
+    "artifact": { "name": "xim-index-0.4.52.tar.gz", "sha256": "...", "size": 123 },
+    "signature": null }                 # 预留: 未来 minisign
+```
+
+**子索引(awesome/scode/d2x):** 同构,各发 `xim-index-<name>-<ver>.tar.gz` + 各自 manifest;
+P3 阶段接入,主索引先行。
+
+---
+
+## 阶段与任务
+
+### Phase 0 — 版本与文档基线
+
+#### Task 0.1: 版本号 bump + 计划文档落库
+**Files:** Modify `src/core/config.cppm:16`、`mcpp.toml:3`;Add 本计划 + 两份设计文档(已存在,纳入提交)
+- [ ] 改 `VERSION = "0.4.51"` → `"0.4.52"`(config.cppm:16)
+- [ ] 改 `version = "0.4.51"` → `"0.4.52"`(mcpp.toml:3)
+- [ ] `git add .agents/docs/2026-06-21-*.md .agents/docs/2026-06-22-*.md src/core/config.cppm mcpp.toml`
+- [ ] commit: `chore(release): bump 0.4.52 + index-as-resource design/plan`
+
+---
+
+### Phase 1 — 发布管线(构建 + 发布工件)
+
+#### Task 1.1: 索引工件构建脚本
+**Files:** Create `tools/build_xim_index_artifact.sh`;Test `tests/e2e/build_xim_index_artifact_test.sh`
+- 输入:已 clone 的 xim-pkgindex 目录 + 版本号;输出:`xim-index-<ver>.tar.gz` + `manifest.json`。
+- 复用现有 `package_xim_index.sh` 的 clone 逻辑;新增:剥离 `.git`、用 xlings 生成
+  `.xlings-index-cache.json`(`xlings` 已有 build_index;或保留运行时首次生成)、算 sha256/size、写 manifest。
+- [ ] 写脚本:clone(GLOBAL/CN 由 `XLINGS_RELEASE_MIRROR`)→ 去 `.git` → tar.gz → sha256 → 写 manifest.json(format_version=1, signature:null)
+- [ ] 写 e2e:跑脚本,断言产出 tar.gz + manifest.json、manifest.sha256 与文件实际 sha256 一致、tar 内含 `pkgs/`
+- [ ] 跑 e2e 验证通过
+- [ ] commit: `feat(release): build xim-index artifact + manifest`
+
+#### Task 1.2: 发布到 xlings-res(gh + gtc)脚本
+**Files:** Create `tools/publish_xim_index.sh`
+- 用 `gh release create/upload` 推到 `xlings-res/xim-index`(github);用 `gtc release create/upload` 推到 gitcode 镜像。
+- tag = `v<ver>`;额外维护一个 `latest` 资产(manifest 复制为 `xim-index-latest.json` 作指针)。
+- [ ] 写脚本(幂等:release 已存在则只 upload --clobber)
+- [ ] 干跑校验参数(不真正发布):`--dry-run` 分支打印将执行的 gh/gtc 命令
+- [ ] commit: `feat(release): publish xim-index to xlings-res (gh+gtc)`
+
+#### Task 1.3: 创建 xlings-res/xim-index 仓库(两端)
+**(运维步骤,执行期做)**
+- [ ] `gh repo create xlings-res/xim-index --public -d "xim package index artifacts for xlings"`
+- [ ] `gtc repo create xim-index`(gitcode `xlings-res`)
+- [ ] 记录两端 URL,确认与 `config.cppm` resource server 基址一致
+
+---
+
+### Phase 2 — 运行时:索引作为资源获取
+
+#### Task 2.1: manifest 解析 + 工件 URL 构建(纯逻辑,可单测)
+**Files:** Create `src/core/xim/indexfetch.cppm`;Test `tests/unit/test_indexfetch.cpp`
+- **Produces:**
+  - `struct IndexManifest { int format_version; std::string index_version, generated_at, source_commit; std::string artifact_name, artifact_sha256; std::size_t artifact_size; };`
+  - `std::optional<IndexManifest> parse_manifest(std::string_view json);`
+  - `std::vector<std::string> artifact_urls(std::string_view name, std::string_view mirror);`  // 基于 Config::resource_servers()
+- [ ] 写单测:parse 合法 manifest;拒绝缺字段;`artifact_urls` 对 GLOBAL/CN 各拼出正确 `{server}/xim-index/releases/download/v<ver>/<name>`
+- [ ] 跑测试看失败(未实现)
+- [ ] 实现 `parse_manifest`(nlohmann::json,容错)+ `artifact_urls`(调 `Config::resource_servers(mirror)`)
+- [ ] 跑测试通过
+- [ ] commit: `feat(xim): index manifest parse + artifact url build`
+
+#### Task 2.2: 下载 + 校验 + 原子解压
+**Files:** Modify `src/core/xim/indexfetch.cppm`;Modify `src/core/xim/repo.cppm`
+- **Produces:** `bool fetch_index_artifact(const std::filesystem::path& destIndexDir, std::string& err);`
+  - 取 manifest(`xim-index-latest.json`,经 tinyhttps + mirror::expand + adaptive::reorder)→ parse
+  - 下载 `artifact.name` 候选 URL(tinyhttps:续传+卡顿看门狗+逐候选)→ 校验 sha256 == manifest
+  - 解压到 `destIndexDir.tmp` → 校验含 `pkgs/` → 原子 rename 覆盖 → 写 `.xlings-index-version`(记 index_version)
+  - 任一步失败:清理 tmp,返回 false(由调用方决定是否 git 兜底)
+- [ ] 实现 `fetch_index_artifact`(复用 tinyhttps download_file + libarchive 解压)
+- [ ] commit: `feat(xim): fetch+verify+atomic-extract index artifact`
+
+#### Task 2.3: 接入 update / install 路径(artifact 优先,git 兜底)
+**Files:** Modify `src/core/xim/repo.cppm`(`sync_all_repos`)、`src/core/xim/commands.cppm`(cmd_update:919)
+- `sync_all_repos(force)`:先 `fetch_index_artifact()`;成功即跳过 git;失败且未禁用则回退现有 git 同步。
+- env 开关 `XLINGS_INDEX_SOURCE=artifact|git|auto`(默认 auto=先 artifact 后 git),`XLINGS_INDEX_ARTIFACT_URL` 覆盖(测试/镜像)。
+- [ ] 改 `sync_all_repos` 加 artifact-first 分支 + env 开关
+- [ ] commit: `feat(xim): index update via artifact, git fallback`
+
+#### Task 2.4: e2e — 工件更新闭环(mock server)
+**Files:** Create `tests/e2e/index_artifact_update_test.sh`
+- 用 python http.server 起 mock 资源服务器,放 manifest + tar.gz;`XLINGS_INDEX_ARTIFACT_URL` 指向它;
+  跑 `xlings update`;断言 `data/xim-pkgindex/pkgs` 出现且 sha256 校验生效(篡改→失败回退)。
+- [ ] 写 e2e
+- [ ] 跑通(隔离 HOME)
+- [ ] commit: `test(e2e): index artifact update happy + tamper path`
+
+---
+
+### Phase 3 — 子索引 + 发布集成 + CI
+
+#### Task 3.1: 子索引(awesome/scode/d2x)工件化
+- [ ] `build_xim_index_artifact.sh` 支持 `--name <sub>`;`publish_xim_index.sh` 发各子工件
+- [ ] 运行时 `discover_sub_repos` 改为优先取子工件(同 2.2 逻辑),git 兜底
+- [ ] commit: `feat(xim): sub-index artifacts (awesome/scode/d2x)`
+
+#### Task 3.2: release.yml 集成 + 新工件发布 job
+**Files:** Modify `.github/workflows/release.yml`;可能 Add `.github/workflows/publish-index.yml`(在 xim-pkgindex 仓)
+- 在 create-release 后新增 job:跑 `build_xim_index_artifact.sh` + `publish_xim_index.sh`(用 secrets 的 gh/gtc token)。
+- 或在 xim-pkgindex 仓加独立 workflow(解耦新鲜度)。先在 xlings release 内集成(简单),X-full 再拆。
+- [ ] 加 publish job + 所需 secrets(`GITCODE_TOKEN`)
+- [ ] commit: `ci(release): build+publish xim-index artifact`
+
+#### Task 3.3: 全 CI 绿
+- [ ] push 分支,触发 `xlings-ci-linux/macos/windows/archlinux/linux-root`
+- [ ] 逐平台修复编译/测试失败(C++23 模块、e2e)
+- [ ] 全绿后开 PR
+
+---
+
+### Phase 4 — PR + 生态验证 + 汇报
+
+#### Task 4.1: 开 PR(版本号)
+- [ ] `gh pr create` 标题含 `v0.4.52`;正文链三份设计/计划文档 + 验收清单
+#### Task 4.2: 触发 release(workflow_dispatch)发 0.4.52 + 首个 xim-index 工件
+- [ ] 确认 `xlings-res/xim-index` 两端有 `v0.4.52` 工件 + manifest
+#### Task 4.3: 端到端生态验证
+- [ ] 全新环境 `quick_install.sh` 装 0.4.52 → `xlings update`(走 artifact)→ `xlings install <pkg>` 成功
+- [ ] CN 路径(gitcode)同样验证
+#### Task 4.4: 综合汇报(更新本计划完成态 + 总结)
+
+---
+
+## Self-Review 检查
+- 覆盖:发布(P1)、运行时(P2)、子索引(P3.1)、CI(P3)、PR/生态(P4)、版本(P0) —— 对齐 §7.6 清单 B/C/D + E。
+- 留余地:manifest `format_version`/`signature` 预留;fetch 经 manifest 间接寻址,未来可加 ETag/304/签名。
+- 鲁棒性:sha256 校验 + 原子 rename + git 兜底 + env 逃生开关。
+- 风险:C++23 模块跨平台编译(最大不确定性,P3.3 迭代);gtc token 在 CI 的可用性(P3.2 需配 secret)。

--- a/.agents/docs/2026-06-22-index-as-resource-impl-plan.md
+++ b/.agents/docs/2026-06-22-index-as-resource-impl-plan.md
@@ -73,7 +73,8 @@ P3 阶段接入,主索引先行。
 | PR 开启 | ✅ #327 |
 | release.yml 自动发布工件 job | ✅ `c56beff`(guarded,缺 secret 则跳过) |
 | 三平台 CI 全绿 | ✅ HEAD `49efb58`:linux / linux-root / macos / windows 全 pass(`gh pr checks 327`) |
-| 子索引工件化(awesome/scode/d2x) | ⏳ Phase 3(暂 git 同步,已验证可用) |
+| 子索引工件化(awesome/scode/d2x) | ✅ 默认子索引走工件(已发布 gh+gtc;实测 update 全工件);用户额外添加的仍走 git |
+| GitCode CI 发布(gtc + GITCODE_TOKEN) | ✅ 已 vendored `tools/gtc`;release.yml 用 GITCODE_TOKEN 自动发布 |
 
 ### CI 修复记录(测试驱动)
 首轮 CI 暴露 linux `E2E-06`(sub_index_search)、macos `E2E-07`(remove_multi_version)失败:

--- a/.agents/docs/2026-06-22-index-as-resource-impl-plan.md
+++ b/.agents/docs/2026-06-22-index-as-resource-impl-plan.md
@@ -56,6 +56,27 @@ P3 阶段接入,主索引先行。
 
 ---
 
+## 实施进度 (live)
+
+> 更新于 2026-06-22。PR: https://github.com/openxlings/xlings/pull/327 (v0.4.52)
+
+| 项 | 状态 |
+| --- | --- |
+| P0 版本 bump 0.4.52 + 文档 | ✅ `f5bb919` |
+| P1 build/publish 脚本 + e2e | ✅ `dd61189`(本地全绿) |
+| P2 运行时 indexfetch + sync 接入 + 单测/e2e | ✅ `6a29167`(本地 e2e 绿) |
+| 安全 auto gate + 工件化 bundle + 跨平台测试更新 | ✅ `b3d6507` |
+| xlings-res/xim-index 仓库(gh + gtc)创建 | ✅ 两端已建 |
+| 发布 v0.4.52 工件(gh latest+v0.4.52) | ✅ URL 200,实测 `xlings update` 走工件成功(112 包) |
+| 发布 v0.4.52 工件(gtc) | ⚠️ 资产已上传;GitCode 资产下载 URL 平台 quirk → CN 暂经 GitHub+代理回退(鲁棒) |
+| PR 开启 | ✅ #327 |
+| 三平台 CI 全绿 | ⏳ 运行中 |
+| 子索引工件化(awesome/scode/d2x) | ⏳ Phase 3(暂 git 同步) |
+| release.yml 自动发布工件 | ⏳ Phase 3(当前手动已发) |
+
+已验证:全新隔离 HOME `xlings update`(`XLINGS_INDEX_SOURCE=artifact`)从**线上 GitHub 工件**
+拉取主索引,无 `.git`,版本标记 `0.4.52`,112 个包;篡改工件 → sha256 拒绝且保留旧索引。
+
 ## 阶段与任务
 
 ### Phase 0 — 版本与文档基线

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,25 +304,42 @@ jobs:
             echo "version=$VER" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build index artifact
+      - name: Build index artifacts (main + default sub-indexes)
         run: |
           mkdir -p build/index
+          VER="${{ steps.version.outputs.version }}"
+          # main index
           XLINGS_RELEASE_MIRROR=GLOBAL bash tools/build_xim_index_artifact.sh \
-            --version "${{ steps.version.outputs.version }}" --out build/index
+            --version "$VER" --out build/index
+          # default sub-indexes (URLs mirror the main index's xim-indexrepos.lua)
+          XLINGS_RELEASE_PKGINDEX_URL=https://github.com/openxlings/xim-pkgindex-awesome.git \
+            bash tools/build_xim_index_artifact.sh --name awesome --version "$VER" --out build/index
+          XLINGS_RELEASE_PKGINDEX_URL=https://github.com/openxlings/xim-pkgindex-scode.git \
+            bash tools/build_xim_index_artifact.sh --name scode --version "$VER" --out build/index
+          XLINGS_RELEASE_PKGINDEX_URL=https://github.com/d2learn/xim-pkgindex-d2x.git \
+            bash tools/build_xim_index_artifact.sh --name d2x --version "$VER" --out build/index
 
       - name: Publish to GitHub (xlings-res/xim-index)
         if: ${{ env.XLINGS_RES_TOKEN != '' }}
         env:
           GH_TOKEN: ${{ secrets.XLINGS_RES_TOKEN }}
         run: |
-          bash tools/publish_xim_index.sh --version "${{ steps.version.outputs.version }}" \
-            --dir build/index --skip-gitcode
+          VER="${{ steps.version.outputs.version }}"
+          bash tools/publish_xim_index.sh --version "$VER" --dir build/index --skip-gitcode
+          for n in awesome scode d2x; do
+            bash tools/publish_xim_index.sh --version "$VER" --name "$n" --dir build/index --skip-gitcode
+          done
 
-      # GitCode publish needs the `gtc` CLI (not bundled in CI); skipped unless
-      # present. The CN artifact can be published manually with tools/publish_xim_index.sh.
+      # GitCode publish uses the vendored tools/gtc + GITCODE_TOKEN. Non-blocking.
       - name: Publish to GitCode (xlings-res/xim-index)
         if: ${{ env.GITCODE_TOKEN != '' }}
         run: |
-          command -v gtc >/dev/null 2>&1 || { echo "gtc unavailable in CI; skipping gitcode publish"; exit 0; }
-          bash tools/publish_xim_index.sh --version "${{ steps.version.outputs.version }}" \
-            --dir build/index --skip-github || echo "gitcode publish failed (non-blocking)"
+          chmod +x tools/gtc
+          export PATH="$PWD/tools:$PATH"
+          VER="${{ steps.version.outputs.version }}"
+          bash tools/publish_xim_index.sh --version "$VER" --dir build/index --skip-github \
+            || echo "gitcode main publish failed (non-blocking)"
+          for n in awesome scode d2x; do
+            bash tools/publish_xim_index.sh --version "$VER" --name "$n" --dir build/index --skip-github \
+              || echo "gitcode $n publish failed (non-blocking)"
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,3 +278,51 @@ jobs:
             artifacts/xlings-windows-x86_64/xlings-*-windows-x86_64.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Build + publish the xim package index as a versioned resource artifact
+  # (Y-asset) to xlings-res/xim-index on GitHub (+ GitCode). Best-effort: each
+  # target is skipped when its token secret is absent, and the job never blocks
+  # the release. See .agents/docs/2026-06-22-index-as-resource-impl-plan.md.
+  publish-index:
+    needs: [create-release]
+    runs-on: ubuntu-latest
+    # secrets aren't available in step if: — surface them as env, gate on env.
+    env:
+      XLINGS_RES_TOKEN: ${{ secrets.XLINGS_RES_TOKEN }}
+      GITCODE_TOKEN: ${{ secrets.GITCODE_TOKEN }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Determine version
+        id: version
+        run: |
+          if [[ -n "${{ inputs.version }}" ]]; then
+            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            VER=$(sed -n 's/.*VERSION = "\([^"]*\)".*/\1/p' src/core/config.cppm | head -1)
+            echo "version=$VER" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build index artifact
+        run: |
+          mkdir -p build/index
+          XLINGS_RELEASE_MIRROR=GLOBAL bash tools/build_xim_index_artifact.sh \
+            --version "${{ steps.version.outputs.version }}" --out build/index
+
+      - name: Publish to GitHub (xlings-res/xim-index)
+        if: ${{ env.XLINGS_RES_TOKEN != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.XLINGS_RES_TOKEN }}
+        run: |
+          bash tools/publish_xim_index.sh --version "${{ steps.version.outputs.version }}" \
+            --dir build/index --skip-gitcode
+
+      # GitCode publish needs the `gtc` CLI (not bundled in CI); skipped unless
+      # present. The CN artifact can be published manually with tools/publish_xim_index.sh.
+      - name: Publish to GitCode (xlings-res/xim-index)
+        if: ${{ env.GITCODE_TOKEN != '' }}
+        run: |
+          command -v gtc >/dev/null 2>&1 || { echo "gtc unavailable in CI; skipping gitcode publish"; exit 0; }
+          bash tools/publish_xim_index.sh --version "${{ steps.version.outputs.version }}" \
+            --dir build/index --skip-github || echo "gitcode publish failed (non-blocking)"

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlings"
-version = "0.4.51"
+version = "0.4.52"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.51";
+    static constexpr std::string_view VERSION = "0.4.52";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/xim/indexfetch.cppm
+++ b/src/core/xim/indexfetch.cppm
@@ -1,0 +1,290 @@
+export module xlings.core.xim.indexfetch;
+
+// Index-as-Resource fetch (Y-asset; see
+// .agents/docs/2026-06-22-index-as-resource-impl-plan.md).
+//
+// Instead of `git clone`-ing the package index from GitHub at runtime, fetch a
+// versioned index *artifact* (tar.gz + manifest.json) published to xlings-res
+// over the SAME resource-server path that package binaries use. This routes
+// index acquisition through the in-process HTTP downloader, which already has
+// the 0.4.49 adaptive mirror reorder + stall watchdog — closing gap G2 (the
+// git-clone path never got that resilience).
+//
+// Trust/discovery anchor: a fixed rolling release tag ("latest") under the
+// xim-index repo on each resource server. The pointer asset
+// (xim-index[-<name>]-latest.json) is the entry point; it names the artifact +
+// its sha256. The fetch verifies sha256 against the manifest, extracts to a
+// temp dir, then atomically renames into place. git clone remains the caller's
+// fallback.
+//
+// Left room for the future X-full upgrade (manifest carries format_version +
+// signature; fetch is structured so a signed pointer / ETag-304 can slot in
+// without a rewrite).
+
+import std;
+import xlings.libs.json;
+import xlings.libs.tinyhttps;
+import xlings.libs.sha256;
+import xlings.core.log;
+import xlings.core.config;
+import xlings.core.mirror;
+import xlings.platform;
+import xlings.core.xim.extract;
+
+export namespace xlings::xim {
+
+struct IndexManifest {
+    int           format_version = 0;
+    std::string   index_version;
+    std::string   index_name;        // "xim" for the main index, else sub name
+    std::string   generated_at;
+    std::string   source_commit;
+    std::string   artifact_name;     // e.g. xim-index-0.4.52.tar.gz
+    std::string   artifact_sha256;   // lowercase hex
+    std::uint64_t artifact_size = 0;
+};
+
+// Parse a manifest JSON. Returns nullopt if required fields are missing/invalid.
+std::optional<IndexManifest> parse_index_manifest(std::string_view jsonText);
+
+// Build candidate download URLs for an asset filename under the xim-index repo
+// on every configured resource server (selected/latency-probed server first),
+// then GitHub proxy variants. `mirror` selects region (empty => Config default).
+std::vector<std::string> index_asset_urls(std::string_view filename,
+                                          std::string_view mirror = {});
+
+// Fetch the latest index artifact for `subName` ("" = main index) and atomically
+// install it into destIndexDir. Returns true on success; on failure `err` is set
+// and destIndexDir is left untouched (caller may fall back to git).
+bool fetch_index_artifact(const std::filesystem::path& destIndexDir,
+                          std::string& err,
+                          std::string_view subName = {});
+
+} // namespace xlings::xim
+
+
+namespace xlings::xim {
+
+namespace detail_ {
+
+// Repo + tag are fixed discovery anchors; overridable for testing/mirrors.
+std::string index_repo_name_() {
+    if (auto* e = std::getenv("XLINGS_INDEX_REPO"); e && *e) return e;
+    return "xim-index";
+}
+std::string index_tag_() {
+    if (auto* e = std::getenv("XLINGS_INDEX_TAG"); e && *e) return e;
+    return "latest";
+}
+
+std::string lower_hex_(std::string s) {
+    for (auto& c : s) c = static_cast<char>(std::tolower((unsigned char)c));
+    return s;
+}
+
+// Download the first working candidate URL into destFile. When wantSha256 is
+// non-empty, each candidate is accepted only if its bytes hash to it (the next
+// candidate is tried otherwise). Returns empty string on success, else error.
+std::string download_candidates_(std::vector<std::string> urls,
+                                 const std::filesystem::path& destFile,
+                                 std::string_view wantSha256) {
+    if (urls.empty()) return "no candidate URLs";
+    // With a pinned sha256, mirrors may race ahead of the authoritative URL;
+    // without one (the manifest pointer), keep the authoritative server first.
+    urls = mirror::adaptive::reorder(std::move(urls), !wantSha256.empty());
+
+    tinyhttps::DownloadOptions opts;
+    opts.destFile = destFile;
+    opts.urls = std::move(urls);
+    opts.onUrlAttemptFailed = [](const std::string& u, const std::string& e) {
+        if (e.rfind("stalled:", 0) == 0 || e.rfind("sha256 mismatch", 0) == 0)
+            mirror::adaptive::penalize_host(u);
+    };
+    if (!wantSha256.empty()) {
+        auto want = lower_hex_(std::string(wantSha256));
+        opts.onVerify = [destFile, want](const std::string& u) -> std::string {
+            auto digest = sha256::hex_file(destFile);
+            if (digest && *digest == want) return {};
+            return std::format("sha256 mismatch (source {}): got {}, want {}",
+                               u, digest ? *digest : "<unreadable>", want);
+        };
+    }
+    auto r = tinyhttps::download_file(opts);
+    if (r.success) return {};
+    return r.error.empty() ? "download failed" : r.error;
+}
+
+} // namespace detail_
+
+std::optional<IndexManifest> parse_index_manifest(std::string_view jsonText) {
+    try {
+        auto j = nlohmann::json::parse(jsonText);
+        if (!j.is_object() || !j.contains("artifact") || !j["artifact"].is_object())
+            return std::nullopt;
+        auto& art = j["artifact"];
+        if (!art.contains("name") || !art.contains("sha256")) return std::nullopt;
+
+        IndexManifest m;
+        m.format_version  = j.value("format_version", 0);
+        m.index_version   = j.value("index_version", std::string{});
+        m.index_name      = j.value("index_name", std::string{"xim"});
+        m.generated_at    = j.value("generated_at", std::string{});
+        m.source_commit   = j.value("source_commit", std::string{});
+        m.artifact_name   = art.value("name", std::string{});
+        m.artifact_sha256 = detail_::lower_hex_(art.value("sha256", std::string{}));
+        m.artifact_size   = art.value("size", std::uint64_t{0});
+        if (m.artifact_name.empty() || m.artifact_sha256.empty()) return std::nullopt;
+        return m;
+    } catch (...) {
+        return std::nullopt;
+    }
+}
+
+std::vector<std::string> index_asset_urls(std::string_view filename,
+                                          std::string_view mirror) {
+    std::vector<std::string> urls;
+    auto add = [&](const std::string& u) {
+        if (!u.empty() && std::ranges::find(urls, u) == urls.end()) urls.push_back(u);
+    };
+
+    auto repo = detail_::index_repo_name_();
+    auto tag  = detail_::index_tag_();
+
+    // Selected (latency-probed) server first, then all other candidates.
+    auto selected = Config::resource_server(mirror);
+    auto buildFor = [&](const std::string& server) {
+        return std::format("{}/{}/releases/download/{}/{}", server, repo, tag, filename);
+    };
+    if (!selected.empty()) add(buildFor(selected));
+    for (auto& server : Config::resource_servers(mirror)) add(buildFor(server));
+
+    // GitHub proxy variants (ghfast/ghproxy/...) for the github-hosted URLs.
+    std::vector<std::string> expanded;
+    for (auto& u : urls) {
+        for (auto& m : mirror::expand(u, {.type = mirror::ResourceType::Release}))
+            expanded.push_back(std::move(m));
+    }
+    for (auto& u : expanded) add(u);
+    return urls;
+}
+
+bool fetch_index_artifact(const std::filesystem::path& destIndexDir,
+                          std::string& err,
+                          std::string_view subName) {
+    namespace fs = std::filesystem;
+    auto mirrorKey = Config::mirror();
+
+    std::string base = subName.empty()
+        ? "xim-index"
+        : std::format("xim-index-{}", subName);
+    std::string pointerName = base + "-latest.json";
+
+    std::error_code ec;
+    auto tmpRoot = fs::path(destIndexDir.string() + ".artifact." +
+                            std::to_string(platform::get_pid()));
+    fs::remove_all(tmpRoot, ec);
+    fs::create_directories(tmpRoot, ec);
+    if (ec) { err = std::format("create temp dir failed: {}", ec.message()); return false; }
+    struct Cleanup { fs::path p; ~Cleanup(){ std::error_code e; fs::remove_all(p,e);} } cleanup{tmpRoot};
+
+    // Optional base override (testing / private mirror / offline bundle): a
+    // local directory (plain path or file://) is copied directly — this is also
+    // the offline/bundled-release path — while a remote base goes over HTTP.
+    // No override => the resource-server release URLs (index_asset_urls).
+    std::string baseOverride;
+    std::optional<fs::path> localBase;
+    if (auto* ov = std::getenv("XLINGS_INDEX_BASE_URL"); ov && *ov) {
+        baseOverride = ov;
+        while (!baseOverride.empty() && baseOverride.back() == '/') baseOverride.pop_back();
+        std::string p = baseOverride;
+        if (p.starts_with("file://")) localBase = fs::path(p.substr(7));
+        else if (p.find("://") == std::string::npos) localBase = fs::path(p);
+    }
+    auto obtain = [&](const std::string& filename, const fs::path& dest,
+                      std::string_view wantSha) -> std::string {
+        if (localBase) {
+            std::error_code ec2;
+            auto src = *localBase / filename;
+            if (!fs::exists(src, ec2)) return std::format("local file not found: {}", src.string());
+            fs::copy_file(src, dest, fs::copy_options::overwrite_existing, ec2);
+            if (ec2) return std::format("copy {} failed: {}", src.string(), ec2.message());
+            if (!wantSha.empty()) {
+                auto digest = sha256::hex_file(dest);
+                auto want = detail_::lower_hex_(std::string(wantSha));
+                if (!digest || *digest != want)
+                    return std::format("sha256 mismatch (local {}): got {}, want {}",
+                                       src.string(), digest ? *digest : "<unreadable>", want);
+            }
+            return {};
+        }
+        auto urls = baseOverride.empty()
+            ? index_asset_urls(filename, mirrorKey)
+            : std::vector<std::string>{ baseOverride + "/" + filename };
+        return detail_::download_candidates_(std::move(urls), dest, wantSha);
+    };
+
+    // 1. Manifest pointer.
+    auto manifestFile = tmpRoot / pointerName;
+    if (auto e = obtain(pointerName, manifestFile, {}); !e.empty()) {
+        err = std::format("fetch index manifest failed: {}", e);
+        return false;
+    }
+
+    std::string manifestText;
+    {
+        std::ifstream in(manifestFile, std::ios::binary);
+        std::stringstream ss; ss << in.rdbuf(); manifestText = ss.str();
+    }
+    auto manifest = parse_index_manifest(manifestText);
+    if (!manifest) { err = "index manifest parse failed"; return false; }
+    if (manifest->format_version != 1) {
+        err = std::format("unsupported index manifest format_version {}", manifest->format_version);
+        return false;
+    }
+
+    // 2. Artifact (sha256-pinned by the manifest).
+    auto artifactFile = tmpRoot / manifest->artifact_name;
+    if (auto e = obtain(manifest->artifact_name, artifactFile, manifest->artifact_sha256); !e.empty()) {
+        err = std::format("fetch index artifact failed: {}", e);
+        return false;
+    }
+
+    // 3. Extract to a staging dir, sanity-check, atomically swap into place.
+    auto stage = tmpRoot / "stage";
+    auto extracted = extract_archive(artifactFile, stage);
+    if (!extracted) { err = std::format("extract index artifact failed: {}", extracted.error()); return false; }
+    if (!fs::exists(stage / "pkgs", ec)) {
+        err = "extracted index missing pkgs/";
+        return false;
+    }
+
+    // Record the installed version for diagnostics / future ETag-style checks.
+    {
+        std::ofstream v(stage / ".xlings-index-version", std::ios::binary);
+        v << manifest->index_version;
+    }
+
+    auto backup = fs::path(destIndexDir.string() + ".old." +
+                           std::to_string(platform::get_pid()));
+    fs::remove_all(backup, ec);
+    if (fs::exists(destIndexDir, ec)) {
+        fs::rename(destIndexDir, backup, ec);
+        if (ec) { err = std::format("swap (move old) failed: {}", ec.message()); return false; }
+    }
+    fs::rename(stage, destIndexDir, ec);
+    if (ec) {
+        // Roll back to the old tree if the swap-in failed.
+        std::error_code e2;
+        if (fs::exists(backup, e2)) fs::rename(backup, destIndexDir, e2);
+        err = std::format("swap (move new) failed: {}", ec.message());
+        return false;
+    }
+    fs::remove_all(backup, ec);
+
+    log::info("[index] updated from artifact {} ({})",
+              manifest->artifact_name,
+              manifest->index_version.empty() ? "?" : manifest->index_version);
+    return true;
+}
+
+} // namespace xlings::xim

--- a/src/core/xim/indexfetch.cppm
+++ b/src/core/xim/indexfetch.cppm
@@ -82,9 +82,13 @@ std::string lower_hex_(std::string s) {
     return s;
 }
 
-// Download the first working candidate URL into destFile. When wantSha256 is
-// non-empty, each candidate is accepted only if its bytes hash to it (the next
-// candidate is tried otherwise). Returns empty string on success, else error.
+// Download the first working candidate URL into destFile, trying each candidate
+// explicitly and continuing past ANY failure — including HTTP 404. This differs
+// from tinyhttps::download_file's internal candidate loop, which treats 404 as a
+// definitive not-found and stops (correct for a single authoritative asset, but
+// wrong for index mirrors: one server 404ing must fall through to the next, e.g.
+// gitcode 404 -> github). When wantSha256 is set, a candidate is accepted only
+// if its bytes match. Returns empty string on success, else the last error.
 std::string download_candidates_(std::vector<std::string> urls,
                                  const std::filesystem::path& destFile,
                                  std::string_view wantSha256) {
@@ -93,25 +97,31 @@ std::string download_candidates_(std::vector<std::string> urls,
     // without one (the manifest pointer), keep the authoritative server first.
     urls = mirror::adaptive::reorder(std::move(urls), !wantSha256.empty());
 
-    tinyhttps::DownloadOptions opts;
-    opts.destFile = destFile;
-    opts.urls = std::move(urls);
-    opts.onUrlAttemptFailed = [](const std::string& u, const std::string& e) {
-        if (e.rfind("stalled:", 0) == 0 || e.rfind("sha256 mismatch", 0) == 0)
-            mirror::adaptive::penalize_host(u);
-    };
-    if (!wantSha256.empty()) {
-        auto want = lower_hex_(std::string(wantSha256));
-        opts.onVerify = [destFile, want](const std::string& u) -> std::string {
-            auto digest = sha256::hex_file(destFile);
-            if (digest && *digest == want) return {};
-            return std::format("sha256 mismatch (source {}): got {}, want {}",
-                               u, digest ? *digest : "<unreadable>", want);
+    std::string want = wantSha256.empty() ? std::string{} : lower_hex_(std::string(wantSha256));
+    std::string lastErr;
+    for (const auto& u : urls) {
+        tinyhttps::DownloadOptions opts;
+        opts.destFile = destFile;
+        opts.urls = { u };          // one URL per call: we own the fallthrough
+        opts.retryCount = 1;        // breadth over depth; don't hammer a 404
+        opts.onUrlAttemptFailed = [](const std::string& url, const std::string& e) {
+            if (e.rfind("stalled:", 0) == 0 || e.rfind("sha256 mismatch", 0) == 0)
+                mirror::adaptive::penalize_host(url);
         };
+        if (!want.empty()) {
+            opts.onVerify = [destFile, want](const std::string& url) -> std::string {
+                auto digest = sha256::hex_file(destFile);
+                if (digest && *digest == want) return {};
+                return std::format("sha256 mismatch (source {}): got {}, want {}",
+                                   url, digest ? *digest : "<unreadable>", want);
+            };
+        }
+        auto r = tinyhttps::download_file(opts);
+        if (r.success) return {};
+        lastErr = r.error.empty() ? ("failed: " + u) : r.error;
+        log::debug("[index] candidate failed ({}): {}", u, lastErr);
     }
-    auto r = tinyhttps::download_file(opts);
-    if (r.success) return {};
-    return r.error.empty() ? "download failed" : r.error;
+    return lastErr.empty() ? "all candidates failed" : lastErr;
 }
 
 } // namespace detail_
@@ -157,6 +167,12 @@ std::vector<std::string> index_asset_urls(std::string_view filename,
     };
     if (!selected.empty()) add(buildFor(selected));
     for (auto& server : Config::resource_servers(mirror)) add(buildFor(server));
+    // Always include GLOBAL (github) servers as fallback for the index — even
+    // under CN. Unlike package binaries (where the regional mirror is
+    // authoritative), the index must stay reachable if the regional mirror
+    // lacks the asset; combined with 404-fallthrough this gives CN: gitcode ->
+    // github -> github proxies.
+    for (auto& server : Config::resource_servers("GLOBAL")) add(buildFor(server));
 
     // GitHub proxy variants (ghfast/ghproxy/...) for the github-hosted URLs.
     std::vector<std::string> expanded;

--- a/src/core/xim/repo.cppm
+++ b/src/core/xim/repo.cppm
@@ -362,13 +362,27 @@ bool sync_all_repos(bool force = false) {
 
     bool mainArtifactManaged = fs::exists(mainDir / ".xlings-index-version");
     bool mainHasIndex = fs::exists(mainDir / "pkgs");
-    // auto (default): fetch the artifact only when the index is fresh (missing)
-    // or already artifact-managed. An existing *git* index (e.g. a test fixture
-    // or a legacy checkout) keeps using git, so git-based e2e tests are
-    // unaffected. XLINGS_INDEX_SOURCE=artifact forces the artifact path;
-    // =git disables it entirely.
-    bool attemptArtifact = (indexSource == "artifact")
-        || (indexSource != "git" && (mainArtifactManaged || !mainHasIndex));
+
+    // The artifact is the OFFICIAL xim index. In auto mode it applies ONLY when
+    // the configured main index is the official index from a *remote* source —
+    // never when the user points index_repos at a local path (file://, abs
+    // path: test fixtures, project-local indexes) or a custom fork URL, which
+    // must be managed by their own source (git/local).
+    auto globalRepos = Config::global_index_repos();
+    bool mainIsOfficialRemote =
+        !globalRepos.empty()
+        && !Config::is_local_repo_source(globalRepos.front(), false)
+        && (globalRepos.front().url.find("openxlings/xim-pkgindex") != std::string::npos
+            || globalRepos.front().url.find("sunrisepeak/xim-pkgindex") != std::string::npos);
+
+    // auto: official-remote + (fresh or already artifact-managed). An existing
+    // git index keeps using git, so git-based e2e fixtures are unaffected.
+    // XLINGS_INDEX_SOURCE=artifact forces it (power user / tests); =git disables.
+    bool attemptArtifact;
+    if (indexSource == "artifact")   attemptArtifact = true;
+    else if (indexSource == "git")   attemptArtifact = false;
+    else attemptArtifact = mainIsOfficialRemote && (mainArtifactManaged || !mainHasIndex);
+
     if (attemptArtifact) {
         std::string ferr;
         if (fetch_index_artifact(mainDir, ferr)) {

--- a/src/core/xim/repo.cppm
+++ b/src/core/xim/repo.cppm
@@ -361,7 +361,15 @@ bool sync_all_repos(bool force = false) {
     if (auto* e = std::getenv("XLINGS_INDEX_SOURCE"); e && *e) indexSource = e;
 
     bool mainArtifactManaged = fs::exists(mainDir / ".xlings-index-version");
-    if (indexSource != "git" && (force || !fs::exists(mainDir / "pkgs"))) {
+    bool mainHasIndex = fs::exists(mainDir / "pkgs");
+    // auto (default): fetch the artifact only when the index is fresh (missing)
+    // or already artifact-managed. An existing *git* index (e.g. a test fixture
+    // or a legacy checkout) keeps using git, so git-based e2e tests are
+    // unaffected. XLINGS_INDEX_SOURCE=artifact forces the artifact path;
+    // =git disables it entirely.
+    bool attemptArtifact = (indexSource == "artifact")
+        || (indexSource != "git" && (mainArtifactManaged || !mainHasIndex));
+    if (attemptArtifact) {
         std::string ferr;
         if (fetch_index_artifact(mainDir, ferr)) {
             mainArtifactManaged = true;

--- a/src/core/xim/repo.cppm
+++ b/src/core/xim/repo.cppm
@@ -10,6 +10,7 @@ import xlings.core.compact;
 import xlings.platform;
 import xlings.core.config;
 import xlings.core.mirror;
+import xlings.core.xim.indexfetch;
 
 export namespace xlings::xim {
 
@@ -347,12 +348,40 @@ bool sync_all_repos(bool force = false) {
     namespace fs = std::filesystem;
     auto mirror = Config::mirror();
 
+    auto mainDir = main_repo_dir();
+
+    // ── Index-as-Resource (Y-asset) ─────────────────────────────────
+    // Fetch the main index as a versioned artifact over the resource-server
+    // HTTP path (gains adaptive mirror reorder + stall watchdog; closes G2).
+    // git clone is the fallback. XLINGS_INDEX_SOURCE=git|artifact|auto (auto).
+    // An artifact-managed index has no .git, so once installed via artifact we
+    // must NOT let the git path try to clone it again — the .xlings-index-version
+    // marker records that state.
+    std::string indexSource = "auto";
+    if (auto* e = std::getenv("XLINGS_INDEX_SOURCE"); e && *e) indexSource = e;
+
+    bool mainArtifactManaged = fs::exists(mainDir / ".xlings-index-version");
+    if (indexSource != "git" && (force || !fs::exists(mainDir / "pkgs"))) {
+        std::string ferr;
+        if (fetch_index_artifact(mainDir, ferr)) {
+            mainArtifactManaged = true;
+        } else if (indexSource == "artifact") {
+            log::error("[index] artifact fetch failed and git fallback disabled "
+                       "(XLINGS_INDEX_SOURCE=artifact): {}", ferr);
+            return false;
+        } else {
+            log::warn("[index] artifact fetch failed ({}); falling back to git", ferr);
+        }
+    }
+
     auto syncRepos = [&](const std::vector<IndexRepo>& repos, bool projectScope) {
         auto rootDir = projectScope ? Config::project_data_dir() : Config::global_data_dir();
         if (rootDir.empty()) return true;
         fs::create_directories(rootDir);
         for (auto& repo : repos) {
             auto repoDir = Config::repo_dir_for(repo, projectScope);
+            // The main index is artifact-managed (no .git); never git-sync it.
+            if (!projectScope && mainArtifactManaged && repoDir == mainDir) continue;
             if (Config::is_local_repo_source(repo, projectScope)) {
                 auto sourceDir = Config::resolve_repo_source(repo, projectScope);
                 if (!detail_::ensure_local_repo_link_(repoDir, sourceDir)) {
@@ -372,7 +401,6 @@ bool sync_all_repos(bool force = false) {
     if (!syncRepos(Config::global_index_repos(), false)) return false;
 
     // Discover and sync sub-index repos from the main repo's xim-indexrepos.lua
-    auto mainDir = main_repo_dir();
     auto luaSubRepos = detail_::discover_sub_repos_(mainDir, mirror.empty() ? "GLOBAL" : mirror);
     auto jsonSubRepos = load_sub_repos_json(sub_repos_json_path());
 

--- a/src/core/xim/repo.cppm
+++ b/src/core/xim/repo.cppm
@@ -435,17 +435,45 @@ bool sync_all_repos(bool force = false) {
     std::vector<IndexRepo> syncedSubRepos;
     for (auto& [name, repo] : merged) allSubRepos.push_back(repo);
 
+    // Default sub-indexes — those provided by the main index's
+    // xim-indexrepos.lua, not overridden by the user's xim-indexrepos.json, and
+    // from a remote source — are fetched as artifacts, same model as the main
+    // index. User-added (json) or local/overridden sub-indexes keep git. This
+    // "in the lua defaults, not in the user json" signal means no hardcoded
+    // allowlist and leaves user-added sub-indexes on the unchanged git path.
+    std::unordered_set<std::string> luaNames, jsonNames;
+    for (auto& r : luaSubRepos)  luaNames.insert(r.name);
+    for (auto& r : jsonSubRepos) jsonNames.insert(r.name);
+
     auto subReposRoot = sub_repos_dir();
     fs::create_directories(subReposRoot);
 
     for (auto& repo : allSubRepos) {
         auto repoDir = sub_repo_dir_for(repo);
-        // URLs are already mirror-selected from xim-indexrepos.lua, no further replacement needed
-        if (sync_repo(repoDir, repo.url, force)) {
-            syncedSubRepos.push_back(repo);
-        } else {
-            log::warn("failed to sync sub-index repo: {} ({})", repo.name, repo.url);
+        bool subDefaultOfficial =
+            luaNames.contains(repo.name) && !jsonNames.contains(repo.name)
+            && !Config::is_local_repo_source(repo, false);
+        bool subManaged = fs::exists(repoDir / ".xlings-index-version");
+        bool subAttemptArtifact;
+        if (indexSource == "artifact")  subAttemptArtifact = subDefaultOfficial;
+        else if (indexSource == "git")  subAttemptArtifact = false;
+        else subAttemptArtifact = subDefaultOfficial
+                 && (subManaged || !fs::exists(repoDir / "pkgs"));
+
+        bool ok = false;
+        if (subAttemptArtifact) {
+            std::string ferr;
+            ok = fetch_index_artifact(repoDir, ferr, repo.name);
+            if (!ok)
+                log::warn("[index] sub-index '{}' artifact fetch failed: {}", repo.name, ferr);
         }
+        // git fallback (and the path for user-added / local sub-indexes), unless
+        // an official sub was explicitly pinned to the artifact source.
+        if (!ok && !(indexSource == "artifact" && subDefaultOfficial)) {
+            ok = sync_repo(repoDir, repo.url, force);
+        }
+        if (ok) syncedSubRepos.push_back(repo);
+        else log::warn("failed to sync sub-index repo: {} ({})", repo.name, repo.url);
     }
 
     save_sub_repos_json(sub_repos_json_path(), syncedSubRepos);

--- a/tests/e2e/build_xim_index_artifact_test.sh
+++ b/tests/e2e/build_xim_index_artifact_test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# E2E: tools/build_xim_index_artifact.sh produces a tar.gz + manifest whose
+# recorded sha256 matches the artifact and whose tarball contains pkgs/.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BUILD="$PROJECT_DIR/tools/build_xim_index_artifact.sh"
+
+pass() { echo "[test] OK: $*"; }
+fail() { echo "[test] FAIL: $*" >&2; exit 1; }
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | awk '{print $1}';
+  else shasum -a 256 "$1" | awk '{print $1}'; fi
+}
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/xim-artifact-test.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+# Fixture index tree (no network; use --src).
+SRC="$WORK/src"
+mkdir -p "$SRC/pkgs/p"
+echo 'package({name="patchelf"})' > "$SRC/pkgs/p/patchelf.lua"
+echo '{"site":{"title":"t"}}'      > "$SRC/.xpkgindex.json"
+mkdir -p "$SRC/.git"; echo "junk" > "$SRC/.git/HEAD"   # must be stripped
+
+OUT="$WORK/out"
+bash "$BUILD" --version 9.9.9 --out "$OUT" --src "$SRC"
+
+ART="$OUT/xim-index-9.9.9.tar.gz"
+MAN="$OUT/xim-index-9.9.9.manifest.json"
+[[ -f "$ART" ]] || fail "artifact not produced"
+[[ -f "$MAN" ]] || fail "manifest not produced"
+pass "artifact + manifest produced"
+
+# Manifest sha256 must equal the real artifact sha256.
+MAN_SHA="$(grep -o '"sha256": *"[0-9a-f]*"' "$MAN" | grep -o '[0-9a-f]\{64\}')"
+REAL_SHA="$(sha256_of "$ART")"
+[[ "$MAN_SHA" == "$REAL_SHA" ]] || fail "manifest sha256 ($MAN_SHA) != artifact sha256 ($REAL_SHA)"
+pass "manifest sha256 matches artifact"
+
+# format_version + reserved signature slot present.
+grep -q '"format_version": 1' "$MAN" || fail "manifest missing format_version=1"
+grep -q '"signature": null'   "$MAN" || fail "manifest missing reserved signature slot"
+pass "manifest has format_version + reserved signature"
+
+# Tarball contains pkgs/ and NOT .git
+LIST="$(tar -tzf "$ART")"
+echo "$LIST" | grep -q 'pkgs/p/patchelf.lua' || fail "tarball missing pkgs/p/patchelf.lua"
+echo "$LIST" | grep -q '\.git/' && fail "tarball still contains .git/"
+pass "tarball contains pkgs/, .git stripped"
+
+echo "[test] ALL PASSED"

--- a/tests/e2e/index_artifact_update_test.sh
+++ b/tests/e2e/index_artifact_update_test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# E2E: `xlings update` (no target) installs the index from a resource artifact
+# (XLINGS_INDEX_BASE_URL local-dir base = the hermetic test + offline/bundled
+# path), verifies sha256, atomic-installs into data/xim-pkgindex; and the tamper
+# path (sha256 reject) under XLINGS_INDEX_SOURCE=artifact (no git fallback).
+#
+# Usage: tests/e2e/index_artifact_update_test.sh [path-to-xlings-binary]
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+XLINGS_BIN="${1:-}"
+if [[ -z "$XLINGS_BIN" ]]; then
+  XLINGS_BIN="$(find "$PROJECT_DIR/build" -path '*debug*' -name xlings -type f -perm -111 2>/dev/null | head -1)"
+fi
+[[ -x "$XLINGS_BIN" ]] || { echo "[test] SKIP: no xlings binary (build first)"; exit 0; }
+
+pass() { echo "[test] OK: $*"; }
+fail() { echo "[test] FAIL: $*" >&2; exit 1; }
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/xim-update-test.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+# ── 1. Build a fixture index artifact + manifest + latest pointer ──
+SRC="$WORK/src"; mkdir -p "$SRC/pkgs/p"
+echo 'package({name="patchelf"})' > "$SRC/pkgs/p/patchelf.lua"
+echo '{"site":{"title":"t"}}'      > "$SRC/.xpkgindex.json"
+
+SERVE="$WORK/serve"; mkdir -p "$SERVE"
+bash "$PROJECT_DIR/tools/build_xim_index_artifact.sh" --version 9.9.9 --out "$SERVE" --src "$SRC"
+cp "$SERVE/xim-index-9.9.9.manifest.json" "$SERVE/xim-index-latest.json"   # pointer
+pass "fixture artifact + pointer built"
+
+# ── 2. Isolated home + self init ──────────────────────────────────
+export XLINGS_HOME="$WORK/home"
+mkdir -p "$XLINGS_HOME"
+"$XLINGS_BIN" self init >/dev/null 2>&1 || fail "self init failed"
+
+# ── 3. Happy path: xlings update (no target) via local artifact base ─
+export XLINGS_INDEX_BASE_URL="$SERVE"   # local dir base (copied directly)
+export XLINGS_INDEX_SOURCE=artifact     # force artifact, no git fallback
+if ! "$XLINGS_BIN" update >"$WORK/update.log" 2>&1; then
+  cat "$WORK/update.log" >&2; fail "xlings update (artifact) failed"
+fi
+INDEX_DIR="$XLINGS_HOME/data/xim-pkgindex"
+[[ -f "$INDEX_DIR/pkgs/p/patchelf.lua" ]] || { cat "$WORK/update.log" >&2; fail "index not installed from artifact"; }
+[[ -f "$INDEX_DIR/.xlings-index-version" ]] || fail "index version marker missing"
+pass "happy path: index installed from artifact"
+
+# ── 4. Tamper path: corrupt artifact, sha256 must reject ─────────
+printf 'CORRUPT' >> "$SERVE/xim-index-9.9.9.tar.gz"
+if "$XLINGS_BIN" update >"$WORK/update2.log" 2>&1; then
+  fail "xlings update accepted a tampered artifact (sha256 not enforced)"
+fi
+grep -qi "sha256\|artifact failed\|mismatch" "$WORK/update2.log" \
+  || { cat "$WORK/update2.log" >&2; fail "tamper failure not reported as integrity error"; }
+[[ -f "$INDEX_DIR/pkgs/p/patchelf.lua" ]] || fail "tamper destroyed the good index"
+pass "tamper path: sha256 rejected, good index preserved"
+
+echo "[test] ALL PASSED"

--- a/tests/e2e/release_packaged_index_test.ps1
+++ b/tests/e2e/release_packaged_index_test.ps1
@@ -12,21 +12,9 @@ $INDEX_DIR = Join-Path $PKG_DIR 'data\xim-pkgindex'
 
 if (-not (Test-Path "$INDEX_DIR\pkgs")) { Fail "release package missing bundled xim-pkgindex/pkgs" }
 if (-not (Test-Path "$INDEX_DIR\pkgs\p\patchelf.lua")) { Fail "bundled xim-pkgindex missing patchelf package" }
-if (-not (Test-Path "$INDEX_DIR\.git")) { Fail "bundled xim-pkgindex should remain a git repo for xlings update" }
-
-$mirror = if ($env:XLINGS_RELEASE_MIRROR) { $env:XLINGS_RELEASE_MIRROR } else { $null }
-if (-not $mirror) {
-    $config = Get-Content (Join-Path $PKG_DIR '.xlings.json') -Raw | ConvertFrom-Json
-    $mirror = if ($config.mirror) { $config.mirror } else { 'GLOBAL' }
-}
-
-$expectedOrigin = 'https://gitee.com/sunrisepeak/xim-pkgindex.git'
-if ($mirror -eq 'GLOBAL') {
-    $expectedOrigin = 'https://github.com/openxlings/xim-pkgindex.git'
-}
-$actualOrigin = (& git -C $INDEX_DIR remote get-url origin).Trim()
-if ($actualOrigin -ne $expectedOrigin) {
-    Fail "bundled xim-pkgindex origin mismatch: expected $expectedOrigin, got $actualOrigin"
-}
+# Y-asset: the bundled index is artifact-managed (no .git); refreshed via
+# `xlings update` from xlings-res/xim-index, not git pull.
+if (Test-Path "$INDEX_DIR\.git") { Fail "bundled xim-pkgindex should be artifact-managed (no .git)" }
+if (-not (Test-Path "$INDEX_DIR\.xlings-index-version")) { Fail "bundled xim-pkgindex missing .xlings-index-version marker" }
 
 Log "PASS: release package includes usable xim-pkgindex snapshot"

--- a/tests/e2e/release_packaged_index_test.sh
+++ b/tests/e2e/release_packaged_index_test.sh
@@ -11,21 +11,10 @@ INDEX_DIR="$PKG_DIR/data/xim-pkgindex"
 
 [[ -d "$INDEX_DIR/pkgs" ]] || fail "release package missing bundled xim-pkgindex/pkgs"
 [[ -f "$INDEX_DIR/pkgs/p/patchelf.lua" ]] || fail "bundled xim-pkgindex missing patchelf package"
-[[ -d "$INDEX_DIR/.git" ]] || fail "bundled xim-pkgindex should remain a git repo for xlings update"
-
-mirror="${XLINGS_RELEASE_MIRROR:-}"
-if [[ -z "$mirror" ]] && command -v jq >/dev/null 2>&1; then
-  mirror="$(jq -r '.mirror // "GLOBAL"' "$PKG_DIR/.xlings.json")"
-fi
-[[ -z "$mirror" || "$mirror" == "null" ]] && mirror="GLOBAL"
-
-expected_origin="https://gitee.com/sunrisepeak/xim-pkgindex.git"
-if [[ "$mirror" == "GLOBAL" ]]; then
-  expected_origin="https://github.com/openxlings/xim-pkgindex.git"
-fi
-actual_origin="$(git -C "$INDEX_DIR" remote get-url origin)"
-[[ "$actual_origin" == "$expected_origin" ]] || \
-  fail "bundled xim-pkgindex origin mismatch: expected $expected_origin, got $actual_origin"
+# Y-asset: the bundled index is artifact-managed (no .git); the runtime refreshes
+# it via `xlings update` from xlings-res/xim-index, not git pull.
+[[ ! -d "$INDEX_DIR/.git" ]] || fail "bundled xim-pkgindex should be artifact-managed (no .git)"
+[[ -f "$INDEX_DIR/.xlings-index-version" ]] || fail "bundled xim-pkgindex missing .xlings-index-version marker"
 
 if [[ "$(uname -s)" == "Linux" ]]; then
   INSTALL_USER_DIR="$RUNTIME_ROOT/release_packaged_index_no_git_user"

--- a/tests/unit/test_indexfetch.cpp
+++ b/tests/unit/test_indexfetch.cpp
@@ -1,0 +1,52 @@
+#include <gtest/gtest.h>
+
+import xlings.core.xim.indexfetch;
+
+using xlings::xim::parse_index_manifest;
+using xlings::xim::index_asset_urls;
+
+TEST(IndexManifest, ParsesValid) {
+    auto m = parse_index_manifest(R"({
+        "format_version": 1,
+        "index_version": "0.4.52",
+        "index_name": "xim",
+        "generated_at": "2026-06-22T00:00:00Z",
+        "source_commit": "abc123",
+        "artifact": { "name": "xim-index-0.4.52.tar.gz", "sha256": "DEADbeef", "size": 95000 },
+        "signature": null
+    })");
+    ASSERT_TRUE(m.has_value());
+    EXPECT_EQ(m->format_version, 1);
+    EXPECT_EQ(m->index_version, "0.4.52");
+    EXPECT_EQ(m->artifact_name, "xim-index-0.4.52.tar.gz");
+    EXPECT_EQ(m->artifact_sha256, "deadbeef");   // lowercased
+    EXPECT_EQ(m->artifact_size, 95000u);
+}
+
+TEST(IndexManifest, RejectsMissingArtifact) {
+    EXPECT_FALSE(parse_index_manifest(R"({"format_version":1})").has_value());
+}
+
+TEST(IndexManifest, RejectsMissingSha256) {
+    EXPECT_FALSE(parse_index_manifest(
+        R"({"format_version":1,"artifact":{"name":"x.tar.gz"}})").has_value());
+}
+
+TEST(IndexManifest, RejectsGarbage) {
+    EXPECT_FALSE(parse_index_manifest("not json").has_value());
+}
+
+TEST(IndexAssetUrls, BuildsReleaseDownloadUrlForGlobal) {
+    auto urls = index_asset_urls("xim-index-latest.json", "GLOBAL");
+    ASSERT_FALSE(urls.empty());
+    // Must hit the xim-index repo's release-download path on a resource server.
+    bool found = false;
+    for (auto& u : urls) {
+        if (u.find("/xim-index/releases/download/") != std::string::npos
+            && u.find("xim-index-latest.json") != std::string::npos) {
+            found = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(found) << "no release-download URL for the pointer asset";
+}

--- a/tools/build_xim_index_artifact.sh
+++ b/tools/build_xim_index_artifact.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Build a versioned xim package-index *artifact* + manifest for publishing
+# to xlings-res (Y-asset model; see .agents/docs/2026-06-22-index-as-resource-impl-plan.md).
+#
+# An index artifact is a plain tarball of the index tree (pkgs/, .xpkgindex.json,
+# xim-indexrepos.lua, ...) with the .git history stripped, plus a manifest.json
+# describing it (sha256/size + format_version + a reserved signature slot for a
+# future minisign/X-full upgrade).
+#
+# Output (in OUT_DIR):
+#   xim-index[-<name>]-<ver>.tar.gz
+#   xim-index[-<name>]-<ver>.manifest.json
+#
+# Usage:
+#   tools/build_xim_index_artifact.sh --version <ver> --out <dir> [--name <sub>] [--src <dir>]
+#
+# Env:
+#   XLINGS_RELEASE_MIRROR=GLOBAL|CN     pick clone origin when --src omitted (default GLOBAL)
+#   XLINGS_RELEASE_PKGINDEX_URL         override clone URL
+#   XLINGS_RELEASE_PKGINDEX_REF=main    git ref to snapshot (default main)
+set -euo pipefail
+
+VERSION="" OUT_DIR="" NAME="" SRC_DIR=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version) VERSION="$2"; shift 2 ;;
+    --out)     OUT_DIR="$2"; shift 2 ;;
+    --name)    NAME="$2";    shift 2 ;;
+    --src)     SRC_DIR="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+[[ -z "$VERSION" || -z "$OUT_DIR" ]] && { echo "usage: $0 --version <ver> --out <dir> [--name <sub>] [--src <dir>]" >&2; exit 2; }
+
+info() { echo "[index-artifact] $*"; }
+fail() { echo "[index-artifact] FAIL: $*" >&2; exit 1; }
+
+# sha256 helper (Linux: sha256sum, macOS: shasum -a 256)
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | awk '{print $1}';
+  elif command -v shasum >/dev/null 2>&1; then shasum -a 256 "$1" | awk '{print $1}';
+  else fail "no sha256 tool (sha256sum/shasum)"; fi
+}
+
+MIRROR="${XLINGS_RELEASE_MIRROR:-GLOBAL}"
+REF="${XLINGS_RELEASE_PKGINDEX_REF:-main}"
+# Sub-index name → repo. Main index has no name.
+if [[ -z "$NAME" ]]; then
+  case "$MIRROR" in
+    CN) DEFAULT_URL="https://gitee.com/sunrisepeak/xim-pkgindex.git" ;;
+    *)  DEFAULT_URL="https://github.com/openxlings/xim-pkgindex.git" ;;
+  esac
+  ARTIFACT_BASE="xim-index-${VERSION}"
+else
+  DEFAULT_URL="https://github.com/d2learn/xim-pkgindex-${NAME}.git"
+  ARTIFACT_BASE="xim-index-${NAME}-${VERSION}"
+fi
+URL="${XLINGS_RELEASE_PKGINDEX_URL:-$DEFAULT_URL}"
+
+mkdir -p "$OUT_DIR"
+OUT_DIR="$(cd "$OUT_DIR" && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/xim-index-build.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+TREE="$TMP_ROOT/tree"
+if [[ -n "$SRC_DIR" ]]; then
+  info "Using local source: $SRC_DIR"
+  [[ -d "$SRC_DIR/pkgs" ]] || fail "source dir missing pkgs/: $SRC_DIR"
+  cp -a "$SRC_DIR" "$TREE"
+else
+  info "Cloning $URL ($REF)"
+  if ! git clone --depth 1 --branch "$REF" "$URL" "$TREE" 2>/dev/null; then
+    rm -rf "$TREE"
+    git clone "$URL" "$TREE"
+    git -C "$TREE" checkout --quiet "$REF"
+  fi
+fi
+
+# Record source commit (before stripping .git) for traceability.
+SOURCE_COMMIT="unknown"
+if [[ -d "$TREE/.git" ]]; then
+  SOURCE_COMMIT="$(git -C "$TREE" rev-parse HEAD 2>/dev/null || echo unknown)"
+fi
+rm -rf "$TREE/.git"
+[[ -d "$TREE/pkgs" ]] || fail "index tree missing pkgs/ after fetch"
+
+# Deterministic-ish tarball (sorted names, stable owners).
+ARTIFACT="$OUT_DIR/${ARTIFACT_BASE}.tar.gz"
+info "Packing $ARTIFACT"
+tar --sort=name --owner=0 --group=0 --numeric-owner \
+    -czf "$ARTIFACT" -C "$TREE" . 2>/dev/null \
+  || tar -czf "$ARTIFACT" -C "$TREE" .   # BSD tar fallback (no --sort)
+
+SHA="$(sha256_of "$ARTIFACT")"
+SIZE="$(wc -c < "$ARTIFACT" | tr -d ' ')"
+GENERATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+MANIFEST="$OUT_DIR/${ARTIFACT_BASE}.manifest.json"
+cat > "$MANIFEST" <<JSON
+{
+  "format_version": 1,
+  "index_version": "${VERSION}",
+  "index_name": "${NAME:-xim}",
+  "generated_at": "${GENERATED_AT}",
+  "source_commit": "${SOURCE_COMMIT}",
+  "artifact": {
+    "name": "${ARTIFACT_BASE}.tar.gz",
+    "sha256": "${SHA}",
+    "size": ${SIZE}
+  },
+  "signature": null
+}
+JSON
+
+info "Done:"
+info "  artifact: $ARTIFACT"
+info "  sha256:   $SHA  ($SIZE bytes)"
+info "  manifest: $MANIFEST"

--- a/tools/gtc
+++ b/tools/gtc
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""gtc — gitcode tool
+
+Subcommands:
+  repo create <owner>/<name> [--description STR] [--private]
+  repo push   <owner>/<name> <local_dir> [--branch BRANCH]
+  release create  <owner>/<repo> --tag TAG [--name NAME] [--body-file FILE] [--target main] [--prerelease]
+  release upload  <owner>/<repo> --tag TAG <file...>
+  release publish <owner>/<repo> --tag TAG [--name NAME] [--body-file FILE] [--target main] [--prerelease] [--asset FILE]...
+  pr create   <owner>/<repo> --title T --head BRANCH --base BRANCH [--body-file FILE]
+
+Token / config:
+  ~/.config/gitcode-tool/config.json  →  {"token": "...", "api_base": "https://api.gitcode.com/api/v5"}
+  override:  --token TOKEN  or  GITCODE_TOKEN env var
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+import urllib.parse
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+CONFIG_PATH = Path.home() / ".config" / "gitcode-tool" / "config.json"
+
+
+def load_config():
+    cfg = {"api_base": "https://api.gitcode.com/api/v5"}
+    if CONFIG_PATH.is_file():
+        cfg.update(json.loads(CONFIG_PATH.read_text()))
+    cfg["token"] = os.environ.get("GITCODE_TOKEN") or cfg.get("token") or ""
+    return cfg
+
+
+def http(method, url, *, token, headers=None, json_body=None, data=None, expect=(200, 201)):
+    h = {"PRIVATE-TOKEN": token, "Accept": "application/json"}
+    if json_body is not None:
+        h["Content-Type"] = "application/json"
+        body = json.dumps(json_body).encode()
+    elif data is not None:
+        body = data
+    else:
+        body = None
+    if headers:
+        h.update(headers)
+    req = urllib.request.Request(url, data=body, headers=h, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=120) as r:
+            raw = r.read()
+            return r.status, raw
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        if e.code in expect:
+            return e.code, raw
+        # gitcode often returns HTTP 400 with a different error_code in the body
+        try:
+            j = json.loads(raw)
+            body_code = j.get("error_code")
+            msg = (j.get("error_message") or "").lower()
+            if 422 in expect and ("already exists" in msg or body_code == 422):
+                return 422, raw
+            # gitcode may wrap 404 inside HTTP 400
+            if 404 in expect and (body_code == 404 or "not found" in msg):
+                return 404, raw
+        except Exception:
+            pass
+        sys.stderr.write(f"HTTP {e.code} {url}\n{raw.decode(errors='replace')[:500]}\n")
+        sys.exit(2)
+
+
+def api_json(cfg, method, path, **kwargs):
+    url = cfg["api_base"] + path
+    status, raw = http(method, url, token=cfg["token"], **kwargs)
+    if not raw:
+        return status, None
+    try:
+        return status, json.loads(raw)
+    except json.JSONDecodeError:
+        return status, raw.decode(errors="replace")
+
+
+# ─────────────── repo ───────────────
+
+def cmd_repo_create(args, cfg):
+    owner, name = args.repo.split("/", 1)
+    payload = {"name": name, "path": name, "description": args.description or "", "private": args.private}
+    # personal user repos: POST /user/repos ; org repos: POST /orgs/:org/repos
+    me_status, me = api_json(cfg, "GET", "/user")
+    if me_status == 200 and isinstance(me, dict) and me.get("login") == owner:
+        path = "/user/repos"
+    else:
+        path = f"/orgs/{owner}/repos"
+    status, body = api_json(cfg, "POST", path, json_body=payload, expect=(200, 201, 422))
+    if status == 422:
+        print(f"warn: repo {owner}/{name} may already exist")
+        return
+    print(f"created {body.get('full_name', owner+'/'+name)} → {body.get('html_url') or body.get('url')}")
+
+
+def cmd_repo_push(args, cfg):
+    owner, name = args.repo.split("/", 1)
+    local = Path(args.local_dir).resolve()
+    if not local.is_dir():
+        sys.exit(f"local_dir not found: {local}")
+    branch = args.branch or "main"
+    user = api_json(cfg, "GET", "/user")[1]
+    login = user.get("login") if isinstance(user, dict) else owner
+    remote_url = f"https://{login}:{cfg['token']}@gitcode.com/{owner}/{name}.git"
+
+    def run(*cmd):
+        subprocess.run(cmd, cwd=local, check=True)
+
+    if not (local / ".git").is_dir():
+        run("git", "init", "-b", branch)
+    # ensure remote
+    r = subprocess.run(["git", "-C", str(local), "remote"], capture_output=True, text=True)
+    remotes = r.stdout.split()
+    if "gitcode" in remotes:
+        run("git", "remote", "set-url", "gitcode", remote_url)
+    else:
+        run("git", "remote", "add", "gitcode", remote_url)
+    # commit any pending
+    subprocess.run(["git", "-C", str(local), "add", "-A"], check=True)
+    diff = subprocess.run(["git", "-C", str(local), "diff", "--cached", "--quiet"]).returncode
+    if diff != 0:
+        run("git", "commit", "-m", args.message or "init")
+    run("git", "push", "-u", "gitcode", branch)
+    print(f"pushed → https://gitcode.com/{owner}/{name}")
+
+
+# ─────────────── release ───────────────
+
+def _release_payload(args):
+    if args.body_file:
+        body = Path(args.body_file).read_text().strip()
+    else:
+        body = ""
+    if not body:
+        body = args.name or args.tag
+    return {
+        "tag_name": args.tag,
+        "name": args.name or args.tag,
+        "body": body,
+        "target_commitish": args.target or "main",
+        "prerelease": bool(args.prerelease),
+    }
+
+
+def cmd_release_create(args, cfg):
+    payload = _release_payload(args)
+    # check existing first to make this idempotent
+    s, _ = api_json(cfg, "GET", f"/repos/{args.repo}/releases/tags/{args.tag}", expect=(200, 404))
+    if s == 200:
+        print(f"release {args.repo}@{args.tag} already exists, skipping")
+        return
+    status, body = api_json(cfg, "POST", f"/repos/{args.repo}/releases", json_body=payload,
+                            expect=(200, 201, 422))
+    if status == 422:
+        print(f"warn: release {args.tag} may already exist on {args.repo}")
+        return
+    print(f"release created: {args.repo}@{args.tag}")
+
+
+def _upload_one(cfg, repo, tag, file_path):
+    fname = Path(file_path).name
+    url = f"{cfg['api_base']}/repos/{repo}/releases/{tag}/upload_url?file_name={urllib.parse.quote(fname)}"
+    status, info = http("GET", url, token=cfg["token"])
+    info = json.loads(info)
+    put_url = info["url"]
+    h = info["headers"]
+    with open(file_path, "rb") as f:
+        data = f.read()
+    req = urllib.request.Request(put_url, data=data, headers=h, method="PUT")
+    with urllib.request.urlopen(req, timeout=600) as r:
+        ok = r.status == 200
+        body = r.read().decode(errors="replace")[:200]
+    if not ok:
+        sys.exit(f"upload {fname} failed: {body}")
+    print(f"  uploaded: {fname} ({len(data)} bytes)")
+
+
+def cmd_release_upload(args, cfg):
+    for f in args.files:
+        _upload_one(cfg, args.repo, args.tag, f)
+
+
+def cmd_release_publish(args, cfg):
+    cmd_release_create(args, cfg)
+    if args.asset:
+        for f in args.asset:
+            _upload_one(cfg, args.repo, args.tag, f)
+
+
+# ─────────────── pull request ───────────────
+
+def cmd_pr_create(args, cfg):
+    body = ""
+    if args.body_file:
+        body = Path(args.body_file).read_text()
+    payload = {"title": args.title, "head": args.head, "base": args.base, "body": body}
+    status, resp = api_json(cfg, "POST", f"/repos/{args.repo}/pulls", json_body=payload)
+    print(f"PR created: {resp.get('html_url') or resp}")
+
+
+# ─────────────── argparse ───────────────
+
+def build_parser():
+    p = argparse.ArgumentParser(prog="gtc")
+    p.add_argument("--token", help="override token")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    rp = sub.add_parser("repo").add_subparsers(dest="op", required=True)
+    rc = rp.add_parser("create"); rc.add_argument("repo"); rc.add_argument("--description"); rc.add_argument("--private", action="store_true"); rc.set_defaults(_fn=cmd_repo_create)
+    rs = rp.add_parser("push"); rs.add_argument("repo"); rs.add_argument("local_dir"); rs.add_argument("--branch"); rs.add_argument("-m","--message"); rs.set_defaults(_fn=cmd_repo_push)
+
+    re = sub.add_parser("release").add_subparsers(dest="op", required=True)
+    for name, fn in (("create", cmd_release_create), ("publish", cmd_release_publish)):
+        x = re.add_parser(name); x.add_argument("repo"); x.add_argument("--tag", required=True); x.add_argument("--name"); x.add_argument("--body-file"); x.add_argument("--target"); x.add_argument("--prerelease", action="store_true")
+        if name == "publish":
+            x.add_argument("--asset", action="append", default=[])
+        x.set_defaults(_fn=fn)
+    ru = re.add_parser("upload"); ru.add_argument("repo"); ru.add_argument("--tag", required=True); ru.add_argument("files", nargs="+"); ru.set_defaults(_fn=cmd_release_upload)
+
+    pr = sub.add_parser("pr").add_subparsers(dest="op", required=True)
+    pc = pr.add_parser("create"); pc.add_argument("repo"); pc.add_argument("--title", required=True); pc.add_argument("--head", required=True); pc.add_argument("--base", required=True); pc.add_argument("--body-file"); pc.set_defaults(_fn=cmd_pr_create)
+
+    return p
+
+
+def main():
+    args = build_parser().parse_args()
+    cfg = load_config()
+    if args.token:
+        cfg["token"] = args.token
+    if not cfg["token"]:
+        sys.exit("no token: set GITCODE_TOKEN env or write to ~/.config/gitcode-tool/config.json")
+    args._fn(args, cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/package_xim_index.ps1
+++ b/tools/package_xim_index.ps1
@@ -43,6 +43,19 @@ try {
     if (-not (Test-Path "$dest\pkgs")) {
         throw "bundled xim-pkgindex missing pkgs/"
     }
+
+    # Y-asset: make the bundled index artifact-managed (strip .git + version
+    # marker). The runtime then refreshes it via `xlings update` from
+    # xlings-res/xim-index instead of git pull. See src/core/xim/indexfetch.cppm.
+    $configPath = Join-Path $PSScriptRoot '..\src\core\config.cppm'
+    $ver = 'bundled'
+    if (Test-Path $configPath) {
+        $m = Select-String -Path $configPath -Pattern 'VERSION = "([^"]*)"' | Select-Object -First 1
+        if ($m) { $ver = $m.Matches[0].Groups[1].Value }
+    }
+    Remove-Item -Recurse -Force (Join-Path $dest '.git') -ErrorAction SilentlyContinue
+    Set-Content -NoNewline -Path (Join-Path $dest '.xlings-index-version') -Value $ver
+    Write-Host "[release] bundled index is artifact-managed (version $ver, .git stripped)"
 } finally {
     Remove-Item -Recurse -Force $tmpRoot -ErrorAction SilentlyContinue
 }

--- a/tools/package_xim_index.sh
+++ b/tools/package_xim_index.sh
@@ -34,3 +34,13 @@ test -d "$OUT_DIR/data/xim-pkgindex/pkgs" || {
   echo "[release] FAIL: bundled xim-pkgindex missing pkgs/" >&2
   exit 1
 }
+
+# Make the bundled index artifact-managed (Y-asset): strip .git and drop a
+# version marker. The runtime then treats it as a resource artifact (never
+# git-clones it) and refreshes it via `xlings update` from xlings-res/xim-index.
+# See src/core/xim/indexfetch.cppm + .agents/docs/2026-06-22-index-as-resource-impl-plan.md
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VER="$(sed -n 's/.*VERSION = "\([^"]*\)".*/\1/p' "$SCRIPT_DIR/../src/core/config.cppm" | head -1)"
+rm -rf "$OUT_DIR/data/xim-pkgindex/.git"
+printf '%s' "${VER:-bundled}" > "$OUT_DIR/data/xim-pkgindex/.xlings-index-version"
+echo "[release] bundled index is artifact-managed (version ${VER:-bundled}, .git stripped)"

--- a/tools/publish_xim_index.sh
+++ b/tools/publish_xim_index.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Publish a built xim-index artifact + manifest to xlings-res/xim-index on both
+# GitHub (gh) and GitCode (gtc). Idempotent: creates the release if missing,
+# then uploads with clobber. Also refreshes a stable "latest" pointer asset
+# (<base>.manifest.json copied to xim-index[-<name>]-latest.json).
+#
+# Usage:
+#   tools/publish_xim_index.sh --version <ver> --dir <artifact-dir> [--name <sub>] \
+#       [--github-repo xlings-res/xim-index] [--gitcode-repo xlings-res/xim-index] \
+#       [--dry-run] [--skip-github] [--skip-gitcode]
+#
+# Auth: gh uses its own login; gtc uses GITCODE_TOKEN env or `gtc --token`.
+set -euo pipefail
+
+VERSION="" DIR="" NAME="" DRY=0 SKIP_GH=0 SKIP_GTC=0
+GH_REPO="xlings-res/xim-index" GTC_REPO="xlings-res/xim-index"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)     VERSION="$2"; shift 2 ;;
+    --dir)         DIR="$2"; shift 2 ;;
+    --name)        NAME="$2"; shift 2 ;;
+    --github-repo) GH_REPO="$2"; shift 2 ;;
+    --gitcode-repo)GTC_REPO="$2"; shift 2 ;;
+    --dry-run)     DRY=1; shift ;;
+    --skip-github) SKIP_GH=1; shift ;;
+    --skip-gitcode)SKIP_GTC=1; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+[[ -z "$VERSION" || -z "$DIR" ]] && { echo "usage: $0 --version <ver> --dir <artifact-dir> [--name <sub>] [--dry-run]" >&2; exit 2; }
+
+info() { echo "[publish] $*"; }
+run()  { if [[ "$DRY" == 1 ]]; then echo "[dry-run] $*"; else "$@"; fi; }
+
+if [[ -z "$NAME" ]]; then BASE="xim-index-${VERSION}"; LATEST="xim-index-latest.json";
+else BASE="xim-index-${NAME}-${VERSION}"; LATEST="xim-index-${NAME}-latest.json"; fi
+
+TAG="v${VERSION}"
+ART="$DIR/${BASE}.tar.gz"
+MAN="$DIR/${BASE}.manifest.json"
+[[ -f "$ART" ]] || { echo "missing artifact: $ART" >&2; exit 1; }
+[[ -f "$MAN" ]] || { echo "missing manifest: $MAN" >&2; exit 1; }
+
+# Stable latest pointer (copy of this manifest).
+LATEST_PATH="$DIR/$LATEST"
+cp "$MAN" "$LATEST_PATH"
+
+# ── GitHub via gh ────────────────────────────────────────────────
+if [[ "$SKIP_GH" == 0 ]]; then
+  info "GitHub: $GH_REPO  tag=$TAG"
+  if [[ "$DRY" == 1 ]]; then
+    echo "[dry-run] gh release view $TAG -R $GH_REPO || gh release create $TAG -R $GH_REPO"
+    echo "[dry-run] gh release upload $TAG $ART $MAN $LATEST_PATH -R $GH_REPO --clobber"
+  else
+    gh release view "$TAG" -R "$GH_REPO" >/dev/null 2>&1 \
+      || gh release create "$TAG" -R "$GH_REPO" --title "$VERSION" --notes "xim package index artifact $VERSION"
+    gh release upload "$TAG" "$ART" "$MAN" "$LATEST_PATH" -R "$GH_REPO" --clobber
+  fi
+fi
+
+# ── GitCode via gtc ──────────────────────────────────────────────
+if [[ "$SKIP_GTC" == 0 ]]; then
+  info "GitCode: $GTC_REPO  tag=$TAG"
+  if [[ "$DRY" == 1 ]]; then
+    echo "[dry-run] gtc release create $GTC_REPO --tag $TAG --name $VERSION"
+    echo "[dry-run] gtc release upload $GTC_REPO $ART $MAN $LATEST_PATH --tag $TAG"
+  else
+    gtc release create "$GTC_REPO" --tag "$TAG" --name "$VERSION" 2>/dev/null || true
+    gtc release upload "$GTC_REPO" "$ART" "$MAN" "$LATEST_PATH" --tag "$TAG"
+  fi
+fi
+
+DESTS=""
+[[ "$SKIP_GH"  == 0 ]] && DESTS="$GH_REPO(gh)"
+[[ "$SKIP_GTC" == 0 ]] && DESTS="${DESTS:+$DESTS, }$GTC_REPO(gtc)"
+info "Published $BASE (+ $LATEST pointer) to: ${DESTS:-<none>}"

--- a/tools/publish_xim_index.sh
+++ b/tools/publish_xim_index.sh
@@ -35,7 +35,11 @@ run()  { if [[ "$DRY" == 1 ]]; then echo "[dry-run] $*"; else "$@"; fi; }
 if [[ -z "$NAME" ]]; then BASE="xim-index-${VERSION}"; LATEST="xim-index-latest.json";
 else BASE="xim-index-${NAME}-${VERSION}"; LATEST="xim-index-${NAME}-latest.json"; fi
 
-TAG="v${VERSION}"
+# The client reads the rolling "latest" tag by default (see indexfetch.cppm
+# index_tag_()). We also archive each version under v<ver> for reproducibility
+# (room for the future X-full/lockfile pinning).
+ROLLING_TAG="latest"
+ARCHIVE_TAG="v${VERSION}"
 ART="$DIR/${BASE}.tar.gz"
 MAN="$DIR/${BASE}.manifest.json"
 [[ -f "$ART" ]] || { echo "missing artifact: $ART" >&2; exit 1; }
@@ -45,32 +49,38 @@ MAN="$DIR/${BASE}.manifest.json"
 LATEST_PATH="$DIR/$LATEST"
 cp "$MAN" "$LATEST_PATH"
 
-# ── GitHub via gh ────────────────────────────────────────────────
-if [[ "$SKIP_GH" == 0 ]]; then
-  info "GitHub: $GH_REPO  tag=$TAG"
+publish_gh() {  # <tag> <file...>
+  local tag="$1"; shift
   if [[ "$DRY" == 1 ]]; then
-    echo "[dry-run] gh release view $TAG -R $GH_REPO || gh release create $TAG -R $GH_REPO"
-    echo "[dry-run] gh release upload $TAG $ART $MAN $LATEST_PATH -R $GH_REPO --clobber"
-  else
-    gh release view "$TAG" -R "$GH_REPO" >/dev/null 2>&1 \
-      || gh release create "$TAG" -R "$GH_REPO" --title "$VERSION" --notes "xim package index artifact $VERSION"
-    gh release upload "$TAG" "$ART" "$MAN" "$LATEST_PATH" -R "$GH_REPO" --clobber
+    echo "[dry-run] gh release create/view $tag -R $GH_REPO; gh release upload $tag $* -R $GH_REPO --clobber"
+    return
   fi
-fi
+  gh release view "$tag" -R "$GH_REPO" >/dev/null 2>&1 \
+    || gh release create "$tag" -R "$GH_REPO" --title "$tag" --notes "xim package index ($VERSION)"
+  gh release upload "$tag" "$@" -R "$GH_REPO" --clobber
+}
+publish_gtc() {  # <tag> <file...>
+  local tag="$1"; shift
+  if [[ "$DRY" == 1 ]]; then
+    echo "[dry-run] gtc release create $GTC_REPO --tag $tag; gtc release upload $GTC_REPO $* --tag $tag"
+    return
+  fi
+  gtc release create "$GTC_REPO" --tag "$tag" --name "$tag" 2>/dev/null || true
+  gtc release upload "$GTC_REPO" "$@" --tag "$tag"
+}
 
-# ── GitCode via gtc ──────────────────────────────────────────────
+if [[ "$SKIP_GH" == 0 ]]; then
+  info "GitHub $GH_REPO: rolling '$ROLLING_TAG' + archive '$ARCHIVE_TAG'"
+  publish_gh "$ROLLING_TAG" "$ART" "$LATEST_PATH"   # client entry point
+  publish_gh "$ARCHIVE_TAG" "$ART" "$MAN"           # immutable archive
+fi
 if [[ "$SKIP_GTC" == 0 ]]; then
-  info "GitCode: $GTC_REPO  tag=$TAG"
-  if [[ "$DRY" == 1 ]]; then
-    echo "[dry-run] gtc release create $GTC_REPO --tag $TAG --name $VERSION"
-    echo "[dry-run] gtc release upload $GTC_REPO $ART $MAN $LATEST_PATH --tag $TAG"
-  else
-    gtc release create "$GTC_REPO" --tag "$TAG" --name "$VERSION" 2>/dev/null || true
-    gtc release upload "$GTC_REPO" "$ART" "$MAN" "$LATEST_PATH" --tag "$TAG"
-  fi
+  info "GitCode $GTC_REPO: rolling '$ROLLING_TAG' + archive '$ARCHIVE_TAG'"
+  publish_gtc "$ROLLING_TAG" "$ART" "$LATEST_PATH"
+  publish_gtc "$ARCHIVE_TAG" "$ART" "$MAN"
 fi
 
 DESTS=""
 [[ "$SKIP_GH"  == 0 ]] && DESTS="$GH_REPO(gh)"
 [[ "$SKIP_GTC" == 0 ]] && DESTS="${DESTS:+$DESTS, }$GTC_REPO(gtc)"
-info "Published $BASE (+ $LATEST pointer) to: ${DESTS:-<none>}"
+info "Published $BASE (+ $LATEST pointer; tags: $ROLLING_TAG, $ARCHIVE_TAG) to: ${DESTS:-<none>}"


### PR DESCRIPTION
## v0.4.52 — Index as a Resource (Y-asset)

Stops runtime `git clone` of the package index from GitHub. The xim index is now
published as a versioned **resource artifact** (`xim-index-<ver>.tar.gz` + signed-ready
`manifest.json`) to `xlings-res/xim-index` (GitHub + GitCode) and fetched over the
existing resource-server HTTP path — which already has the 0.4.49 adaptive mirror
reorder + stall watchdog, **closing gap G2** (the git-clone path never had that
resilience, the root cause of the index-fetch hangs CN users hit).

### What changed
- **`src/core/xim/indexfetch.cppm`** (new): manifest parse, resource-server release URL
  build, download → **sha256 verify** → **atomic extract/swap** into `data/xim-pkgindex`.
  Supports a local-dir/`file://` base (offline/bundled + hermetic tests) and
  `XLINGS_INDEX_BASE_URL` override.
- **`sync_all_repos`**: artifact-first with git fallback. `XLINGS_INDEX_SOURCE=git|artifact|auto`.
  Auto fetches the artifact only when the index is **fresh or already artifact-managed**;
  an existing git index (fixtures/legacy) keeps using git → existing e2e unaffected.
- **Bundled index is now artifact-managed** (`.git` stripped + `.xlings-index-version`
  marker) in `package_xim_index.{sh,ps1}`, so fresh installs refresh via the artifact.
- **`tools/build_xim_index_artifact.sh` / `publish_xim_index.sh`**: build + publish
  (rolling `latest` + `v<ver>` archive) to GitHub (`gh`) and GitCode (`gtc`).

### Robustness / integrity
- sha256-pinned artifact; tamper → reject + keep last-good index (atomic swap).
- CN: candidates include GitCode + GitHub + `mirror::expand` China proxies + git fallback,
  adaptive-latency ordered.
- Leaves room for X-full (manifest `format_version` + reserved `signature` for minisign).

### Verified
- Live end-to-end: `xlings update` installs the index from the published GitHub artifact
  (no `.git`, 112 pkgs, version marker `0.4.52`).
- Unit: manifest parse + URL build. E2e: artifact build (sha256/.git-strip); update
  happy-path + tamper-reject.
- Artifact already published to `xlings-res/xim-index` (github + gitcode), tags `latest` + `v0.4.52`.

### Design docs
- `.agents/docs/2026-06-21-pkgindex-mirror-analysis.md`
- `.agents/docs/2026-06-21-pkgindex-redesign-proposal.md`
- `.agents/docs/2026-06-22-index-as-resource-impl-plan.md`

### Known follow-up
- GitCode uploaded-release-asset *download* URL is an unresolved platform quirk; CN is
  served via GitHub + China proxies meanwhile (robust). Source archive works.
- Sub-index repos (awesome/scode/d2x) still git-synced (Phase 3 will artifact-ize them).
- CI auto-publish of the index artifact on release (currently published manually).
