### PR TITLE
feat(xim): migrate default sub-indexes to artifact (index ecosystem unification P0)

### DIFF
--- a/.agents/docs/2026-06-25-index-ecosystem-unification-plan.md
+++ b/.agents/docs/2026-06-25-index-ecosystem-unification-plan.md
@@ -1,0 +1,268 @@
+# 索引生态全面打通 — 主索引 + 默认子索引统一 artifact 化方案
+
+**日期**: 2026-06-25
+**类型**: 方案 / 架构 (plan + architecture)
+**范围**: 把**主索引 `xim-pkgindex` + 其默认子索引(`awesome`/`scode`/`d2x`)** 统一到同一套
+index-as-resource(artifact)机制,git 仅作回退;打通发布侧(跨仓 CI)与客户端消费,
+并修掉拖累体验的 CN 代理问题。**后加的非默认索引仓(如 `fromsource`)、用户自定义仓不在本轮目标内**
+——它们自动落到 git 回退路径,保持兼容即可。
+**决策(已拍板)**:
+- 子索引传输形态 = **统一到 artifact,git 仅回退**(与主索引同构,一套代码)。
+- 完整性 = **本轮只做传输完整性**(artifact sha256 已有 + 指针双发对账);
+  端到端签名(minisign)/内容寻址留作后续阶段。
+**关联**:
+- `2026-06-21-pkgindex-mirror-analysis.md`(差距 G1–G6 的来源)
+- `2026-06-21-pkgindex-redesign-proposal.md`、`2026-06-22-index-as-resource-impl-plan.md`(主索引 artifact 化)
+- `2026-06-24-pkgindex-publish-decoupling-ci.md`(发布解耦,本方案承接其 P0 未尽部分)
+
+---
+
+## 0. TL;DR
+
+主索引已经现代化(指针 + 内容哈希 artifact + gitcode/github 双源 + 延迟重排 + 卡顿看门狗 +
+sha256)。**默认子索引的客户端消费、发版打包、多 key 组合指针其实都已经写好了** —— 缺的不是
+"从零实现",而是 **4 个最后一公里缺口**:
+
+1. **迁移闸**:已有 git 副本的子索引在 `auto` 模式下永不自动切 artifact(现网用户卡在 git)。
+2. **子仓发布未解耦**:改默认子索引,artifact 只在"下次 xlings 发版"才刷新。
+3. **CN 代理 403**:代理无条件套到 `gitcode.com`/`gitee.com` 等国内域名,白费尝试 + 降权。
+4. **URL/org 不一致 + json 卫生**:`subDefaultOfficial` 判定要求 lua/json/release.yml 三处 URL 一致,
+   现状不一致会让子索引**静默退回 git**。
+
+闭上这 4 个缺口,即达成"主索引 + 默认子索引全面 artifact 化、git 仅回退、改即发布、弱网/被墙不卡"。
+
+---
+
+## 0.5 实施进度与范围调整(2026-06-25,实现期更新)
+
+**范围调整(用户拍板)**:
+- **C3(CN 代理直连白名单)→ 取消**。实测用户本地代理对 CN 域名已直连,403 非代理策略问题,不改 `tinyhttps`。
+- **C2 → 简化**。不在各子仓加 `publish-artifact.yml`;只需 `xim-pkgindex` 仓一个**手动可触发
+  (`workflow_dispatch`)** 的发布(发版 `release.yml` 已兜底"至少发版时刷新")。
+- **幽灵 `fromsource` → 不 prune、不特殊处理**。它非 lua 默认,自然走 git 回退,互不影响。
+
+**已完成并端到端验证(P0 客户端,本仓)**:
+- **C1 迁移闸** + **C4 lua 权威合并(修 org 漂移)** 已实现,抽为纯函数
+  `merge_sub_repos` / `sub_should_attempt_artifact`(`src/core/xim/repo.cppm`),并接入 `sync_all_repos`。
+- 单测 8 个全绿(`tests/unit/test_main.cpp` 的 `XimSubReposTest`)。
+- **实机验证**:用新二进制 `xlings update` —— `awesome`/`scode`/`d2x` 从 git **迁移到 artifact**
+  (各写出 `.xlings-index-version`、删除 `.git`),`fromsource` 正确保持 git;
+  `xim-indexrepos.json` 的 org 漂移(awesome/scode 旧 `d2learn`)被 lua 权威**自愈**为 `openxlings`。
+
+**待办**:C2 手动发布工作流(`xim-pkgindex` 仓);C5 指针双发对账(P2);签名(后续阶段)。
+
+---
+
+## 1. 现状(精确核实)— 已建成 vs 缺口
+
+### 1.1 已经建成的(不要重复造)
+
+| 能力 | 状态 | 证据 |
+|---|---|---|
+| 主索引 artifact 拉取(指针→tarball→sha256→原子替换) | ✅ | `indexfetch.cppm:317-392` |
+| **默认子索引 artifact 拉取(客户端)** | ✅ **已实现** | `repo.cppm:489-516`,`fetch_index_artifact(repoDir, ferr, repo.name)` |
+| 多 key 组合指针 `xim-index-pointers.json`(`indexes.{xim,awesome,scode,d2x}`) | ✅ | `indexfetch.cppm:308-311`;`push_index_pointers.sh:52` 合并不覆盖 |
+| **发版时打包+发布默认子索引 artifact** | ✅ | `release.yml:383-411`(`--name awesome/scode/d2x`,GH+GitCode 双发) |
+| 主索引 push 即发布(解耦 CI) | ✅ | `xim-pkgindex` 仓 `publish-artifact.yml`(decoupling-ci.md §4.5) |
+| 延迟重排 + 卡顿看门狗 + host 惩罚(artifact 路径) | ✅ | `adaptive.cppm`、`tinyhttps.cppm`(10KiB/s×15s) |
+| 子索引 artifact 失败 → git 回退 | ✅ | `repo.cppm:511-513` |
+
+> 即:**一个全新安装(主&子索引目录都不存在)今天就会全程走 artifact**。问题只出在"已装过的存量用户"和"发布新鲜度"。
+
+### 1.2 实测当前机器状态(为什么你的 log 子索引走了 git)
+
+```
+主索引 xim-pkgindex:        .xlings-index-version=303aa7f, 无 .git  → artifact-managed ✅
+子索引 awesome/scode/d2x/fromsource: 无 marker, 有 pkgs/         → git-managed ❌
+```
+
+`auto` 判定(`repo.cppm:499-500`):
+```cpp
+subAttemptArtifact = subDefaultOfficial && (subManaged || !exists(repoDir/"pkgs"));
+```
+子索引**有 pkgs/、无 marker** → `(false || false)` → **不切 artifact**,继续 git。这与主索引同款的
+"存量 git 副本不自动迁移"保护一致 —— 主索引早先被重装过所以已迁,子索引没有,于是卡在半迁移态。
+
+---
+
+## 2. 目标架构
+
+**一句话**:主索引与默认子索引**完全同构**——同一份多 key 指针、同一个 `fetch_index_artifact`、
+同一套韧性机制;git 退化为纯回退(被墙/artifact 不可用/非默认仓/本地源时)。
+
+```
+                    xlings-res/xim-index   (GitHub + GitCode 双端)
+                    ├─ xim-index-pointers.json   ← 组合指针(多 key, 仓库文件, 可覆盖)
+                    │     { format_version:1, indexes:{
+                    │         xim:{artifact,sha256,...},
+                    │         awesome:{...}, scode:{...}, d2x:{...} } }
+                    └─ releases/<tag>/xim-index[-<name>]-<hash>.tar.gz  ← 内容哈希命名, immutable
+
+客户端 xlings update (repo.cppm:sync_all_repos)
+  1. 取组合指针(CN: raw.gitcode → raw.github 回退)            [无 sha,双发对账]
+  2. 主索引:    fetch_index_artifact(mainDir)                  [sha256 pin]
+  3. 默认子索引: fetch_index_artifact(subDir, name)  × {awesome,scode,d2x}
+        └ 失败 / 非默认仓(fromsource/自定义/本地)→ git 回退 (sync_repo)
+  4. catalog.rebuild → 合并主+子为单一 catalog (index.cppm:244)
+
+发布侧(改即发布,内容哈希解绑 xlings 版本)
+  xim-pkgindex         push pkgs/** → publish-artifact.yml → 发 xim   artifact + 合并 xim   key
+  xim-pkgindex-awesome push pkgs/** → publish-artifact.yml → 发 awesome ...  + 合并 awesome key   ← 新增
+  xim-pkgindex-scode   push pkgs/** → publish-artifact.yml → ...                                 ← 新增
+  xim-pkgindex-d2x     push pkgs/** → publish-artifact.yml → ...                                 ← 新增
+  xlings release       仍发"已知好"的整套配对(保留, 非唯一通道)
+```
+
+**为什么"统一 artifact"顺带解决了无 CN 镜像(G1)**:子索引 artifact 本就发到 `xlings-res/xim-index`
+的 **GitCode 端**,CN 用户取子索引 = 取 gitcode artifact,不再被迫 git-clone github。git 路径上
+"子索引无国内镜像"的痛点在默认路径上自然消失(git 仅在 artifact 全挂时才回退)。
+
+---
+
+## 3. 多仓库角色与协作(本节为多仓协作说明,落地需跨仓改动)
+
+| 仓库 | 角色 | 本方案需要的改动 | 谁来改 |
+|---|---|---|---|
+| **`openxlings/xlings`**(本仓) | 客户端 C++ + 发布脚本/CI 源 | 迁移闸(C1)、CN 代理白名单(C3)、URL 规范化(C4)、指针对账(C5)、`release.yml` 子索引命名对齐 | 本仓 PR |
+| **`openxlings/xim-pkgindex`** | 主索引内容 + 默认子索引声明 `xim-indexrepos.lua` | 规范化默认子仓 URL 到唯一 org(C4) | 跨仓(已有 vendored `tools/`) |
+| **`openxlings/xim-pkgindex-awesome`** | 默认子索引内容 | **新增 `publish-artifact.yml`**(C2)+ vendored `tools/` | 跨仓 |
+| **`openxlings/xim-pkgindex-scode`** | 默认子索引内容 | **新增 `publish-artifact.yml`**(C2) | 跨仓 |
+| **`d2learn/xim-pkgindex-d2x`** | 默认子索引内容(注意属 `d2learn` org) | **新增 `publish-artifact.yml`**(C2) | 跨仓(跨 org,需协调 d2learn) |
+| **`xlings-res/xim-index`** | 资源仓:artifact 资产 + 组合指针 | 无需代码,作为发布目标;指针文件 = 各仓"合并自己 key" | secrets 已配 |
+
+**跨仓一致性约束(关键,不满足则子索引静默退回 git)**:同一个默认子索引,其
+**① `xim-indexrepos.lua` 的 URL、② 客户端持久化的 `xim-indexrepos.json` URL、③ `release.yml` /
+各子仓 CI 发布时用的 repo URL,以及 ④ 组合指针里的 key 名** 必须全部对齐:
+
+- key 名(`awesome`/`scode`/`d2x`)是客户端 `repo.name` → 指针 key 的唯一纽带(URL 仅用于 git 回退)。
+- `subDefaultOfficial` 判定(`repo.cppm:492-494`)要求 `luaUrl[name] == repo.url`;若 lua 与 json
+  org 不一致(实测:home 副本 lua 用 `openxlings/awesome`,json 用 `d2learn/awesome`),判定为 false,
+  该子索引**永不走 artifact**。必须收敛到唯一 canonical org(见 C4)。
+
+> **GitCode 资产命名注意**:GitCode release 资产不可覆盖,故 artifact 用**内容哈希 immutable 命名**
+> (`xim-index-<hash>.tar.gz`),指针(`xim-index-pointers.json`)走**仓库文件 push + GH release asset
+> 双发**(可覆盖/可 raw 读)。已在 decoupling-ci.md §4.5 验证;本方案沿用。
+
+---
+
+## 4. 缺口与改造(逐项)
+
+### C1 — 迁移闸:让存量 git 子索引自动切 artifact 【客户端,小】
+**问题**:`auto` 下有 pkgs/无 marker 的默认子索引永不迁移(§1.2)。
+**改动**(`repo.cppm:499-500`):当**主索引已是 artifact-managed**时,把默认子索引视作"同一索引单元",
+即使已有 pkgs 也尝试 artifact:
+```cpp
+else subAttemptArtifact = subDefaultOfficial
+         && (subManaged || !exists(repoDir/"pkgs") || mainArtifactManaged);
+```
+失败仍自动回退 git(`repo.cppm:511-513`),零风险。效果:存量用户**下次 `xlings update` 即完成迁移**
+(主已 artifact → 子跟进),无需 `--force` 或重装。
+**验证**:本机主索引已 artifact(`303aa7f`),改后一次 update 应使 awesome/scode/d2x 写出
+`.xlings-index-version` 且不再打印 `updating index repo:`。
+
+### C2 — 默认子索引发布(简化版:`xim-pkgindex` 一个手动工作流)【CI】
+**问题**:子索引内容变更后,artifact 只在下次 xlings 发版刷新。
+**改动(简化,用户拍板)**:**不**在各子仓加 CI;在 `xim-pkgindex` 仓加一个
+**`workflow_dispatch` 手动可触发**的发布工作流即可,需要时主动重打包默认子索引并移指针:
+- 触发:`workflow_dispatch`(可带 `name` 参数选 awesome/scode/d2x 或 all)。
+- 脚本:复用本仓 `tools/build_xim_index_artifact.sh` + `publish_xim_index.sh`(`--name <sub>`),
+  发到 `xlings-res/xim-index`(GH+GitCode),`push_index_pointers.sh` 只 update 自己 key(合并不覆盖)。
+- **发版兜底**:`xlings release` 的 `release.yml:383-411` 仍在发版时整套发布默认子索引,保证"至少发版时刷新"。
+**(原"各子仓各加 publish-artifact.yml"方案取消)**
+
+### C3 — ~~CN 代理直连白名单~~ 【取消】
+**决策:不做**。实测用户本地代理对 CN 域名(gitcode/gitee)已直连,日志里的 403 非 xlings 代理策略
+问题,而是该次代理出口的偶发。不在 `tinyhttps` 内置 CN 直连名单,保持默认 `NO_PROXY` 语义即可。
+
+### C4 — URL/org 规范化(lua 权威自愈)【已实现,本仓】
+**问题**:lua / json / release.yml 三处 org 不齐(实测 json 把 awesome/scode 钉在旧 `d2learn`,
+lua 已是 `openxlings`)→ `subDefaultOfficial` 为 false → 子索引静默退回 git。
+**改动(已实现)**:`merge_sub_repos` 令 **lua 默认对其自身 name 权威**,json 只补 lua 没有的
+用户自定义仓 → org 漂移的默认仍判定为 official 并迁移 artifact,陈旧 json 在下次 `save_sub_repos_json`
+**自愈**为 lua 的 canonical org。**不 prune 幽灵 `fromsource`**(它非 lua 默认,留作 json-only 走 git)。
+> 跨仓收尾(可选 P1):把 release.yml / lua 的默认子仓 org 固定下来不再漂移,减少自愈发生。
+**问题**:lua(home: `openxlings/awesome` vs dev: `d2learn/awesome`)、json(`d2learn/*` + 幽灵 `fromsource`)、
+`release.yml`(`openxlings/awesome`+`openxlings/scode`+`d2learn/d2x`)三处 org 不齐 → `subDefaultOfficial`
+可能为 false → 子索引静默退回 git。
+**改动**:
+1. 选定每个默认子仓的 **canonical org**(建议 awesome/scode = `openxlings`,d2x = `d2learn`,与 release.yml 对齐),
+   统一写入 `xim-pkgindex/xim-indexrepos.lua` 的 GLOBAL 与 CN(CN 此后由 artifact 承载,git 回退 URL 与 GLOBAL 同)。
+2. 客户端:`save_sub_repos_json` 在写回时**以 lua 默认为准 prune 掉已不在 lua 的默认条目**
+   (清掉 `fromsource` 这类幽灵;用户自定义条目保留)。
+3. 一次性:文档说明存量用户 `xim-indexrepos.json` 里 org 漂移会被下次 update 以 lua 为准纠正。
+
+### C5 — 指针传输完整性(本轮档位) 【客户端 + 发布,小】
+**问题**:组合指针自身 `obtain_file(..., {})` 无 sha(`indexfetch.cppm:301`);artifact 有 sha256 但指针没有。
+**改动(本轮只做传输完整性)**:
+- 发布侧:指针**双发对账**——GH release asset 与 raw 仓库文件两路发布,客户端取到后比对两路一致
+  (已天然双源,补一次交叉校验日志即可);或在指针里加 `pointers_sha256` 自描述字段供二次校验。
+- 不引入私钥/签名。**端到端签名(minisign)、内容寻址列入后续阶段(§7)。**
+
+---
+
+## 5. 分阶段落地
+
+| 阶段 | 内容 | 仓库 | 收益 |
+|---|---|---|---|
+| **P0(客户端先行,纯本仓,立即见效)** | C1 迁移闸 + C3 CN 代理白名单 + C4 客户端 json prune | xlings | 存量用户子索引一次 update 即迁 artifact;消除 403;体验立刻变好 |
+| **P1(发布解耦,跨仓)** | C2 三个默认子仓加 `publish-artifact.yml` + C4 规范化 lua/release.yml org | xim-pkgindex-{awesome,scode,d2x} + xim-pkgindex | "改子索引即发布",不再等发版 |
+| **P2(完整性 + 收尾)** | C5 指针双发对账;统一 mcpp-index 路径(若需) | xlings + xlings-res | 传输完整性加固 |
+| **后续(本轮不做)** | minisign 端到端签名 / 内容寻址 / 稀疏索引 | 全生态 | 镜像/代理不可信下的投毒防护 |
+
+**推荐顺序**:**P0 → P1 → P2**。P0 不依赖任何跨仓改动,可独立先发一版,马上改善体验;
+P1 跨仓(含 d2learn 协调)单独推进;P2 收尾。
+
+---
+
+## 6. 兼容性 / 回滚 / 风险
+
+- **回退保留**:`XLINGS_INDEX_SOURCE=git` 一键回到全 git;artifact 任一步失败自动 git 回退,**不破坏现有 e2e/本地 fixture**(本地/file:// 源永不走 artifact,`repo.cppm:441`、`494`)。
+- **非默认/自定义仓不受影响**:不在 lua 默认集、URL 被 override、或本地源的子索引继续 git(含 `fromsource`)。
+- **C1 风险**:几乎为零(失败回退 git)。需 e2e 覆盖"主 artifact + 子存量 git → 迁移"场景。
+- **C3 风险**:特殊网络下国内站也需代理 → `XLINGS_PROXY_CN_DIRECT=off` 兜底。
+- **C2 风险(跨仓)**:d2x 跨 org,需 d2learn 配合 secrets/Actions;未配齐前 d2x 仍靠 xlings 发版刷新(降级可接受)。
+- **C4 风险**:org 选错会让 `subDefaultOfficial` 全 false → 全退 git(功能不丢,只是没迁)。改动后必须验证三处一致。
+
+---
+
+## 7. 文件级改动清单
+
+**`openxlings/xlings`(本仓,P0/P2)**
+- `src/core/xim/repo.cppm`
+  - `:499-500` 迁移闸:auto 条件加 `|| mainArtifactManaged`(C1)
+  - `save_sub_repos_json` 调用处 `:518`:写回时按 lua 默认 prune 幽灵默认条目(C4)
+- `src/libs/tinyhttps.cppm`
+  - `env_proxy_for_ :175-197`:内置 CN 直连名单 + `XLINGS_PROXY_CN_DIRECT` 开关(C3)
+- `src/core/xim/indexfetch.cppm`
+  - 指针获取处 `:301`:双发对账 / `pointers_sha256` 二次校验(C5)
+- `.github/workflows/release.yml`
+  - `:383-411`:子索引命名改内容哈希、org 与 lua 对齐(C4/C2 对齐)
+- 测试:e2e 增"存量 git 子索引迁 artifact"、"CN 直连无代理"两用例
+
+**`openxlings/xim-pkgindex`(P1)**
+- `xim-indexrepos.lua`:默认子仓 URL 收敛到 canonical org(C4)
+
+**`xim-pkgindex-awesome` / `xim-pkgindex-scode` / `d2learn/xim-pkgindex-d2x`(P1,跨仓)**
+- 新增 `.github/workflows/publish-artifact.yml` + vendored `tools/`(C2)
+- 仓库 secrets:`XLINGS_RES_TOKEN`、`GITCODE_TOKEN`
+
+---
+
+## 8. 后续阶段(本轮明确不做,留档)
+
+- **端到端签名**:对组合指针(或校验清单)做 **minisign**(Ed25519),客户端内置公钥验签 →
+  任意镜像/CDN/代理可不被信任(对应 mirror-analysis G5;配方是可执行 Lua,安全敞口大)。
+  代价:跨仓公钥分发 + 各发布 CI 私钥 secret 管理。
+- **内容寻址**:用哈希命名指针,只对一个小"根指针"签名,缓存天然安全。
+- **稀疏索引**:包数量持续增长后,参考 Cargo sparse / Homebrew 逐包 JSON,按需取元数据。
+- **ETag/304 条件请求**:替代当前 7 天节流,新鲜度更精准(G6)。
+
+---
+
+## 9. 验收标准
+
+1. 全新安装:主 + awesome/scode/d2x **全部 artifact-managed**(各有 `.xlings-index-version`,无 `.git`)。
+2. 存量用户(主 artifact、子 git):一次 `xlings update` 后子索引完成迁移,日志不再有 `updating index repo:`。
+3. CN + 本地代理:`xlings update --verbose` **无 gitcode 403、无 penalize**;gitcode 直连命中。
+4. 改任一默认子索引 push:对应 artifact 在 `xlings-res/xim-index`(GH+GitCode)自动刷新,组合指针仅该 key 变更,兄弟 key 不丢。
+5. `XLINGS_INDEX_SOURCE=git` 全程回退 git 正常;`fromsource`/自定义/本地子索引继续 git。

--- a/src/core/xim/repo.cppm
+++ b/src/core/xim/repo.cppm
@@ -161,6 +161,53 @@ std::string sync_repo_url(const std::string& url, const std::string& mirror) {
     return detail_::sync_repo_url_(url, mirror);
 }
 
+// Merge the main index's lua-declared default sub-indexes with the
+// persisted / locally-added json list.
+//
+// Lua defaults are AUTHORITATIVE for their own names: if the official index
+// moves a default to a new org/URL, the lua URL wins over a stale json entry
+// (which save_sub_repos_json wrote from a previous sync), and the json is
+// healed on the next save. The json contributes ONLY names that are NOT lua
+// defaults — i.e. user-added sub-indexes (a private fork, or a once-default
+// repo that has since been dropped from the lua, like `fromsource`).
+//
+// This is what lets an org-drifted default (json pinned to the old org) keep
+// classifying as default-official so it can migrate to the artifact path; a
+// json-overrides-lua merge would leave it stuck on git forever.
+std::vector<IndexRepo> merge_sub_repos(const std::vector<IndexRepo>& luaDefaults,
+                                       const std::vector<IndexRepo>& jsonRepos) {
+    std::unordered_map<std::string, IndexRepo> seen;
+    std::vector<IndexRepo> out;
+    out.reserve(luaDefaults.size() + jsonRepos.size());
+    for (auto& r : luaDefaults) {
+        if (seen.emplace(r.name, r).second) out.push_back(r);
+    }
+    for (auto& r : jsonRepos) {
+        if (seen.emplace(r.name, r).second) out.push_back(r);
+    }
+    return out;
+}
+
+// Decide whether a sub-index should be fetched as a versioned artifact (vs git
+// clone/pull). Mirrors the main index's gating:
+//   - indexSource "artifact": force artifact for default-official subs.
+//   - indexSource "git":      always git.
+//   - indexSource "auto":     artifact for a default-official sub that is fresh
+//     (no pkgs), already artifact-managed, OR — once the MAIN index is
+//     artifact-managed — to MIGRATE an existing git checkout (the whole index
+//     is one unit; this is the C1 migration gate so existing installs don't
+//     stay split: main on artifact, subs on git).
+// Non-default / URL-overridden / local sub-indexes are never artifact-fetched.
+bool sub_should_attempt_artifact(bool isDefaultOfficial,
+                                 const std::string& indexSource,
+                                 bool subManaged, bool subHasPkgs,
+                                 bool mainArtifactManaged) {
+    if (indexSource == "artifact") return isDefaultOfficial;
+    if (indexSource == "git")      return false;
+    return isDefaultOfficial
+        && (subManaged || !subHasPkgs || mainArtifactManaged);
+}
+
 // A local repo source (file:// URL or a filesystem path) has no network host,
 // so the TCP reachability probe below always reports it "unreachable" and would
 // wrongly skip it. Local sources are always reachable — let git clone/pull
@@ -460,26 +507,24 @@ bool sync_all_repos(bool force = false) {
     auto luaSubRepos = detail_::discover_sub_repos_(mainDir, mirror.empty() ? "GLOBAL" : mirror);
     auto jsonSubRepos = load_sub_repos_json(sub_repos_json_path());
 
-    // Merge: Lua-discovered repos + locally-added JSON repos (JSON overrides)
-    std::unordered_map<std::string, IndexRepo> merged;
-    for (auto& repo : luaSubRepos) merged[repo.name] = repo;
-    for (auto& repo : jsonSubRepos) merged[repo.name] = repo;
-
-    std::vector<IndexRepo> allSubRepos;
+    // Merge: lua defaults are authoritative for their own names; json adds only
+    // user-added sub-indexes (names absent from the lua defaults). See
+    // merge_sub_repos for why json must NOT override lua defaults (an
+    // org-drifted default would otherwise stay pinned to a stale json URL and
+    // never migrate to the artifact path).
+    auto allSubRepos = merge_sub_repos(luaSubRepos, jsonSubRepos);
     std::vector<IndexRepo> syncedSubRepos;
-    for (auto& [name, repo] : merged) allSubRepos.push_back(repo);
 
     // Default sub-indexes — those provided by the main index's
-    // xim-indexrepos.lua at their declared (non-overridden) URL and from a
+    // xim-indexrepos.lua at their declared (now-authoritative) URL and from a
     // remote source — are fetched as artifacts, same model as the main index.
     // User-added sub-indexes (in xim-indexrepos.json but NOT a lua default),
     // URL-overridden ones, and local (file://) sources keep git.
     //
-    // The signal is "name is a lua default AND its URL still matches the lua
-    // default" — NOT "absent from the json". save_sub_repos_json() writes the
-    // synced defaults back into xim-indexrepos.json after every sync, so an
-    // "absent from json" test would wrongly drop every default after the first
-    // sync (the bug that left CN users git-pulling sub-indexes from github).
+    // The signal is "name is a lua default AND its URL matches the lua default".
+    // Because merge_sub_repos makes lua authoritative, repo.url == luaUrl for
+    // every lua default, so this also recognises a default whose official org
+    // moved (the stale json copy no longer overrides it).
     std::unordered_map<std::string, std::string> luaUrl;
     for (auto& r : luaSubRepos) luaUrl[r.name] = r.url;
 
@@ -493,11 +538,9 @@ bool sync_all_repos(bool force = false) {
             luaIt != luaUrl.end() && luaIt->second == repo.url
             && !Config::is_local_repo_source(repo, false);
         bool subManaged = fs::exists(repoDir / ".xlings-index-version");
-        bool subAttemptArtifact;
-        if (indexSource == "artifact")  subAttemptArtifact = subDefaultOfficial;
-        else if (indexSource == "git")  subAttemptArtifact = false;
-        else subAttemptArtifact = subDefaultOfficial
-                 && (subManaged || !fs::exists(repoDir / "pkgs"));
+        bool subAttemptArtifact = sub_should_attempt_artifact(
+            subDefaultOfficial, indexSource, subManaged,
+            fs::exists(repoDir / "pkgs"), mainArtifactManaged);
 
         bool ok = false;
         if (subAttemptArtifact) {

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -1734,6 +1734,87 @@ TEST(XimSubReposTest, SyncRepoUrlKeepsGithubOnCNMirror) {
     EXPECT_EQ(url, "https://github.com/openxlings/xim-pkgindex-awesome.git");
 }
 
+// ── merge_sub_repos: lua defaults are authoritative for their own names ──
+// (C4) The official index may move a default to a new org/URL; the lua URL must
+// win over a stale json entry so the sub still classifies as default-official.
+// json contributes ONLY names absent from lua (user-added sub-indexes).
+TEST(XimSubReposTest, MergeSubReposLuaDefaultWinsOverStaleJson) {
+    std::vector<xlings::IndexRepo> lua = {
+        {"awesome", "https://github.com/openxlings/xim-pkgindex-awesome.git"},
+        {"scode",   "https://github.com/openxlings/xim-pkgindex-scode.git"},
+    };
+    // json: stale org for awesome (old d2learn) + a user-added fork.
+    std::vector<xlings::IndexRepo> json = {
+        {"awesome",    "https://github.com/d2learn/xim-pkgindex-awesome.git"},
+        {"fromsource", "https://github.com/d2learn/xim-pkgindex-fromsource.git"},
+    };
+
+    auto merged = xlings::xim::merge_sub_repos(lua, json);
+    ASSERT_EQ(merged.size(), 3u);
+    std::unordered_map<std::string, std::string> byName;
+    for (auto& r : merged) byName[r.name] = r.url;
+    // lua wins for the default that drifted org
+    EXPECT_EQ(byName["awesome"], "https://github.com/openxlings/xim-pkgindex-awesome.git");
+    EXPECT_EQ(byName["scode"],   "https://github.com/openxlings/xim-pkgindex-scode.git");
+    // user-added json-only repo preserved
+    EXPECT_EQ(byName["fromsource"], "https://github.com/d2learn/xim-pkgindex-fromsource.git");
+}
+
+TEST(XimSubReposTest, MergeSubReposJsonOnlyPreserved) {
+    std::vector<xlings::IndexRepo> lua = {};
+    std::vector<xlings::IndexRepo> json = {
+        {"fromsource", "https://github.com/d2learn/xim-pkgindex-fromsource.git"},
+    };
+    auto merged = xlings::xim::merge_sub_repos(lua, json);
+    ASSERT_EQ(merged.size(), 1u);
+    EXPECT_EQ(merged[0].name, "fromsource");
+}
+
+// ── sub_should_attempt_artifact: the C1 migration gate ──
+TEST(XimSubReposTest, SubArtifactAutoFreshDefault) {
+    // auto + default + fresh (no pkgs) → artifact
+    EXPECT_TRUE(xlings::xim::sub_should_attempt_artifact(
+        /*isDefaultOfficial=*/true, "auto",
+        /*subManaged=*/false, /*subHasPkgs=*/false, /*mainArtifactManaged=*/false));
+}
+
+TEST(XimSubReposTest, SubArtifactAutoExistingGitNoMainMigration) {
+    // auto + default + existing git checkout (has pkgs, not managed) +
+    // main NOT artifact-managed → stay git (no migration)
+    EXPECT_FALSE(xlings::xim::sub_should_attempt_artifact(
+        true, "auto", /*subManaged=*/false, /*subHasPkgs=*/true,
+        /*mainArtifactManaged=*/false));
+}
+
+TEST(XimSubReposTest, SubArtifactAutoMigratesWhenMainArtifactManaged) {
+    // auto + default + existing git checkout + MAIN is artifact-managed
+    // → migrate the sub to artifact too (the whole index is one unit). [C1]
+    EXPECT_TRUE(xlings::xim::sub_should_attempt_artifact(
+        true, "auto", /*subManaged=*/false, /*subHasPkgs=*/true,
+        /*mainArtifactManaged=*/true));
+}
+
+TEST(XimSubReposTest, SubArtifactAutoAlreadyManaged) {
+    EXPECT_TRUE(xlings::xim::sub_should_attempt_artifact(
+        true, "auto", /*subManaged=*/true, /*subHasPkgs=*/true, false));
+}
+
+TEST(XimSubReposTest, SubArtifactNonDefaultNeverArtifact) {
+    EXPECT_FALSE(xlings::xim::sub_should_attempt_artifact(
+        /*isDefaultOfficial=*/false, "auto", false, false, true));
+    EXPECT_FALSE(xlings::xim::sub_should_attempt_artifact(
+        /*isDefaultOfficial=*/false, "artifact", false, false, true));
+}
+
+TEST(XimSubReposTest, SubArtifactSourceOverrides) {
+    // git mode disables artifact even for a fresh default
+    EXPECT_FALSE(xlings::xim::sub_should_attempt_artifact(
+        true, "git", false, false, true));
+    // artifact mode forces it for a default regardless of fs state
+    EXPECT_TRUE(xlings::xim::sub_should_attempt_artifact(
+        true, "artifact", false, true, false));
+}
+
 // ============================================================
 // xim add-xpkg / local repo tests
 // ============================================================


### PR DESCRIPTION
## What

Closes the client-side last mile of the index ecosystem unification (plan:
`.agents/docs/2026-06-25-index-ecosystem-unification-plan.md`): default
sub-indexes (`awesome`/`scode`/`d2x`) now follow the **same artifact path** as
the main index instead of staying on git clone/pull.

Two pure, unit-tested helpers extracted from `sync_all_repos`:

- **`merge_sub_repos`** — lua defaults are **authoritative** for their own names;
  json contributes only user-added repos. Fixes the org-drift case where a stale
  `xim-indexrepos.json` URL (awesome/scode pinned to old `d2learn` org) made
  `subDefaultOfficial` false and left the sub stuck on git forever. The stale
  json **self-heals** on the next save.
- **`sub_should_attempt_artifact`** — the **C1 migration gate**. In `auto` mode a
  default sub also adopts artifact when the **main index is already
  artifact-managed**, so existing installs don't stay split (main on artifact,
  subs on git).

## Scope notes (per maintainer decision)

- **C3 (CN proxy direct-connect whitelist): dropped** — local proxy already
  direct-connects CN hosts; the 403 was not an xlings proxy-policy issue.
- **C2 (sub-index publish): simplified** — a single manual `workflow_dispatch` in
  `xim-pkgindex` (separate repo); `release.yml` already covers release-time.
- **`fromsource` ghost entry: untouched** — not a lua default, correctly stays on git.

## Verification

- Unit: 8 new `XimSubReposTest` cases (merge authority + migration gate) — all green.
- E2E (real `xlings update` with the built binary):
  - `awesome`/`scode`/`d2x`: git → **artifact** (`.xlings-index-version` written, `.git` removed)
  - `fromsource`: correctly **stays git**
  - `xim-indexrepos.json` org drift (d2learn → openxlings) **self-healed**
- `test_mirror` failure observed locally is a pre-existing **local-env artifact**
  (empty `~/.xlings/data/github-mirrors.json` override); passes once removed. Not in this diff's scope.

## Files

- `src/core/xim/repo.cppm` — helpers + wiring
- `tests/unit/test_main.cpp` — unit tests
- `.agents/docs/2026-06-25-index-ecosystem-unification-plan.md` — plan + architecture + multi-repo coordination