### PR TITLE
chore(release): bump xlings to 0.4.64

### DIFF
--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlings"
-version = "0.4.63"
+version = "0.4.64"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.63";
+    static constexpr std::string_view VERSION = "0.4.64";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 


### PR DESCRIPTION
Summary:
- bump xlings to 0.4.64 so the released client embeds mcpplibs.xpkg 0.0.45

Test plan:
- run all platform CI and E2E workflows