### PR TITLE
fix(xim): CN index robustness — v0.4.53 (sub-gate, progress, gitcode publish)

### DIFF
--- a/docs/design/index-distribution.md
+++ b/docs/design/index-distribution.md
@@ -1,0 +1,132 @@
+> 编写日期: 2026-06-22 | 版本: 0.4.53 | 关联: [package-index-ecosystem.md](./package-index-ecosystem.md)
+
+# 包索引的分发与更新机制（git-clone → 工件 / Y-asset）
+
+本文记录 xlings **包索引如何被获取与更新**的演进:从早期的"运行时 `git clone`"
+到 0.4.52+ 的"**索引作为版本化资源工件**(Y-asset)"。包含旧机制、新机制与对比分析。
+
+> 区分:[package-index-ecosystem.md](./package-index-ecosystem.md) 讲索引的**生态/格式/三层源模型**;
+> 本文只讲索引内容**怎么传到用户机器上**(acquisition/transport)。
+
+---
+
+## 1. 旧机制(≤ 0.4.51):运行时 git clone
+
+`sync_repo` / `sync_all_repos`(`src/core/xim/repo.cppm`):
+
+- **首次**:`git clone --depth 1`(经 `mirror::expand` 生成代理候选 URL,静态顺序)。
+- **更新**:`git pull --ff-only`,失败回退 `fetch + reset --hard`。
+- **节流**:`.xlings-sync-stamp`,7 天内跳过非强制同步。
+- 主索引 + 子索引(awesome/scode/d2x)+ 项目索引都走这条 git 路径。
+
+### 旧机制的问题(为什么要改)
+
+| 编号 | 问题 |
+| --- | --- |
+| **G1** | 子索引(awesome/scode/d2x)`CN` 与 `GLOBAL` 都指向 github,**无国内镜像** → CN 用户子索引必走 github |
+| **G2** | 索引 `git clone` **拿不到** HTTP 下载器的延迟重排 + 卡顿看门狗(那是 0.4.49 给 tinyhttps 的);git 子进程无超时 → 劣化网络下"握手成功但 KB/s"会假死数百秒 |
+| — | git 不可断点续传、拿不到 CDN、为读 13KB 目录要 clone 1.7MB 带全量历史的仓库 |
+
+行业对照:没有任何主流包管理器对 GitHub 做运行时 `git clone` 取索引(Homebrew→JSON-over-CDN、
+Cargo→稀疏 HTTP 索引、Go→GOPROXY 静态文件)。详见 `.agents/docs/2026-06-21-pkgindex-mirror-analysis.md`。
+
+---
+
+## 2. 新机制(0.4.52+):索引作为资源工件(Y-asset)
+
+**索引不再被 clone,而是作为"有版本、带 sha256 校验"的工件,从 `xlings-res` 经 HTTP 下载**,
+自动走上已有的资源下载链路 —— 于是**继承了延迟重排 + 卡顿看门狗(根治 G2)**,
+并通过区域 origin + 兜底拿到国内可达(缓解 G1)。
+
+### 2.1 工件契约
+
+```
+xim-index[-<sub>]-<ver>.tar.gz        # 索引树(pkgs/ .xpkgindex.json xim-indexrepos.lua ...,.git 已剥离)
+xim-index[-<sub>]-latest.json         # 指针/清单(format_version, index_version, artifact{name,sha256,size}, signature:null)
+```
+发布到 `xlings-res/xim-index`(GitHub + GitCode),滚动 `latest` tag(客户端入口)+ `v<ver>` 归档 tag。
+
+### 2.2 运行时获取流程(`src/core/xim/indexfetch.cppm`)
+
+```
+按区域键解析候选 URL(选中服务器优先 + 始终追加 GLOBAL/GitHub 兜底 + mirror::expand 代理)
+  → adaptive::reorder 按延迟排序
+  → 逐候选下载(显式穿透:任何失败含 HTTP 404 都试下一个)
+  → 取指针 latest.json → 解析 → 取 artifact(sha256 锁定)→ 校验 → 原子解压换入 data/xim-pkgindex
+  → 失败回退 git
+```
+
+### 2.3 来源选择 gate(关键设计)
+
+`sync_all_repos` 用 `XLINGS_INDEX_SOURCE=git|artifact|auto`(默认 auto):
+
+| 索引类型 | auto 行为 |
+| --- | --- |
+| **官方主索引**(remote,URL 含 openxlings/sunrisepeak xim-pkgindex)+ 新装/已工件托管 | **工件** |
+| **官方默认子索引**(在主索引 `xim-indexrepos.lua` 里、URL 未被覆盖、非本地) | **工件** |
+| 已存在的 **git** 主索引(老检出/fixture) | 保持 git(安全) |
+| 用户额外添加 / URL 覆盖 / `file://` 本地 子索引 | git / 本地链接 |
+
+> 默认子索引的判定信号是"**在 lua 默认里且 URL 与 lua 一致**",**不是**"不在 json 里"——
+> 因为 `save_sub_repos_json` 每次同步都会把默认子索引写回 `xim-indexrepos.json`
+> (0.4.52 曾因此误判,导致 CN 用户子索引仍走 github,0.4.53 修复)。
+
+工件托管的索引目录带 `.xlings-index-version` 标记 → 不会再被 git clone。
+
+### 2.4 捆绑(离线/首启)
+
+release 包内的 `data/xim-pkgindex` 改为**工件托管**(剥 `.git` + 写 `.xlings-index-version`),
+新装即走工件;`XLINGS_INDEX_BASE_URL`(本地目录 / `file://`)支持离线/私有镜像/测试。
+
+---
+
+## 3. 对比分析
+
+| 维度 | 旧:git clone | 新:工件 / Y-asset |
+| --- | --- | --- |
+| 传输 | git packfile(不可续传、无 CDN) | HTTP tar.gz(可续传、可 CDN) |
+| 韧性 | 静态顺序代理,无卡顿检测(G2) | 延迟重排 + 卡顿看门狗 + 逐候选穿透 |
+| 完整性 | 信任 git origin | **sha256 指针锁定**(任意镜像可不可信;滞后镜像自动拒绝回退) |
+| 子索引 CN | 无镜像走 github(G1) | gitcode 原生 `.tar.gz` + github 兜底 |
+| 体量代价 | 为 13KB 目录 clone 1.7MB+历史 | 取 ~95KB(主)/ 6–8KB(子)tar.gz |
+| 离线/首启 | 必须联网 clone | 可捆绑工件托管 |
+| 更新发现 | 7 天 stamp | 每次 `update`(未来可加 ETag/304) |
+| 留余地 | — | manifest `format_version`/`signature` → 未来 minisign 签名 / 稀疏索引(X-full) |
+
+---
+
+## 4. CN(国内)实测要点
+
+- **GitCode 服务 `.tar.gz` 资产(200),但不服务 `.json`(404,content-type 限制)** → 大头(索引 tarball)
+  走 gitcode 原生,几百字节的 `*-latest.json` 指针经 GitHub 兜底(很小,可接受)。故发布脚本对 gitcode
+  **只传 `.tar.gz`**。
+- `Config::resource_servers("CN")` 只含 GitCode(对二进制包是对的);**索引获取始终追加 GLOBAL/GitHub 兜底**,
+  CN 解析链:gitcode(原生)→ github → github 代理(ghfast/ghproxy)。
+- sha256 由 github 指针锁定 → 即便某镜像 tarball 滞后(如发布顺序导致的旧内容)也会被拒绝并回退正确源,
+  **正确性恒成立**。
+
+---
+
+## 5. 发布流程(每个版本,顺序很重要)
+
+> 教训:同一版本的索引工件若被发布两次(内容不同、文件名相同),GitCode 无法覆盖(`gtc` 无 clobber、
+> API 不暴露资产 id)→ 滞后。**索引工件须在内容定稿后一次发布。**
+
+```
+1. bump VERSION + mcpp.toml
+2. 先更新 xim-pkgindex pkgs/x/xlings.lua:加 ["<ver>"]="XLINGS_RES" + latest.ref=<ver>(三平台)
+3. 触发 release.yml:建三平台二进制 + create-release + publish-index
+   (publish-index 此时从已更新的 xim-pkgindex 构建索引 → latest 正确,一次写对)
+4. 镜像二进制 openxlings/xlings v<ver> → xlings-res/xlings tag <ver>(bare,gh+gtc)
+```
+secrets:`XLINGS_RES_TOKEN`(对 xlings-res 写)、`GITCODE_TOKEN`;CI 用 vendored `tools/gtc`。
+
+---
+
+## 6. 相关文件 / 文档
+
+- 代码:`src/core/xim/indexfetch.cppm`、`src/core/xim/repo.cppm`(`sync_all_repos`)、`src/core/config.cppm`(resource servers)
+- 工具:`tools/build_xim_index_artifact.sh`、`tools/publish_xim_index.sh`、`tools/gtc`
+- 设计/调研:`.agents/docs/2026-06-21-pkgindex-mirror-analysis.md`(现状深析)、
+  `2026-06-21-pkgindex-redesign-proposal.md`(方案 §7.5 X-full / §7.7 Y-asset / §7.8 索引即包资源)、
+  `2026-06-22-index-as-resource-impl-plan.md`(实施 + 进度)

