### PR TITLE
fix(xim): gitcode-native .tar.gz index pointer — v0.4.54 (fix CN update hang)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -343,3 +343,13 @@ jobs:
             bash tools/publish_xim_index.sh --version "$VER" --name "$n" --dir build/index --skip-github \
               || echo "gitcode $n publish failed (non-blocking)"
           done
+
+      # Push the rolling pointers as repo files (overwriteable, served raw) to
+      # both GitHub and GitCode. This is what clients read to find the latest
+      # artifact; repo files (unlike gitcode release assets) can be updated.
+      - name: Push index pointers (raw repo files, gh + gtc)
+        if: ${{ env.XLINGS_RES_TOKEN != '' || env.GITCODE_TOKEN != '' }}
+        env:
+          XLINGS_RES_TOKEN: ${{ secrets.XLINGS_RES_TOKEN }}
+          GITCODE_TOKEN: ${{ secrets.GITCODE_TOKEN }}
+        run: bash tools/push_index_pointers.sh build/index

--- a/docs/design/index-distribution.md
+++ b/docs/design/index-distribution.md
@@ -97,9 +97,13 @@ release 包内的 `data/xim-pkgindex` 改为**工件托管**(剥 `.git` + 写 `.
 
 ## 4. CN(国内)实测要点
 
-- **GitCode 服务 `.tar.gz` 资产(200),但不服务 `.json`(404,content-type 限制)** → 大头(索引 tarball)
-  走 gitcode 原生,几百字节的 `*-latest.json` 指针经 GitHub 兜底(很小,可接受)。故发布脚本对 gitcode
-  **只传 `.tar.gz`**。
+- **GitCode 服务 `.tar.gz` 资产(200),但不服务 `.json`(404,content-type 限制)。**
+  - 因此 **0.4.54 起指针改为 `.tar.gz`**:`xim-index[-sub]-latest.tar.gz`(内含 `manifest.json`),
+    GitCode 原生可下 → CN 客户端**指针也走 gitcode**,不再回退 github 代理。
+  - 教训(0.4.53):`.json` 指针在 gitcode 404 → 回退到 TCP 延迟低但**不服务该资源**的 github 代理
+    (kkgithub/ghfast),每个吃满 ~30s 读超时 → `xlings update` 卡数分钟。`.tar.gz` 指针根治。
+  - 防御:候选下载对**超时/无响应**的主机做 session 内 penalize(但 404 不罚,因为只是该 mirror 缺此资源)。
+  - 兼容:`*-latest.json` 仍发到 GitHub(供 0.4.53 客户端);GitCode 只发 `.tar.gz`。
 - `Config::resource_servers("CN")` 只含 GitCode(对二进制包是对的);**索引获取始终追加 GLOBAL/GitHub 兜底**,
   CN 解析链:gitcode(原生)→ github → github 代理(ghfast/ghproxy)。
 - sha256 由 github 指针锁定 → 即便某镜像 tarball 滞后(如发布顺序导致的旧内容)也会被拒绝并回退正确源,

--- a/docs/design/index-distribution.md
+++ b/docs/design/index-distribution.md
@@ -95,15 +95,28 @@ release 包内的 `data/xim-pkgindex` 改为**工件托管**(剥 `.git` + 写 `.
 
 ---
 
-## 4. CN(国内)实测要点
+## 4. CN(国内)设计与实测要点(0.4.54 定稿)
 
-- **GitCode 服务 `.tar.gz` 资产(200),但不服务 `.json`(404,content-type 限制)。**
-  - 因此 **0.4.54 起指针改为 `.tar.gz`**:`xim-index[-sub]-latest.tar.gz`(内含 `manifest.json`),
-    GitCode 原生可下 → CN 客户端**指针也走 gitcode**,不再回退 github 代理。
-  - 教训(0.4.53):`.json` 指针在 gitcode 404 → 回退到 TCP 延迟低但**不服务该资源**的 github 代理
-    (kkgithub/ghfast),每个吃满 ~30s 读超时 → `xlings update` 卡数分钟。`.tar.gz` 指针根治。
-  - 防御:候选下载对**超时/无响应**的主机做 session 内 penalize(但 404 不罚,因为只是该 mirror 缺此资源)。
-  - 兼容:`*-latest.json` 仍发到 GitHub(供 0.4.53 客户端);GitCode 只发 `.tar.gz`。
+GitCode 平台约束(均实测):release 资产**只能新建**(gtc 不能覆盖、API 删除 405,且大文件上传偶发
+`obs_callback EOF` 变成"列出但 404 的幽灵资产");raw 仓库文件**可 git push 覆盖**但 `.json` 需用
+`raw.gitcode.com/<o>/<r>/raw/main/<f>` 形式(`/main/` 形式返回 HTML),且**短时间多次请求会被限流**。
+
+由此定稿设计:
+
+- **指针 = 合并的单文件 `xim-index-pointers.json`(仓库文件,git push 覆盖)**,内含所有索引
+  `{"format_version":1,"indexes":{"xim":{...},"awesome":{...},"scode":{...},"d2x":{...}}}`。
+  - 一次 raw 取回**全部**索引指针 → 避免 gitcode raw 限流(之前一版一取会触发 403)。
+  - 仓库文件可 git push 覆盖 → 绕开 gitcode release 不能覆盖/删除的限制。
+- **工件 = 版本号唯一的 release 资产**(只新建,从不覆盖)。
+- **索引候选不挂 github 代理**(ghfast/ghproxy/kkgithub):它们 TCP 连得上但常不服务该资源,
+  延迟低被排前 → 每个 ~30s 超时,正是 CN "fetching package index" 卡死主因。索引只用
+  **gitcode + github 直连**(分区排序);gitcode 未命中即快速回退 github。
+- 防御:对**超时/无响应**主机 session 内 penalize(404 不罚)。
+- **可配置(为自建服务器留口)**:`XLINGS_INDEX_BASE_URL`(env)或 `.xlings.json` 的 `xim.index-base`
+  (字符串或 `{GLOBAL,CN}`)指定指针+工件的基地址;自建服务器只需在该 base 下提供
+  `xim-index-pointers.json` + `xim-index[-sub]-<ver>.tar.gz` 静态文件即可。
+
+实测(CN,无 VPN-绕过配置):`xlings update` 主+3 子索引全走工件、12s、无卡顿、无回退 git。
 - `Config::resource_servers("CN")` 只含 GitCode(对二进制包是对的);**索引获取始终追加 GLOBAL/GitHub 兜底**,
   CN 解析链:gitcode(原生)→ github → github 代理(ghfast/ghproxy)。
 - sha256 由 github 指针锁定 → 即便某镜像 tarball 滞后(如发布顺序导致的旧内容)也会被拒绝并回退正确源,

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlings"
-version = "0.4.53"
+version = "0.4.54"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.53";
+    static constexpr std::string_view VERSION = "0.4.54";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -59,6 +59,7 @@ private:
 
     PathInfo paths_;
     std::string mirror_;
+    std::string indexBase_;   // xim.index-base override (region-resolved); empty = default xlings-res
     std::string lang_;
     std::string globalActiveSubos_ = "default";
     xvm::VersionDB globalVersions_;
@@ -100,6 +101,23 @@ private:
             { "GLOBAL", { "https://github.com/xlings-res" } },
             { "CN", { "https://gitcode.com/xlings-res" } },
         };
