### PR TITLE
fix(xim): cache artifact index by version marker — v0.4.55 (stop rebuild every command)

### DIFF
--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlings"
-version = "0.4.54"
+version = "0.4.55"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.54";
+    static constexpr std::string_view VERSION = "0.4.55";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/xim/repo.cppm
+++ b/src/core/xim/repo.cppm
@@ -520,7 +520,24 @@ bool sync_all_repos(bool force = false) {
 std::string get_repo_head_hash(const std::filesystem::path& repoDir) {
     namespace fs = std::filesystem;
     auto headFile = repoDir / ".git" / "HEAD";
-    if (!fs::exists(headFile)) return {};
+    if (!fs::exists(headFile)) {
+        // Artifact-managed index (no .git): key the parsed-index cache
+        // (.xlings-index-cache.json) on the .xlings-index-version marker.
+        // Artifacts are version-unique, so the marker is a stable cache key
+        // that changes only on re-install. Without this the hash is empty and
+        // load_or_rebuild disables caching -> a full index rebuild (the noisy
+        // "[1/7] awesome::..." scan) on EVERY xlings install/search.
+        auto verFile = repoDir / ".xlings-index-version";
+        if (fs::exists(verFile)) {
+            try {
+                auto v = platform::read_file_to_string(verFile.string());
+                while (!v.empty() && (v.back() == '\n' || v.back() == '\r' || v.back() == ' '))
+                    v.pop_back();
+                if (!v.empty()) return "artifact:" + v;
+            } catch (...) {}
+        }
+        return {};
+    }
 
     try {
         auto content = platform::read_file_to_string(headFile.string());


### PR DESCRIPTION
Artifact-managed index (no .git) returned an empty repo-head-hash, which disabled the parsed-index cache (load_or_rebuild skips cache on empty hash) → full index rebuild ('[1/7] awesome::...') on EVERY install/search, most visible on Windows. Fix: key the cache on .xlings-index-version ('artifact:<ver>') when there's no .git. Verified: subsequent commands reuse the cache (0 rebuild lines).