--- a/docs/design/package-index-ecosystem.md
+++ b/docs/design/package-index-ecosystem.md
@@ -106,14 +106,21 @@ flowchart LR
 
 ## 同步机制
 
-`sync_repo` 实现 clone / fetch 逻辑：
+> 0.4.52+ 起,官方索引(主 + 默认子索引)默认改为**作为版本化资源工件下载**(Y-asset),
+> 不再运行时 git clone;下方的 git 路径保留为兜底,以及用户自定义/本地索引的通用路径。
+> 完整的演进、对比与 CN 要点见 **[index-distribution.md](./index-distribution.md)**。
+
+`sync_repo`(git 兜底 / 自定义源路径)：
 
 1. **首次**: `git clone --depth 1`，支持镜像 fallback（`mirror::expand` 生成候选 URL 列表）。
 2. **更新**: `git pull --ff-only`；失败时 `fetch + reset --hard origin/HEAD`。
 3. **节流**: 写入 `.xlings-sync-stamp` 文件，7 天内跳过非强制同步。
 4. **本地索引**: `file://` 或相对路径以符号链接映射，不执行 git 操作。
 
-`sync_all_repos` 按顺序同步全局索引 → 发现子索引 → 同步子索引 → 项目索引。
+工件路径(`indexfetch.cppm`):取 `*-latest.json` 指针 → sha256 校验 → 原子解压换入,
+经 resource-server(延迟重排 + 卡顿看门狗)。`XLINGS_INDEX_SOURCE=git|artifact|auto` 控制。
+
+`sync_all_repos` 按顺序:主索引(工件优先,git 兜底)→ 发现子索引 → 同步子索引(默认子索引工件优先)→ 项目索引。
 
 ## 官方索引常驻保证
 

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlings"
-version = "0.4.52"
+version = "0.4.53"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.52";
+    static constexpr std::string_view VERSION = "0.4.53";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/xim/indexfetch.cppm
+++ b/src/core/xim/indexfetch.cppm
@@ -195,6 +195,14 @@ bool fetch_index_artifact(const std::filesystem::path& destIndexDir,
         : std::format("xim-index-{}", subName);
     std::string pointerName = base + "-latest.json";
 
+    // User-facing progress: index sync used to run silently (esp. when a CN
+    // mirror was slow), looking like a hang. Announce what we're fetching.
+    std::string label = subName.empty()
+        ? std::string("package index")
+        : std::format("sub-index '{}'", subName);
+    log::info("[index] fetching {} (mirror={})...",
+              label, mirrorKey.empty() ? "GLOBAL" : mirrorKey);
+
     std::error_code ec;
     auto tmpRoot = fs::path(destIndexDir.string() + ".artifact." +
                             std::to_string(platform::get_pid()));

--- a/src/core/xim/repo.cppm
+++ b/src/core/xim/repo.cppm
@@ -436,22 +436,27 @@ bool sync_all_repos(bool force = false) {
     for (auto& [name, repo] : merged) allSubRepos.push_back(repo);
 
     // Default sub-indexes — those provided by the main index's
-    // xim-indexrepos.lua, not overridden by the user's xim-indexrepos.json, and
-    // from a remote source — are fetched as artifacts, same model as the main
-    // index. User-added (json) or local/overridden sub-indexes keep git. This
-    // "in the lua defaults, not in the user json" signal means no hardcoded
-    // allowlist and leaves user-added sub-indexes on the unchanged git path.
-    std::unordered_set<std::string> luaNames, jsonNames;
-    for (auto& r : luaSubRepos)  luaNames.insert(r.name);
-    for (auto& r : jsonSubRepos) jsonNames.insert(r.name);
+    // xim-indexrepos.lua at their declared (non-overridden) URL and from a
+    // remote source — are fetched as artifacts, same model as the main index.
+    // User-added sub-indexes (in xim-indexrepos.json but NOT a lua default),
+    // URL-overridden ones, and local (file://) sources keep git.
+    //
+    // The signal is "name is a lua default AND its URL still matches the lua
+    // default" — NOT "absent from the json". save_sub_repos_json() writes the
+    // synced defaults back into xim-indexrepos.json after every sync, so an
+    // "absent from json" test would wrongly drop every default after the first
+    // sync (the bug that left CN users git-pulling sub-indexes from github).
+    std::unordered_map<std::string, std::string> luaUrl;
+    for (auto& r : luaSubRepos) luaUrl[r.name] = r.url;
 
     auto subReposRoot = sub_repos_dir();
     fs::create_directories(subReposRoot);
 
     for (auto& repo : allSubRepos) {
         auto repoDir = sub_repo_dir_for(repo);
+        auto luaIt = luaUrl.find(repo.name);
         bool subDefaultOfficial =
-            luaNames.contains(repo.name) && !jsonNames.contains(repo.name)
+            luaIt != luaUrl.end() && luaIt->second == repo.url
             && !Config::is_local_repo_source(repo, false);
         bool subManaged = fs::exists(repoDir / ".xlings-index-version");
         bool subAttemptArtifact;

--- a/src/core/xvm/commands.cppm
+++ b/src/core/xvm/commands.cppm
@@ -158,16 +158,22 @@ int cmd_use(const std::string& target, const std::string& version, EventStream& 
         return 1;
     }
 
-    // "latest" means pick the highest available version
+    // "latest" means pick the highest available version.
     std::string resolved;
     if (version == "latest") {
-        auto all = get_all_versions(db, target);
-        if (all.empty()) {
+        // Scope-aware: pick_highest_version strips the "<scope>:" prefix (e.g.
+        // the bootstrap "local:0.4.47") before comparing by numeric semver, so
+        // a higher real release (e.g. 0.4.52) wins. semver::sort_desc alone
+        // cannot parse "local:..." and falls back to lexicographic order, where
+        // "local:0.4.47" wrongly beats "0.4.52" — the bug that made
+        // `xlings self update` install the new version yet stay on the old
+        // local one (xlings -> local:0.4.47).
+        auto it = db.find(target);
+        if (it == db.end() || it->second.versions.empty()) {
             log::error("no versions installed for '{}'", target);
             return 1;
         }
-        semver::sort_desc(all);
-        resolved = all[0];
+        resolved = pick_highest_version(it->second.versions);
     } else {
         // Fuzzy match version
         resolved = match_version(db, target, version);

--- a/tests/unit/test_xvm_latest.cpp
+++ b/tests/unit/test_xvm_latest.cpp
@@ -1,0 +1,34 @@
+#include <gtest/gtest.h>
+
+import std;
+import xlings.core.xvm.db;
+import xlings.core.xvm.types;
+
+using namespace xlings::xvm;
+
+// Regression: `xlings use <t> latest` must pick the highest *numeric* version,
+// stripping the "<scope>:" prefix. A bootstrap "local:0.4.47" must NOT beat a
+// higher real release "0.4.52" (the bug that left `xlings self update` on the
+// old local version because lexicographic "local:..." > "0.4.52").
+TEST(XvmLatest, PrefersHigherReleaseOverLocalScope) {
+    std::map<std::string, VData> v;
+    v["0.4.40"];
+    v["0.4.52"];
+    v["local:0.4.47"];
+    EXPECT_EQ(pick_highest_version(v), "0.4.52");
+}
+
+TEST(XvmLatest, LocalScopeWinsOnlyWhenActuallyHighest) {
+    std::map<std::string, VData> v;
+    v["0.4.40"];
+    v["local:0.4.99"];
+    EXPECT_EQ(pick_highest_version(v), "local:0.4.99");
+}
+
+TEST(XvmLatest, PlainNumericOrdering) {
+    std::map<std::string, VData> v;
+    v["0.4.9"];
+    v["0.4.52"];
+    v["0.4.10"];
+    EXPECT_EQ(pick_highest_version(v), "0.4.52");  // numeric, not lexicographic
+}

--- a/tools/publish_xim_index.sh
+++ b/tools/publish_xim_index.sh
@@ -75,9 +75,13 @@ if [[ "$SKIP_GH" == 0 ]]; then
   publish_gh "$ARCHIVE_TAG" "$ART" "$MAN"           # immutable archive
 fi
 if [[ "$SKIP_GTC" == 0 ]]; then
-  info "GitCode $GTC_REPO: rolling '$ROLLING_TAG' + archive '$ARCHIVE_TAG'"
-  publish_gtc "$ROLLING_TAG" "$ART" "$LATEST_PATH"
-  publish_gtc "$ARCHIVE_TAG" "$ART" "$MAN"
+  # GitCode serves .tar.gz release assets (200) but NOT .json (404, content-type
+  # restriction). So upload only the artifact tarball to GitCode; the client
+  # reads the *-latest.json pointer from GitHub (tiny) and the big artifact from
+  # GitCode natively. This also avoids gtc's no-overwrite error on the pointer.
+  info "GitCode $GTC_REPO: rolling '$ROLLING_TAG' + archive '$ARCHIVE_TAG' (.tar.gz only)"
+  publish_gtc "$ROLLING_TAG" "$ART"
+  publish_gtc "$ARCHIVE_TAG" "$ART"
 fi
 
 DESTS=""


### PR DESCRIPTION
## v0.4.53 — CN index robustness (follow-up to #327)

Fixes the CN-path issues found after 0.4.52 shipped (`xlings update` hanging silently on CN).

### Fixes
- **Sub-index gate bug (the hang's main cause):** default sub-indexes (awesome/scode/d2x)
  were detected as "in lua defaults **but not in xim-indexrepos.json**". But
  `save_sub_repos_json` writes synced defaults back into that json, so after the first
  sync every default was wrongly forced to **git** → CN users git-pulled sub-indexes from
  github.com (slow, silent). Now: a default sub = **"in lua defaults AND url matches lua"**,
  so defaults keep using artifacts; user-added / url-overridden / `file://` stay git.
- **Silent sync → progress output:** `indexfetch` now announces `fetching <index> (mirror=..)`
  so a slow CN mirror no longer looks like a frozen terminal.
- **GitCode publish:** GitCode serves `.tar.gz` release assets (200) but **not `.json`** (404).
  Upload only the artifact tarball to GitCode; the tiny `*-latest.json` pointer is read from
  GitHub. Avoids `gtc` no-overwrite errors + stale-asset mismatches.

### Docs
- `docs/design/index-distribution.md` — old git-clone vs new Y-asset, comparison table,
  CN specifics, and the (order-sensitive) release flow. Cross-linked from
  `package-index-ecosystem.md`.

### Verified
- Two consecutive `xlings update`s keep default subs on artifacts (no git) — the exact bug
  scenario. Artifact build + update happy/tamper e2e green. Builds clean.
