### PR TITLE
feat(aarch64): cross-build xlings to aarch64-linux-musl + Android CI

### DIFF
--- a/.github/workflows/xlings-ci-aarch64.yml
+++ b/.github/workflows/xlings-ci-aarch64.yml
@@ -1,0 +1,90 @@
+name: xlings-ci-aarch64
+
+# aarch64 / Android closed-loop CI for xlings.
+#
+# xlings is built by mcpp, so an aarch64 xlings is produced exactly like an
+# aarch64 mcpp: cross-compile with `mcpp build --target aarch64-linux-musl`
+# using the cross toolchain from the xlings ecosystem
+# (xim:aarch64-linux-musl-gcc -> xlings-res), then run under qemu-aarch64.
+#
+# The aarch64 cross support lives in mcpp itself, so we self-host a fresh
+# cross-capable mcpp from source (mcpp main) rather than relying on the pinned
+# bootstrap mcpp. The artifact is a fully static musl aarch64 ELF — runnable
+# natively in Termux on an Android phone (no bionic dependency).
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  BOOTSTRAP_XLINGS_VERSION: '0.4.51'
+
+jobs:
+  cross-build-and-run:
+    name: cross-build xlings aarch64 (host x86_64) + qemu run
+    runs-on: ubuntu-24.04
+    timeout-minutes: 70
+    steps:
+      - name: Checkout xlings
+        uses: actions/checkout@v4
+
+      - name: Install system deps + qemu-user-static
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y curl git build-essential qemu-user-static
+          qemu-aarch64-static --version | head -1
+
+      - name: Install bootstrap xlings
+        env:
+          XLINGS_NON_INTERACTIVE: 1
+          XLINGS_VERSION: ${{ env.BOOTSTRAP_XLINGS_VERSION }}
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
+          echo "XLINGS_HOME=$HOME/.xlings"       >> "$GITHUB_ENV"
+          echo "$HOME/.xlings/subos/current/bin" >> "$GITHUB_PATH"
+          echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"
+
+      - name: Cache xlings package payloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.xlings/data/xpkgs
+          key: xlings-deps-aarch64-${{ runner.os }}-${{ hashFiles('.xlings.json') }}
+          restore-keys: |
+            xlings-deps-aarch64-${{ runner.os }}-
+
+      - name: Bootstrap mcpp + GLOBAL mirror
+        run: |
+          xlings config --mirror GLOBAL 2>/dev/null || true
+          xlings update -y 2>/dev/null || xlings update 2>/dev/null || true
+          xlings install mcpp -y
+          mcpp --version
+
+      - name: Build cross-capable mcpp from source (mcpp main)
+        run: |
+          git clone --depth 1 https://github.com/mcpp-community/mcpp /tmp/mcpp-src
+          cd /tmp/mcpp-src
+          mcpp self config --mirror GLOBAL 2>/dev/null || true
+          mcpp build
+          MCPP=$(realpath "$(find target -type f -name mcpp -printf '%T@ %p\n' | sort -rn | head -1 | cut -d' ' -f2)")
+          test -x "$MCPP"
+          "$MCPP" self config --mirror GLOBAL
+          echo "MCPP=$MCPP" >> "$GITHUB_ENV"
+
+      - name: Cross-build xlings -> aarch64 static, run under qemu
+        run: |
+          "$MCPP" build --target aarch64-linux-musl
+          bin=$(find target/aarch64-linux-musl -type f -name xlings | head -1)
+          echo "== file =="; file "$bin"
+          file "$bin" | grep -q "ARM aarch64" || { echo "NOT aarch64"; exit 1; }
+          file "$bin" | grep -q "statically linked" || { echo "NOT static"; exit 1; }
+          echo "== qemu xlings --version =="
+          ver=$(qemu-aarch64-static "$bin" --version)
+          echo "$ver"
+          echo "$ver" | grep -q "xlings" || { echo "xlings --version failed under qemu"; exit 1; }

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -26,6 +26,11 @@ windows = "llvm@20.1.7"
 toolchain = "gcc@15.1.0-musl"
 linkage = "static"
 
+# aarch64 (ARM64) static target — host-aware (native musl-gcc on ARM,
+# cross aarch64-linux-musl-gcc on x86). linkage=static implied by -musl.
+[target.aarch64-linux-musl]
+linkage = "static"
+
 [dependencies]
 ftxui = "6.1.9"
 


### PR DESCRIPTION
Gives xlings the same aarch64/Android support as mcpp. xlings is built by mcpp, so an aarch64 xlings is a **fully static musl aarch64 ELF** — runnable natively in Termux on Android (no bionic dep).

Validated locally: cross-builds (with ftxui/libarchive/xpkg deps) and runs under qemu-aarch64 → `xlings 0.4.55`.

- `mcpp.toml`: `[target.aarch64-linux-musl]` (host-aware native vs cross).
- `.github/workflows/xlings-ci-aarch64.yml`: self-hosts a cross-capable mcpp from source, cross-builds xlings, qemu-runs. Uses the cross toolchain via `xim:aarch64-linux-musl-gcc` → `xlings-res`.

Ecosystem: depends on `openxlings/xim-pkgindex` (aarch64-linux-musl-gcc, merged) + `xlings-res/aarch64-linux-musl-gcc` asset. Part of the aarch64/Android closed-loop (mcpp#146).