### PR TITLE
ci: split Linux e2e into a parallel workflow + per-test timing

### DIFF
--- a/.github/workflows/xlings-ci-linux-e2e.yml
+++ b/.github/workflows/xlings-ci-linux-e2e.yml
@@ -1,4 +1,14 @@
-name: xlings-ci-linux
+name: xlings-ci-linux-e2e
+
+# The Linux E2E suite, split out of xlings-ci-linux.yml so it runs in PARALLEL
+# with the build + unit-test job instead of after it. Shares the same cache
+# lineage, so it restores a warm sandbox; the only added wall-clock vs. the
+# inline version is one extra release build. The E2E-02..E2E-28 block runs via
+# tests/e2e/run_all.sh, which times each test and prints a slowest-first
+# summary (mirrors mcpp's runner). E2E-00 / E2E-01 stay discrete steps here
+# because they're interleaved with the release build.
+#
+# Paired: xlings-ci-linux.yml (build + unit tests + release artifact).
 
 on:
   push:
@@ -8,25 +18,19 @@ on:
 
 env:
   GIT_TERMINAL_PROMPT: 0
-  # CI runs on github.com; force GLOBAL mirror so xim doesn't try gitee
-  # endpoints (which need auth and aren't reachable in CI).
   XLINGS_RELEASE_MIRROR: GLOBAL
-  # Pinned bootstrap xlings used to install mcpp. Bump together with
-  # XIM_PKGINDEX_REF so CI uses a known-good xlings + package index pair.
   BOOTSTRAP_XLINGS_VERSION: v0.4.49
-  # Must contain the mcpp version pinned in .xlings.json (0.0.57).
   XIM_PKGINDEX_REF: fbcad0320fbf84271b710650402ac7ed1a8fa64f
 
 jobs:
-  build-and-test:
+  e2e:
     runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # ── Phase 1: Configure Environment via xlings ─────────────────
-
+      # ── Phase 1: environment (same as xlings-ci-linux.yml) ─────────
       - name: Install system deps
         run: |
           sudo apt-get update -qq
@@ -77,44 +81,28 @@ jobs:
           rm -rf "$HOME/.mcpp/registry/data/mcpplibs"
           rm -rf "$GITHUB_WORKSPACE/.mcpp/registry/data/mcpplibs"
 
-      - name: Prepare unit fixture index repo
+      - name: Prepare fixture index repo
         run: |
-          bash tests/e2e/prepare_fixture_index.sh ../xim-pkgindex
+          bash tests/e2e/prepare_fixture_index.sh
 
-      # ── Phase 1.5: Unit Tests ────────────────────────────────────
-
-      - name: Build and run unit tests
+      # ── E2E-00 (pre-release: mcpp builds xlings from source) ───────
+      - name: "E2E-00: mcpp builds xlings from source"
         run: |
-          mcpp build
-          mcpp test || {
-            status=$?
-            echo "::group::mcpp build diagnostics"
-            ninja_bin="$(command -v ninja || true)"
-            if [[ -z "$ninja_bin" ]]; then
-              ninja_bin="$(find "$HOME/.mcpp" "$XLINGS_HOME" -name ninja -type f -perm -111 2>/dev/null | head -1 || true)"
-            fi
-            if [[ -z "$ninja_bin" ]]; then
-              echo "ninja not found"
-            else
-              while IFS= read -r build_file; do
-                build_dir="$(dirname "$build_file")"
-                echo "\$ $ninja_bin -C $build_dir -v"
-                "$ninja_bin" -C "$build_dir" -v || true
-              done < <(find target -name build.ninja -type f | sort)
-            fi
-            echo "::endgroup::"
-            exit "$status"
-          }
+          bash tests/e2e/mcpp_build_xlings_test.sh
 
-      # ── Phase 2: Build via Release Script ───────────────────────
-      # NOTE: the E2E suite (E2E-00..E2E-28) moved to xlings-ci-linux-e2e.yml
-      # so it runs in parallel with this build+unit job. This job keeps the
-      # release build + artifact upload.
-
+      # ── Phase 2: build the release artifact ────────────────────────
       - name: Build (linux_release)
         run: |
           chmod +x ./tools/linux_release.sh
           SKIP_NETWORK_VERIFY=1 ./tools/linux_release.sh
