### PR TITLE
chore(release): bump version to 0.4.59

### DIFF
--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlings"
-version = "0.4.58"
+version = "0.4.59"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.58";
+    static constexpr std::string_view VERSION = "0.4.59";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 


### PR DESCRIPTION
Cut **0.4.59** to ship the index-fetch fixes that landed after v0.4.58 but are not in any release:

- **#339** fetch index artifacts via versioned tag (GitCode `latest` 404)
- **#338** exempt local (`file://`) sources from the index-repo reachability probe

#339 is client-side: 0.4.59 requests index artifacts at `releases/download/v0.4.59/...`, so the release's `publish-index` job must (and does) publish **v0.4.59-tagged** index artifacts to `xlings-res/xim-index` on GitHub + GitCode.

Bumps `src/core/config.cppm` (`VERSION`) and `mcpp.toml` (`version`). The Release workflow reads the version from `config.cppm`.