### PR TITLE
fix(release): bound every mirror network op + idempotent re-runs

### DIFF
--- a/.github/workflows/mirror-binaries.yml
+++ b/.github/workflows/mirror-binaries.yml
@@ -1,0 +1,45 @@
+# On-demand (re)mirror of release binaries to xlings-res (GitHub + GitCode).
+#
+# release.yml runs the same script automatically; this workflow is the rescue
+# path when that job was cancelled, timed out, or GitCode dropped some assets
+# — re-running the whole release pipeline just to top up a mirror is wasteful.
+# The script is idempotent: assets that already verify (200 + size match) are
+# skipped, so a re-run only uploads what is actually missing.
+#
+# Counterpart of xim-pkgindex's publish-sub-indexes.yml (same on-demand
+# top-up pattern for index artifacts).
+name: Mirror Binaries (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version to mirror (e.g. 0.4.65)'
+        required: true
+        type: string
+      project:
+        description: 'Project whose binaries to mirror'
+        type: choice
+        options: [xlings, mcpp]
+        default: xlings
+
+permissions:
+  contents: read
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      XLINGS_RES_TOKEN: ${{ secrets.XLINGS_RES_TOKEN }}
+      GITCODE_TOKEN: ${{ secrets.GITCODE_TOKEN }}
+      GH_TOKEN: ${{ secrets.XLINGS_RES_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Mirror binaries to xlings-res (gh + gtc)
+        if: ${{ env.XLINGS_RES_TOKEN != '' }}
+        run: |
+          chmod +x tools/gtc tools/mirror_res.sh
+          export PATH="$PWD/tools:$PATH"
+          bash tools/mirror_res.sh "${{ inputs.project }}" "${{ inputs.version }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -447,6 +447,10 @@ jobs:
   mirror-binaries:
     needs: [create-release]
     runs-on: ubuntu-latest
+    # Hard backstop: normal runtime is 2-5 min. Without this, a stalled
+    # GitCode upload/verify pinned the job for 40+ min (v0.4.65). The script
+    # itself bounds every network call; this catches anything it can't.
+    timeout-minutes: 15
     env:
       XLINGS_RES_TOKEN: ${{ secrets.XLINGS_RES_TOKEN }}
       GITCODE_TOKEN: ${{ secrets.GITCODE_TOKEN }}

--- a/tools/gtc
+++ b/tools/gtc
@@ -173,7 +173,10 @@ def _upload_one(cfg, repo, tag, file_path):
     with open(file_path, "rb") as f:
         data = f.read()
     req = urllib.request.Request(put_url, data=data, headers=h, method="PUT")
-    with urllib.request.urlopen(req, timeout=600) as r:
+    # 120s socket-inactivity cap (was 600): assets are <10 MB, a healthy OBS
+    # PUT finishes in seconds, and callers retry — a stalled connection must
+    # fail fast instead of pinning a CI job (v0.4.65 mirror hung 40+ min).
+    with urllib.request.urlopen(req, timeout=120) as r:
         ok = r.status == 200
         body = r.read().decode(errors="replace")[:200]
     if not ok:

--- a/tools/mirror_res.sh
+++ b/tools/mirror_res.sh
@@ -51,30 +51,60 @@ for a in "${ASSETS[@]}"; do
 done
 
 # ── GitHub (gh --clobber, reliable) ───────────────────────────────
+# probe <url> -> "code size", hard wall-clock capped. Every network check in
+# this script MUST go through this (or an equivalent bounded call): a stalled
+# CDN connection with no --max-time hung the v0.4.65 mirror job for 40+ min
+# (3 fast failures, then a timeout-less upload/verify stall).
+probe() {
+  curl -sL --connect-timeout 10 --max-time 90 -o /dev/null \
+       -w '%{http_code} %{size_download}' "$1" 2>/dev/null || echo "ERR 0"
+}
+asset_size() { stat -c%s "$1" 2>/dev/null || stat -f%z "$1"; }
+
 if [[ -n "${XLINGS_RES_TOKEN:-}" ]] || gh auth status >/dev/null 2>&1; then
   info "GitHub $GH_DST tag $VER"
   GH_TOKEN="${XLINGS_RES_TOKEN:-}" gh release view "$VER" -R "$GH_DST" >/dev/null 2>&1 \
     || GH_TOKEN="${XLINGS_RES_TOKEN:-}" gh release create "$VER" -R "$GH_DST" --title "$VER" --notes "$PROJ $VER (mirror of $SRC_REPO)"
+  # One asset-list call so idempotent re-runs (release re-run after a cancel,
+  # manual top-up) skip what is already fully mirrored. Size must match the
+  # local file — a partial upload from an interrupted run is re-clobbered.
+  existing="$(GH_TOKEN="${XLINGS_RES_TOKEN:-}" gh release view "$VER" -R "$GH_DST" \
+                --json assets --jq '.assets[] | "\(.name) \(.size)"' 2>/dev/null || true)"
   for a in "${ASSETS[@]}"; do
+    if grep -qx "$a $(asset_size "$DL/$a")" <<< "$existing"; then
+      info "gh $a already mirrored, skip"
+      continue
+    fi
     GH_TOKEN="${XLINGS_RES_TOKEN:-}" gh release upload "$VER" "$DL/$a" -R "$GH_DST" --clobber
   done
 else
   info "no github auth; skipping github mirror"
 fi
 
-# ── GitCode (gtc, per-file retry — multi-file upload can 502 and drop files) ──
+# ── GitCode (gtc, per-file — multi-file upload can 502 and drop files) ──────
 if [[ -n "${GITCODE_TOKEN:-}" ]] && command -v gtc >/dev/null 2>&1; then
   info "GitCode $GTC_DST tag $VER"
   gtc release create "$GTC_DST" --tag "$VER" --name "$VER" 2>/dev/null || true
-  # Upload then verify the actual DOWNLOAD is 200 (gtc can report success yet
-  # leave a phantom/missing asset — obs_callback flakiness), retry up to 5.
   for a in "${ASSETS[@]}"; do
-    for try in 1 2 3 4 5; do
-      gtc release upload "$GTC_DST" "$DL/$a" --tag "$VER" >/dev/null 2>&1 || true
-      if [[ "$(curl -fsSL -o /dev/null -w '%{http_code}' -L "https://gitcode.com/${GTC_DST}/releases/download/${VER}/${a}" 2>/dev/null)" == 200 ]]; then
-        break
-      fi
-      echo "[mirror] gtc $a not 200 after try $try, retrying..."; sleep 4
+    url="https://gitcode.com/${GTC_DST}/releases/download/${VER}/${a}"
+    want="$(asset_size "$DL/$a")"
+    # Skip if already fully mirrored (same download-verify the retry loop
+    # uses), so re-runs only touch the assets that are actually missing.
+    read -r code size <<< "$(probe "$url")"
+    if [[ "$code" == 200 && "$size" == "$want" ]]; then
+      info "gtc $a already mirrored, skip"
+      continue
+    fi
+    # Upload, then verify the actual DOWNLOAD is 200 with the right size (gtc
+    # can report success yet leave a phantom/missing asset — obs_callback
+    # flakiness). Each attempt is bounded: 180s upload cap + 90s probe cap,
+    # so a fully-degraded GitCode fails this asset in <15 min instead of
+    # hanging the job (release.yml also has a job-level timeout backstop).
+    for try in 1 2 3; do
+      timeout -k 10 180 gtc release upload "$GTC_DST" "$DL/$a" --tag "$VER" >/dev/null 2>&1 || true
+      read -r code size <<< "$(probe "$url")"
+      [[ "$code" == 200 && "$size" == "$want" ]] && break
+      echo "[mirror] gtc $a not OK after try $try (code=$code size=$size/want=$want), retrying..."; sleep 5
     done
   done
 else
@@ -86,7 +116,7 @@ info "verify:"
 rc=0
 for host in "github.com/$GH_DST" "gitcode.com/$GTC_DST"; do
   for a in "${ASSETS[@]}"; do
-    code=$(curl -fsSL -o /dev/null -w '%{http_code}' -L "https://${host}/releases/download/${VER}/${a}" 2>/dev/null || echo ERR)
+    read -r code _ <<< "$(probe "https://${host}/releases/download/${VER}/${a}")"
     echo "  $code  https://${host}/releases/download/${VER}/${a}"
     [[ "$code" == 200 ]] || rc=1
   done


### PR DESCRIPTION
## Why v0.4.65 mirror-binaries hung 40+ min

[Run 29330380023](https://github.com/openxlings/xlings/actions/runs/29330380023/job/87083610265): `gtc xlings-0.4.65-linux-aarch64.tar.gz not 200 after try 1..3`, then 40 min of silence.

Three compounding defects:
1. **`tools/gtc` PUT: `urlopen(timeout=600)`** — 10 min of allowed socket inactivity *per attempt* (and it's an inactivity timeout, so a slow-dripping OBS connection stretches further).
2. **Verify `curl` had no `--max-time`** — could hang indefinitely.
3. **No job timeout** — a hang blocks the pipeline for up to 6 h. (The step is already non-blocking on *failure* — only a *hang* could pin it, which is exactly what happened.)

The earlier fix in this area (GET-not-HEAD verification, per-file retry) addressed *correctness* of verification; it never bounded the *time* of each operation — that's the gap that bit today, triggered by GitCode OBS degrading mid-run (x86_64 pair uploaded fine at 12:27, everything after failed/hung).

## Fix (no behavior change on the happy path)
- `probe()` helper: every network check capped (connect 10s / total 90s); gtc upload wrapped in `timeout 180`; retries 5→3. Worst case per asset is now ~14 min **for a fully-degraded GitCode**, and the job backstop (`timeout-minutes: 15`) caps the whole job.
- **Idempotent re-runs**: skip assets already fully mirrored (GitHub: one asset-list API call; GitCode: the same bounded download-verify), with **size match** so partial uploads are re-clobbered. A re-run after a cancel now takes seconds, not a full re-upload.
- **New `mirror-binaries.yml` (workflow_dispatch)**: on-demand top-up (version + project inputs) — rescuing a dropped mirror no longer requires re-running the whole release. Same pattern as xim-pkgindex `publish-sub-indexes.yml`.

## Verified
- `bash -n` / `py_compile` / YAML parse clean.
- Full local dry-run against the live v0.4.65 release: 8/8 GitHub assets detected and skipped (no re-upload), 6 missing GitCode assets correctly reported, runtime 43 s.

## Rescue plan after merge
Cancel the stuck run, then dispatch `mirror-binaries.yml` with `version=0.4.65` — it will upload only the 6 missing GitCode assets.