### PR TITLE
fix(arch): use aarch64 (not arm64) as the Linux/Windows arch token

### DIFF
--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -122,7 +122,14 @@ bool is_archive_(const std::filesystem::path& path) {
 
 std::string detect_arch_() {
 #if defined(__aarch64__) || defined(_M_ARM64)
+    // Per-OS arch token, matching LLVM's release naming: Linux/Windows use the
+    // GNU/uname-m spelling `aarch64` (consistent with the aarch64-linux-*
+    // toolchain triples), while Apple uses its own `arm64`.
+  #if defined(__APPLE__)
     return "arm64";
+  #else
+    return "aarch64";
+  #endif
 #elif defined(__x86_64__) || defined(_M_X64)
     return "x86_64";
 #elif defined(__i386__) || defined(_M_IX86)

--- a/tools/other/quick_install.sh
+++ b/tools/other/quick_install.sh
@@ -38,9 +38,13 @@ detect_os() {
 }
 
 detect_arch() {
+    # Preserve the native per-OS spelling: Linux `uname -m` reports `aarch64`
+    # (GNU/triple convention), macOS reports `arm64` (Apple). Matches LLVM's
+    # per-OS release asset naming.
     case "$(uname -m)" in
         x86_64|amd64)   echo "x86_64" ;;
-        aarch64|arm64)  echo "arm64" ;;
+        aarch64)        echo "aarch64" ;;
+        arm64)          echo "arm64" ;;
         *)              echo "unknown" ;;
     esac
 }


### PR DESCRIPTION
Aligns the arch token with LLVM's release naming and GNU/`uname -m`: **Linux/Windows → `aarch64`**, **Apple → `arm64`** (per-OS, exactly like LLVM). Previously `detect_arch_` returned `arm64` everywhere (a macOS-ism) which mismatched the `aarch64-linux-*` toolchain triples and `uname -m`.

- `installer.cppm` `detect_arch_()`: `aarch64` on non-Apple, `arm64` on Apple — drives XLINGS_RES asset URL token.
- `quick_install.sh` `detect_arch()`: preserve native per-OS uname spelling.

Companion: aarch64 release assets (mcpp/xlings) are (re)named `-linux-aarch64`.