+
+      - name: "E2E-01: Bootstrap Home (portable + installed)"
+        run: |
+          bash tests/e2e/bootstrap_home_test.sh
+
+      - name: Uninstall old Xlings
+        run: |
+          xlings self uninstall -y || rm -rf "$HOME/.xlings"
 
       - name: Prepare release artifact
         run: |
@@ -122,9 +110,7 @@ jobs:
           [[ -z "$tarball" ]] && { echo "No release tarball found"; exit 1; }
           cp "$tarball" build/release.tar.gz
 
-      - name: Attach artifact
-        uses: actions/upload-artifact@v4
-        if: success()
-        with:
-          name: xlings-linux-x86_64
-          path: build/release.tar.gz
+      # ── E2E-02..E2E-28 via the timed runner (slowest-first summary) ─
+      - name: "E2E suite (E2E-02..E2E-28, timed)"
+        run: |
+          bash tests/e2e/run_all.sh build/release.tar.gz

--- a/tests/e2e/run_all.sh
+++ b/tests/e2e/run_all.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# tests/e2e/run_all.sh — run the release-artifact E2E block (E2E-02..E2E-28)
+# with per-test timing + a slowest-first summary, mirroring mcpp's runner.
+#
+# Usage:  bash tests/e2e/run_all.sh <release-tarball>
+#         (release tarball = build/release.tar.gz, produced by linux_release.sh)
+#
+# The pre-release tests E2E-00 (mcpp builds xlings) and E2E-01 (bootstrap home)
+# stay as discrete workflow steps because they're interleaved with the release
+# build; everything from E2E-02 onward runs here against the built artifact.
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+cd "$ROOT"
+
+TARBALL="${1:-build/release.tar.gz}"
+if [[ ! -f "$TARBALL" ]]; then
+    echo "FATAL: release tarball not found at $TARBALL"
+    echo "Run tools/linux_release.sh first (or pass the path)."
+    exit 1
+fi
+TARBALL="$(cd "$(dirname "$TARBALL")" && pwd)/$(basename "$TARBALL")"  # absolute
+
+# CI is non-interactive; several install tests need this and it's harmless
+# for the rest. (E2E-03 used to set it inline.)
+export XLINGS_NON_INTERACTIVE=1
+
+# ── portable millisecond timer (bash 5 EPOCHREALTIME, else whole-second date) ──
+_t_ms() {
+    if [[ -n "${EPOCHREALTIME:-}" ]]; then
+        local er=${EPOCHREALTIME} s us
+        s=${er%.*}; us=${er#*.}
+        echo $(( 10#$s * 1000 + 10#$us / 1000 ))
+    else
+        echo $(( $(date +%s) * 1000 ))
+    fi
+}
+_fmt_ms() {
+    local ms=$1
+    if (( ms < 1000 )); then echo "${ms}ms"; else
+        printf '%d.%02ds' $(( ms / 1000 )) $(( (ms % 1000) / 10 ))
+    fi
+}
+
+# ── test manifest: "LABEL|SCRIPT|ARG|FLAGS" ──
+#   ARG   = "T" → pass the release tarball, "" → no arg
+#   FLAGS = "allowfail" → a non-zero exit is tolerated (e.g. GitHub rate limits)
+TESTS=(
+    "E2E-02 |release_self_install_test.sh|T|"
+    "E2E-02a|release_packaged_index_test.sh|T|"
+    "E2E-02b|self_uninstall_test.sh|T|"
+    "E2E-03 |release_quick_install_test.sh||allowfail"
+    "E2E-04 |release_subos_smoke_test.sh|T|"
+    "E2E-05 |project_e2e_test.sh||"
+    "E2E-06 |sub_index_search_test.sh||"
+    "E2E-07 |sub_index_install_test.sh||"
+    "E2E-08 |index_cache_test.sh||"
+    "E2E-09 |legacy_config_test.sh||"
+    "E2E-10 |pkginfo_install_dir_test.sh||"
+    "E2E-11 |script_type_install_test.sh||"
+    "E2E-12 |elfpatch_install_verify_test.sh|T|"
+    "E2E-13 |remove_multi_version_test.sh||"
+    "E2E-14 |tui_utf8_test.sh||"
+    "E2E-15 |xlings_self_replace_test.sh||"
+    "E2E-16 |self_doctor_test.sh||"
+    "E2E-17 |cli_target_compat_test.sh||"
+    "E2E-18 |cli_short_alias_removal_test.sh||"
+    "E2E-19 |mirror_fallback_test.sh||"
+    "E2E-20 |remove_self_guard_test.sh||"
+    "E2E-21 |build_deps_split_test.sh||"
+    "E2E-22 |subos_workspace_c2_schema_test.sh||"
+    "E2E-23 |subos_install_remove_isolation_test.sh||"
+    "E2E-24 |nested_xlings_home_test.sh||"
+    "E2E-25 |subos_sandbox_test.sh||"
+    "E2E-26 |subos_sandbox_gpu_test.sh||"
+    "E2E-27 |install_silent_failure_test.sh||"
+    "E2E-28 |shim_owner_anchoring_test.sh||"
+)
+
+PASS=0; FAIL=0; SOFTFAIL=0
+FAILED_TESTS=()
+TIMINGS=()
+
+for entry in "${TESTS[@]}"; do
+    IFS='|' read -r label script arg flags <<< "$entry"
+    label="${label// /}"
+    echo
+    echo "=== $label: $script ==="
+    args=()
+    [[ "$arg" == "T" ]] && args+=("$TARBALL")
+
+    _start=$(_t_ms)
+    bash "$HERE/$script" "${args[@]}"
+    rc=$?
+    _dur=$(( $(_t_ms) - _start ))
+    TIMINGS+=("$_dur $label $script")
+    d="$(_fmt_ms "$_dur")"
+
+    if [[ $rc -eq 0 ]]; then
+        echo "PASS: $label ($script, $d)"
+        ((PASS++))
+    elif [[ "$flags" == *allowfail* ]]; then
+        echo "SOFT-FAIL: $label ($script, exit $rc, $d) — tolerated (e.g. network/rate-limit)"
+        ((SOFTFAIL++))
+    else
+        echo "FAIL: $label ($script, exit $rc, $d)"
+        ((FAIL++))
+        FAILED_TESTS+=("$label ($script, exit $rc)")
+    fi
+done
+
+echo
+echo "==============================================="
+if [[ ${#TIMINGS[@]} -gt 0 ]]; then
+    total=0
+    for t in "${TIMINGS[@]}"; do total=$(( total + ${t%% *} )); done
+    echo "E2E timing (slowest first; executed total $(_fmt_ms "$total")):"
+    printf '%s\n' "${TIMINGS[@]}" | sort -rn | head -15 | while read -r ms label script; do
+        printf '  %8s  %-8s %s\n' "$(_fmt_ms "$ms")" "$label" "$script"
+    done
+    echo "==============================================="
+fi
+echo "E2E Summary: $PASS passed, $FAIL failed, $SOFTFAIL soft-failed (tolerated)"
+if [[ $FAIL -gt 0 ]]; then
+    echo "Failed: ${FAILED_TESTS[*]}"
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Mirrors the mcpp e2e-split: the `xlings-ci-linux` job ran build + unit tests + **~29 inline E2E steps in series**. Split the E2E suite into its own workflow so it runs **in parallel** on the same warm caches — per-PR critical path drops from `build+unit+e2e` to `max(build+unit, e2e)`.

## Changes
- **`xlings-ci-linux.yml`** — keeps env setup + unit tests + the release build + artifact upload; drops the `E2E-00..E2E-28` steps (262 → 130 lines).
- **`xlings-ci-linux-e2e.yml`** (new) — replicates the setup, runs the interleaved `E2E-00 → release-build → E2E-01 → release-artifact` steps, then the `E2E-02..E2E-28` block via `tests/e2e/run_all.sh`.
- **`tests/e2e/run_all.sh`** (new) — a timed runner like mcpp's: a manifest of the release-artifact E2E block, a portable ms timer (bash 5 `EPOCHREALTIME`, else `date`), per-test elapsed + a **slowest-first summary**. `E2E-03` keeps its tolerated-failure semantics (GitHub rate limits) via an `allowfail` flag.

```
E2E timing (slowest first; executed total …):
   42.1s  E2E-04   release_subos_smoke_test.sh
   18.7s  E2E-02   release_self_install_test.sh
   …
E2E Summary: 28 passed, 0 failed, 1 soft-failed (tolerated)
```

Dry-run (stubbed scripts) verified manifest parse, tarball arg-passing, timing, slowest-first summary, and soft-fail → exit 0.

> Note: a new required check `xlings-ci-linux-e2e / e2e` should be added to branch protection so e2e still gates merges (admin).