### PR TITLE
ci(e2e): retry mcpp sandbox bootstrap on transient network flake

### DIFF
--- a/src/core/xim/indexfetch.cppm
+++ b/src/core/xim/indexfetch.cppm
@@ -50,8 +50,12 @@ std::optional<IndexManifest> parse_index_manifest(std::string_view jsonText);
 // Build candidate download URLs for an asset filename under the xim-index repo
 // on every configured resource server (selected/latency-probed server first),
 // then GitHub proxy variants. `mirror` selects region (empty => Config default).
+// `version` (e.g. "0.4.58" / "72b00a4") selects the release tag: when given,
+// the versioned tag `v<version>` is tried first (GitCode only serves assets via
+// the versioned tag, not the rolling `latest`), with `latest` kept as fallback.
 std::vector<std::string> index_asset_urls(std::string_view filename,
-                                          std::string_view mirror = {});
+                                          std::string_view mirror = {},
+                                          std::string_view version = {});
 
 // Fetch the latest index artifact for `subName` ("" = main index) and atomically
 // install it into destIndexDir. Returns true on success; on failure `err` is set
@@ -201,28 +205,41 @@ std::optional<IndexManifest> parse_index_manifest(std::string_view jsonText) {
 }
 
 std::vector<std::string> index_asset_urls(std::string_view filename,
-                                          std::string_view mirror) {
+                                          std::string_view mirror,
+                                          std::string_view version) {
     std::vector<std::string> urls;
     auto add = [&](const std::string& u) {
         if (!u.empty() && std::ranges::find(urls, u) == urls.end()) urls.push_back(u);
     };
 
     auto repo = detail_::index_repo_name_();
-    auto tag  = detail_::index_tag_();
+
+    // Release tag(s) to try, in order. GitCode only serves release assets via
+    // the VERSIONED tag (`v<version>`); its rolling `latest` tag 404s on the
+    // `releases/download/latest/<asset>` path (GitHub serves both). So when we
+    // know the version, try `v<version>` first and keep `latest` as a fallback.
+    std::vector<std::string> tags;
+    if (!version.empty()) tags.push_back("v" + std::string(version));
+    if (auto def = detail_::index_tag_(); std::ranges::find(tags, def) == tags.end())
+        tags.push_back(def);
 
     // Selected (latency-probed) server first, then all other candidates.
     auto selected = Config::resource_server(mirror);
-    auto buildFor = [&](const std::string& server) {
+    auto buildFor = [&](const std::string& server, const std::string& tag) {
         return std::format("{}/{}/releases/download/{}/{}", server, repo, tag, filename);
     };
-    if (!selected.empty()) add(buildFor(selected));
-    for (auto& server : Config::resource_servers(mirror)) add(buildFor(server));
+    auto addServer = [&](const std::string& server) {
+        if (server.empty()) return;
+        for (auto& tag : tags) add(buildFor(server, tag));
+    };
+    addServer(selected);
+    for (auto& server : Config::resource_servers(mirror)) addServer(server);
     // Always include GLOBAL (github) servers as fallback for the index — even
     // under CN. Unlike package binaries (where the regional mirror is
     // authoritative), the index must stay reachable if the regional mirror
     // lacks the asset; combined with 404-fallthrough this gives CN: gitcode ->
     // github -> github proxies.
-    for (auto& server : Config::resource_servers("GLOBAL")) add(buildFor(server));
+    for (auto& server : Config::resource_servers("GLOBAL")) addServer(server);
 
     // NB: deliberately NO github-proxy expansion (ghfast/ghproxy/kkgithub) for
     // the index. Those proxies are often TCP-reachable but don't actually serve
@@ -330,7 +347,7 @@ bool fetch_index_artifact(const std::filesystem::path& destIndexDir,
     // Artifact (sha256-pinned by the manifest); release asset, versioned name.
     auto artifactFile = tmpRoot / manifest.artifact_name;
     if (auto e = detail_::obtain_file(manifest.artifact_name,
-                    index_asset_urls(manifest.artifact_name, mirrorKey),
+                    index_asset_urls(manifest.artifact_name, mirrorKey, manifest.index_version),
                     artifactFile, manifest.artifact_sha256); !e.empty()) {
         err = std::format("fetch index artifact failed: {}", e);
         return false;

--- a/tests/e2e/mcpp_build_xlings_test.sh
+++ b/tests/e2e/mcpp_build_xlings_test.sh
@@ -57,14 +57,46 @@ mkdir -p "$MCPP_HOME_DIR" "$XLINGS_HOME_DIR"
 MCPP_BIN="$(resolve_mcpp_bin "$MCPP_BIN")"
 
 log "Testing mcpp can build xlings with isolated homes..."
-rm -rf "$ROOT_DIR/target/$MCPP_TARGET"
-(
-  cd "$ROOT_DIR"
-  env -u XLINGS_PROJECT_DIR \
-    MCPP_HOME="$MCPP_HOME_DIR" \
-    XLINGS_HOME="$XLINGS_HOME_DIR" \
-    "$MCPP_BIN" build --target "$MCPP_TARGET" --print-fingerprint --no-cache
-)
+
+# mcpp's first-time sandbox bootstrap downloads patchelf + ninja from the
+# network. On a fresh CI runner (cold cache) that fetch occasionally flakes
+# (transient 5xx/404 / connection reset), leaving the sandbox half-initialized
+# ("failed to bootstrap patchelf ... ; patchelf missing") and failing the whole
+# E2E suite. Retry the build a few times, wiping the isolated mcpp sandbox
+# between attempts so the bootstrap re-runs from a clean slate. We retry ONLY
+# transient bootstrap failures; real build/compile errors are surfaced
+# immediately instead of being masked (and paid for 3x).
+MCPP_BUILD_ATTEMPTS="${MCPP_BUILD_ATTEMPTS:-3}"
+BUILD_LOG="$RUNTIME_DIR/mcpp_build.out"
+
+run_mcpp_build() {
+  rm -rf "$ROOT_DIR/target/$MCPP_TARGET" "$MCPP_HOME_DIR"
+  mkdir -p "$MCPP_HOME_DIR"
+  (
+    cd "$ROOT_DIR"
+    env -u XLINGS_PROJECT_DIR \
+      MCPP_HOME="$MCPP_HOME_DIR" \
+      XLINGS_HOME="$XLINGS_HOME_DIR" \
+      "$MCPP_BIN" build --target "$MCPP_TARGET" --print-fingerprint --no-cache
+  )
+}
+
+attempt=1
+while true; do
+  status=0
+  run_mcpp_build 2>&1 | tee "$BUILD_LOG" || status="${PIPESTATUS[0]}"
+  [[ "$status" -eq 0 ]] && break
+
+  if ! grep -qE 'failed to bootstrap (patchelf|ninja)|patchelf missing|ninja missing' "$BUILD_LOG"; then
+    fail "mcpp build failed (exit $status) — not a transient sandbox-bootstrap flake"
+  fi
+  if [[ "$attempt" -ge "$MCPP_BUILD_ATTEMPTS" ]]; then
+    fail "mcpp sandbox bootstrap kept failing after $MCPP_BUILD_ATTEMPTS attempts"
+  fi
+  log "mcpp build attempt $attempt hit a transient sandbox-bootstrap flake; resetting sandbox and retrying ($((attempt + 1))/$MCPP_BUILD_ATTEMPTS)..."
+  attempt=$((attempt + 1))
+  sleep 5
+done
 
 XLINGS_MCPP_BIN="$(find "$ROOT_DIR/target/$MCPP_TARGET" -path '*/bin/xlings' -type f -executable | head -1)"
 [[ -n "$XLINGS_MCPP_BIN" ]] || fail "mcpp build did not produce a target/*/bin/xlings binary"

--- a/tests/unit/test_indexfetch.cpp
+++ b/tests/unit/test_indexfetch.cpp
@@ -50,3 +50,22 @@ TEST(IndexAssetUrls, BuildsReleaseDownloadUrlForGlobal) {
     }
     EXPECT_TRUE(found) << "no release-download URL for the pointer asset";
 }
+
+TEST(IndexAssetUrls, PrefersVersionedTagWhenVersionGiven) {
+    // GitCode only serves assets via the versioned tag (`v<version>`), not the
+    // rolling `latest` (404 on releases/download/latest/...). When the version
+    // is known, the versioned-tag URL must be present and ordered before the
+    // `latest` URL on the same server.
+    auto urls = index_asset_urls("xim-index-scode-0.4.58.tar.gz", "GLOBAL", "0.4.58");
+    ASSERT_FALSE(urls.empty());
+    auto firstVersioned = std::string::npos, firstLatest = std::string::npos;
+    for (std::size_t i = 0; i < urls.size(); ++i) {
+        if (urls[i].find("/releases/download/v0.4.58/") != std::string::npos
+            && firstVersioned == std::string::npos) firstVersioned = i;
+        if (urls[i].find("/releases/download/latest/") != std::string::npos
+            && firstLatest == std::string::npos) firstLatest = i;
+    }
+    EXPECT_NE(firstVersioned, std::string::npos) << "no v0.4.58 versioned-tag URL";
+    if (firstLatest != std::string::npos)
+        EXPECT_LT(firstVersioned, firstLatest) << "versioned tag must precede latest";
+}


### PR DESCRIPTION
## Problem

The post-merge `main` run for #339 ([run 28071712843](https://github.com/openxlings/xlings/actions/runs/28071712843/job/83107451940)) failed at **E2E-00: mcpp builds xlings from source**:

```
warning: failed to bootstrap patchelf into mcpp sandbox; subsequent xim installs may skip ELF rewriting
warning: failed to bootstrap ninja into mcpp sandbox (exit 1)
error: patchelf missing: .../mcpp-home/registry/data/xpkgs/xim-x-patchelf/0.18.0/bin/patchelf
##[error]Process completed with exit code 2.
```

## Analysis

- mcpp's first-time sandbox bootstrap downloads **patchelf + ninja** from the network into a **fresh isolated sandbox every run** (`tests/e2e/runtime/mcpp_build_xlings/mcpp-home`, wiped at script start). The `~/.mcpp` / `~/.xlings/data/xpkgs` caches don't cover that isolated home, so the bootstrap is inherently network-dependent on each run.
- The **exact same commit passed on the PR run** ([28071185545](https://github.com/openxlings/xlings/actions/runs/28071185545)) minutes earlier, and **#337's run passed on main** — so this is a **transient bootstrap flake on a cold-cache runner**, not a code regression. (The merged change in #339 only touches index-artifact URL tag selection and is unrelated to this bootstrap path.)
- There was **no retry**, so a single network hiccup fails the entire E2E suite.

## Fix

Wrap `mcpp build` in a bounded retry (`MCPP_BUILD_ATTEMPTS=3`), wiping the isolated mcpp sandbox between attempts so the bootstrap re-runs from a clean slate. We retry **only** the transient sandbox-bootstrap signature (`failed to bootstrap patchelf|ninja` / `patchelf missing`); **real build/compile errors are surfaced immediately** instead of being masked (and paid for 3×).

Verified the loop semantics under `set -euo pipefail` against four scenarios: flake-then-success (retries & passes), persistent flake (fails after 3), real compile error (fails fast, no retry), clean build (passes through).