### PR TITLE
feat(mirror): mirror-latest — manual post-release GitCode top-up + runbook

### DIFF
--- a/.agents/docs/2026-07-15-gitcode-large-asset-mirror-runbook.md
+++ b/.agents/docs/2026-07-15-gitcode-large-asset-mirror-runbook.md
@@ -84,6 +84,17 @@ retries", it is a broken/phantom attachment: GitCode has **no** asset/release
 delete via API (v5 returns 405, exposes no release id), so delete it in the
 GitCode release **web UI**, then re-run the command.
 
+## Validation
+
+The tooling was verified end-to-end from a CN host before adoption:
+
+- **Steady state** (nothing missing, v0.4.65): 16 assets skipped, 0 downloads,
+  all 16 URLs (8 assets × 2 hosts) `OK`, ~40 s.
+- **Gap-fill** (a real GitHub-only gap constructed on a throwaway tag): the
+  script detected the gap, downloaded from the public GitHub URL, uploaded to
+  GitCode, and verified — the GitCode copy was `sha256`-identical to the
+  source, and a second run was a clean idempotent skip.
+
 ## Related
 
 - Probe: openxlings/xlings#371 (throwaway; closed).

--- a/.agents/docs/2026-07-15-gitcode-large-asset-mirror-runbook.md
+++ b/.agents/docs/2026-07-15-gitcode-large-asset-mirror-runbook.md
@@ -1,0 +1,91 @@
+# Runbook: GitCode large-asset mirror (manual post-release step)
+
+**Status:** active procedure · **Date:** 2026-07-15 · **Owner:** release maintainer
+
+## TL;DR
+
+After every `xlings` release, run this once from **any environment with a
+healthy GitCode (CN) network route** — a CN shell/box/cloud terminal, not tied
+to any specific machine:
+
+```bash
+# needs: tools/gtc + a GitCode token (env GITCODE_TOKEN, or
+#        ~/.config/gitcode-tool/config.json). GitHub side is auto-skipped.
+tools/mirror-latest.sh xlings
+```
+
+It uploads only the GitCode assets that release CI could not, verifies all
+platforms on both hosts, and is a ~40 s no-op when nothing is missing. Done.
+
+## Why this step exists
+
+The release pipeline mirrors every binary to two hosts so `XLINGS_RES`
+downloads resolve for all regions:
+
+- **GitHub** (`github.com/xlings-res/xlings`) — GLOBAL.
+- **GitCode** (`gitcode.com/xlings-res/xlings`) — CN acceleration.
+
+**A GitHub-hosted CI runner cannot upload large (>~8 MiB) assets to GitCode.**
+The runner sits in Azure-US; GitCode's asset store is Huawei Cloud OBS in CN.
+The cross-border upload path sustains only ~15–30 KB/s and every method times
+out, so a 27 MiB asset never completes.
+
+This was not a guess — probe PR **openxlings/xlings#371** measured it from a
+GitHub runner against the real 27 MiB asset:
+
+| method | result | speed | uploaded before timeout |
+|---|---|---|---|
+| gtc (urllib PUT) | timeout | — | — |
+| curl default | timeout | 31 KB/s | 6.2 / 27 MB |
+| curl --http1.1 | timeout | 15 KB/s | 3.0 MB |
+| curl --limit-rate 300k | timeout | 15 KB/s | 4.2 MB |
+| curl --limit-rate 1M | timeout | 24 KB/s | 4.8 MB |
+
+The same files upload in ~10 s from a CN host via the same `gtc`. So this is a
+network-route fact, not a script/protocol/rate-limit issue, and not a GitCode
+fault. Protocol, timeout, and rate-limit tuning were all tried and rejected.
+
+## Why it is a manual step and not automated
+
+- **Correctness does not depend on it.** CN clients already fall back to the
+  GitHub asset URLs (`build_xlings_res_fallback_urls_` in
+  `src/core/xim/installer.cppm`), so a missing GitCode copy only costs CN
+  download speed, never availability.
+- **It is low-volume and low-frequency** — ~2–4 big files, once per release.
+- Standing infra to do it automatically (CN cron / VM / self-hosted runner)
+  is possible but was judged not worth the cost/maintenance/attack-surface for
+  a per-release convenience. Revisit if releases become frequent.
+
+## What the CI does on its own
+
+- `release.yml` → `mirror-binaries` job: mirrors everything to GitHub + the
+  small GitCode assets; fail-fast (non-blocking) on the big GitCode ones. It
+  is bounded (`timeout-minutes: 15`, per-call caps) after the v0.4.65 incident
+  where an unbounded stalled upload pinned the job for 40+ min (#369, #370).
+- `mirror-binaries.yml` (manual dispatch): same script, for re-mirroring the
+  GitHub side / small assets on demand. Also cannot do the big GitCode assets.
+
+## The manual procedure in detail
+
+1. A release has published (GitHub assets exist on `openxlings/xlings`).
+2. From a CN-routed environment with `tools/gtc` and a GitCode token:
+   ```bash
+   tools/mirror-latest.sh xlings
+   ```
+   - Resolves the latest release version automatically.
+   - Skips assets already mirrored (no download for those).
+   - Downloads only the missing ones from the public GitHub release URL and
+     uploads them to GitCode, then verifies 200 + size on both hosts.
+3. Confirm the final `verify:` block shows `OK` for all 16 URLs (8 assets ×
+   2 hosts). `all platforms mirrored OK` means done.
+
+If a GitCode asset is reported "registered but not downloadable after
+retries", it is a broken/phantom attachment: GitCode has **no** asset/release
+delete via API (v5 returns 405, exposes no release id), so delete it in the
+GitCode release **web UI**, then re-run the command.
+
+## Related
+
+- Probe: openxlings/xlings#371 (throwaway; closed).
+- Mirror hardening: openxlings/xlings#369, #370.
+- Tooling: `tools/mirror-latest.sh`, `tools/mirror_res.sh`.

--- a/.github/workflows/mirror-binaries.yml
+++ b/.github/workflows/mirror-binaries.yml
@@ -6,6 +6,13 @@
 # The script is idempotent: assets that already verify (200 + size match) are
 # skipped, so a re-run only uploads what is actually missing.
 #
+# NOTE — GitCode big assets (>~8 MiB) still CANNOT be uploaded from here: this
+# runs on a GitHub-hosted runner, which hits the same cross-border upload wall
+# as release.yml (probe PR #371). For those, run `tools/mirror-latest.sh` from
+# a CN environment instead. This workflow is still useful for re-mirroring the
+# GitHub side and the small GitCode assets. Runbook:
+# .agents/docs/2026-07-15-gitcode-large-asset-mirror-runbook.md
+#
 # Counterpart of xim-pkgindex's publish-sub-indexes.yml (same on-demand
 # top-up pattern for index artifacts).
 name: Mirror Binaries (manual)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -450,6 +450,16 @@ jobs:
     # Hard backstop: normal runtime is 2-5 min. Without this, a stalled
     # GitCode upload/verify pinned the job for 40+ min (v0.4.65). The script
     # itself bounds every network call; this catches anything it can't.
+    #
+    # KNOWN LIMITATION — GitCode big assets: a GitHub-hosted runner CANNOT
+    # upload assets larger than ~8 MiB to GitCode (cross-border runner->OBS
+    # sustains only ~15-30 KB/s and times out; proven in probe PR #371). This
+    # job therefore mirrors everything to GitHub + the small GitCode assets,
+    # and is fail-fast (non-blocking) on the big GitCode ones. A maintainer
+    # finishes the GitCode mirror AFTER release by running, from any CN
+    # environment: `tools/mirror-latest.sh xlings`. Correctness does not depend
+    # on it — CN clients fall back to the GitHub asset URLs. Runbook:
+    # .agents/docs/2026-07-15-gitcode-large-asset-mirror-runbook.md
     timeout-minutes: 15
     env:
       XLINGS_RES_TOKEN: ${{ secrets.XLINGS_RES_TOKEN }}

--- a/tools/mirror-latest.sh
+++ b/tools/mirror-latest.sh
@@ -1,20 +1,30 @@
 #!/usr/bin/env bash
-# Resolve the latest published <project> release and (re)mirror its binaries to
-# xlings-res via mirror_res.sh. Idempotent — already-mirrored assets are
-# skipped — so it is safe to run on a schedule.
+# MANUAL POST-RELEASE STEP — top up the GitCode binary mirror for the latest
+# release. Resolve the latest published <project> release and (re)mirror its
+# binaries to xlings-res via mirror_res.sh. Idempotent: already-mirrored assets
+# are skipped, so a run with nothing missing is a cheap no-op (~40 s).
 #
-# Its reason to exist: GitHub-hosted runners CANNOT upload large (>~8 MiB)
-# assets to GitCode — the cross-border runner->Huawei-Cloud-OBS path sustains
-# only ~15-30 KB/s and every method times out (proven in openxlings/xlings
-# probe PR #371). The release/mirror CI is therefore fail-fast, and this script
-# is the CN-side top-up: run it from a machine with a healthy GitCode route
-# (e.g. a daily user cron / systemd timer) and it fills whatever the CI could
-# not, uploading only the missing assets.
+# WHY THIS IS MANUAL (not in CI): GitHub-hosted runners CANNOT upload large
+# (>~8 MiB) assets to GitCode — the cross-border runner->Huawei-Cloud-OBS path
+# sustains only ~15-30 KB/s and every upload method times out (proven in
+# openxlings/xlings probe PR #371; runbook:
+# .agents/docs/2026-07-15-gitcode-large-asset-mirror-runbook.md). So the
+# release/mirror CI is fail-fast on big assets, and a maintainer finishes the
+# CN mirror by running THIS from any environment with a healthy GitCode route
+# (a CN shell/box/cloud terminal — NOT tied to any one machine). It uploads
+# only the assets CI could not.
+#
+# Not automated on a schedule on purpose: correctness does not depend on it —
+# CN clients already fall back to the GitHub asset URLs (see
+# build_xlings_res_fallback_urls_ in src/core/xim/installer.cppm); the GitCode
+# copy is only a CN-acceleration convenience, needed for ~2-4 big files per
+# release. Standing infra (CN cron/VM/self-hosted runner) is an option if
+# releases ever get frequent enough to make the manual step tiresome.
 #
 # Token handling: GITCODE_TOKEN is loaded from ~/.config/gitcode-tool/config.json
-# when unset, so a non-interactive timer needs no extra env. The GitHub mirror
-# side uses XLINGS_RES_TOKEN or `gh auth` and is skipped (not failed) when
-# neither is available — GitHub assets are already published by release CI.
+# when unset. The GitHub mirror side uses XLINGS_RES_TOKEN or `gh auth` and is
+# skipped (not failed) when neither is present — GitHub assets are already
+# published by release CI; this run only fixes the GitCode side.
 #
 # Usage: tools/mirror-latest.sh [project]     # project: xlings (default) | mcpp
 set -euo pipefail

--- a/tools/mirror-latest.sh
+++ b/tools/mirror-latest.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Resolve the latest published <project> release and (re)mirror its binaries to
+# xlings-res via mirror_res.sh. Idempotent — already-mirrored assets are
+# skipped — so it is safe to run on a schedule.
+#
+# Its reason to exist: GitHub-hosted runners CANNOT upload large (>~8 MiB)
+# assets to GitCode — the cross-border runner->Huawei-Cloud-OBS path sustains
+# only ~15-30 KB/s and every method times out (proven in openxlings/xlings
+# probe PR #371). The release/mirror CI is therefore fail-fast, and this script
+# is the CN-side top-up: run it from a machine with a healthy GitCode route
+# (e.g. a daily user cron / systemd timer) and it fills whatever the CI could
+# not, uploading only the missing assets.
+#
+# Token handling: GITCODE_TOKEN is loaded from ~/.config/gitcode-tool/config.json
+# when unset, so a non-interactive timer needs no extra env. The GitHub mirror
+# side uses XLINGS_RES_TOKEN or `gh auth` and is skipped (not failed) when
+# neither is available — GitHub assets are already published by release CI.
+#
+# Usage: tools/mirror-latest.sh [project]     # project: xlings (default) | mcpp
+set -euo pipefail
+
+PROJ="${1:-xlings}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+case "$PROJ" in
+  xlings) SRC_REPO="openxlings/xlings" ;;
+  mcpp)   SRC_REPO="mcpp-community/mcpp" ;;
+  *) echo "[mirror-latest] unknown project '$PROJ' (expected xlings|mcpp)" >&2; exit 2 ;;
+esac
+
+# GitCode token from the standard gtc config when not already in the env.
+if [[ -z "${GITCODE_TOKEN:-}" ]]; then
+  cfg="${HOME}/.config/gitcode-tool/config.json"
+  if [[ -f "$cfg" ]]; then
+    GITCODE_TOKEN="$(python3 -c "import json;print(json.load(open('$cfg')).get('token',''))" 2>/dev/null || true)"
+    export GITCODE_TOKEN
+  fi
+fi
+if [[ -z "${GITCODE_TOKEN:-}" ]]; then
+  echo "[mirror-latest] WARN: no GITCODE_TOKEN (env or $HOME/.config/gitcode-tool/config.json) — GitCode side will be skipped" >&2
+fi
+
+# Latest published release tag -> bare version. Prefer gh; fall back to the
+# unauthenticated GitHub API so a locked-keyring timer still resolves it.
+tag="$(gh release view -R "$SRC_REPO" --json tagName --jq .tagName 2>/dev/null || true)"
+if [[ -z "$tag" ]]; then
+  tag="$(curl -s --connect-timeout 10 --max-time 30 \
+           "https://api.github.com/repos/$SRC_REPO/releases/latest" \
+         | python3 -c "import json,sys;print(json.load(sys.stdin).get('tag_name',''))" 2>/dev/null || true)"
+fi
+[[ -n "$tag" ]] || { echo "[mirror-latest] ERROR: could not resolve latest $SRC_REPO release" >&2; exit 1; }
+ver="${tag#v}"
+echo "[mirror-latest] $PROJ latest release = $tag -> version $ver"
+
+export PATH="$here:$PATH"   # ensure the vendored gtc is found
+exec "$here/mirror_res.sh" "$PROJ" "$ver"

