### PR TITLE
feat(xim): persist declared xpkg exports to .xpkg-exports.json

### DIFF
--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -1600,6 +1600,28 @@ public:
                 executor.apply_install_stamp_if_empty(ctx);
             }
 
+            // Persist declared exports next to the payload
+            // (<install_dir>/.xpkg-exports.json) so downstream consumers
+            // (e.g. mcpp's toolchain link model) read the DECLARED runtime
+            // metadata (loader/abi/libdirs) instead of re-deriving it by
+            // convention. Paths are written in their declared RELATIVE form —
+            // consumers join against the payload root, so the file stays
+            // valid across copies and symlink inheritance. Idempotent; also
+            // written for already-installed payloads so existing installs
+            // gain the file on their next resolve.
+            if (!node.exports.loader.empty() || !node.exports.abi.empty()
+                || !node.exports.libdirs.empty()) {
+                nlohmann::json rt;
+                if (!node.exports.loader.empty())  rt["loader"]  = node.exports.loader;
+                if (!node.exports.abi.empty())     rt["abi"]     = node.exports.abi;
+                if (!node.exports.libdirs.empty()) rt["libdirs"] = node.exports.libdirs;
+                nlohmann::json j;
+                j["runtime"] = std::move(rt);
+                std::ofstream exportsOs(ctx.install_dir / ".xpkg-exports.json");
+                if (exportsOs) exportsOs << j.dump(2) << "\n";
+                else log::debug("{}: could not write .xpkg-exports.json", node.name);
+            }
+
             // Apply elfpatch auto-patching if the install hook enabled it
             if (!payloadInstalled) {
                 // Ensure binDir is in PATH so elfpatch can find patchelf


### PR DESCRIPTION
Companion to the hermetic toolchain link model work (mcpp-community/mcpp#196, mcpp issue #195).

glibc.lua declares `exports.runtime.loader` precisely so consumers don't hardcode the loader path — but the declaration never reached disk, so consumers re-derived it by convention. This persists the declared exports (relative form) to `<install_dir>/.xpkg-exports.json` at install time. mcpp's loader resolver already treats this file as its highest-priority source and falls back to a triple map + glob without it, so this PR is non-blocking for the mcpp release train.

Note: local build verification wasn't possible on this machine (pre-existing local toolchain-header issue affects clean main identically); relying on CI for the compile check.