### PR TITLE
fix(xim): host-free toolchain BUILD env for install() hooks (LIBRARY_PATH/CPATH)

### DIFF
--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -1484,6 +1484,22 @@ public:
                 std::string oldPath = std::getenv("PATH") ? std::getenv("PATH") : "";
                 std::vector<std::string> setEnvKeys;
                 std::string newPath = oldPath;
+                // Also assemble a host-free toolchain BUILD env from the same
+                // build-deps: their lib/ (+ lib64/) feed LIBRARY_PATH (crt1.o,
+                // crti.o, libm, ...) and their include/ feeds CPATH (stdlib.h,
+                // kernel uapi headers). gcc's specs wire xim:glibc only for the
+                // RUNTIME (rpath/dynamic-linker), not the build-time startfile/
+                // library/header search — without this, install() source builds
+                // fail to find crt/headers on a host-free runner (or silently
+                // fall back to the host's /usr, breaking host-free).
+                std::string oldLibPath = std::getenv("LIBRARY_PATH") ? std::getenv("LIBRARY_PATH") : "";
+                std::string oldCPath   = std::getenv("CPATH") ? std::getenv("CPATH") : "";
+                std::string newLibPath = oldLibPath;
+                std::string newCPath   = oldCPath;
+                auto prependEnv_ = [](std::string& acc, const std::string& dir) {
+                    acc = acc.empty() ? dir
+                        : dir + std::string(1, platform::PATH_SEPARATOR) + acc;
+                };
                 for (auto& bd : node.build_deps) {
                     auto bdDir = locate_dep_install_dir_(plan, dataDir, bd);
                     if (bdDir.empty()) {
@@ -1510,12 +1526,22 @@ public:
                     if (std::filesystem::exists(bdDir / "bin")) {
                         newPath = bdBin + std::string(1, platform::PATH_SEPARATOR) + newPath;
                     }
+                    for (const char* sub : {"lib", "lib64"}) {
+                        if (std::filesystem::exists(bdDir / sub))
+                            prependEnv_(newLibPath, (bdDir / sub).string());
+                    }
+                    if (std::filesystem::exists(bdDir / "include"))
+                        prependEnv_(newCPath, (bdDir / "include").string());
                     log::debug("[{}] build_dep {} -> {} (env {})",
                                node.name, bd, bdDir.string(), envKey);
                 }
                 if (!setEnvKeys.empty()) {
                     platform::set_env_variable("PATH", newPath);
                 }
+                if (newLibPath != oldLibPath)
+                    platform::set_env_variable("LIBRARY_PATH", newLibPath);
+                if (newCPath != oldCPath)
+                    platform::set_env_variable("CPATH", newCPath);
 
                 auto hookResult = executor.run_hook(
                     mcpplibs::xpkg::HookType::Install, ctx);
@@ -1527,6 +1553,10 @@ public:
                         platform::set_env_variable(k, "");
                     }
                 }
+                if (newLibPath != oldLibPath)
+                    platform::set_env_variable("LIBRARY_PATH", oldLibPath);
+                if (newCPath != oldCPath)
+                    platform::set_env_variable("CPATH", oldCPath);
 
                 if (!hookResult.success) {
                     log::error("install hook failed for {}: {}",


### PR DESCRIPTION
## 问题

`install()` xpkg hook 从源码构建的包(如 `compat.opencv` 用 CMake 编 OpenCV)在**冷/host-free 环境**(CI runner 无宿主 libc-dev)下失败:`xim:gcc` 找不到
- 链接期:`crt1.o` / `crti.o` / `-lm`(都在 `<xim:glibc>/lib`)
- 编译期:`stdlib.h` / `limits.h` + 内核 uapi 头(在 `<xim:glibc>/include`、`<xim:linux-headers>/include`)

`xim:gcc` 的 specs 只把 `xim:glibc` 接到**运行期**(rpath/dynamic-linker),**没接构建期**的 startfile/库/头搜索路径。mcpp 自己的构建靠 `LIBRARY_PATH`/`CPATH` 提供这些,但 `install()` hook 的子进程继承不到。开发主机上 gcc 静默 fallback 到宿主 `/usr`(能过但**违反 host-free**);极简 CI runner 没 libc-dev → 硬失败。`compat.openblas` 躲过是因为它只编译+归档 `.a`,从不链接可执行文件。

## 修复

扩展 `installer.cppm::execute` 里**已有的** per-hook build-dep 环境注入(原本只把每个 `build_dep` 的 `bin/` 前插 PATH,跑完还原):同一循环里再把
- `<bdDir>/lib`(+`lib64/`)→ `LIBRARY_PATH`
- `<bdDir>/include` → `CPATH`

hook 前设、跑完还原(含错误路径)。由**包声明的 build_deps 驱动** —— 一个源码构建包声明 `xim:glibc` + `xim:linux-headers` 作为 build_deps,即自动获得 host-free 构建环境,descriptor **零环境接线**。

## 验证

- ✅ **编译**:`mcpp build`(release)exit 0,**对着仓库当前 pin 的 libxpkg 0.0.42** —— 本改动 **xlings-only,不需动 libxpkg**。
- ✅ **代码路径证实**:实跑 opencv install(),进程 env 里 PATH 已含 `xim-x-{cmake,gcc,glibc}/.../bin`,证明该循环确对 opencv 执行、glibc 被解析。
- ⏳ **端到端(opencv host-free 变绿)**:待本 PR CI + 一版带此改动的 xlings 发布后,由 mcpp-index opencv workspace CI 冷环境验证(本地因宿主 libc 掩盖 + mcpp 重新物化自带 xlings 二进制,无法干净复现)。

## 关联
- 根因分析:mcpp-index `.agents/docs/2026-07-09-install-hook-toolchain-build-env-gap.md`
- 实施步骤:mcpp-index `.agents/docs/2026-07-09-opencv-unblock-implementation-steps.md`
- 下游消费者:mcpp-index `compat.opencv`(PR #67,待本修复发布后去掉临时环境接线再合入)

> Draft:提交供 review + 跑 CI,不主动合入/发版。