--- a/tools/mirror_res.sh
+++ b/tools/mirror_res.sh
@@ -45,12 +45,6 @@ info() { echo "[mirror] $*"; }
 
 DL="$(mktemp -d)"; trap 'rm -rf "$DL"' EXIT
 
-info "downloading $SRC_REPO v$VER assets ($PROJ)"
-for a in "${ASSETS[@]}"; do
-  gh release download "v$VER" -R "$SRC_REPO" -D "$DL" -p "$a" 2>/dev/null || { echo "[mirror] FAIL: missing $a in $SRC_REPO v$VER" >&2; exit 1; }
-done
-
-# ── GitHub (gh --clobber, reliable) ───────────────────────────────
 # probe <url> -> "code size", hard wall-clock capped. Every network check in
 # this script MUST go through this (or an equivalent bounded call): a stalled
 # CDN connection with no --max-time hung the v0.4.65 mirror job for 40+ min
@@ -63,6 +57,32 @@ probe() {
 }
 asset_size() { stat -c%s "$1" 2>/dev/null || stat -f%z "$1"; }
 
+# Expected asset sizes from the SOURCE release — ONE API call, no body
+# download. Lets the skip-if-already-mirrored checks below run without first
+# pulling ~48 MB every time (steady-state re-runs, e.g. a daily CN top-up
+# cron, then move no bytes). Empty entries just fall back to a real download.
+declare -A WANT=()
+while IFS=$'\t' read -r _n _s; do [[ -n "$_n" ]] && WANT["$_n"]="$_s"; done < <(
+  GH_TOKEN="${XLINGS_RES_TOKEN:-}" gh release view "v$VER" -R "$SRC_REPO" \
+    --json assets --jq '.assets[] | "\(.name)\t\(.size)"' 2>/dev/null || true)
+
+# Download a single source asset into $DL on demand (only when an upload
+# actually needs the bytes). Retries because CN->GitHub can be slow/flaky
+# (~100 KB/s; a 9 MB asset ~100 s) and a single give-up must not abort the run.
+ensure_local() {
+  local a="$1" try
+  [[ -f "$DL/$a" ]] && return 0
+  for try in 1 2 3; do
+    if gh release download "v$VER" -R "$SRC_REPO" -D "$DL" -p "$a" --clobber 2>/dev/null; then
+      return 0
+    fi
+    echo "[mirror] download $a attempt $try failed, retrying..." >&2; sleep 5
+  done
+  echo "[mirror] FAIL: cannot download $a from $SRC_REPO v$VER after 3 tries" >&2
+  return 1
+}
+
+gh_failed=()
 if [[ -n "${XLINGS_RES_TOKEN:-}" ]] || gh auth status >/dev/null 2>&1; then
   info "GitHub $GH_DST tag $VER"
   GH_TOKEN="${XLINGS_RES_TOKEN:-}" gh release view "$VER" -R "$GH_DST" >/dev/null 2>&1 \
