### PR TITLE
fix(tools): merge index pointers instead of overwrite (preserve sibling keys)

### DIFF
--- a/.agents/docs/2026-06-24-pkgindex-publish-decoupling-ci.md
+++ b/.agents/docs/2026-06-24-pkgindex-publish-decoupling-ci.md
@@ -98,6 +98,16 @@ termux-android-adaptation §3):
 
 ---
 
+## 4.5 进度 + 关键修复:指针**合并**而非覆盖(2026-06-24)
+
+- **✅ 落地**:`xim-pkgindex`、`mcpp-community/mcpp-index` 两仓均已加 `publish-artifact.yml`
+  + vendored `tools/`(含 `gtc`),push `pkgs/**` 即发 artifact(内容哈希命名)+ 移指针到
+  `xlings-res/{xim-index,mcpp-index}`(GitHub + GitCode)。实测 CI 成功、两端 artifact 字节一致。
+- **🐛→✅ 指针合并修复**:`push_index_pointers.sh` 原先 `cp` **覆盖**组合指针 —— 单个索引仓的
+  per-repo CI 单独发布时会把**兄弟 key(awesome/scode/d2x)冲掉**。改为把本仓(重)建的 key
+  `update` **合并**进既有指针(每仓只更新自己的 key)。先在 xim-pkgindex 的 vendored 副本修正,
+  再同步回 xlings 源 `tools/push_index_pointers.sh`(本 PR;两份现已一致)。
+
 ## 5. 一句话
 
 **把 artifact 发布脚本(本就 standalone)搬进 xim-pkgindex 仓的 push/手动/定时 CI,artifact

--- a/tools/push_index_pointers.sh
+++ b/tools/push_index_pointers.sh
@@ -48,7 +48,22 @@ push_one() {  # <clone-url> <label>
   fi
   # Clean legacy per-index pointers + any probe files; keep only the combined one.
   rm -f "$tmp"/xim-index-*latest.json "$tmp"/ptest.* "$tmp"/ptestnoext "$tmp"/pov.json 2>/dev/null || true
-  cp "$COMBINED" "$tmp"/xim-index-pointers.json
+  # MERGE our (re)built keys INTO the existing combined pointer, preserving
+  # sibling indexes' keys. Each index repo (xim, awesome, scode, d2x) publishes
+  # independently and must update ONLY its own key — a plain overwrite would drop
+  # the others (regression seen when xim-pkgindex's per-repo CI published alone).
+  python3 - "$tmp/xim-index-pointers.json" "$COMBINED" <<'PYMERGE'
+import sys, json, os
+dst, src = sys.argv[1], sys.argv[2]
+base = {"format_version": 1, "indexes": {}}
+if os.path.exists(dst):
+    try: base = json.load(open(dst, encoding="utf-8"))
+    except Exception: base = {"format_version": 1, "indexes": {}}
+base.setdefault("indexes", {})
+base["indexes"].update(json.load(open(src, encoding="utf-8")).get("indexes", {}))
+base["format_version"] = 1
+json.dump(base, open(dst, "w", encoding="utf-8"), indent=2)
+PYMERGE
   git -C "$tmp" add -A
   if git -C "$tmp" diff --cached --quiet; then
     echo "[pointers] $label: no change"; rm -rf "$tmp"; return 0


### PR DESCRIPTION
`tools/push_index_pointers.sh` overwrote the combined `xim-index-pointers.json` with only the keys rebuilt in the current run. When a single index repo's per-repo publish CI runs alone (e.g. `xim-pkgindex`), that **dropped the sibling indexes' keys** (`awesome`/`scode`/`d2x`) from the resource repo's combined pointer — the regression caught while wiring up the decoupled per-repo publish CIs.

Fix: **merge** the (re)built keys into the existing pointer (`base["indexes"].update(...)`) so each repo updates only its own key. This syncs the xlings source with the fix already vendored into `xim-pkgindex/tools/push_index_pointers.sh`.

No behavior change for the all-keys-at-once path; only the partial-publish path is corrected. `bash -n` clean; the two copies are now byte-identical.