### PR TITLE
fix(theme): frame OSC-11 reply read to stop leaking into shell input (#368) [v0.4.66]

### DIFF
--- a/.agents/docs/2026-07-15-issue368-osc11-framed-read-design.md
+++ b/.agents/docs/2026-07-15-issue368-osc11-framed-read-design.md
@@ -1,0 +1,70 @@
+# OSC-11 背景色查询：从「50ms 单次 read」改为「有界帧读 + DSR/CPR 栅栏」— 修复终端回复泄漏
+
+**日期**: 2026-07-15
+**类型**: 方案 / 修复 (design + bugfix)
+**状态**: Implemented
+**范围**: 修复 [#368](https://github.com/openxlings/xlings/issues/368)（Tabby 下 OSC-11 回复泄漏进 zsh 输入缓冲区）。仅改客户端 `xlings` 二进制，无跨仓改动。
+**关联代码**:
+- `src/platform/unix.cppm:103-160`（`query_terminal_is_light()`，Linux/macOS 共用）
+- `src/platform.cppm:37`（`export using platform_impl::query_terminal_is_light`）
+- `src/ui/theme.cppm:63-70`（`detect_()`，检测顺序：env → OSC-11 → COLORFGBG → Dark）
+- `src/core/config.cppm:16`（`VERSION` 0.4.65 → 0.4.66）
+- `tests/unit/test_terminal_query.cpp`（新增回归测试）
+
+---
+
+## 0. TL;DR
+
+`xlings` 无参运行时会用 OSC-11 (`ESC ] 11 ; ? ESC \`) 询问终端背景色以选深/浅色主题。当前实现（`unix.cppm`）有两条**不成立的时序假设**：
+
+1. **整个终端往返必须在 50ms 内开始**（单次 `select()`，硬编码 50ms 超时）。
+2. **单次 `read()` 必须一次读到足够解析的完整回复**。
+
+Tabby（Electron + xterm.js + PTY，多层异步边界）的回复常晚于 50ms 到达。此时：`select()` 超时 → 函数返回 `nullopt` → `RestoreGuard` 立刻**恢复 ECHO** → Tabby 的合法 OSC-11 回复随后到达 tty 输入侧 → 被回显成 `^[]11;rgb:1717/1717/1717^[\` 并被 zsh/ZLE 当作命令输入。分片回复是同一根因的另一种表现（首个 `read()` 只拿到前缀）。
+
+**根因不是 Tabby**，而是查询端的不安全假设：符合规范的终端**不保证**在一次 read 或 50ms 内返回完整 OSC 回复。
+
+**修复**：把回复当作**帧字节流**处理，并用一个**确定性栅栏**判定「终端已回完」：
+
+- 在 OSC-11 查询后**紧跟一个 DSR 光标位置查询** `ESC [ 6 n`。终端按输入顺序处理，故 CPR 回复 `ESC [ <行> ; <列> R` 必然排在 OSC-11 回复（若支持）之后。**收到 CPR 即证明 OSC-11 回复（若有）已全部到达并被我们读走**。
+- 用**单调总截止时间**（默认 500ms，可经 `XLINGS_TERM_QUERY_TIMEOUT_MS` 覆盖，钳制 [50, 5000]）循环 `select()`/`read()`，累积进有界缓冲区，直到出现 CPR 终止符 `R`、缓冲区满、或超时。
+- **在读循环全程保持 ECHO 关闭**（`RestoreGuard` 仍在函数末尾恢复），因此把 OSC-11 回复**和** CPR 一并读走消费，不会泄漏、不回显。
+
+对**能应答的终端**（绝大多数，含 Tabby）栅栏在数毫秒内命中即返回，无泄漏、无输入丢失，是干净路径。只有「既不应答 OSC-11 也不应答 DSR」的罕见 tty 才会走满超时（每进程一次性成本）。
+
+## 1. 为什么用 DSR/CPR 栅栏而不是「单纯加大超时」
+
+Issue 里已点明：*「单纯增大超时只降低概率，不解决分片读，也不解决刚好在新截止时间之后到达的回复。」*
+
+- **加大超时**：仍是「猜一个够大的数」。回复晚于新阈值到达仍泄漏；分片时首个 read 拿到前缀就解析失败。
+- **读到终止符为止**（BEL `\a` / ST `ESC \`）：能处理分片，但**无法判定「终端不支持 OSC-11」**——不支持时永远等不到 OSC 终止符，只能走满超时；且若我们一见 OSC 终止符就停，尚在途中的其它回复仍可能泄漏。
+- **DSR/CPR 栅栏**（本方案，`termbg` 等成熟实现采用）：几乎所有支持 OSC-11 的终端都支持 DSR。CPR 是**确定性完成信号**——收到它就知道「终端已把该发的都发完」，这正是把 ECHO 安全恢复所需要的判据。既处理慢、又处理分片，还能区分「不支持 OSC-11」（只回 CPR、不回 OSC）。
+
+`R` 作为停止符是安全的：我们只发送 OSC-11 + DSR 两个查询；OSC-11 回复体（`ESC ] 11 ; rgb:HHHH/HHHH/HHHH` + ST/BEL）只含十六进制与分隔符，绝不含 `R`。故缓冲区中首个 `R` 唯一标记 CPR 结束。
+
+## 2. 可测试性重构
+
+`query_terminal_is_light()` 直接开 `/dev/tty` + 改 termios，CI 里没有受控 tty，无法单测。故拆成两块纯逻辑 + 一个薄封装：
+
+1. **`parse_terminal_bg_is_light(std::string_view buf) -> std::optional<bool>`**（纯函数，导出）
+   在累积缓冲区里找 `rgb:`，解析三个 16-bit 通道，按 Rec.601 luma 阈值（32768）判浅色。可直接用字节串单测：完整回复、BEL/ST 终止、前置无关字节、畸形、无 rgb。
+2. **`read_terminal_query_reply(int fd, std::chrono::milliseconds timeout) -> std::string`**（导出）
+   在给定 fd 上做「单调截止时间 + 循环 select/read + 有界累积 + 见 `R` 即停」的帧读。用 `socketpair` 单测：另一端线程按 立即 / 延迟>50ms / 分片 / 无应答 各场景写入，验证「有界时间内返回、拿到正确字节、终止符处理」。
+3. **`query_terminal_is_light()`**（薄封装）：`isatty` 卫语句 → 开 `/dev/tty` → termios raw → 写 `OSC-11 + DSR` → `read_terminal_query_reply` → `parse_terminal_bg_is_light`。termios/`/dev/tty` 部分不在 CI 单测覆盖（无受控 tty），逻辑全在上面两块被覆盖。
+
+## 3. 验收（对应 Issue 的 Acceptance Criteria）
+
+针对每个「延迟 / 分片 / 畸形 / 无应答」场景：
+- 函数在**有界时间**内返回或回退 ✓（单调截止时间）；
+- 原 termios 状态被恢复 ✓（`RestoreGuard` 不变）；
+- **无 OSC 字节泄漏进父 shell** ✓（读循环消费 OSC 回复 + CPR，ECHO 全程关闭）；
+- 无关输入不丢失 ✓（不做 `tcflush` 盲刷，只读走终端自己产生的应答字节）。
+
+单测覆盖：立即完整回复、延迟 > 50ms、跨多次 read 分片、BEL 与 ST 两种终止符、畸形回复、完全无回复、OSC 回复前有无关字节。`/dev/tty` + termios 路径与「stdout/stderr 重定向但存在受控 tty」由既有 `isatty` 卫语句处理，保持不变。
+
+## 4. 兼容性 / 风险
+
+- 对 macOS Terminal、iTerm2、Alacritty、Kitty、WezTerm、Windows Terminal 等**能应答**的终端：栅栏毫秒级命中，行为等价于旧实现但更稳。
+- 新发一个 DSR 查询：CPR 回复被我们完整读走消费，屏幕上不可见。
+- 罕见「isatty 但既不应答 OSC 也不应答 DSR」的 tty：走满超时（默认 500ms，可下调）后回退到 COLORFGBG/Dark，每进程一次，不挂死。
+- Windows 走 `windows.cppm` 自己的 stub，不受影响。

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.65";
+    static constexpr std::string_view VERSION = "0.4.66";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/platform.cppm
+++ b/src/platform.cppm
@@ -35,6 +35,13 @@ namespace platform {
     export using platform_impl::get_pid;
     export using platform_impl::is_process_alive;
     export using platform_impl::query_terminal_is_light;
+#if !defined(_WIN32)
+    // POSIX-only building blocks of query_terminal_is_light(), exposed for
+    // unit testing without a controlling tty (see #368). No Windows stub —
+    // read_terminal_query_reply() operates on a POSIX fd.
+    export using platform_impl::parse_terminal_bg_is_light;
+    export using platform_impl::read_terminal_query_reply;
+#endif
     export using platform_impl::ProcessHandle;
     export using platform_impl::spawn_command;
     export using platform_impl::wait_or_kill;

--- a/src/platform/unix.cppm
+++ b/src/platform/unix.cppm
@@ -89,17 +89,106 @@ namespace platform_impl {
         int fd_ { -1 };
     };
 
+    // Parse an accumulated terminal reply buffer for an OSC-11 background
+    // color and classify it as light (true) or dark (false). Returns
+    // std::nullopt when no well-formed `rgb:RRRR/GGGG/BBBB` reply is present.
+    //
+    // Pure and side-effect free so the classification logic is unit-testable
+    // without a controlling tty (see tests/unit/test_terminal_query.cpp).
+    // The buffer may contain unrelated leading bytes (e.g. a CPR fence) and
+    // may be terminated by either ST (\e\\) or BEL (\a) — parsing keys off
+    // the `rgb:` marker, not the terminator.
+    export std::optional<bool> parse_terminal_bg_is_light(std::string_view s) {
+        auto p = s.find("rgb:");
+        if (p == std::string_view::npos || p + 4 + 14 > s.size()) return std::nullopt;
+        auto hex4 = [&](std::size_t off) -> int {
+            int v = 0;
+            for (int i = 0; i < 4 && off + i < s.size(); ++i) {
+                char c = s[off + i];
+                int d = (c >= '0' && c <= '9') ? c - '0'
+                      : (c >= 'a' && c <= 'f') ? c - 'a' + 10
+                      : (c >= 'A' && c <= 'F') ? c - 'A' + 10 : -1;
+                if (d < 0) return -1;
+                v = v * 16 + d;
+            }
+            return v;  // 16-bit channel, 0..65535
+        };
+        int r = hex4(p + 4), g = hex4(p + 9), b = hex4(p + 14);
+        if (r < 0 || g < 0 || b < 0) return std::nullopt;
+        // Rec. 601 luma; threshold at half-bright.
+        return (0.299 * r + 0.587 * g + 0.114 * b) > 32768.0;
+    }
+
+    // Read a terminal query reply from `fd` as a framed byte stream: loop
+    // select()+read() against ONE monotonic deadline, accumulating fragments
+    // into a bounded buffer, and stop as soon as the DSR reply's terminator
+    // 'R' (a CPR: ESC[<row>;<col>R) is seen. The caller writes an OSC-11
+    // query IMMEDIATELY followed by a DSR (ESC[6n); because terminals process
+    // input in order, the CPR necessarily arrives after the OSC-11 reply (if
+    // any). Seeing it is a deterministic "terminal is done" fence — no valid
+    // OSC-11 reply body contains 'R', so the first 'R' uniquely marks it.
+    //
+    // This fixes #368: the old single-50ms-select + single-read gave up on a
+    // slow (Tabby/Electron/xterm.js) or fragmented reply, restored ECHO, and
+    // let the reply leak into the parent shell. Reading through the CPR
+    // consumes the whole reply while ECHO is still disabled, so nothing leaks.
+    export std::string read_terminal_query_reply(int fd,
+                                                 std::chrono::milliseconds timeout) {
+        std::string acc;
+        acc.reserve(64);
+        constexpr std::size_t kCap = 512;   // bounded buffer
+        const auto deadline = std::chrono::steady_clock::now() + timeout;
+        for (;;) {
+            auto now = std::chrono::steady_clock::now();
+            if (now >= deadline) break;
+            auto us = std::chrono::duration_cast<std::chrono::microseconds>(
+                          deadline - now).count();
+            fd_set rfds; FD_ZERO(&rfds); FD_SET(fd, &rfds);
+            struct timeval tv{
+                static_cast<time_t>(us / 1000000),
+                static_cast<suseconds_t>(us % 1000000)
+            };
+            int rv = ::select(fd + 1, &rfds, nullptr, nullptr, &tv);
+            if (rv < 0) { if (errno == EINTR) continue; break; }
+            if (rv == 0) break;                     // deadline reached
+            char buf[256];
+            auto n = ::read(fd, buf, sizeof(buf));
+            if (n < 0) { if (errno == EINTR) continue; break; }
+            if (n == 0) break;                      // EOF
+            acc.append(buf, static_cast<std::size_t>(n));
+            if (acc.find('R') != std::string::npos) break;   // CPR fence
+            if (acc.size() >= kCap) break;
+        }
+        return acc;
+    }
+
+    // Overall deadline for the terminal background query. Default 500 ms,
+    // overridable via XLINGS_TERM_QUERY_TIMEOUT_MS (clamped to [50, 5000]).
+    // Responsive terminals hit the CPR fence in a few ms and return early;
+    // the deadline only bites on a tty that answers neither OSC-11 nor DSR.
+    static std::chrono::milliseconds term_query_timeout_() {
+        long ms = 500;
+        if (const char* v = std::getenv("XLINGS_TERM_QUERY_TIMEOUT_MS")) {
+            char* end = nullptr;
+            long parsed = std::strtol(v, &end, 10);
+            if (end != v && parsed > 0) ms = parsed;
+        }
+        if (ms < 50)   ms = 50;
+        if (ms > 5000) ms = 5000;
+        return std::chrono::milliseconds{ms};
+    }
+
     // Query the controlling terminal for its background color via the
     // OSC-11 sequence (xterm spec, supported by xterm / iTerm2 / Alacritty
     // / Kitty / WezTerm / modern Windows Terminal). Returns std::nullopt
     // if there's no controlling tty, the terminal doesn't respond within
-    // ~50 ms, or the reply is malformed.
+    // the query deadline, or the reply is malformed.
     //
     // Lives in the shared `unix` partition because the implementation
-    // (open /dev/tty + termios raw mode + select-with-timeout + parse the
-    // hex reply) is identical across Linux and macOS — both inherit the
-    // POSIX terminal API. windows.cppm provides its own stub. Putting it
-    // here means linux.cppm and macos.cppm carry no copy of this code.
+    // (open /dev/tty + termios raw mode + framed read + parse the hex reply)
+    // is identical across Linux and macOS — both inherit the POSIX terminal
+    // API. windows.cppm provides its own stub. Putting it here means
+    // linux.cppm and macos.cppm carry no copy of this code.
     export std::optional<bool> query_terminal_is_light() {
         // If our own stdout AND stderr are not terminals, we're a child whose
         // output is captured by a parent (e.g. mcpp driving `xlings interface`
@@ -126,37 +215,16 @@ namespace platform_impl {
             ~RestoreGuard() { ::tcsetattr(fd, TCSANOW, &s); }
         } _r{fd, saved};
 
-        static constexpr char query[] = "\033]11;?\033\\";
+        // OSC-11 background query, immediately followed by a DSR cursor
+        // position request. The CPR reply to the DSR is our fence (see
+        // read_terminal_query_reply): once it arrives we know the OSC-11
+        // reply, if any, has fully arrived and been consumed — so ECHO is
+        // never restored with terminal bytes still pending in the input.
+        static constexpr char query[] = "\033]11;?\033\\\033[6n";
         if (::write(fd, query, sizeof(query) - 1) < 0) return std::nullopt;
 
-        fd_set rfds; FD_ZERO(&rfds); FD_SET(fd, &rfds);
-        struct timeval tv{0, 50 * 1000};  // 50 ms
-        if (::select(fd + 1, &rfds, nullptr, nullptr, &tv) <= 0) return std::nullopt;
-
-        char buf[64]{};
-        auto n = ::read(fd, buf, sizeof(buf) - 1);
-        if (n <= 0) return std::nullopt;
-
-        // Reply: \e]11;rgb:RRRR/GGGG/BBBB\e\\ (or \a terminator).
-        std::string_view s{buf, static_cast<std::size_t>(n)};
-        auto p = s.find("rgb:");
-        if (p == std::string_view::npos || p + 4 + 14 > s.size()) return std::nullopt;
-        auto hex4 = [&](std::size_t off) -> int {
-            int v = 0;
-            for (int i = 0; i < 4 && off + i < s.size(); ++i) {
-                char c = s[off + i];
-                int d = (c >= '0' && c <= '9') ? c - '0'
-                      : (c >= 'a' && c <= 'f') ? c - 'a' + 10
-                      : (c >= 'A' && c <= 'F') ? c - 'A' + 10 : -1;
-                if (d < 0) return -1;
-                v = v * 16 + d;
-            }
-            return v;  // 16-bit channel, 0..65535
-        };
-        int r = hex4(p + 4), g = hex4(p + 9), b = hex4(p + 14);
-        if (r < 0 || g < 0 || b < 0) return std::nullopt;
-        // Rec. 601 luma; threshold at half-bright.
-        return (0.299 * r + 0.587 * g + 0.114 * b) > 32768.0;
+        std::string reply = read_terminal_query_reply(fd, term_query_timeout_());
+        return parse_terminal_bg_is_light(reply);
     }
 
     // Atomically replace `dst` with the contents of `src`, even when `dst`

--- a/src/ui/theme.cppm
+++ b/src/ui/theme.cppm
@@ -27,8 +27,10 @@ using ftxui::Decorator;
 //      c. Fall back to Dark — the safe default for most modern terms.
 //
 // Detection runs at most once per process (cached). Cost is one
-// 50-ms terminal round-trip on first color access; the result is
-// reused for the lifetime of the program.
+// terminal round-trip on first color access, bounded by a monotonic
+// deadline (default 500 ms, XLINGS_TERM_QUERY_TIMEOUT_MS) but normally
+// returning in a few ms via a DSR/CPR fence; the result is reused for
+// the lifetime of the program.
 
 enum class Background { Dark, Light };
 

--- a/tests/unit/test_terminal_query.cpp
+++ b/tests/unit/test_terminal_query.cpp
@@ -1,0 +1,186 @@
+// Unit tests for the OSC-11 terminal background-color query path.
+//
+// Regression coverage for issue #368: on terminals whose OSC-11 reply is
+// slow (Tabby/Electron/xterm.js) or fragmented across reads, the old
+// "single 50ms select + single read" implementation gave up early, restored
+// ECHO, and let the terminal reply leak into the parent shell's input.
+//
+// The fix reframes the reply as a byte stream read until a deterministic
+// DSR/CPR fence (or a monotonic deadline). Two pure, fd-based helpers are
+// extracted so the logic is testable without a controlling tty:
+//
+//   parse_terminal_bg_is_light(buf)      — parse an accumulated reply buffer
+//   read_terminal_query_reply(fd, timeout) — framed read until CPR 'R'/deadline
+//
+// The read loop is exercised over a socketpair whose far end plays the
+// terminal: replying immediately, after >50ms, fragmented, or not at all.
+#include <gtest/gtest.h>
+
+// POSIX-only: exercises socketpair(2) and the POSIX-only helpers
+// (parse_terminal_bg_is_light / read_terminal_query_reply). On Windows the
+// background query goes through windows.cppm's own stub, so there is nothing
+// to test here.
+#if !defined(_WIN32)
+
+#include <sys/socket.h>
+#include <unistd.h>
+
+import std;
+import xlings.platform;
+
+using xlings::platform::parse_terminal_bg_is_light;
+using xlings::platform::read_terminal_query_reply;
+
+namespace {
+
+// A complete OSC-11 reply for the given 8-bit gray value, ST-terminated,
+// followed by a CPR (cursor position report) that acts as the fence.
+std::string osc_reply_st(int gray8) {
+    char hx[3];
+    std::snprintf(hx, sizeof(hx), "%02x", gray8 & 0xff);
+    std::string h4 = std::string(hx) + hx;  // 8-bit 0xNN -> 16-bit 0xNNNN
+    return "\033]11;rgb:" + h4 + "/" + h4 + "/" + h4 + "\033\\" + "\033[2;1R";
+}
+
+// Same, but BEL-terminated OSC reply.
+std::string osc_reply_bel(int gray8) {
+    char hx[3];
+    std::snprintf(hx, sizeof(hx), "%02x", gray8 & 0xff);
+    std::string h4 = std::string(hx) + hx;
+    return "\033]11;rgb:" + h4 + "/" + h4 + "/" + h4 + "\a" + "\033[1;1R";
+}
+
+void write_all(int fd, std::string_view s) {
+    while (!s.empty()) {
+        auto n = ::write(fd, s.data(), s.size());
+        if (n <= 0) break;
+        s.remove_prefix(static_cast<std::size_t>(n));
+    }
+}
+
+}  // namespace
+
+// ── Pure parser ────────────────────────────────────────────────
+
+TEST(TerminalQueryParse, DarkBackground) {
+    // 0x17 gray (Tabby's #171717) -> luma well below the mid threshold.
+    auto r = parse_terminal_bg_is_light("\033]11;rgb:1717/1717/1717\033\\");
+    ASSERT_TRUE(r.has_value());
+    EXPECT_FALSE(*r);  // dark
+}
+
+TEST(TerminalQueryParse, LightBackground) {
+    auto r = parse_terminal_bg_is_light("\033]11;rgb:eeee/eeee/eeee\033\\");
+    ASSERT_TRUE(r.has_value());
+    EXPECT_TRUE(*r);  // light
+}
+
+TEST(TerminalQueryParse, BelTerminator) {
+    auto r = parse_terminal_bg_is_light("\033]11;rgb:ffff/ffff/ffff\a");
+    ASSERT_TRUE(r.has_value());
+    EXPECT_TRUE(*r);
+}
+
+TEST(TerminalQueryParse, LeadingGarbageBeforeReply) {
+    // Unrelated bytes before the OSC reply must not defeat parsing.
+    auto r = parse_terminal_bg_is_light("junk\033[2;1R\033]11;rgb:0000/0000/0000\033\\");
+    ASSERT_TRUE(r.has_value());
+    EXPECT_FALSE(*r);
+}
+
+TEST(TerminalQueryParse, MalformedHexRejected) {
+    EXPECT_FALSE(parse_terminal_bg_is_light("\033]11;rgb:zzzz/0000/0000\033\\").has_value());
+}
+
+TEST(TerminalQueryParse, NoRgbRejected) {
+    EXPECT_FALSE(parse_terminal_bg_is_light("\033[2;1R").has_value());
+    EXPECT_FALSE(parse_terminal_bg_is_light("").has_value());
+}
+
+TEST(TerminalQueryParse, TruncatedReplyRejected) {
+    // "rgb:" present but not enough channel bytes follow.
+    EXPECT_FALSE(parse_terminal_bg_is_light("\033]11;rgb:1717/17").has_value());
+}
+
+// ── Framed read loop over a socketpair ─────────────────────────
+
+class FramedRead : public ::testing::Test {
+protected:
+    int rd() const { return sv[0]; }  // our (reader) end
+    int wr() const { return sv[1]; }  // terminal (writer) end
+
+    void SetUp() override {
+        ASSERT_EQ(0, ::socketpair(AF_UNIX, SOCK_STREAM, 0, sv));
+    }
+    void TearDown() override {
+        if (sv[0] >= 0) ::close(sv[0]);
+        if (sv[1] >= 0) ::close(sv[1]);
+    }
+    int sv[2] { -1, -1 };
+};
+
+TEST_F(FramedRead, ImmediateCompleteReply) {
+    write_all(wr(), osc_reply_st(0x17));
+    auto buf = read_terminal_query_reply(rd(), std::chrono::milliseconds{500});
+    auto r = parse_terminal_bg_is_light(buf);
+    ASSERT_TRUE(r.has_value());
+    EXPECT_FALSE(*r);
+}
+
+TEST_F(FramedRead, DelayedReplyPast50ms) {
+    std::string payload = osc_reply_st(0xee);
+    std::thread t([&] {
+        std::this_thread::sleep_for(std::chrono::milliseconds{120});
+        write_all(wr(), payload);
+    });
+    auto buf = read_terminal_query_reply(rd(), std::chrono::milliseconds{800});
+    t.join();
+    auto r = parse_terminal_bg_is_light(buf);
+    ASSERT_TRUE(r.has_value());
+    EXPECT_TRUE(*r);  // light — old 50ms impl would have missed this
+}
+
+TEST_F(FramedRead, FragmentedAcrossReads) {
+    std::thread t([&] {
+        write_all(wr(), "\033]11;rgb:");
+        std::this_thread::sleep_for(std::chrono::milliseconds{30});
+        write_all(wr(), "eeee/eeee");
+        std::this_thread::sleep_for(std::chrono::milliseconds{30});
+        write_all(wr(), "/eeee\033\\");
+        std::this_thread::sleep_for(std::chrono::milliseconds{30});
+        write_all(wr(), "\033[2;1R");  // CPR fence arrives last
+    });
+    auto buf = read_terminal_query_reply(rd(), std::chrono::milliseconds{800});
+    t.join();
+    auto r = parse_terminal_bg_is_light(buf);
+    ASSERT_TRUE(r.has_value());
+    EXPECT_TRUE(*r);
+}
+
+TEST_F(FramedRead, BelTerminatedReply) {
+    write_all(wr(), osc_reply_bel(0xff));
+    auto buf = read_terminal_query_reply(rd(), std::chrono::milliseconds{500});
+    auto r = parse_terminal_bg_is_light(buf);
+    ASSERT_TRUE(r.has_value());
+    EXPECT_TRUE(*r);
+}
+
+TEST_F(FramedRead, StopsAtCprFence) {
+    // Everything the terminal sends is consumed up to and including the CPR,
+    // so nothing is left to leak back into the shell.
+    write_all(wr(), osc_reply_st(0x40));
+    auto buf = read_terminal_query_reply(rd(), std::chrono::milliseconds{500});
+    EXPECT_NE(buf.find('R'), std::string::npos);  // consumed through CPR
+}
+
+TEST_F(FramedRead, NoResponseReturnsWithinDeadline) {
+    // Terminal answers neither OSC-11 nor DSR: must return bounded, not hang.
+    auto t0 = std::chrono::steady_clock::now();
+    auto buf = read_terminal_query_reply(rd(), std::chrono::milliseconds{150});
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - t0);
+    EXPECT_LT(elapsed.count(), 600);  // bounded by the deadline (+slack)
+    EXPECT_FALSE(parse_terminal_bg_is_light(buf).has_value());
+}
+
+#endif  // !defined(_WIN32)


### PR DESCRIPTION
## Problem

Fixes #368. `xlings` auto-detects the terminal background via an OSC-11 query. The old implementation (`src/platform/unix.cppm`) made two unsafe timing assumptions:

1. The reply must begin within a single **50ms** `select()`.
2. A single `read()` must contain enough of the reply to parse.

Neither holds for a PTY. On **Tabby** (Electron/xterm.js/PTY, multiple async boundaries) the OSC-11 reply routinely arrives after 50ms. `select()` times out → the function returns → `RestoreGuard` re-enables ECHO → the terminal's valid reply then lands in the tty, echoed as `^[]11;rgb:1717/1717/1717^[\` and injected into zsh's input buffer. A fragmented reply produces the same leak.

The root cause is in the **querying application**, not Tabby: a standards-compliant terminal is not required to answer within 50ms or in one read.

## Fix — framed read + DSR/CPR fence

- Send the OSC-11 query immediately followed by a **DSR** cursor-position request (`ESC[6n`). Terminals process input in order, so the **CPR** reply (`ESC[<row>;<col>R`) necessarily arrives *after* the OSC-11 reply. Reading through the CPR is a deterministic "terminal is done" fence: the whole OSC-11 reply is consumed **while ECHO is still disabled**, so nothing leaks — even when the reply is slow or fragmented.
- Loop `select()`/`read()` against one **monotonic deadline** (default 500ms, override `XLINGS_TERM_QUERY_TIMEOUT_MS`, clamped `[50,5000]`), accumulating into a bounded buffer until the CPR `R`, the cap, or the deadline.
- Extract logic into two pure, fd-based helpers (`parse_terminal_bg_is_light`, `read_terminal_query_reply`) so it is unit-testable without a controlling tty; `query_terminal_is_light()` stays a thin termios wrapper. Helpers are POSIX-only (guarded in `platform.cppm`; the test is `#if !defined(_WIN32)`).

## Tests

`tests/unit/test_terminal_query.cpp` (13 cases, all green via `mcpp test`):
- **Parser**: dark/light, BEL & ST terminators, leading garbage before the reply, malformed hex, truncated reply.
- **Framed read over a `socketpair`**: immediate, delayed >50ms, fragmented across reads, BEL-terminated, CPR fence consumed, no-response returns within deadline.

**End-to-end verified against the real binary over a PTY** (shell keeps the tty open, mirroring zsh):
- Control (forced 30ms deadline ≈ old behavior): 120ms-delayed reply **leaks**.
- Fix (default framed read): same 120ms reply — and a 300ms reply — **do not leak**.

## Acceptance criteria (from the issue)

- ✅ Complete reply consumed internally; no bytes appear in output or the parent shell.
- ✅ Slow/fragmented replies fall back cleanly within a bounded time.
- ✅ Unsupported terminals time out without hanging.
- ✅ Original termios restored in all paths.

Bump `VERSION` 0.4.65 → **0.4.66**. Design: `.agents/docs/2026-07-15-issue368-osc11-framed-read-design.md`.