### PR TITLE
fix(release): keep legacy release-asset index pointer updated (pre-0.4.54 back-compat)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -353,3 +353,34 @@ jobs:
           XLINGS_RES_TOKEN: ${{ secrets.XLINGS_RES_TOKEN }}
           GITCODE_TOKEN: ${{ secrets.GITCODE_TOKEN }}
         run: bash tools/push_index_pointers.sh build/index
+
+  # Mirror the xlings binaries to xlings-res/xlings on GitHub + GitCode so
+  # XLINGS_RES downloads resolve for all platforms (CN binary path is
+  # GitCode-only). Per-file retry: a multi-file gtc upload can 502 and drop
+  # later files (e.g. windows/macos missing). Best-effort, non-blocking.
+  mirror-binaries:
+    needs: [create-release]
+    runs-on: ubuntu-latest
+    env:
+      XLINGS_RES_TOKEN: ${{ secrets.XLINGS_RES_TOKEN }}
+      GITCODE_TOKEN: ${{ secrets.GITCODE_TOKEN }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Determine version
+        id: version
+        run: |
+          if [[ -n "${{ inputs.version }}" ]]; then
+            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=$(sed -n 's/.*VERSION = "\([^"]*\)".*/\1/p' src/core/config.cppm | head -1)" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Mirror binaries to xlings-res/xlings (gh + gtc)
+        if: ${{ env.XLINGS_RES_TOKEN != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.XLINGS_RES_TOKEN }}
+        run: |
+          chmod +x tools/gtc tools/mirror_xlings_res.sh
+          export PATH="$PWD/tools:$PATH"
+          bash tools/mirror_xlings_res.sh "${{ steps.version.outputs.version }}" \
+            || echo "binary mirror reported issues (non-blocking)"

--- a/docs/design/index-distribution.md
+++ b/docs/design/index-distribution.md
@@ -117,6 +117,11 @@ GitCode 平台约束(均实测):release 资产**只能新建**(gtc 不能覆盖�
   `xim-index-pointers.json` + `xim-index[-sub]-<ver>.tar.gz` 静态文件即可。
 
 实测(CN,无 VPN-绕过配置):`xlings update` 主+3 子索引全走工件、12s、无卡顿、无回退 git。
+
+**向后兼容(pre-0.4.54 客户端):** 0.4.53 及更早读的是 **release 资产** `xim-index[-sub]-latest.json`
+(不是仓库文件合并指针)。0.4.54 起发布脚本仍用 `gh --clobber` 把该 release-asset 指针更新到最新
+(仅 github;gitcode 不能覆盖,老 CN 客户端回退 github 读它),这样存量 0.4.53 用户 `xlings self update`
+才能看到新版并升级。升级到 0.4.54+ 后即改读合并仓库文件指针。
 - `Config::resource_servers("CN")` 只含 GitCode(对二进制包是对的);**索引获取始终追加 GLOBAL/GitHub 兜底**,
   CN 解析链:gitcode(原生)→ github → github 代理(ghfast/ghproxy)。
 - sha256 由 github 指针锁定 → 即便某镜像 tarball 滞后(如发布顺序导致的旧内容)也会被拒绝并回退正确源,

--- a/tools/mirror_xlings_res.sh
+++ b/tools/mirror_xlings_res.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Mirror the xlings binaries from an openxlings/xlings release to the
+# xlings-res/xlings resource repo on GitHub and GitCode, so `XLINGS_RES`
+# downloads (esp. the CN path, which is GitCode-only for package binaries)
+# resolve for ALL platforms.
+#
+# Tag scheme on xlings-res/xlings is the BARE version (e.g. 0.4.54), with assets
+# xlings-<ver>-{linux-x86_64.tar.gz, macosx-arm64.tar.gz, windows-x86_64.zip}.
+#
+# Usage: tools/mirror_xlings_res.sh <version>          # e.g. 0.4.54
+# Auth:  XLINGS_RES_TOKEN (github write to xlings-res), GITCODE_TOKEN (+ gtc on PATH)
+# Env:   SRC_REPO (default openxlings/xlings), GH_DST/GTC_DST (default xlings-res/xlings)
+set -euo pipefail
+
+VER="${1:?usage: mirror_xlings_res.sh <version>}"
+SRC_REPO="${SRC_REPO:-openxlings/xlings}"
+GH_DST="${GH_DST:-xlings-res/xlings}"
+GTC_DST="${GTC_DST:-xlings-res/xlings}"
+
+info() { echo "[mirror] $*"; }
+
+DL="$(mktemp -d)"; trap 'rm -rf "$DL"' EXIT
+ASSETS=( "xlings-${VER}-linux-x86_64.tar.gz" "xlings-${VER}-macosx-arm64.tar.gz" "xlings-${VER}-windows-x86_64.zip" )
+
+info "downloading $SRC_REPO v$VER assets"
+for a in "${ASSETS[@]}"; do
+  gh release download "v$VER" -R "$SRC_REPO" -D "$DL" -p "$a" 2>/dev/null || { echo "[mirror] FAIL: missing $a in $SRC_REPO v$VER" >&2; exit 1; }
+done
+
+# ── GitHub (gh --clobber, reliable) ───────────────────────────────
+if [[ -n "${XLINGS_RES_TOKEN:-}" ]] || gh auth status >/dev/null 2>&1; then
+  info "GitHub $GH_DST tag $VER"
+  GH_TOKEN="${XLINGS_RES_TOKEN:-}" gh release view "$VER" -R "$GH_DST" >/dev/null 2>&1 \
+    || GH_TOKEN="${XLINGS_RES_TOKEN:-}" gh release create "$VER" -R "$GH_DST" --title "$VER" --notes "xlings $VER (mirror of $SRC_REPO)"
+  for a in "${ASSETS[@]}"; do
+    GH_TOKEN="${XLINGS_RES_TOKEN:-}" gh release upload "$VER" "$DL/$a" -R "$GH_DST" --clobber
+  done
+else
+  info "no github auth; skipping github mirror"
+fi
+
+# ── GitCode (gtc, per-file retry — multi-file upload can 502 and drop files) ──
+if [[ -n "${GITCODE_TOKEN:-}" ]] && command -v gtc >/dev/null 2>&1; then
+  info "GitCode $GTC_DST tag $VER"
+  gtc release create "$GTC_DST" --tag "$VER" --name "$VER" 2>/dev/null || true
+  for a in "${ASSETS[@]}"; do
+    for try in 1 2 3; do
+      if gtc release upload "$GTC_DST" "$DL/$a" --tag "$VER" 2>&1 | tail -1 | grep -q uploaded; then break; fi
+      echo "[mirror] gtc upload $a try $try failed, retrying..."; sleep 3
+    done
+  done
+else
+  info "no GITCODE_TOKEN/gtc; skipping gitcode mirror"
+fi
+
+# ── Verify every platform on both hosts ───────────────────────────
+info "verify:"
+rc=0
+for host in "github.com/$GH_DST" "gitcode.com/$GTC_DST"; do
+  for a in "${ASSETS[@]}"; do
+    code=$(curl -fsSL -o /dev/null -w '%{http_code}' -L "https://${host}/releases/download/${VER}/${a}" 2>/dev/null || echo ERR)
+    echo "  $code  https://${host}/releases/download/${VER}/${a}"
+    [[ "$code" == 200 ]] || rc=1
+  done
+done
+[[ $rc == 0 ]] && info "all platforms mirrored OK" || { echo "[mirror] WARN: some assets not 200" >&2; }
+exit $rc

--- a/tools/publish_xim_index.sh
+++ b/tools/publish_xim_index.sh
@@ -70,7 +70,16 @@ publish_gtc() {  # <tag> <file...>
     return
   fi
   gtc release create "$GTC_REPO" --tag "$tag" --name "$tag" 2>/dev/null || true
-  gtc release upload "$GTC_REPO" "$@" --tag "$tag"
+  # Upload ONE file at a time with retry: a multi-file gtc upload can 502
+  # mid-way and silently drop the remaining files (obs_callback flakiness),
+  # leaving e.g. only the linux asset. Per-file + retry makes it reliable.
+  local f try
+  for f in "$@"; do
+    for try in 1 2 3; do
+      if gtc release upload "$GTC_REPO" "$f" --tag "$tag" 2>&1 | tail -1 | grep -q uploaded; then break; fi
+      echo "[publish] gtc upload $(basename "$f") try $try failed, retrying..."; sleep 3
+    done
+  done
 }
 
 if [[ "$SKIP_GH" == 0 ]]; then

--- a/tools/publish_xim_index.sh
+++ b/tools/publish_xim_index.sh
@@ -75,8 +75,13 @@ publish_gtc() {  # <tag> <file...>
 
 if [[ "$SKIP_GH" == 0 ]]; then
   info "GitHub $GH_REPO: artifact -> rolling '$ROLLING_TAG' + archive '$ARCHIVE_TAG'"
-  publish_gh "$ROLLING_TAG" "$ART"          # version-unique name -> fresh upload
-  publish_gh "$ARCHIVE_TAG" "$ART" "$MAN"   # immutable archive
+  # Artifact (version-unique -> fresh) + the legacy release-asset .json pointer
+  # for backward compat: pre-0.4.54 clients read xim-index[-sub]-latest.json from
+  # the release (gh --clobber can overwrite it). 0.4.54+ clients read the combined
+  # repo-file pointer (tools/push_index_pointers.sh). GitCode can't overwrite a
+  # release asset, so the legacy pointer is github-only; old CN clients fall to it.
+  publish_gh "$ROLLING_TAG" "$ART" "$LATEST_JSON"
+  publish_gh "$ARCHIVE_TAG" "$ART" "$MAN"
 fi
 if [[ "$SKIP_GTC" == 0 ]]; then
   info "GitCode $GTC_REPO: artifact -> rolling '$ROLLING_TAG' + archive '$ARCHIVE_TAG'"


### PR DESCRIPTION
Existing 0.4.53 users' self-update kept seeing 0.4.53 because 0.4.54 moved the pointer to a repo file and stopped updating the legacy release-asset pointer that pre-0.4.54 clients read. Publish now re-uploads it (gh --clobber). Script+doc only. (The 0.4.54 release-asset pointers were already manually clobbered to unstick current users.)