+    }
+
+    // Resolve xim.index-base from a config json. Accepts a flat string or a
+    // region object {"GLOBAL":"...","CN":"..."}. Lets a deployment point the
+    // index pointer+artifact at a self-hosted server without code changes.
+    static std::string resolve_index_base_(const nlohmann::json& json, const std::string& mirror) {
+        if (!json.contains("xim") || !json["xim"].is_object()) return {};
+        auto& xim = json["xim"];
+        if (!xim.contains("index-base")) return {};
+        auto& ib = xim["index-base"];
+        if (ib.is_string()) return ib.get<std::string>();
+        if (ib.is_object()) {
+            std::string key = mirror.empty() ? "GLOBAL" : mirror;
+            if (ib.contains(key) && ib[key].is_string()) return ib[key].get<std::string>();
+            if (ib.contains("GLOBAL") && ib["GLOBAL"].is_string()) return ib["GLOBAL"].get<std::string>();
+        }
+        return {};
     }
 
     static void load_index_repos_from_json_(const nlohmann::json& json,
@@ -474,6 +492,7 @@ private:
                         globalVersions_ = xvm::versions_from_json(json["versions"]);
                     load_index_repos_from_json_(json, globalIndexRepos_);
                     load_resource_servers_from_json_(json, globalResourceServers_);
+                    if (auto v = resolve_index_base_(json, mirror_); !v.empty()) indexBase_ = v;
                 }
             } catch (...) {}
         }
@@ -581,6 +600,7 @@ private:
                 }
                 load_index_repos_from_json_(json, projectIndexRepos_);
                 load_resource_servers_from_json_(json, projectResourceServers_);
+                if (auto v = resolve_index_base_(json, mirror_); !v.empty()) indexBase_ = v;  // project overrides global
                 projectSubosName_ = load_project_subos_name_(json);
 
                 auto projectStatePath = project_state_path_();
@@ -763,6 +783,9 @@ public:
     [[nodiscard]] static std::string resource_server(std::string_view mirror = {}) {
         return instance_().selected_resource_server_for_(mirror);
     }
