### PR TITLE
chore(release): bump version to 0.4.60

### DIFF
--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.59";
+    static constexpr std::string_view VERSION = "0.4.60";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 


### PR DESCRIPTION
Cut **0.4.60** to ship the index ecosystem unification client change (#342) to real users via `xlings self update` / fresh install.

- #342 — default sub-indexes (awesome/scode/d2x) migrate git → artifact (C1 migration gate + lua-authoritative merge).

After merge, dispatch `release.yml` → builds static binaries (linux/macos/windows/aarch64) + publishes main & default sub-index artifacts to `xlings-res/xim-index` (GitHub + GitCode), closing the loop end-to-end.