### PR TITLE
docs(xpkg): publish resource source and compat contract

### DIFF
--- a/.agents/docs/2026-07-11-xpkg-resource-expression-design.md
+++ b/.agents/docs/2026-07-11-xpkg-resource-expression-design.md
@@ -2,7 +2,7 @@
 
 > 日期：2026-07-11
 > 修订：2026-07-12
-> 状态：已实现，待随 xlings 发布
+> 状态：已实现并随 xlings 0.4.63、libxpkg 0.0.44 发布
 > 适用版本：libxpkg 0.0.44+
 > 范围：libxpkg 解析/compat、xlings 安装器、官方 xim-pkgindex
 

--- a/.agents/skills/xlings-contributing/SKILL.md
+++ b/.agents/skills/xlings-contributing/SKILL.md
@@ -142,6 +142,17 @@ XLINGS_BIN=$(find target -path '*/bin/xlings' -type f | head -1) \
 for t in tests/e2e/subos_xpkg_*.sh; do
   XLINGS_BIN=$XLINGS_BIN bash "$t" | tail -1
 done
+
+### Step 5.1: xpkg / resource changes
+
+涉及 `xpm`、官方资源或 `xim-pkgindex` 的改动必须遵守以下契约：
+
+- `libxpkg` 是解析、compat 和资源归一化的唯一入口；不要在 xlings 中新增第二套 Lua 解析器或 URL 模板展开器。
+- 默认来源使用 `xpm.source = "xlings-res"` 或 URL template；版本项仍保持原有 `platform -> version` 模型。
+- 官方二进制资源为每个受支持平台/架构提供 SHA256。多架构 hash 缺失时索引生成器应 fail closed。
+- 保留并测试旧的 `"XLINGS_RES"`、`res = true`、显式 URL、mirror、`ref` 和旧单 hash 写法。
+- 资源表达测试至少覆盖 x86_64/aarch64、根级/平台级 source、显式 URL 覆盖、mirror 和旧客户端兼容 fixture。
+- 修改资源缓存、下载或发布链时，除 `mcpp build && mcpp test` 外，使用隔离 `XLINGS_HOME` 验证坏缓存自愈、SHA256 校验和实际 release 资产。
 ```
 
 ### Step 6: Commit

--- a/docs/README.md
+++ b/docs/README.md
@@ -104,6 +104,7 @@ SubOS 提供三级隔离,满足从日常开发到 Agent 安全执行的不同需
 | 文档 | 内容 |
 |------|------|
 | [SubOS-as-XPKG](design/subos-as-xpkg.md) | type="subos" 包格式、fork 机制、非交互执行 |
+| [xpkg 资源解析](design/xpkg-resource-resolution.md) | `xpm.source`、多架构 SHA256、libxpkg compat 与索引发布契约 |
 | [xvm 版本管理](design/xvm-version-management.md) | 版本视图 + 引用计数实现多版本共存 |
 | [SubOS 隔离机制](design/subos-isolation.md) | 三级隔离(shell / FS / image)的实现细节 |
 | [包索引生态](design/package-index-ecosystem.md) | 去中心化索引设计 |
@@ -113,6 +114,6 @@ SubOS 提供三级隔离,满足从日常开发到 Agent 安全执行的不同需
 
 | 文档 | 内容 |
 |------|------|
-| [xpkg 包描述格式 v1](spec/xpkg-manifest-v1.md) | .lua 包描述文件的字段、type、hook 约定 |
+| [xpkg 包描述格式 v1](spec/xpkg-manifest-v1.md) | .lua 包描述文件的字段、type、hook、`xpm.source` 与多架构资源约定 |
 | [.xlings.json 字段](spec/xlings-json-schema.md) | 配置文件各字段语义 |
 | [Interface NDJSON v1](spec/interface-ndjson-v1.md) | 请求/响应/事件协议 |

--- a/docs/design/package-index-ecosystem.md
+++ b/docs/design/package-index-ecosystem.md
@@ -84,6 +84,17 @@ flowchart LR
 
 查找顺序：项目配置 → 全局配置 → 内置默认值 → GLOBAL 兜底。
 
+### xpkg 资源声明契约（0.4.63）
+
+包配方保持 `xpm.<platform>.<version>` 原模型，并可用根级或平台级
+`xpm.source = "xlings-res" | <URL template>` 消除重复 URL。版本项显式 `url` 覆盖
+默认 source；多架构资源使用 per-arch SHA256。官方二进制的每个受支持架构都必须有
+权威 hash，索引生成器缺少资产、sidecar 或 hash 时 fail closed。
+
+旧的裸 `"XLINGS_RES"`、`res = true`、单 URL、mirror、`ref` 和单 hash 继续解析，
+但新配方推荐 `source` 形式。详细字段、模板占位符和兼容优先级见
+[xpkg 资源解析设计](xpkg-resource-resolution.md)。
+
 ## 配置方式
 
 在 `.xlings.json`（全局或项目级）中声明：

--- a/docs/design/xpkg-resource-resolution.md
+++ b/docs/design/xpkg-resource-resolution.md
@@ -1,0 +1,61 @@
+# xpkg 资源解析与兼容设计
+
+> 编写日期: 2026-07-12 | 版本: 0.4.63
+
+## 1. 设计结论
+
+xlings 不重新设计 `xpm` 的平台/版本矩阵，只增加可选默认来源 `xpm.source`。libxpkg
+是解析、compat 和资源归一化的唯一入口；xlings 安装器只负责资源服务器策略、下载和缓存。
+
+```lua
+xpm = {
+    source = "xlings-res", -- 或 URL template
+    linux = {
+        ["latest"] = { ref = "1.0.0" },
+        ["1.0.0"] = {
+            sha256 = { x86_64 = "<x86-hash>", aarch64 = "<arm-hash>" },
+        },
+    },
+}
+```
+
+## 2. source 与优先级
+
+`source` 可放在 `xpm` 根级或平台级。平台级覆盖根级；版本项显式 `url` 覆盖默认
+source。支持：
+
+- `"xlings-res"`：按用户 `GLOBAL`/`CN` 资源服务器配置生成官方 URL。
+- HTTP(S) URL template：支持 `${name}`、`${version}`、`${os}`、`${arch}`、
+  `${arch_alias}` 和 `${ext}`。
+
+资源归一化顺序为：跟随 `ref`、选择 per-arch map、读取显式 URL、读取平台/root
+source、展开模板、选择 mirror。多架构 hash 缺失时 fail closed；完全没有 hash 仍为
+兼容旧包而允许下载，但不会被视为密码学验证。
+
+## 3. 兼容输入
+
+以下形式继续支持：
+
+- 字符串 URL；
+- `"XLINGS_RES"`；
+- `{ url = ..., sha256 = ..., ref = ... }`；
+- URL mirror table；
+- per-arch resource map；
+- URL template + per-arch SHA256；
+- 历史 `res = true + sha256`。
+
+新配方推荐 `xpm.source = "xlings-res"` 或 URL template；`res = true` 和裸
+`"XLINGS_RES"` 仅作为历史兼容写法。
+
+## 4. 索引与发布要求
+
+官方二进制的每个受支持平台/架构必须有权威 SHA256。`xim-pkgindex` 的版本检查器从
+release sidecar/manifest 生成配方，缺失资源、sidecar 或 hash 时 fail closed。GitHub RES
+与 GitCode RES 必须逐字节一致；`xim-index` 索引工件和软件包二进制是两类独立资源。
+
+## 5. 相关规范
+
+- [xpkg manifest v1 与资源扩展](../spec/xpkg-manifest-v1.md)
+- [包索引生态](package-index-ecosystem.md)
+- [索引分发](index-distribution.md)
+- [完整实施台账](../../.agents/docs/2026-07-11-issue-356-partial-download-cache-fix-plan.md)

--- a/docs/spec/xpkg-manifest-v1.md
+++ b/docs/spec/xpkg-manifest-v1.md
@@ -1,6 +1,6 @@
 # xpkg 包描述文件规范 (spec v1)
 
-> 编写日期: 2026-05-17 | 版本: 0.4.36
+> 编写日期: 2026-07-12 | 版本: 0.4.63
 
 ## 1. 概述
 
@@ -77,6 +77,71 @@ xpkg 包描述文件是一个 Lua 脚本（`.lua`），用于声明软件包的�
 - `deps` — 依赖声明，见第 7 节
 - `inherits` — 字符串，继承另一平台的配置
 - `exports` — 导出声明（高级，用于 ELF patch）
+
+### 5.3 资源来源扩展（xlings 0.4.63 / libxpkg 0.0.44）
+
+`xpm.source` 是保持原有 `platform -> version` 模型不变的可选默认来源。它不是新的
+版本 DSL，版本项、`ref`、mirror 和显式 `url` 仍按本节原有规则解析。
+
+```lua
+xpm = {
+    source = "xlings-res", -- 官方资源服务器
+    linux = {
+        ["latest"] = { ref = "1.2.0" },
+        ["1.2.0"] = {
+            sha256 = {
+                x86_64 = "<linux-x86_64-sha256>",
+                aarch64 = "<linux-aarch64-sha256>",
+            },
+        },
+    },
+}
+```
+
+`source` 支持两种字符串：
+
+- `"xlings-res"`：由 xlings 按用户资源服务器配置生成 URL；官方二进制推荐使用此形式并为每个受支持架构提供 SHA256。
+- URL 模板：普通 HTTP(S) 模板，可使用 `${name}`、`${version}`、`${os}`、`${arch}`、`${arch_alias}` 和 `${ext}`。
+
+来源可以放在 `xpm` 根级，也可以放在某个平台表中；平台级值覆盖根级值。版本项的显式
+`url` 始终覆盖默认 `source`。模板 URL 示例：
+
+```lua
+xpm = {
+    source = "https://github.com/acme/foo/releases/download/${version}/foo-${os}-${arch_alias}.${ext}",
+    linux = {
+        ["1.0.0"] = {
+            arch_alias = { x86_64 = "amd64", aarch64 = "arm64" },
+            sha256 = { x86_64 = "<amd64-sha256>", aarch64 = "<arm64-sha256>" },
+        },
+    },
+}
+```
+
+多架构资源仍使用原版本项模型，支持两种表达：
+
+```lua
+-- URL 模板 + 每架构 hash
+["1.0.0"] = {
+    url = "https://example.test/foo-${version}-${arch}.tar.gz",
+    sha256 = { x86_64 = "<x86-hash>", aarch64 = "<arm-hash>" },
+}
+
+-- 上游 URL 不规则时，为每架构分别声明资源
+["2.0.0"] = {
+    x86_64 = { url = "https://example.test/foo-amd64.tar.gz", sha256 = "<x86-hash>" },
+    aarch64 = { url = "https://example.test/foo-arm64.tar.gz", sha256 = "<arm-hash>" },
+}
+```
+
+旧写法 `"XLINGS_RES"`、`res = true`、单 URL、mirror table 和旧单 hash 继续兼容。
+其中 `res = true + sha256` 是历史输入，新包应使用 `xpm.source = "xlings-res"`。
+架构 hash 缺失时新 libxpkg 对多架构项 fail closed；完全没有 hash 仍可为兼容旧包而下载，
+但不表示资源经过密码学完整性验证。
+
+所有资源表达首先由 libxpkg compat 统一归一化为最终平台、架构、URL、mirror 和 SHA256；
+xlings 安装器不再维护第二套 Lua 解析器。包作者只需验证目标客户端版本和索引 CI，不应在
+hook 中自行解析 `source` 或拼接资源服务器地址。
 
 ## 6. 生命周期钩子函数
 


### PR DESCRIPTION
## Summary
- document xpm.source, URL templates, per-arch SHA256, and legacy compatibility in the public xpkg spec
- add the public resource-resolution design and update contributor guidance
- align the dynamic design doc with the released xlings 0.4.63/libxpkg 0.0.44 contract

## Validation
- git diff --check
- documentation and skill changes only

Refs: #356