@@ -73,6 +93,13 @@ if [[ -n "${XLINGS_RES_TOKEN:-}" ]] || gh auth status >/dev/null 2>&1; then
   existing="$(GH_TOKEN="${XLINGS_RES_TOKEN:-}" gh release view "$VER" -R "$GH_DST" \
                 --json assets --jq '.assets[] | "\(.name) \(.size)"' 2>/dev/null || true)"
   for a in "${ASSETS[@]}"; do
+    want="${WANT[$a]:-}"
+    if [[ -n "$want" ]] && grep -qx "$a $want" <<< "$existing"; then
+      info "gh $a already mirrored, skip"
+      continue
+    fi
+    ensure_local "$a" || { gh_failed+=("$a"); continue; }
+    # Re-check with the true local size (covers the empty-WANT fallback).
     if grep -qx "$a $(asset_size "$DL/$a")" <<< "$existing"; then
       info "gh $a already mirrored, skip"
       continue
@@ -81,6 +108,9 @@ if [[ -n "${XLINGS_RES_TOKEN:-}" ]] || gh auth status >/dev/null 2>&1; then
   done
 else
   info "no github auth; skipping github mirror"
+fi
+if [[ ${#gh_failed[@]} -gt 0 ]]; then
+  echo "[mirror] github incomplete (${#gh_failed[@]} asset(s)): ${gh_failed[*]}" >&2
 fi
 
 # ── GitCode (gtc, per-file — multi-file upload can 502 and drop files) ──────
@@ -104,16 +134,25 @@ except Exception:
   gtc_failed=()
   for a in "${ASSETS[@]}"; do
     url="https://gitcode.com/${GTC_DST}/releases/download/${VER}/${a}"
-    want="$(asset_size "$DL/$a")"
-    # Skip if already fully mirrored, so re-runs only touch actual gaps.
+    want="${WANT[$a]:-}"
+    # Skip if already fully mirrored (using the source size when known), so
+    # re-runs only touch actual gaps — no download for assets already present.
     read -r code size <<< "$(probe "$url")"
-    if [[ "$code" == 200 && "$size" == "$want" ]]; then
+    if [[ -n "$want" && "$code" == 200 && "$size" == "$want" ]]; then
       info "gtc $a already mirrored, skip"
       continue
     fi
     if grep -qxF "$a" <<< "$registered"; then
       echo "[mirror] WARN: gtc $a registered on the release but not downloadable (code=$code size=$size/want=$want) — broken attachment; delete it in the GitCode release UI, then re-run mirror-binaries.yml" >&2
       gtc_failed+=("$a")
+      continue
+    fi
+    # Need the bytes to (re)upload — fetch on demand, then settle the true
+    # size (covers the empty-WANT fallback and re-checks the skip condition).
+    ensure_local "$a" || { gtc_failed+=("$a"); continue; }
+    want="$(asset_size "$DL/$a")"
+    if [[ "$code" == 200 && "$size" == "$want" ]]; then
+      info "gtc $a already mirrored, skip"
       continue
     fi
     # Upload, then verify the actual DOWNLOAD is 200 with the right size

--- a/tools/mirror_res.sh
+++ b/tools/mirror_res.sh
@@ -51,31 +51,56 @@ DL="$(mktemp -d)"; trap 'rm -rf "$DL"' EXIT
 # (3 fast failures, then a timeout-less upload/verify stall).
 probe() {
   local out
-  out="$(curl -sL --connect-timeout 10 --max-time 90 -o /dev/null \
+  out="$(curl -sL --connect-timeout 10 --max-time 60 -o /dev/null \
            -w '%{http_code} %{size_download}' "$1" 2>/dev/null)" \
     && echo "$out" || echo "ERR 0"
 }
+# probe with retries. Cross-border GETs (esp. from a CN host) flake
+# intermittently even for present assets — a single transient failure must NOT
+# be read as "missing/broken". Returns 0 on the first 200 (size-matched when a
+# want is given), so a healthy asset resolves on attempt 1 with no delay.
+probe_ok() {
+  local url="$1" want="${2:-}" code size
+  for _ in 1 2 3; do
+    read -r code size <<< "$(probe "$url")"
+    if [[ "$code" == 200 ]] && { [[ -z "$want" ]] || [[ "$size" == "$want" ]]; }; then
+      return 0
+    fi
+    sleep 3
+  done
+  return 1
+}
 asset_size() { stat -c%s "$1" 2>/dev/null || stat -f%z "$1"; }
 
-# Expected asset sizes from the SOURCE release — ONE API call, no body
-# download. Lets the skip-if-already-mirrored checks below run without first
-# pulling ~48 MB every time (steady-state re-runs, e.g. a daily CN top-up
-# cron, then move no bytes). Empty entries just fall back to a real download.
+# Expected asset sizes from the SOURCE release — ONE call, no body download.
+# Lets the skip-if-already-mirrored checks below run without first pulling
+# ~48 MB every time (steady-state re-runs, e.g. a daily CN top-up cron, then
+# move no bytes). Uses the PUBLIC GitHub API (no auth) so a headless timer with
+# a locked gh keyring still works; empty entries just fall back to a download.
 declare -A WANT=()
 while IFS=$'\t' read -r _n _s; do [[ -n "$_n" ]] && WANT["$_n"]="$_s"; done < <(
-  GH_TOKEN="${XLINGS_RES_TOKEN:-}" gh release view "v$VER" -R "$SRC_REPO" \
-    --json assets --jq '.assets[] | "\(.name)\t\(.size)"' 2>/dev/null || true)
+  curl -s --connect-timeout 10 --max-time 30 \
+       "https://api.github.com/repos/$SRC_REPO/releases/tags/v$VER" \
+  | python3 -c 'import json,sys
+try:
+    for a in json.load(sys.stdin).get("assets", []):
+        print(a["name"] + "\t" + str(a["size"]))
+except Exception:
+    pass' 2>/dev/null || true)
 
 # Download a single source asset into $DL on demand (only when an upload
-# actually needs the bytes). Retries because CN->GitHub can be slow/flaky
-# (~100 KB/s; a 9 MB asset ~100 s) and a single give-up must not abort the run.
+# actually needs the bytes), via the PUBLIC release URL — no gh/auth, so it
+# runs headless. Retries because CN->GitHub can be slow/flaky (~100 KB/s; a
+# 27 MB asset ~4-5 min) and a single give-up must not abort the whole run.
 ensure_local() {
   local a="$1" try
   [[ -f "$DL/$a" ]] && return 0
   for try in 1 2 3; do
-    if gh release download "v$VER" -R "$SRC_REPO" -D "$DL" -p "$a" --clobber 2>/dev/null; then
+    if curl -fsSL --connect-timeout 15 --max-time 600 -o "$DL/$a" \
+         "https://github.com/$SRC_REPO/releases/download/v$VER/$a"; then
       return 0
     fi
+    rm -f "$DL/$a"
     echo "[mirror] download $a attempt $try failed, retrying..." >&2; sleep 5
   done
   echo "[mirror] FAIL: cannot download $a from $SRC_REPO v$VER after 3 tries" >&2
@@ -137,13 +162,17 @@ except Exception:
     want="${WANT[$a]:-}"
     # Skip if already fully mirrored (using the source size when known), so
     # re-runs only touch actual gaps — no download for assets already present.
-    read -r code size <<< "$(probe "$url")"
-    if [[ -n "$want" && "$code" == 200 && "$size" == "$want" ]]; then
+    # probe_ok retries, so a flaky cross-border GET doesn't force a needless
+    # re-upload or a false "broken attachment" verdict below. When the source
+    # size is unknown (WANT lookup missed) it falls back to a 200-only check —
+    # a GitCode asset only registers after the full OBS callback, so "present"
+    # already implies "complete".
+    if probe_ok "$url" "$want"; then
       info "gtc $a already mirrored, skip"
       continue
     fi
     if grep -qxF "$a" <<< "$registered"; then
-      echo "[mirror] WARN: gtc $a registered on the release but not downloadable (code=$code size=$size/want=$want) — broken attachment; delete it in the GitCode release UI, then re-run mirror-binaries.yml" >&2
+      echo "[mirror] WARN: gtc $a registered on the release but not downloadable after retries — likely a broken/phantom attachment; delete it in the GitCode release UI, then re-run mirror-binaries.yml (or mirror-latest.sh)" >&2
       gtc_failed+=("$a")
       continue
     fi
@@ -151,7 +180,7 @@ except Exception:
     # size (covers the empty-WANT fallback and re-checks the skip condition).
     ensure_local "$a" || { gtc_failed+=("$a"); continue; }
     want="$(asset_size "$DL/$a")"
-    if [[ "$code" == 200 && "$size" == "$want" ]]; then
+    if probe_ok "$url" "$want"; then
       info "gtc $a already mirrored, skip"
       continue
     fi
@@ -167,13 +196,12 @@ except Exception:
     for try in 1 2; do
       rc=0
       timeout -k 10 90 gtc release upload "$GTC_DST" "$DL/$a" --tag "$VER" >/dev/null 2>&1 || rc=$?
-      read -r code size <<< "$(probe "$url")"
-      if [[ "$code" == 200 && "$size" == "$want" ]]; then ok=1; break; fi
+      if probe_ok "$url" "$want"; then ok=1; break; fi
       if [[ "$rc" == 124 || "$rc" == 137 ]]; then
         echo "[mirror] gtc $a upload STALLED (killed at 90s) — systemic on GitCode's side, not retrying" >&2
         break
       fi
-      [[ "$try" == 1 ]] && echo "[mirror] gtc $a not OK (rc=$rc code=$code size=$size/want=$want), one retry..."
+      [[ "$try" == 1 ]] && echo "[mirror] gtc $a not OK (rc=$rc), one retry..."
     done
     [[ -n "$ok" ]] || gtc_failed+=("$a")
   done
@@ -189,9 +217,9 @@ info "verify:"
 rc=0
 for host in "github.com/$GH_DST" "gitcode.com/$GTC_DST"; do
   for a in "${ASSETS[@]}"; do
-    read -r code _ <<< "$(probe "https://${host}/releases/download/${VER}/${a}")"
-    echo "  $code  https://${host}/releases/download/${VER}/${a}"
-    [[ "$code" == 200 ]] || rc=1
+    url="https://${host}/releases/download/${VER}/${a}"
+    # probe_ok retries so a flaky cross-border GET isn't reported as a gap.
+    if probe_ok "$url"; then echo "  OK    $url"; else echo "  MISS  $url"; rc=1; fi
   done
 done
 [[ $rc == 0 ]] && info "all platforms mirrored OK" || { echo "[mirror] WARN: some assets not 200" >&2; }

--- a/tools/mirror_res.sh
+++ b/tools/mirror_res.sh
@@ -198,7 +198,7 @@ except Exception:
       timeout -k 10 90 gtc release upload "$GTC_DST" "$DL/$a" --tag "$VER" >/dev/null 2>&1 || rc=$?
       if probe_ok "$url" "$want"; then ok=1; break; fi
       if [[ "$rc" == 124 || "$rc" == 137 ]]; then
-        echo "[mirror] gtc $a upload STALLED (killed at 90s) — systemic on GitCode's side, not retrying" >&2
+        echo "[mirror] gtc $a upload STALLED (killed at 90s) — cross-border runner->OBS wall (see probe PR #371); from a GitHub runner this cannot succeed. Finish the GitCode mirror by running tools/mirror-latest.sh from a CN environment." >&2
         break
       fi
       [[ "$try" == 1 ]] && echo "[mirror] gtc $a not OK (rc=$rc), one retry..."
@@ -207,6 +207,7 @@ except Exception:
   done
   if [[ ${#gtc_failed[@]} -gt 0 ]]; then
     echo "[mirror] gitcode incomplete (${#gtc_failed[@]} asset(s)): ${gtc_failed[*]}" >&2
+    echo "[mirror] hint: if this ran on a GitHub runner, big assets are expected to fail here — run tools/mirror-latest.sh from a CN environment to finish (runbook: .agents/docs/2026-07-15-gitcode-large-asset-mirror-runbook.md)" >&2
   fi
 else
   info "no GITCODE_TOKEN/gtc; skipping gitcode mirror"


### PR DESCRIPTION
Adds the tooling + documentation for finishing the **GitCode** binary mirror after a release.

Probe PR #371 proved a GitHub-hosted runner **cannot** upload large (>~8 MiB) assets to GitCode — the cross-border runner→Huawei-Cloud-OBS path sustains only ~15–30 KB/s and every method times out. The same files upload in ~10 s from a CN host, so it is a network-route fact, not a script/GitCode fault.

**Decision: no standing automation.** A maintainer finishes the GitCode mirror by running one command from **any CN environment** (a CN shell / cloud terminal / box — not tied to any personal machine). Correctness never depends on it: CN clients already fall back to the GitHub asset URLs (`build_xlings_res_fallback_urls_`), so the GitCode copy is a CN-acceleration convenience for the ~2–4 big files per release.

```bash
tools/mirror-latest.sh xlings   # after a release, from a CN-routed environment
```

### What it adds
- **`tools/mirror-latest.sh`** (new): the manual post-release command. Resolves the latest published release (public GitHub API, no auth needed), loads `GITCODE_TOKEN` from `~/.config/gitcode-tool/config.json` when unset, then `exec`s `mirror_res.sh`. Idempotent (~40 s no-op when nothing is missing).
- **`tools/mirror_res.sh`** hardening (shared by release CI + this command): expected sizes from one release-API call → skip already-mirrored assets → lazy-download only the gaps via public URLs (no `gh` auth) with retries; **retrying cross-border probes** so a flaky GET is not misread as a missing/broken asset; keeps the #369/#370 bounded-upload + stall-no-retry behaviour.
- **Annotations** in `release.yml` + `mirror-binaries.yml`: document the GitHub-runner GitCode big-asset limitation and point to the manual step + runbook.
- **`.agents/docs/2026-07-15-gitcode-large-asset-mirror-runbook.md`**: single source of truth — the #371 measurements, why it is manual, the exact procedure, and the validation below.

### Verified end-to-end (from a CN host)
- **Steady state** (v0.4.65, nothing missing): 16 skips, 0 downloads, all 16 URLs OK, ~40 s.
- **Gap-fill** (a real GitHub-only gap constructed on a throwaway tag): detect gap → download from the public GitHub URL → upload to GitCode → verify. GitCode copy `sha256`-identical to source; a second run was a clean idempotent skip. Throwaway GitHub releases were deleted afterward.
- Two bugs were found and fixed during this testing: an f-string `SyntaxError` that silently emptied the size-map (caused false "broken attachment" verdicts) and cross-border probe flakiness (added retry-before-conclude). See commit history.

### Scope / safety
Touches only release-mirror shell scripts + workflow comments + one design doc — **no impact on the build / install / runtime paths.** The two CI failures seen during review (`e2e` patchelf bootstrap; Windows `build-and-test` raw.githubusercontent connection reset) were unrelated network flakes and passed on rerun.

> Note: an earlier draft of this PR proposed a scheduled systemd user timer on a developer machine; that was rejected (must not depend on a personal machine) in favour of the manual command above. No timer/cron is part of this PR.