+    // xim.index-base override (env XLINGS_INDEX_BASE_URL takes precedence in the
+    // caller). Empty => default xlings-res raw-pointer + release-artifact path.
+    [[nodiscard]] static std::string index_base() { return instance_().indexBase_; }
 
     [[nodiscard]] static xvm::VersionDB versions() {
         auto& self = instance_();

--- a/src/core/xim/indexfetch.cppm
+++ b/src/core/xim/indexfetch.cppm
@@ -128,6 +128,52 @@ std::string download_candidates_(std::vector<std::string> urls,
     return lastErr.empty() ? "all candidates failed" : lastErr;
 }
 
+// Index source base override (env now; config key folded in by the caller via
+// Config). When set to a local dir / file:// it's copied; a remote base means
+// "<base>/<filename>". Empty => use the passed remoteUrls (xlings-res default).
+struct BaseOverride {
+    std::string base;                      // remote base, or empty
+    std::optional<std::filesystem::path> local;  // local dir, if base is local
+};
+BaseOverride resolve_base_() {
+    BaseOverride b;
+    std::string v;
+    if (auto* e = std::getenv("XLINGS_INDEX_BASE_URL"); e && *e) v = e;
+    else v = Config::index_base();   // .xlings.json xim.index-base (region-aware), else ""
+    if (v.empty()) return b;
+    while (!v.empty() && v.back() == '/') v.pop_back();
+    b.base = v;
+    if (v.starts_with("file://")) b.local = std::filesystem::path(v.substr(7));
+    else if (v.find("://") == std::string::npos) b.local = std::filesystem::path(v);
+    return b;
+}
+
+// Obtain `filename` into `dest`: local-dir copy, or remote (base override, else
+// the given remoteUrls). Verifies sha256 when wantSha is non-empty.
+std::string obtain_file(const std::string& filename, std::vector<std::string> remoteUrls,
+                        const std::filesystem::path& dest, std::string_view wantSha) {
+    namespace fs = std::filesystem;
+    auto b = resolve_base_();
+    if (b.local) {
+        std::error_code ec;
+        auto src = *b.local / filename;
+        if (!fs::exists(src, ec)) return std::format("local file not found: {}", src.string());
+        fs::copy_file(src, dest, fs::copy_options::overwrite_existing, ec);
+        if (ec) return std::format("copy {} failed: {}", src.string(), ec.message());
+        if (!wantSha.empty()) {
+            auto digest = sha256::hex_file(dest);
+            auto want = lower_hex_(std::string(wantSha));
+            if (!digest || *digest != want)
+                return std::format("sha256 mismatch (local {}): got {}, want {}",
+                                   src.string(), digest ? *digest : "<unreadable>", want);
+        }
+        return {};
+    }
+    auto urls = b.base.empty() ? std::move(remoteUrls)
+                               : std::vector<std::string>{ b.base + "/" + filename };
+    return download_candidates_(std::move(urls), dest, wantSha);
+}
+
 } // namespace detail_
 
 std::optional<IndexManifest> parse_index_manifest(std::string_view jsonText) {
@@ -178,14 +224,77 @@ std::vector<std::string> index_asset_urls(std::string_view filename,
     // github -> github proxies.
     for (auto& server : Config::resource_servers("GLOBAL")) add(buildFor(server));
 
-    // GitHub proxy variants (ghfast/ghproxy/...) for the github-hosted URLs.
-    std::vector<std::string> expanded;
-    for (auto& u : urls) {
-        for (auto& m : mirror::expand(u, {.type = mirror::ResourceType::Release}))
-            expanded.push_back(std::move(m));
-    }
-    for (auto& u : expanded) add(u);
+    // NB: deliberately NO github-proxy expansion (ghfast/ghproxy/kkgithub) for
+    // the index. Those proxies are often TCP-reachable but don't actually serve
+    // the asset, so a fast-latency-but-dead proxy ranked ahead of github causes
+    // a ~30s timeout per dead host (the CN "fetching package index" hang). The
+    // index is small; gitcode + github-direct (region-ordered) is enough, and a
+    // gitcode 404/miss falls through to github fast.
     return urls;
+}
+
+// Raw-file URLs for the rolling pointer (a file committed to the index repo,
+// updated by git push, served raw). github.com/<org> ->
+// raw.githubusercontent.com/<org>/<repo>/main/<f>; gitcode.com/<org> ->
+// raw.gitcode.com/<org>/<repo>/raw/main/<f>. Region-ordered + GLOBAL fallback.
+std::vector<std::string> index_pointer_urls(std::string_view filename,
+                                            std::string_view mirror) {
+    auto repo = detail_::index_repo_name_();
+    std::vector<std::string> urls;
+    auto add = [&](const std::string& u){
+        if (!u.empty() && std::ranges::find(urls, u) == urls.end()) urls.push_back(u);
+    };
+    auto rawFor = [&](const std::string& server) -> std::string {
+        auto pos = server.find("://");
+        std::string rest = pos == std::string::npos ? server : server.substr(pos + 3);
+        auto slash = rest.find('/');
+        if (slash == std::string::npos) return {};
+        std::string host = rest.substr(0, slash);
+        std::string org  = rest.substr(slash + 1);
+        while (!org.empty() && org.back() == '/') org.pop_back();
+        if (host.find("github.com") != std::string::npos)
+            return std::format("https://raw.githubusercontent.com/{}/{}/main/{}", org, repo, filename);
+        if (host.find("gitcode.com") != std::string::npos)
+            // Correct raw form is .../<o>/<r>/raw/main/<f> — it serves the RAW
+            // bytes (incl .json). The .../main/<f> form (no /raw/) returns the
+            // HTML web page. (403s seen while probing were request rate-limiting.)
+            return std::format("https://raw.gitcode.com/{}/{}/raw/main/{}", org, repo, filename);
+        return {};
+    };
+    auto selected = Config::resource_server(mirror);
+    if (!selected.empty()) add(rawFor(selected));
+    for (auto& s : Config::resource_servers(mirror))   add(rawFor(s));
+    for (auto& s : Config::resource_servers("GLOBAL")) add(rawFor(s));
+    return urls;
+}
+
+// Cached fetch of the COMBINED pointer file (xim-index-pointers.json): ONE raw
+// fetch per process covering ALL indexes (main + subs). One fetch (vs one per
+// index) avoids gitcode raw rate-limiting, and is the single file a self-hosted
+// index server must serve. Format:
+//   {"format_version":1,"indexes":{"xim":{<manifest>},"awesome":{<manifest>},...}}
+const std::map<std::string, IndexManifest>& load_index_pointers(std::string_view mirror) {
+    static std::map<std::string, IndexManifest> cache;
+    static std::once_flag once;
+    std::call_once(once, [&] {
+        namespace fs = std::filesystem;
+        auto tmp = fs::temp_directory_path() /
+                   std::format("xim-index-pointers.{}.json", platform::get_pid());
+        std::error_code ec; fs::remove(tmp, ec);
+        auto err = detail_::obtain_file("xim-index-pointers.json",
+                       index_pointer_urls("xim-index-pointers.json", mirror), tmp, {});
+        if (!err.empty()) { log::warn("[index] pointer fetch failed: {}", err); return; }
+        std::string text;
+        { std::ifstream in(tmp, std::ios::binary); std::stringstream ss; ss << in.rdbuf(); text = ss.str(); }
+        fs::remove(tmp, ec);
+        try {
+            auto j = nlohmann::json::parse(text);
+            if (j.contains("indexes") && j["indexes"].is_object())
+                for (auto it = j["indexes"].begin(); it != j["indexes"].end(); ++it)
+                    if (auto m = parse_index_manifest(it.value().dump())) cache[it.key()] = *m;
+        } catch (...) { log::warn("[index] pointer parse failed"); }
+    });
+    return cache;
 }
 
 bool fetch_index_artifact(const std::filesystem::path& destIndexDir,
@@ -193,23 +302,22 @@ bool fetch_index_artifact(const std::filesystem::path& destIndexDir,
                           std::string_view subName) {
     namespace fs = std::filesystem;
     auto mirrorKey = Config::mirror();
+    std::string key = subName.empty() ? std::string("xim") : std::string(subName);
 
-    std::string base = subName.empty()
-        ? "xim-index"
-        : std::format("xim-index-{}", subName);
-    // Pointer is a .tar.gz (containing manifest.json), NOT a .json: GitCode
-    // serves .tar.gz release assets (200) but 404s .json, so a .json pointer
-    // forced CN clients to fall through to dead github proxies (multi-minute
-    // hang). A .tar.gz pointer is fetched from the regional mirror natively.
-    std::string pointerName = base + "-latest.tar.gz";
-
-    // User-facing progress: index sync used to run silently (esp. when a CN
-    // mirror was slow), looking like a hang. Announce what we're fetching.
     std::string label = subName.empty()
         ? std::string("package index")
         : std::format("sub-index '{}'", subName);
     log::info("[index] fetching {} (mirror={})...",
               label, mirrorKey.empty() ? "GLOBAL" : mirrorKey);
+
+    auto& pointers = load_index_pointers(mirrorKey);
+    auto pit = pointers.find(key);
+    if (pit == pointers.end()) { err = std::format("no pointer entry for '{}'", key); return false; }
+    const IndexManifest& manifest = pit->second;
+    if (manifest.format_version != 1) {
+        err = std::format("unsupported index manifest format_version {}", manifest.format_version);
+        return false;
+    }
 
     std::error_code ec;
     auto tmpRoot = fs::path(destIndexDir.string() + ".artifact." +
@@ -219,66 +327,11 @@ bool fetch_index_artifact(const std::filesystem::path& destIndexDir,
     if (ec) { err = std::format("create temp dir failed: {}", ec.message()); return false; }
     struct Cleanup { fs::path p; ~Cleanup(){ std::error_code e; fs::remove_all(p,e);} } cleanup{tmpRoot};
 
-    // Optional base override (testing / private mirror / offline bundle): a
-    // local directory (plain path or file://) is copied directly — this is also
-    // the offline/bundled-release path — while a remote base goes over HTTP.
-    // No override => the resource-server release URLs (index_asset_urls).
-    std::string baseOverride;
-    std::optional<fs::path> localBase;
-    if (auto* ov = std::getenv("XLINGS_INDEX_BASE_URL"); ov && *ov) {
-        baseOverride = ov;
-        while (!baseOverride.empty() && baseOverride.back() == '/') baseOverride.pop_back();
-        std::string p = baseOverride;
-        if (p.starts_with("file://")) localBase = fs::path(p.substr(7));
-        else if (p.find("://") == std::string::npos) localBase = fs::path(p);
-    }
-    auto obtain = [&](const std::string& filename, const fs::path& dest,
-                      std::string_view wantSha) -> std::string {
-        if (localBase) {
-            std::error_code ec2;
-            auto src = *localBase / filename;
-            if (!fs::exists(src, ec2)) return std::format("local file not found: {}", src.string());
-            fs::copy_file(src, dest, fs::copy_options::overwrite_existing, ec2);
-            if (ec2) return std::format("copy {} failed: {}", src.string(), ec2.message());
-            if (!wantSha.empty()) {
-                auto digest = sha256::hex_file(dest);
-                auto want = detail_::lower_hex_(std::string(wantSha));
-                if (!digest || *digest != want)
-                    return std::format("sha256 mismatch (local {}): got {}, want {}",
-                                       src.string(), digest ? *digest : "<unreadable>", want);
-            }
-            return {};
-        }
-        auto urls = baseOverride.empty()
-            ? index_asset_urls(filename, mirrorKey)
-            : std::vector<std::string>{ baseOverride + "/" + filename };
-        return detail_::download_candidates_(std::move(urls), dest, wantSha);
-    };
-
-    // 1. Manifest pointer (a .tar.gz containing manifest.json).
-    auto pointerFile = tmpRoot / pointerName;
-    if (auto e = obtain(pointerName, pointerFile, {}); !e.empty()) {
-        err = std::format("fetch index manifest failed: {}", e);
-        return false;
-    }
-    auto ptrDir = tmpRoot / "ptr";
-    auto ptrEx = extract_archive(pointerFile, ptrDir);
-    if (!ptrEx) { err = std::format("extract index pointer failed: {}", ptrEx.error()); return false; }
-    std::string manifestText;
-    {
-        std::ifstream in(ptrDir / "manifest.json", std::ios::binary);
-        std::stringstream ss; ss << in.rdbuf(); manifestText = ss.str();
-    }
-    auto manifest = parse_index_manifest(manifestText);
-    if (!manifest) { err = "index manifest parse failed"; return false; }
-    if (manifest->format_version != 1) {
-        err = std::format("unsupported index manifest format_version {}", manifest->format_version);
-        return false;
-    }
-
-    // 2. Artifact (sha256-pinned by the manifest).
-    auto artifactFile = tmpRoot / manifest->artifact_name;
-    if (auto e = obtain(manifest->artifact_name, artifactFile, manifest->artifact_sha256); !e.empty()) {
+    // Artifact (sha256-pinned by the manifest); release asset, versioned name.
+    auto artifactFile = tmpRoot / manifest.artifact_name;
+    if (auto e = detail_::obtain_file(manifest.artifact_name,
+                    index_asset_urls(manifest.artifact_name, mirrorKey),
+                    artifactFile, manifest.artifact_sha256); !e.empty()) {
         err = std::format("fetch index artifact failed: {}", e);
         return false;
     }
@@ -295,7 +348,7 @@ bool fetch_index_artifact(const std::filesystem::path& destIndexDir,
     // Record the installed version for diagnostics / future ETag-style checks.
     {
         std::ofstream v(stage / ".xlings-index-version", std::ios::binary);
-        v << manifest->index_version;
+        v << manifest.index_version;
     }
 
     auto backup = fs::path(destIndexDir.string() + ".old." +
@@ -316,8 +369,8 @@ bool fetch_index_artifact(const std::filesystem::path& destIndexDir,
     fs::remove_all(backup, ec);
 
     log::info("[index] updated from artifact {} ({})",
-              manifest->artifact_name,
-              manifest->index_version.empty() ? "?" : manifest->index_version);
+              manifest.artifact_name,
+              manifest.index_version.empty() ? "?" : manifest.index_version);
     return true;
 }
 

--- a/src/core/xim/indexfetch.cppm
+++ b/src/core/xim/indexfetch.cppm
@@ -105,7 +105,11 @@ std::string download_candidates_(std::vector<std::string> urls,
         opts.urls = { u };          // one URL per call: we own the fallthrough
         opts.retryCount = 1;        // breadth over depth; don't hammer a 404
         opts.onUrlAttemptFailed = [](const std::string& url, const std::string& e) {
-            if (e.rfind("stalled:", 0) == 0 || e.rfind("sha256 mismatch", 0) == 0)
+            // Demote a host that stalled / served bad bytes / timed out / gave no
+            // response so later fetches this session skip it. Do NOT penalize on
+            // plain 404/401: the asset is just absent on that mirror (e.g. gitcode
+            // 404s .json) — the host is fine for other assets.
+            if (e.find("404") == std::string::npos && e.find("401") == std::string::npos)
                 mirror::adaptive::penalize_host(url);
         };
         if (!want.empty()) {
@@ -193,7 +197,11 @@ bool fetch_index_artifact(const std::filesystem::path& destIndexDir,
     std::string base = subName.empty()
         ? "xim-index"
         : std::format("xim-index-{}", subName);
-    std::string pointerName = base + "-latest.json";
+    // Pointer is a .tar.gz (containing manifest.json), NOT a .json: GitCode
+    // serves .tar.gz release assets (200) but 404s .json, so a .json pointer
+    // forced CN clients to fall through to dead github proxies (multi-minute
+    // hang). A .tar.gz pointer is fetched from the regional mirror natively.
+    std::string pointerName = base + "-latest.tar.gz";
 
     // User-facing progress: index sync used to run silently (esp. when a CN
     // mirror was slow), looking like a hang. Announce what we're fetching.
@@ -247,16 +255,18 @@ bool fetch_index_artifact(const std::filesystem::path& destIndexDir,
         return detail_::download_candidates_(std::move(urls), dest, wantSha);
     };
 
-    // 1. Manifest pointer.
-    auto manifestFile = tmpRoot / pointerName;
-    if (auto e = obtain(pointerName, manifestFile, {}); !e.empty()) {
+    // 1. Manifest pointer (a .tar.gz containing manifest.json).
+    auto pointerFile = tmpRoot / pointerName;
+    if (auto e = obtain(pointerName, pointerFile, {}); !e.empty()) {
         err = std::format("fetch index manifest failed: {}", e);
         return false;
     }
-
+    auto ptrDir = tmpRoot / "ptr";
+    auto ptrEx = extract_archive(pointerFile, ptrDir);
+    if (!ptrEx) { err = std::format("extract index pointer failed: {}", ptrEx.error()); return false; }
     std::string manifestText;
     {
-        std::ifstream in(manifestFile, std::ios::binary);
+        std::ifstream in(ptrDir / "manifest.json", std::ios::binary);
         std::stringstream ss; ss << in.rdbuf(); manifestText = ss.str();
     }
     auto manifest = parse_index_manifest(manifestText);

--- a/tests/e2e/index_artifact_update_test.sh
+++ b/tests/e2e/index_artifact_update_test.sh
@@ -29,10 +29,13 @@ echo '{"site":{"title":"t"}}'      > "$SRC/.xpkgindex.json"
 
 SERVE="$WORK/serve"; mkdir -p "$SERVE"
 bash "$PROJECT_DIR/tools/build_xim_index_artifact.sh" --version 9.9.9 --out "$SERVE" --src "$SRC"
-# Pointer is a .tar.gz containing manifest.json (gitcode-native; see indexfetch).
-_pt="$(mktemp -d)"; cp "$SERVE/xim-index-9.9.9.manifest.json" "$_pt/manifest.json"
-tar -czf "$SERVE/xim-index-latest.tar.gz" -C "$_pt" manifest.json; rm -rf "$_pt"
-pass "fixture artifact + pointer built"
+# Combined pointer file the client fetches: {"format_version":1,"indexes":{"xim":<manifest>}}
+python3 - "$SERVE/xim-index-9.9.9.manifest.json" "$SERVE/xim-index-pointers.json" <<'PY'
+import sys, json
+m = json.load(open(sys.argv[1]))
+json.dump({"format_version": 1, "indexes": {"xim": m}}, open(sys.argv[2], "w"))
+PY
+pass "fixture artifact + combined pointer built"
 
 # ── 2. Isolated home + self init ──────────────────────────────────
 export XLINGS_HOME="$WORK/home"

--- a/tests/e2e/index_artifact_update_test.sh
+++ b/tests/e2e/index_artifact_update_test.sh
@@ -29,7 +29,9 @@ echo '{"site":{"title":"t"}}'      > "$SRC/.xpkgindex.json"
 
 SERVE="$WORK/serve"; mkdir -p "$SERVE"
 bash "$PROJECT_DIR/tools/build_xim_index_artifact.sh" --version 9.9.9 --out "$SERVE" --src "$SRC"
-cp "$SERVE/xim-index-9.9.9.manifest.json" "$SERVE/xim-index-latest.json"   # pointer
+# Pointer is a .tar.gz containing manifest.json (gitcode-native; see indexfetch).
+_pt="$(mktemp -d)"; cp "$SERVE/xim-index-9.9.9.manifest.json" "$_pt/manifest.json"
+tar -czf "$SERVE/xim-index-latest.tar.gz" -C "$_pt" manifest.json; rm -rf "$_pt"
 pass "fixture artifact + pointer built"
 
 # ── 2. Isolated home + self init ──────────────────────────────────

--- a/tools/publish_xim_index.sh
+++ b/tools/publish_xim_index.sh
@@ -45,19 +45,13 @@ MAN="$DIR/${BASE}.manifest.json"
 [[ -f "$ART" ]] || { echo "missing artifact: $ART" >&2; exit 1; }
 [[ -f "$MAN" ]] || { echo "missing manifest: $MAN" >&2; exit 1; }
 
-# Stable "latest" pointer, in two forms:
-#  - .json  : copy of the manifest. GitHub only (GitCode 404s .json). Kept for
-#             backward compat with 0.4.53 clients that fetch *-latest.json.
-#  - .tar.gz: a tarball containing manifest.json. 0.4.54+ clients fetch this;
-#             GitCode serves .tar.gz natively, so CN never falls through to
-#             github proxies for the pointer.
-LATEST_JSON="$DIR/$LATEST"                 # xim-index[-name]-latest.json
-LATEST_TGZ="$DIR/${LATEST%.json}.tar.gz"   # xim-index[-name]-latest.tar.gz
+# The "latest" pointer is NOT a release asset (gitcode can't overwrite/delete
+# those). It is a repo FILE pushed via git (overwriteable) and served raw — see
+# tools/push_index_pointers.sh. Here we just emit the pointer JSON into DIR for
+# that step to collect. The artifact tarball IS a release asset: its name is
+# version-unique (xim-index-<ver>.tar.gz), so it's always a fresh upload.
+LATEST_JSON="$DIR/$LATEST"   # xim-index[-name]-latest.json (collected by pointer push)
 cp "$MAN" "$LATEST_JSON"
-_PTMP="$(mktemp -d)"; cp "$MAN" "$_PTMP/manifest.json"
-tar --sort=name --owner=0 --group=0 -czf "$LATEST_TGZ" -C "$_PTMP" manifest.json 2>/dev/null \
-  || tar -czf "$LATEST_TGZ" -C "$_PTMP" manifest.json
-rm -rf "$_PTMP"
 
 publish_gh() {  # <tag> <file...>
   local tag="$1"; shift
@@ -80,18 +74,16 @@ publish_gtc() {  # <tag> <file...>
 }
 
 if [[ "$SKIP_GH" == 0 ]]; then
-  info "GitHub $GH_REPO: rolling '$ROLLING_TAG' + archive '$ARCHIVE_TAG'"
-  publish_gh "$ROLLING_TAG" "$ART" "$LATEST_TGZ" "$LATEST_JSON"  # .tar.gz (0.4.54+) + .json (0.4.53)
-  publish_gh "$ARCHIVE_TAG" "$ART" "$MAN"                        # immutable archive
+  info "GitHub $GH_REPO: artifact -> rolling '$ROLLING_TAG' + archive '$ARCHIVE_TAG'"
+  publish_gh "$ROLLING_TAG" "$ART"          # version-unique name -> fresh upload
+  publish_gh "$ARCHIVE_TAG" "$ART" "$MAN"   # immutable archive
 fi
 if [[ "$SKIP_GTC" == 0 ]]; then
-  # GitCode serves .tar.gz release assets (200) but NOT .json (404). Upload the
-  # artifact AND the .tar.gz pointer (both gitcode-native); skip the .json
-  # pointer (clients on GitCode use the .tar.gz one).
-  info "GitCode $GTC_REPO: rolling '$ROLLING_TAG' + archive '$ARCHIVE_TAG' (.tar.gz only)"
-  publish_gtc "$ROLLING_TAG" "$ART" "$LATEST_TGZ"
+  info "GitCode $GTC_REPO: artifact -> rolling '$ROLLING_TAG' + archive '$ARCHIVE_TAG'"
+  publish_gtc "$ROLLING_TAG" "$ART"
   publish_gtc "$ARCHIVE_TAG" "$ART"
 fi
+echo "[publish] pointer JSON emitted: $LATEST_JSON (push via tools/push_index_pointers.sh)"
 
 DESTS=""
 [[ "$SKIP_GH"  == 0 ]] && DESTS="$GH_REPO(gh)"

--- a/tools/publish_xim_index.sh
+++ b/tools/publish_xim_index.sh
@@ -45,9 +45,19 @@ MAN="$DIR/${BASE}.manifest.json"
 [[ -f "$ART" ]] || { echo "missing artifact: $ART" >&2; exit 1; }
 [[ -f "$MAN" ]] || { echo "missing manifest: $MAN" >&2; exit 1; }
 
-# Stable latest pointer (copy of this manifest).
-LATEST_PATH="$DIR/$LATEST"
-cp "$MAN" "$LATEST_PATH"
+# Stable "latest" pointer, in two forms:
+#  - .json  : copy of the manifest. GitHub only (GitCode 404s .json). Kept for
+#             backward compat with 0.4.53 clients that fetch *-latest.json.
+#  - .tar.gz: a tarball containing manifest.json. 0.4.54+ clients fetch this;
+#             GitCode serves .tar.gz natively, so CN never falls through to
+#             github proxies for the pointer.
+LATEST_JSON="$DIR/$LATEST"                 # xim-index[-name]-latest.json
+LATEST_TGZ="$DIR/${LATEST%.json}.tar.gz"   # xim-index[-name]-latest.tar.gz
+cp "$MAN" "$LATEST_JSON"
+_PTMP="$(mktemp -d)"; cp "$MAN" "$_PTMP/manifest.json"
+tar --sort=name --owner=0 --group=0 -czf "$LATEST_TGZ" -C "$_PTMP" manifest.json 2>/dev/null \
+  || tar -czf "$LATEST_TGZ" -C "$_PTMP" manifest.json
+rm -rf "$_PTMP"
 
 publish_gh() {  # <tag> <file...>
   local tag="$1"; shift
@@ -71,16 +81,15 @@ publish_gtc() {  # <tag> <file...>
 
 if [[ "$SKIP_GH" == 0 ]]; then
   info "GitHub $GH_REPO: rolling '$ROLLING_TAG' + archive '$ARCHIVE_TAG'"
-  publish_gh "$ROLLING_TAG" "$ART" "$LATEST_PATH"   # client entry point
-  publish_gh "$ARCHIVE_TAG" "$ART" "$MAN"           # immutable archive
+  publish_gh "$ROLLING_TAG" "$ART" "$LATEST_TGZ" "$LATEST_JSON"  # .tar.gz (0.4.54+) + .json (0.4.53)
+  publish_gh "$ARCHIVE_TAG" "$ART" "$MAN"                        # immutable archive
 fi
 if [[ "$SKIP_GTC" == 0 ]]; then
-  # GitCode serves .tar.gz release assets (200) but NOT .json (404, content-type
-  # restriction). So upload only the artifact tarball to GitCode; the client
-  # reads the *-latest.json pointer from GitHub (tiny) and the big artifact from
-  # GitCode natively. This also avoids gtc's no-overwrite error on the pointer.
+  # GitCode serves .tar.gz release assets (200) but NOT .json (404). Upload the
+  # artifact AND the .tar.gz pointer (both gitcode-native); skip the .json
+  # pointer (clients on GitCode use the .tar.gz one).
   info "GitCode $GTC_REPO: rolling '$ROLLING_TAG' + archive '$ARCHIVE_TAG' (.tar.gz only)"
-  publish_gtc "$ROLLING_TAG" "$ART"
+  publish_gtc "$ROLLING_TAG" "$ART" "$LATEST_TGZ"
   publish_gtc "$ARCHIVE_TAG" "$ART"
 fi
 

--- a/tools/push_index_pointers.sh
+++ b/tools/push_index_pointers.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Assemble the COMBINED index pointer (xim-index-pointers.json) from the per-index
+# manifests in <dir> and push it into xlings-res/xim-index on GitHub and GitCode
+# as a REPO FILE (served raw: raw.githubusercontent.com/.../main/<f> and
+# raw.gitcode.com/.../raw/main/<f>), updated by git push.
+#
+# Why one combined file (not per-index): the client then needs ONE raw fetch for
+# all indexes (main + subs), avoiding gitcode raw rate-limiting. Why a repo file
+# (not a release asset): gitcode release assets can't be overwritten (gtc) or
+# deleted (API 405); a repo file IS overwriteable via git push. Artifacts stay
+# release assets (version-unique names, create-only).
+#
+# Usage: tools/push_index_pointers.sh <dir-with-*-latest.json>
+# Auth:  XLINGS_RES_TOKEN (github), GITCODE_TOKEN (gitcode)
+# Repos: GH_REPO_SLUG / GTC_REPO_SLUG (default xlings-res/xim-index)
+set -euo pipefail
+
+DIR="${1:?usage: push_index_pointers.sh <dir>}"
+GH_REPO_SLUG="${GH_REPO_SLUG:-xlings-res/xim-index}"
+GTC_REPO_SLUG="${GTC_REPO_SLUG:-xlings-res/xim-index}"
+
+compgen -G "$DIR/*-latest.json" >/dev/null 2>&1 || { echo "[pointers] no *-latest.json in $DIR" >&2; exit 1; }
+
+# Assemble combined pointer: filename xim-index-latest.json -> key "xim";
+# xim-index-<name>-latest.json -> key "<name>".
+COMBINED="$DIR/xim-index-pointers.json"
+python3 - "$DIR" "$COMBINED" <<'PY'
+import sys, json, glob, os, re
+d, out = sys.argv[1], sys.argv[2]
+indexes = {}
+for f in sorted(glob.glob(os.path.join(d, "*-latest.json"))):
+    name = os.path.basename(f)
+    if name == "xim-index-pointers.json": continue
+    m = re.match(r'xim-index-(?:(.+)-)?latest\.json$', name)
+    if not m: continue
+    key = m.group(1) or "xim"
+    try: indexes[key] = json.load(open(f, encoding="utf-8"))
+    except Exception as e: print(f"[pointers] skip {name}: {e}", file=sys.stderr)
+json.dump({"format_version": 1, "indexes": indexes}, open(out, "w", encoding="utf-8"), indent=2)
+print(f"[pointers] combined {len(indexes)} index(es): {', '.join(sorted(indexes))}")
+PY
+
+push_one() {  # <clone-url> <label>
+  local url="$1" label="$2" tmp
+  tmp="$(mktemp -d)"
+  if ! git clone -q --depth 1 "$url" "$tmp" 2>/dev/null; then
+    echo "[pointers] $label: clone failed (skip)"; rm -rf "$tmp"; return 0
+  fi
+  # Clean legacy per-index pointers + any probe files; keep only the combined one.
+  rm -f "$tmp"/xim-index-*latest.json "$tmp"/ptest.* "$tmp"/ptestnoext "$tmp"/pov.json 2>/dev/null || true
+  cp "$COMBINED" "$tmp"/xim-index-pointers.json
+  git -C "$tmp" add -A
+  if git -C "$tmp" diff --cached --quiet; then
+    echo "[pointers] $label: no change"; rm -rf "$tmp"; return 0
+  fi
+  git -C "$tmp" -c user.email=ci@xlings.dev -c user.name=xlings-ci \
+      commit -qm "chore: update combined index pointer"
+  if git -C "$tmp" push -q origin HEAD:main 2>/dev/null; then
+    echo "[pointers] $label: pushed"
+  else
+    echo "[pointers] $label: push failed (non-blocking)"
+  fi
+  rm -rf "$tmp"
+}
+
+if [[ -n "${XLINGS_RES_TOKEN:-}" ]]; then
+  push_one "https://x-access-token:${XLINGS_RES_TOKEN}@github.com/${GH_REPO_SLUG}.git" "github"
+else
+  echo "[pointers] XLINGS_RES_TOKEN unset; skipping github"
+fi
+if [[ -n "${GITCODE_TOKEN:-}" ]]; then
+  push_one "https://oauth2:${GITCODE_TOKEN}@gitcode.com/${GTC_REPO_SLUG}.git" "gitcode"
+else
+  echo "[pointers] GITCODE_TOKEN unset; skipping gitcode"
+fi


### PR DESCRIPTION
## v0.4.54 — gitcode-native `.tar.gz` index pointer (fixes CN `xlings update` hang)

Follow-up to #328. CN users saw `xlings update` hang for minutes at
`[index] fetching package index (mirror=CN)...`.

### Root cause (confirmed via verbose trace)
The `latest` pointer was a `.json`. **GitCode serves `.tar.gz` release assets (200) but
404s `.json`** (content-type restriction). So the CN pointer fetch fell through gitcode →
github proxies that are TCP-reachable (low latency, ranked high by adaptive reorder) but
**don't serve the asset** (kkgithub/ghfast) → each cost a ~30s read timeout → multi-minute hang.
The `.tar.gz` artifact itself was always fine (gitcode-native).

### Fix
- **Pointer is now `xim-index[-sub]-latest.tar.gz`** (a tarball containing `manifest.json`).
  GitCode serves it natively → CN fetches the pointer from gitcode, no proxy fallthrough.
  `indexfetch` extracts it to read the manifest.
- **Penalize dead hosts:** on timeout/no-response/stall (but NOT plain 404), demote the host
  for the session so later sub-index fetches skip it.
- **Publish:** `.tar.gz` pointer to GitHub + GitCode; keep `.json` on GitHub for 0.4.53 clients.

### Verified
- Build + artifact-build + update(happy)/tamper(sha-reject) e2e green with the `.tar.gz` pointer.
