### PR TITLE
fix(xim): surface multi-repo install failures + best-effort catalog (#374) [0.4.67]

### DIFF
--- a/.agents/docs/2026-07-19-issue374-multi-repo-silent-exit-design.md
+++ b/.agents/docs/2026-07-19-issue374-multi-repo-silent-exit-design.md
@@ -1,0 +1,309 @@
+# Issue #374 — `install_packages` 多 index_repos 静默 exit 1 分析与修复设计
+
+**日期**: 2026-07-19
+**状态**: Bug confirmed（隔离环境实测复现，见 §3），fix proposed（未实现）
+**Issue**: [openxlings/xlings#374](https://github.com/openxlings/xlings/issues/374)，下游追踪 mcpp-community/mcpp#238
+**影响版本**: 0.4.62 实测复现（当前源码 0.4.66 同）
+**关联代码**:
+- `src/core/xim/catalog.cppm:351-375`（`rebuild()` fail-fast）
+- `src/core/xim/repo.cppm:542-566,625-626`（`sync_all_repos` 项目 repo fail-fast）
+- `src/core/xim/commands.cppm:114-123,180-197,255-260,399-409`（`cmd_install` 用 `log::error` 而非 stream）
+- `src/core/log.cppm:151-164`（`log::error` → stderr，TUI 模式下**完全静默**）
+- `src/interface.cppm:181-185`（interface 入口 `set_tui_mode(true)`）
+- `src/runtime/event.cppm:35-63`（`ErrorEvent` / `ErrorCode` 结构化错误——已有但 xim 层未用）
+- `src/core/subos.cppm:96,371,...`（**同仓库内已正确使用** `stream.emit(ErrorEvent{...})` 的范式）
+
+---
+
+## 0. 结论先行（Verdict）
+
+**是真实问题，且已实测复现。** 与 2026-05-22 的 `exitCode=0` 静默吞失败（已在 `commands.cppm:456` 修复）是**不同的第二个 bug**：这次是**解析/建库阶段** exit **1**，NDJSON 流里**零诊断**。
+
+根因是两条**架构级**缺陷叠加，issue 标题里的"≥2 index_repos"只是**触发条件**，不是根因：
+
+1. **可观测性缺口（"silent" 的来源）**：xim 命令层所有失败都走全局 `log::error(...)`，它写 stderr/日志文件，而 interface 入口把进程设成 `tui_mode=true` → `log::error` 被**整条吞掉**（连 stderr 都不到）。而 NDJSON 协议**本就有** `ErrorEvent` 结构化错误事件，interface 框架层自己在用，`subos.cppm` 命令层也在用——**唯独 xim 命令层不用**。于是任何非零退出都产出 `{"exitCode":1,"kind":"result"}` + 空事件流。**这条影响所有 exit-1 路径，不止多 repo。**
+
+2. **catalog 跨 repo "全有或全无"（"≥2 repos" 触发的来源）**：`PackageCatalog::rebuild()` 对第一个建库失败的 repo 直接 `return std::unexpected` → **一个坏 repo 拖垮整个 catalog**，健康 repo 也一起废。单 repo 时没有"另一个"能坏；一旦多命名空间继承 + 默认命名空间重定向生出第 2 个 repo（且它无 `pkgs/`/不可 sync/重定向到空目标），整库 fail。讽刺的是**紧挨着的 sub-index 早就是 best-effort**（`sync_all_repos` 里 warn+continue），只有 main/project repo 是致命的。
+
+次要facet：跨 repo 同名裸名解析走 `resolve_target` 的 ambiguous 硬失败，也被同样吞掉（见 §4.3）。
+
+---
+
+## 1. 现象（Issue 复述）
+
+mcpp 通过 `xlings interface install_packages` 装包，当项目 `.xlings.json` 的 `index_repos` 有 **≥2 项**时：
+
+```
+{"exitCode":1,"kind":"result"}
+```
+
+——exit 1，但 NDJSON 流里没有任何 error / data / log 事件，消费方无法知道**哪个 repo / 哪个包**失败。单 repo 配置一切正常。
+
+Issue 给出的触发组合：
+- 根级 `[indices]` 继承（多命名空间仓库）
+- 默认命名空间重定向
+
+二者叠加产出多条 `index_repos`（如 `mcpplibs` + `local-dev`）。真实场景：多命名空间 workspace 里的 opencv/ffmpeg 模块包。
+
+Issue 期望：要么跨所有 repo 解析（first-match-wins），要么发出结构化错误事件，指明搜了哪些 repo、哪个包解析失败。
+
+---
+
+## 2. 根因链（代码级）
+
+### 2.1 `catalog.rebuild()` 对单个坏 repo fail-fast
+
+`src/core/xim/catalog.cppm:351-375`：
+
+```cpp
+std::expected<void, std::string> rebuild(bool forceRebuild = false) {
+    projectRepos_.clear();
+    globalRepos_.clear();
+    auto specs = repo_specs_();                       // 项目 repos + 全局 repos + sub-index + local
+    for (auto& spec : specs) {
+        auto state = make_state_(spec);
+        auto hash = get_repo_head_hash(spec.dir);
+        auto result = state.index.load_or_rebuild(hash, forceRebuild);
+        if (!result) {
+            return std::unexpected(result.error());   // ← 第一个坏 repo 就整库放弃
+        }
+        ...
+    }
+    loaded_ = true;
+    return {};
+}
+```
+
+`load_or_rebuild` → `build()` 在 repo 目录无 `pkgs/` 时返回 `unexpected`：
+
+```cpp
+// src/core/xim/index.cppm:146-148
+if (!fs::exists(repoDir_ / "pkgs")) {
+    return std::unexpected(
+        std::format("pkgs/ directory not found in {}", repoDir_.string()));
+}
+```
+
+于是：第 2 个项目 repo（重定向生成的 `local-dev` 之类，无 `pkgs/` / sync 失败 / 重定向到空目标）→ `rebuild()` 在它身上 `unexpected` → `loaded_` 永远 false。
+
+### 2.2 `sync_all_repos` 对项目 repo 也 fail-fast
+
+`src/core/xim/repo.cppm:542-566, 625-626`：
+
+```cpp
+auto syncRepos = [&](const std::vector<IndexRepo>& repos, bool projectScope) {
+    for (auto& repo : repos) {
+        ...
+        if (Config::is_local_repo_source(repo, projectScope)) {
+            if (!detail_::ensure_local_repo_link_(repoDir, sourceDir)) {
+                return false;                         // ← 一个坏 repo → 整个 sync 放弃
+            }
+            continue;
+        }
+        if (!sync_repo(repoDir, url, force)) {
+            return false;                             // ← 同上
+        }
+    }
+    return true;
+};
+...
+if (Config::has_project_config() && !Config::project_index_repos().empty()) {
+    if (!syncRepos(Config::project_index_repos(), true)) return false;  // ← 项目 repo sync fail-fast
+    // ↓↓↓ 紧接着的 sub-index 却是 best-effort（warn + continue）↓↓↓
+    for (auto& [name, repo] : projMerged) {
+        if (sync_repo(...)) { ... }
+        else { log::warn("failed to sync project sub-index repo: ..."); }   // ← 一致性对比
+    }
+}
+```
+
+**同一函数内，项目 repo 是致命的，sub-index 是 best-effort。** 这个不一致就是根因 2 的直接体现。
+
+`ensure_local_repo_link_` 在源目录无 `pkgs/` 时 `return false`（repo.cppm:25-28），本地重定向目标为空即触发。
+
+### 2.3 catalog 建不起来 → `cmd_install` 用 `log::error` 退出
+
+`src/core/xim/commands.cppm:114-123`：
+
+```cpp
+auto& catalog = get_catalog();          // 内部首个 rebuild 失败 → loaded_=false（get_catalog 无 stream）
+if (!catalog.is_loaded()) {
+    log::info("package index not available, updating...");
+    sync_all_repos(true);               // 又 fail-fast，false
+    auto rebuildResult = catalog.rebuild();
+    if (!rebuildResult || !catalog.is_loaded()) {
+        log::error("package index not available");   // ← 关键：走 log::error
+        return 1;
+    }
+}
+```
+
+### 2.4 `log::error` 在 interface 模式下被完全吞掉
+
+`src/interface.cppm:184-185`：
+
+```cpp
+stream.set_enabled(tui_listener, false);
+platform::set_tui_mode(true);           // ← interface 入口把进程设成 TUI 模式
+```
+
+`src/core/log.cppm:151-164`：
+
+```cpp
+export template<typename... Args>
+void error(std::format_string<Args...> fmt, Args&&... args) {
+    auto msg = std::format(fmt, std::forward<Args>(args)...);
+    if (!platform::is_tui_mode()) {       // ← TUI 模式 → 整块跳过（连 stderr 都不写）
+        std::print(stderr, "[error] ");
+        ...
+    }
+    write_to_file_("[error] ", msg);      // 只有配了日志文件才留痕
+}
+```
+
+**链闭合**：catalog fail-fast（2.1/2.2）→ `cmd_install` 走 `log::error` 退出（2.3）→ interface 的 TUI 模式吞掉 `log::error`（2.4）→ 消费方只看到 `{"exitCode":1,"kind":"result"}`，零诊断。
+
+---
+
+## 3. 实测复现（2026-07-19 测得）
+
+完全本地化（无网络），用现成 release 二进制（0.4.62）+ fixture 索引，用只读 `plan_install`（不下载）隔离"建库失败"这一根因：
+
+```
+全局 XLINGS_HOME：index_repos = [{xim → tests/fixtures/xim-pkgindex 绝对路径}]  # 本地，无网络
+项目 A（单 repo）：index_repos = [{projgood → 一个有 pkgs/ 的合法目录}]
+项目 B（双 repo）：index_repos = [{projgood → 合法}, {projbad → 存在但无 pkgs/}]
+目标：plan_install ninja（只在全局 xim 索引里）
+```
+
+| | 项目 A（单 repo，合法） | 项目 B（双 repo，第 2 个无 pkgs/） |
+|---|---|---|
+| exit code | `0` | `1` |
+| NDJSON stdout | `install_plan` 事件 + `result` | **只有** `{"exitCode":1,"kind":"result"}` |
+| stderr | 空 | **空**（错误被 TUI 模式吞掉，连 `2>/dev/null` 都不需要） |
+
+项目 A 输出：
+```
+{"dataKind":"install_plan","kind":"data","payload":{"packages":[["xim:ninja@1.12.1",""]]}}
+{"exitCode":0,"kind":"result"}
+```
+项目 B 输出：
+```
+{"exitCode":1,"kind":"result"}
+```
+
+与 issue 症状逐字吻合。复现脚本存于 `scratchpad/repro374/`（可移植为 e2e 用例，见 §6）。
+
+> 注：比 issue 报告的还严重一点——错误不仅"不在 NDJSON 里"，而是**任何地方都没有**（stderr 也空），因为 interface 的 `tui_mode=true` 直接关掉了 `log::error` 的终端输出。
+
+---
+
+## 4. 修复设计（按优先级）
+
+三层，对应两条根因 + 一个次要 facet。P0 单独就能让 issue 的"零诊断"消失；P1 才从结构上根治"≥2 repo 就崩"。
+
+### 4.1 P0 — 让命令层失败在 wire 上可见（治"silent"，收益最大）
+
+问题本质是**两条并行诊断通道**：全局 `log::*`（stderr/文件，TUI 下静默）与 `EventStream`（NDJSON wire）。xim 命令层对某些事 `stream.emit(DataEvent)`、对失败却 `log::error` → 用错了通道。`subos.cppm` 早已示范正确做法。三个互补动作：
+
+**(a) 系统性：把全局 logger 桥接到 EventStream（一处修，覆盖所有 `log::error`）**
+
+`log` 是底层模块（只 `import xlings.platform`），不能反向依赖 runtime。用**类型擦除的 sink**保持分层干净：
+
+```cpp
+// core/log.cppm 新增
+export void set_sink(std::function<void(Level, std::string_view)> sink);  // 由上层注入
+// error()/warn() 里，除现有分支外，若 sink 已装则 sink(Level::Error, msg);
+```
+
+interface 会话（`interface.cppm` 建 session 时）注入一个 sink，把 `Level::Error/Warn` 转成 `LogEvent`（或 `ErrorEvent`）发到 stream。**这样所有现存及未来的 `log::error` 在 interface 模式下自动落到 NDJSON**，不用逐点改、也不会再漏。CLI 模式不装 sink，行为不变。
+
+**(b) 定点升级：`cmd_install` 关键失败点发 rich `ErrorEvent`（对齐 subos.cppm 范式）**
+
+对 issue 最相关的三处，emit 带 `ErrorCode` + `hint` 的结构化错误（比裸 LogEvent 更好，指明搜了哪些 repo）：
+
+```cpp
+// commands.cppm: catalog 建不起来（2.3 处）
+stream.emit(ErrorEvent{
+    .code = ErrorCode::NotFound,
+    .message = "package index not available: " + <累积的 per-repo 失败原因>,
+    .recoverable = true,
+    .hint = "run `xlings update`, or check index_repos in .xlings.json",
+});
+// commands.cppm:180-197 not-found / 182-185 ambiguous 两处同理
+//   not-found → NotFound + "searched repos: [xim, projgood, projbad]"
+//   ambiguous → InvalidInput + 候选列表（format_ambiguous_candidates 已现成）
+```
+
+**(c) 兜底不变量：非零退出 ⇒ wire 上至少一个 error 事件**
+
+在 `interface::run`（`interface.cppm:282-289` 出结果前）或 `exit_result` 包装处加断言式兜底：capability 返回非零、且本次执行期间未发过任何 `ErrorEvent`，则合成一个通用 `ErrorEvent{Internal, "install_packages failed (exit N)"}`。粗，但**保证协议自洽**、防未来回归——"非零退出必有错误事件"成为可测不变量。
+
+### 4.2 P1 — catalog/sync 跨 repo：降级而非崩塌（治"≥2 repo"）
+
+把"全有或全无"改成"best-effort + 上报被跳过的 repo"，对齐紧挨着的 sub-index 已有行为。
+
+**(a) `rebuild()` fail-soft**：不再首个失败即 `return unexpected`；把每个坏 repo 记进 `std::vector<RepoLoadError>{name,scope,dir,error}`，继续建其余；`loaded_ = (至少 global 主索引已载入)`。新增 `catalog.load_warnings()` 供命令层读取——**catalog 保持 stream 无关**（正确分层），由 `cmd_install` 在 `get_catalog()` 后把 warnings 通过 P0 通道 emit 出去。
+
+```cpp
+for (auto& spec : specs) {
+    auto result = state.index.load_or_rebuild(hash, forceRebuild);
+    if (!result) {
+        loadWarnings_.push_back({spec.name, spec.scope, spec.dir, result.error()});
+        continue;                                   // ← 跳过坏 repo，不拖垮全库
+    }
+    (spec.scope == Project ? projectRepos_ : globalRepos_).push_back(std::move(state));
+}
+loaded_ = !globalRepos_.empty() || !projectRepos_.empty();
+return loaded_ ? std::expected<void,std::string>{}
+              : std::unexpected("no index repo could be loaded");
+```
+
+**(b) `sync_all_repos` 项目 repo fail-soft**：把 `syncRepos(project_index_repos, true)` 里的 `return false` 改成 warn + continue（和其下 sub-index 循环完全一致），单个项目 repo sync 失败不再中断整个 sync。
+
+**结果**：§3 的项目 B 变成——`projbad` 被跳过并在 wire 上 warn（"repo 'projbad' skipped: pkgs/ not found"），`ninja` 仍从健康索引解析成功，exit 0。这正是 issue 期望的"健康 repo 照常出包 + 结构化诊断指明哪个 repo 出事"。被跳过的 repo **绝不静默**——靠 P0 保证被 emit。
+
+### 4.3 P2 —（可选）跨 repo 同名裸名的优先级策略
+
+`resolve_target`（catalog.cppm:397-409）对裸名多命中走 ambiguous 硬失败。issue 的"first match wins"可作为**配置开启**的增强：按 `index_repos` 声明顺序取第一个。默认仍保留 ambiguous 结构化错误（静默二选一会掩盖真实冲突）——但有了 P0，即便保持现状，ambiguous 也终于在 wire 上可见了。**P2 非必需**，P0+P1 已解 issue。
+
+---
+
+## 5. 优先级与兼容性
+
+| 优先级 | 改动 | 解决 | 破坏性 |
+|---|---|---|---|
+| **P0** | logger→stream 桥 + 定点 ErrorEvent + 非零兜底 | issue 的"零诊断"（所有 exit-1 路径） | 无（CLI 不装 sink；纯增量） |
+| **P1** | rebuild/sync fail-soft + 上报跳过 | "≥2 repo 就崩"的结构根因 | 行为更健壮：坏 repo 从"整库 fail"→"跳过+warn"；单 repo 配置零影响 |
+| P2 | 声明顺序 first-match（配置开关） | 跨 repo 同名裸名 | 默认关，opt-in |
+
+**建议落地顺序**：先 P0（小、单独就让 issue 症状消失、可测不变量防回归），P1 紧随（真正让多命名空间 workspace 稳），P2 视需要。
+
+**关键兼容性**：P1 把"坏 repo 致命"改成"best-effort"，与同函数内 sub-index 的既有语义一致，不是新范式。唯一需盯的：坏 repo 被跳过后若目标恰只在坏 repo 里，则应是**结构化 NotFound**（P0 保证），而非静默——这正是 §6 要断言的。
+
+---
+
+## 6. 验证 / 测试
+
+新增 e2e（模仿 `tests/e2e/install_silent_failure_test.sh`），三条断言：
+
+1. **不变量**：任意导致非零 exit 的 interface 调用，NDJSON 流里**必有 ≥1 个 `kind":"error"` 或 `level":"error"` 事件**（P0 兜底）。
+2. **§3 复现回归**：双 repo（第 2 个无 `pkgs/`）+ 目标在健康索引 → **exit 0** + 一条"repo skipped"的 warn/error 事件（P1）。
+3. **真缺失**：双 repo + 目标哪个 repo 都没有 → **exit 非零** + 结构化 `NotFound` 事件（含搜索过的 repo 列表）。
+
+复现脚手架（已验证可用）：本地 fixture 索引 + 绝对路径 index_repos + `XLINGS_INDEX_SOURCE=git`（免 artifact/网络）+ 只读 `plan_install`。
+
+## 7. 涉及面
+
+`log::error` 静默 + 命令层不发 `ErrorEvent` 影响**所有** xim capability 的失败可观测性，不止 install：`cmd_search/cmd_remove/cmd_update/cmd_info/cmd_list` 全部同款（都用 `log::error(...); return 1;`）。P0 的 logger→stream 桥一次性覆盖它们。`cmd_update` 内部调 `cmd_install`，额外继承本 bug。
+
+## 8. 与 2026-05-22 静默失败的区别
+
+| | 2026-05-22（已修） | 本 issue #374 |
+|---|---|---|
+| 阶段 | 下载/安装（per-package） | 解析/建库（catalog） |
+| exit | **0**（假成功） | **1**（真失败但无诊断） |
+| 根因 | `failedCount` 不进退出码 | catalog fail-fast + `log::error` 被 TUI 吞 |
+| 现状 | 已修（`commands.cppm:456`） | 本文档提案 |
+
+两者共同暴露一件事：**interface 契约声称"事件描述过程、result 携带码"，但命令层的失败诊断没进事件通道。** P0 是这条契约的系统性补齐。

--- a/mcpp.lock
+++ b/mcpp.lock
@@ -33,7 +33,7 @@ hash    = "fnv1a:3465dd0bd5d7aa20"
 
 [package."mcpplibs.xpkg"]
 namespace = "mcpplibs"
-version = "0.0.44"
-source  = "index+mcpplibs@0.0.44"
-hash    = "fnv1a:750b1f1ed374ad3d"
+version = "0.0.45"
+source  = "index+mcpplibs@0.0.45"
+hash    = "fnv1a:33400813b5eea84f"
 

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlings"
-version = "0.4.64"
+version = "0.4.67"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "0.4.66";
+    static constexpr std::string_view VERSION = "0.4.67";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/xim/catalog.cppm
+++ b/src/core/xim/catalog.cppm
@@ -37,6 +37,17 @@ struct PackageMatch {
     bool installed { false };
 };
 
+// #374: a single index repo that could not be loaded during rebuild
+// (no pkgs/, unsynced, empty redirect target). Recorded instead of
+// aborting the whole catalog; the command layer surfaces these on the
+// wire so a skipped repo is never silent.
+struct RepoLoadWarning {
+    std::string name;
+    PackageScope scope { PackageScope::Global };
+    std::filesystem::path dir;
+    std::string error;
+};
+
 std::string canonical_package_name(std::string_view namespaceName, std::string_view name) {
     if (namespaceName.empty()) return std::string(name);
     return std::string(namespaceName) + ":" + std::string(name);
@@ -168,6 +179,7 @@ class PackageCatalog {
 
     std::vector<RepoState> projectRepos_;
     std::vector<RepoState> globalRepos_;
+    std::vector<RepoLoadWarning> loadWarnings_;
     bool loaded_ { false };
 
     static std::vector<RepoIndexSpec> repo_specs_() {
@@ -351,6 +363,7 @@ public:
     std::expected<void, std::string> rebuild(bool forceRebuild = false) {
         projectRepos_.clear();
         globalRepos_.clear();
+        loadWarnings_.clear();
 
         auto specs = repo_specs_();
         log::debug("catalog rebuild: {} repo(s), force={}", specs.size(), forceRebuild);
@@ -361,7 +374,18 @@ public:
             auto hash = get_repo_head_hash(spec.dir);
             auto result = state.index.load_or_rebuild(hash, forceRebuild);
             if (!result) {
-                return std::unexpected(result.error());
+                // #374: best-effort. A single degenerate/unsynced repo (no
+                // pkgs/, unreachable URL, empty default-namespace redirect
+                // target) must NOT collapse the whole catalog — that is the
+                // exact ">=2 index_repos -> silent exit 1" trigger. Record
+                // the skip and keep loading the rest; the command layer
+                // emits these as wire warnings so the skip is never silent.
+                // Mirrors the best-effort handling sub-index repos already
+                // get in sync_all_repos. loaded_ below still hard-fails only
+                // when NOTHING could be loaded.
+                loadWarnings_.push_back({spec.name, spec.scope, spec.dir, result.error()});
+                log::debug("catalog: skipping repo '{}': {}", spec.name, result.error());
+                continue;
             }
             if (spec.scope == PackageScope::Project) {
                 projectRepos_.push_back(std::move(state));
@@ -370,11 +394,22 @@ public:
             }
         }
 
-        loaded_ = true;
+        loaded_ = !projectRepos_.empty() || !globalRepos_.empty();
+        if (!loaded_) {
+            return std::unexpected(loadWarnings_.empty()
+                ? std::string("no index repositories configured")
+                : loadWarnings_.front().error);
+        }
         return {};
     }
 
     bool is_loaded() const { return loaded_; }
+
+    // #374: repos skipped during the last rebuild (best-effort). The
+    // command layer emits these on the EventStream so a degraded
+    // multi-repo config is visible to interface consumers (mcpp), not
+    // silently swallowed.
+    const std::vector<RepoLoadWarning>& load_warnings() const { return loadWarnings_; }
 
     // When project and global have the same package, keep only project-scoped match
     static std::vector<PackageMatch> prefer_project_scope_(std::vector<PackageMatch> matches) {

--- a/src/core/xim/commands.cppm
+++ b/src/core/xim/commands.cppm
@@ -117,9 +117,30 @@ int cmd_install(std::span<const std::string> targets, bool yes, bool noDeps,
         sync_all_repos(true);
         auto rebuildResult = catalog.rebuild();
         if (!rebuildResult || !catalog.is_loaded()) {
-            log::error("package index not available");
+            // #374: emit a structured error on the EventStream instead of a
+            // bare log::error (which interface mode's tui_mode suppresses) so
+            // programmatic consumers see WHY the exit is non-zero rather than
+            // a silent {"exitCode":1,"kind":"result"} with an empty stream.
+            stream.emit(ErrorEvent{
+                .code = ErrorCode::NotFound,
+                .message = std::string("package index not available")
+                    + (rebuildResult ? std::string{} : ": " + rebuildResult.error()),
+                .recoverable = true,
+                .hint = "run `xlings update`, or check index_repos in .xlings.json",
+            });
             return 1;
         }
+    }
+
+    // #374: surface any index repos skipped during the best-effort catalog
+    // build so a degraded multi-repo config is visible to interface consumers
+    // (mcpp) instead of silently ignored. Non-fatal — healthy repos still
+    // resolve; this only makes the skip observable on the wire.
+    for (auto& w : catalog.load_warnings()) {
+        stream.emit(LogEvent{LogLevel::warn,
+            "index repo '" + w.name + "' skipped ("
+            + (w.scope == PackageScope::Project ? "project" : "global")
+            + " scope): " + w.error});
     }
 
     auto platform = detect_platform();
@@ -127,6 +148,17 @@ int cmd_install(std::span<const std::string> targets, bool yes, bool noDeps,
     std::vector<PackageMatch> requestedMatches;
     // C2 (#366 UX): allow at most one on-demand index refresh per install call.
     bool refreshedForMissing = false;
+
+    // #374: for structured not-found errors, name the repos we searched so
+    // interface consumers can see the resolution scope (the issue asks to
+    // identify "which repositories were searched").
+    auto searched_repos_ = [&]() {
+        std::string s;
+        auto add = [&](const std::string& n) { if (!s.empty()) s += ", "; s += n; };
+        for (auto& r : Config::project_index_repos()) add(r.name);
+        for (auto& r : Config::global_index_repos()) add(r.name);
+        return s;
+    };
 
     // Idempotency: `install` is NOT supposed to be a silent upgrader.
     // If the package already has a version active in the current sub-OS
@@ -180,19 +212,39 @@ int cmd_install(std::span<const std::string> targets, bool yes, bool noDeps,
         if (!match) {
             // Ambiguous matches: show error directly, don't fall through to fuzzy
             if (match.error().contains("ambiguous")) {
-                log::error("{}", match.error());
+                // #374: structured error on the wire (was a swallowed log::error)
+                stream.emit(ErrorEvent{
+                    .code = ErrorCode::InvalidInput,
+                    .message = match.error(),
+                    .recoverable = true,
+                    .hint = "install a specific candidate with its full namespace:name@version",
+                });
                 return 1;
             }
             // Explicit namespace (e.g. scode:linux-headers) -- don't fuzzy-match
             // across other namespaces, which can cause infinite recursion
             if (target.find(':') != std::string::npos) {
-                log::error("{}", match.error());
+                // #374: structured error on the wire (was a swallowed log::error)
+                stream.emit(ErrorEvent{
+                    .code = ErrorCode::NotFound,
+                    .message = match.error(),
+                    .recoverable = true,
+                    .hint = "searched repos: [" + searched_repos_()
+                        + "]; run `xlings update` if the package was just published",
+                });
                 return 1;
             }
             // Try fuzzy search for suggestions
             auto fuzzy = catalog.search(target, platform);
             if (fuzzy.empty()) {
-                log::error("{}", match.error());
+                // #374: structured error on the wire (was a swallowed log::error)
+                stream.emit(ErrorEvent{
+                    .code = ErrorCode::NotFound,
+                    .message = match.error(),
+                    .recoverable = true,
+                    .hint = "searched repos: [" + searched_repos_()
+                        + "]; run `xlings update` if the package was just published",
+                });
                 return 1;
             }
             if (fuzzy.size() > 5) fuzzy.resize(5);
@@ -247,14 +299,24 @@ int cmd_install(std::span<const std::string> targets, bool yes, bool noDeps,
     // Resolve dependencies
     auto planResult = resolve(catalog, targetVec, platform);
     if (!planResult) {
-        log::error("dependency resolution failed: {}", planResult.error());
+        // #374: structured error on the wire (was a swallowed log::error)
+        stream.emit(ErrorEvent{
+            .code = ErrorCode::InvalidInput,
+            .message = "dependency resolution failed: " + planResult.error(),
+            .recoverable = true,
+        });
         return 1;
     }
 
     auto& plan = *planResult;
     if (plan.has_errors()) {
+        // #374: structured errors on the wire (were swallowed log::error)
         for (auto& err : plan.errors) {
-            log::error("{}", err);
+            stream.emit(ErrorEvent{
+                .code = ErrorCode::InvalidInput,
+                .message = err,
+                .recoverable = true,
+            });
         }
         return 1;
     }
@@ -402,7 +464,14 @@ int cmd_install(std::span<const std::string> targets, bool yes, bool noDeps,
                     ++successCount;
                     break;
                 case InstallPhase::Failed:
-                    log::error("[{}] failed: {}", status.name, status.message);
+                    // #374: structured per-package failure on the wire so
+                    // interface consumers see WHICH package failed (was a
+                    // swallowed log::error). failedCount still drives exitCode.
+                    stream.emit(ErrorEvent{
+                        .code = ErrorCode::Internal,
+                        .message = "[" + status.name + "] failed: " + status.message,
+                        .recoverable = true,
+                    });
                     ++failedCount;
                     break;
                 default:
@@ -428,7 +497,12 @@ int cmd_install(std::span<const std::string> targets, bool yes, bool noDeps,
         dlRenderer, cancel, useAfterInstall);
 
     if (!result) {
-        log::error("install failed: {}", result.error());
+        // #374: structured error on the wire (was a swallowed log::error)
+        stream.emit(ErrorEvent{
+            .code = ErrorCode::Internal,
+            .message = "install failed: " + result.error(),
+            .recoverable = false,
+        });
         return 1;
     }
 

--- a/src/core/xim/repo.cppm
+++ b/src/core/xim/repo.cppm
@@ -23,7 +23,10 @@ bool ensure_local_repo_link_(const std::filesystem::path& localDir,
 
     std::error_code ec;
     if (!fs::exists(sourceDir, ec) || !fs::exists(sourceDir / "pkgs", ec)) {
-        log::error("local index repo missing pkgs/: {}", sourceDir.string());
+        // #374: caller (syncRepos) now treats this as a best-effort skip and
+        // emits the user-facing warning naming the repo; keep this at debug
+        // so a tolerated missing-pkgs source is not reported as a hard error.
+        log::debug("local index repo missing pkgs/: {}", sourceDir.string());
         return false;
     }
 
@@ -539,28 +542,43 @@ bool sync_all_repos(bool force = false) {
         }
     }
 
+    // #374: best-effort. A single degenerate/unreachable index repo (no
+    // pkgs/, empty default-namespace redirect target, dead URL) must NOT
+    // abort the whole sync and collapse the catalog — that is the exact
+    // ">=2 index_repos -> silent exit 1" trigger. Skip the bad repo with a
+    // warning and keep syncing the rest, mirroring the best-effort handling
+    // the sub-index loop below already has. Returns false only when NOTHING
+    // in a non-empty list could be synced; the catalog rebuild's load-gate
+    // is the real "nothing usable" safety net.
     auto syncRepos = [&](const std::vector<IndexRepo>& repos, bool projectScope) {
         auto rootDir = projectScope ? Config::project_data_dir() : Config::global_data_dir();
         if (rootDir.empty()) return true;
         fs::create_directories(rootDir);
+        int total = 0, ok = 0;
         for (auto& repo : repos) {
+            ++total;
             auto repoDir = Config::repo_dir_for(repo, projectScope);
             // The main index is artifact-managed (no .git); never git-sync it.
-            if (!projectScope && mainArtifactManaged && repoDir == mainDir) continue;
+            if (!projectScope && mainArtifactManaged && repoDir == mainDir) { ++ok; continue; }
             if (Config::is_local_repo_source(repo, projectScope)) {
                 auto sourceDir = Config::resolve_repo_source(repo, projectScope);
                 if (!detail_::ensure_local_repo_link_(repoDir, sourceDir)) {
-                    return false;
+                    log::warn("index repo '{}' skipped: local source has no pkgs/ ({})",
+                              repo.name, sourceDir.string());
+                    continue;
                 }
+                ++ok;
                 continue;
             }
 
             auto url = detail_::sync_repo_url_(repo.url, mirror);
             if (!sync_repo(repoDir, url, force)) {
-                return false;
+                log::warn("index repo '{}' skipped: sync failed ({})", repo.name, url);
+                continue;
             }
+            ++ok;
         }
-        return true;
+        return total == 0 || ok > 0;
     };
 
     if (!syncRepos(Config::global_index_repos(), false)) return false;

--- a/src/interface.cppm
+++ b/src/interface.cppm
@@ -82,9 +82,14 @@ public:
     InterfaceSession& operator=(const InterfaceSession&) = delete;
 
     void emit_event(const Event& e) {
+        // #374: track whether any structured error reached the wire so run()
+        // can guarantee "non-zero exit ⇒ at least one error event".
+        if (std::get_if<ErrorEvent>(&e)) saw_error_.store(true, std::memory_order_relaxed);
         auto line = event_to_ndjson_line_(e);
         if (!line.empty()) emit_raw_line_(line);
     }
+
+    bool saw_error() const { return saw_error_.load(std::memory_order_relaxed); }
 
     void emit_result(int exitCode, std::string_view raw_content) {
         nlohmann::json line;
@@ -166,6 +171,7 @@ private:
     EventStream& stream_;
     CancellationToken& token_;
     std::mutex io_mtx_;
+    std::atomic<bool> saw_error_ { false };
     std::atomic<std::chrono::steady_clock::time_point> last_emit_;
     std::jthread heartbeat_thread_;
     std::jthread stdin_thread_;
@@ -286,6 +292,24 @@ export int run(const mcpplibs::cmdline::ParsedArgs& args,
                 ? parsed["exitCode"].get<int>() : 0;
         }
     }
+
+    // #374: guarantee the interface invariant "non-zero exit ⇒ at least one
+    // error event on the wire". Any capability that exits non-zero without
+    // having emitted an ErrorEvent (e.g. a cmd_* path still routing failures
+    // through log::error, which interface mode suppresses) would otherwise
+    // produce a bare {"exitCode":N,"kind":"result"} with no diagnostics —
+    // exactly the issue #374 silent failure. Synthesize a generic error as a
+    // backstop so consumers always get a reason.
+    if (exit_code != 0 && !session.saw_error()) {
+        session.emit_event(Event{ErrorEvent{
+            .code = ErrorCode::Internal,
+            .message = cap_name + " failed (exit " + std::to_string(exit_code)
+                + ") with no error detail on the stream",
+            .recoverable = false,
+            .hint = "re-run with the xlings CLI (non-interface) for full diagnostics",
+        }});
+    }
+
     session.emit_result(exit_code, result);
     return exit_code;
 }

--- a/src/interface.cppm
+++ b/src/interface.cppm
@@ -270,16 +270,27 @@ export int run(const mcpplibs::cmdline::ParsedArgs& args,
     try {
         result = cap->execute(cap_args, stream, &token);
     } catch (const CancelledException&) {
+        // #374: a client-initiated cancel is a normal, expected control-plane
+        // action — emit the dedicated E_CANCELLED (recoverable) so it reaches
+        // the wire with the CORRECT code. Emitting it also marks saw_error(),
+        // so the generic non-zero-exit backstop below does not fire and
+        // mislabel the cancellation as an internal xlings bug.
+        session.emit_event(Event{ErrorEvent{
+            .code = ErrorCode::Cancelled,
+            .message = "operation cancelled",
+            .recoverable = true,
+        }});
         result = nlohmann::json({{"exitCode", 130}}).dump();
         exit_code = 130;
     } catch (const std::exception& e) {
-        nlohmann::json err = {
-            {"kind", "error"},
-            {"code", std::string(to_wire_string(ErrorCode::Internal))},
-            {"message", std::string("internal: ") + e.what()},
-            {"recoverable", false}
-        };
-        std::cout << err.dump() << "\n";
+        // #374: route through the session (marks saw_error()) instead of a
+        // raw std::cout write — otherwise the backstop below would fire and
+        // emit a SECOND, generic error line on top of this specific one.
+        session.emit_event(Event{ErrorEvent{
+            .code = ErrorCode::Internal,
+            .message = std::string("internal: ") + e.what(),
+            .recoverable = false,
+        }});
         result = nlohmann::json({{"exitCode", 1}}).dump();
         exit_code = 1;
     }

--- a/tests/e2e/interface_multi_repo_error_visibility_test.sh
+++ b/tests/e2e/interface_multi_repo_error_visibility_test.sh
@@ -6,16 +6,16 @@
 #
 # Two independent architectural defects combine to produce the bug:
 #
-#   Root defect 1 (observability): the xim command layer reports failures
+#   Root defect 1 (observability): the xim command layer reported failures
 #   via the global log::error(), which is fully suppressed in interface
 #   mode (platform::set_tui_mode(true)). The NDJSON stream carries a
-#   first-class ErrorEvent kind, but cmd_install never emits it — so a
-#   non-zero exit produces {"exitCode":1,"kind":"result"} with an empty
-#   event stream. The consumer (mcpp) cannot tell what failed.
+#   first-class ErrorEvent kind, but cmd_install never emitted it — so a
+#   non-zero exit produced {"exitCode":1,"kind":"result"} with an empty
+#   event stream. The consumer (mcpp) could not tell what failed.
 #
 #   Root defect 2 (multi-repo robustness): PackageCatalog::rebuild() and
 #   sync_all_repos() fail-fast on the first bad repo, so one degenerate
-#   index_repo collapses the whole catalog — even the healthy repos.
+#   index_repo collapsed the whole catalog — even the healthy repos.
 #
 # Assertions (design doc §6):
 #   A1 (P1 best-effort skip): 2 project repos, 2nd has no pkgs/, target
@@ -25,6 +25,9 @@
 #      everywhere → NON-ZERO exit AND at least one {"kind":"error"} event
 #      on the wire (never a bare result envelope).
 #
+# Fully self-contained/offline: builds its own local global + project
+# indexes under the runtime dir; never mutates tests/fixtures.
+#
 # Refs: .agents/docs/2026-07-19-issue374-multi-repo-silent-exit-design.md
 
 set -euo pipefail
@@ -32,11 +35,10 @@ set -euo pipefail
 # shellcheck source=./project_test_lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
 
-require_fixture_index
-
 RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/interface_multi_repo_error_visibility"
 HOME_DIR="$RUNTIME_DIR/home"
 APP_DIR="$RUNTIME_DIR/app"          # the "project" dir (has .xlings.json, NOT an xlings home)
+GLOBAL_DIR="$RUNTIME_DIR/global_index"  # local global (xim) index — offline, no sub-repos
 GOOD_DIR="$RUNTIME_DIR/proj_good"   # a valid project index (has pkgs/)
 BAD_DIR="$RUNTIME_DIR/proj_bad"     # degenerate: dir exists but no pkgs/
 
@@ -46,15 +48,17 @@ cleanup
 
 XLINGS_BIN="$(find_xlings_bin)"
 
-mkdir -p "$HOME_DIR/subos/default/bin" "$APP_DIR" "$GOOD_DIR/pkgs/t" "$BAD_DIR"
+mkdir -p "$HOME_DIR/subos/default/bin" "$APP_DIR" \
+         "$GLOBAL_DIR/pkgs/g" "$GOOD_DIR/pkgs/t" "$BAD_DIR"
 
-# ── a VALID project index with one package "toolx" (script type, no
-#    download — plan_install only resolves, never installs) ───────────
-cat > "$GOOD_DIR/pkgs/t/toolx.lua" <<'LUA'
+# A script-type package with no download — plan_install only resolves,
+# never installs, so an empty version resource is fine.
+emit_pkg() { # $1=dir $2=name
+  cat > "$1" <<LUA
 package = {
     spec = "1",
-    name = "toolx",
-    description = "Test fixture: healthy project-repo package (issue #374 coverage)",
+    name = "$2",
+    description = "Test fixture package (issue #374 coverage)",
     type = "package",
     archs = {"x86_64", "aarch64"},
     status = "stable",
@@ -66,20 +70,26 @@ package = {
 }
 function install() return true end
 LUA
+}
 
-# ── the DEGENERATE project index: exists, but NO pkgs/ (models a
-#    default-namespace redirect / empty local-dev repo) ───────────────
+emit_pkg "$GLOBAL_DIR/pkgs/g/globaltool.lua" "globaltool"   # in the global (xim) index
+emit_pkg "$GOOD_DIR/pkgs/t/toolx.lua"        "toolx"        # in the healthy project repo
+# neutralise sub-index discovery for both local indexes (stay offline)
+printf 'xim_indexrepos = {}\n' > "$GLOBAL_DIR/xim-indexrepos.lua"
+printf 'xim_indexrepos = {}\n' > "$GOOD_DIR/xim-indexrepos.lua"
+
+# the DEGENERATE project index: exists, but NO pkgs/ (models a
+# default-namespace redirect / empty local-dev repo)
 printf 'placeholder — deliberately no pkgs/ subdir\n' > "$BAD_DIR/README.md"
 
-# ── global home: xim namespace -> local fixture (offline), sub-indexes
-#    neutralised so nothing reaches the network ────────────────────────
+# global home: xim -> local offline index; sub-indexes neutralised
 cat > "$HOME_DIR/.xlings.json" <<JSON
 {
   "activeSubos": "default",
   "mirror": "GLOBAL",
   "subos": {"default": {"dir": ""}},
   "index_repos": [
-    {"name": "xim", "url": "$FIXTURE_INDEX_DIR"}
+    {"name": "xim", "url": "$GLOBAL_DIR"}
   ]
 }
 JSON
@@ -98,7 +108,6 @@ RUN_PROJ() {
 RUN_HOME self init >/dev/null 2>&1 || fail "self init failed"
 mkdir -p "$HOME_DIR/data/xim-index-repos"
 printf '{}\n' > "$HOME_DIR/data/xim-index-repos/xim-indexrepos.json"
-printf 'xim_indexrepos = {}\n' > "$FIXTURE_INDEX_DIR/xim-indexrepos.lua" 2>/dev/null || true
 
 # project manifest: TWO index_repos, the 2nd (projbad) is degenerate
 cat > "$APP_DIR/.xlings.json" <<JSON

--- a/tests/e2e/interface_multi_repo_error_visibility_test.sh
+++ b/tests/e2e/interface_multi_repo_error_visibility_test.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# interface_multi_repo_error_visibility_test.sh — regression test for
+# issue #374: `interface install_packages` / `plan_install` silently
+# exits 1 (no error event on the NDJSON wire) when a project configures
+# >=2 index_repos and one of them is degenerate (no pkgs/).
+#
+# Two independent architectural defects combine to produce the bug:
+#
+#   Root defect 1 (observability): the xim command layer reports failures
+#   via the global log::error(), which is fully suppressed in interface
+#   mode (platform::set_tui_mode(true)). The NDJSON stream carries a
+#   first-class ErrorEvent kind, but cmd_install never emits it — so a
+#   non-zero exit produces {"exitCode":1,"kind":"result"} with an empty
+#   event stream. The consumer (mcpp) cannot tell what failed.
+#
+#   Root defect 2 (multi-repo robustness): PackageCatalog::rebuild() and
+#   sync_all_repos() fail-fast on the first bad repo, so one degenerate
+#   index_repo collapses the whole catalog — even the healthy repos.
+#
+# Assertions (design doc §6):
+#   A1 (P1 best-effort skip): 2 project repos, 2nd has no pkgs/, target
+#      resolves in the HEALTHY repo → exit 0, install_plan emitted, AND a
+#      wire event naming the skipped bad repo (not silently ignored).
+#   A2 (P0 invariant + structured error): 2 project repos, target absent
+#      everywhere → NON-ZERO exit AND at least one {"kind":"error"} event
+#      on the wire (never a bare result envelope).
+#
+# Refs: .agents/docs/2026-07-19-issue374-multi-repo-silent-exit-design.md
+
+set -euo pipefail
+
+# shellcheck source=./project_test_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
+
+require_fixture_index
+
+RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/interface_multi_repo_error_visibility"
+HOME_DIR="$RUNTIME_DIR/home"
+APP_DIR="$RUNTIME_DIR/app"          # the "project" dir (has .xlings.json, NOT an xlings home)
+GOOD_DIR="$RUNTIME_DIR/proj_good"   # a valid project index (has pkgs/)
+BAD_DIR="$RUNTIME_DIR/proj_bad"     # degenerate: dir exists but no pkgs/
+
+cleanup() { rm -rf "$RUNTIME_DIR"; }
+trap cleanup EXIT
+cleanup
+
+XLINGS_BIN="$(find_xlings_bin)"
+
+mkdir -p "$HOME_DIR/subos/default/bin" "$APP_DIR" "$GOOD_DIR/pkgs/t" "$BAD_DIR"
+
+# ── a VALID project index with one package "toolx" (script type, no
+#    download — plan_install only resolves, never installs) ───────────
+cat > "$GOOD_DIR/pkgs/t/toolx.lua" <<'LUA'
+package = {
+    spec = "1",
+    name = "toolx",
+    description = "Test fixture: healthy project-repo package (issue #374 coverage)",
+    type = "package",
+    archs = {"x86_64", "aarch64"},
+    status = "stable",
+    xpm = {
+        linux   = { ["latest"] = { ref = "1.0.0" }, ["1.0.0"] = {} },
+        macosx  = { ["latest"] = { ref = "1.0.0" }, ["1.0.0"] = {} },
+        windows = { ["latest"] = { ref = "1.0.0" }, ["1.0.0"] = {} },
+    },
+}
+function install() return true end
+LUA
+
+# ── the DEGENERATE project index: exists, but NO pkgs/ (models a
+#    default-namespace redirect / empty local-dev repo) ───────────────
+printf 'placeholder — deliberately no pkgs/ subdir\n' > "$BAD_DIR/README.md"
+
+# ── global home: xim namespace -> local fixture (offline), sub-indexes
+#    neutralised so nothing reaches the network ────────────────────────
+cat > "$HOME_DIR/.xlings.json" <<JSON
+{
+  "activeSubos": "default",
+  "mirror": "GLOBAL",
+  "subos": {"default": {"dir": ""}},
+  "index_repos": [
+    {"name": "xim", "url": "$FIXTURE_INDEX_DIR"}
+  ]
+}
+JSON
+
+RUN_HOME() {
+  ( cd /tmp && env -i HOME="$HOME" USER="${USER:-ci}" SHELL="${SHELL:-/bin/sh}" \
+      PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" XLINGS_INDEX_SOURCE=git \
+      "$XLINGS_BIN" "$@" )
+}
+RUN_PROJ() {
+  ( cd "$APP_DIR" && env -i HOME="$HOME" USER="${USER:-ci}" SHELL="${SHELL:-/bin/sh}" \
+      PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" XLINGS_INDEX_SOURCE=git \
+      "$XLINGS_BIN" "$@" )
+}
+
+RUN_HOME self init >/dev/null 2>&1 || fail "self init failed"
+mkdir -p "$HOME_DIR/data/xim-index-repos"
+printf '{}\n' > "$HOME_DIR/data/xim-index-repos/xim-indexrepos.json"
+printf 'xim_indexrepos = {}\n' > "$FIXTURE_INDEX_DIR/xim-indexrepos.lua" 2>/dev/null || true
+
+# project manifest: TWO index_repos, the 2nd (projbad) is degenerate
+cat > "$APP_DIR/.xlings.json" <<JSON
+{
+  "index_repos": [
+    {"name": "projgood", "url": "$GOOD_DIR"},
+    {"name": "projbad",  "url": "$BAD_DIR"}
+  ]
+}
+JSON
+
+# ════════════════════════════════════════════════════════════════════
+# A1: healthy target resolves despite a broken sibling repo (P1),
+#     and the skipped repo is surfaced on the wire (not silent).
+# ════════════════════════════════════════════════════════════════════
+log "A1: plan_install toolx with 2 project repos (2nd degenerate) → exit 0 + skip surfaced"
+
+set +e
+out_a1="$(RUN_PROJ interface plan_install --args '{"targets":["toolx"]}' 2>/dev/null)"
+rc_a1=$?
+set -e
+echo "$out_a1" | sed 's/^/    /'
+
+[[ "$rc_a1" -eq 0 ]] \
+  || fail "A1: expected exit 0 (healthy repo should still resolve), got $rc_a1
+$out_a1"
+echo "$out_a1" | grep -q '"dataKind":"install_plan"' \
+  || fail "A1: no install_plan event — toolx did not resolve from the healthy repo
+$out_a1"
+echo "$out_a1" | grep -q 'projbad' \
+  || fail "A1: the skipped bad repo 'projbad' is NOT surfaced on the wire (silent skip)
+$out_a1"
+log "  ✓ A1: exit 0, toolx planned, projbad skip surfaced on wire"
+
+# ════════════════════════════════════════════════════════════════════
+# A2: genuinely-missing target → non-zero exit MUST carry a structured
+#     error event on the wire (the core issue #374 invariant).
+# ════════════════════════════════════════════════════════════════════
+log "A2: plan_install <missing> with 2 project repos → non-zero + {\"kind\":\"error\"} on wire"
+
+set +e
+out_a2="$(RUN_PROJ interface plan_install --args '{"targets":["nonexistent-pkg-zzz"]}' 2>/dev/null)"
+rc_a2=$?
+set -e
+echo "$out_a2" | sed 's/^/    /'
+
+[[ "$rc_a2" -ne 0 ]] \
+  || fail "A2: expected non-zero exit for a missing package, got $rc_a2
+$out_a2"
+echo "$out_a2" | grep -q '"kind":"error"' \
+  || fail "A2: non-zero exit produced NO {\"kind\":\"error\"} event — this is the issue #374 silent failure
+$out_a2"
+log "  ✓ A2: non-zero exit carries a structured error event"
+
+# Also exercise the destructive install_packages capability (the exact
+# entry point mcpp uses) on the missing target — same invariant.
+log "A2b: install_packages <missing> → non-zero + structured error"
+set +e
+out_a2b="$(RUN_PROJ interface install_packages \
+            --args '{"targets":["nonexistent-pkg-zzz"],"yes":true}' 2>/dev/null)"
+rc_a2b=$?
+set -e
+[[ "$rc_a2b" -ne 0 ]] \
+  || fail "A2b: install_packages missing target exit was $rc_a2b, expected non-zero
+$out_a2b"
+echo "$out_a2b" | grep -q '"kind":"error"' \
+  || fail "A2b: install_packages non-zero exit produced NO structured error event
+$out_a2b"
+log "  ✓ A2b: install_packages non-zero exit carries a structured error event"
+
+log "PASS: issue #374 multi-repo error visibility covered"

--- a/tests/e2e/run_all.sh
+++ b/tests/e2e/run_all.sh
@@ -78,6 +78,7 @@ TESTS=(
     "E2E-26 |subos_sandbox_gpu_test.sh||"
     "E2E-27 |install_silent_failure_test.sh||"
     "E2E-28 |shim_owner_anchoring_test.sh||"
+    "E2E-29 |interface_multi_repo_error_visibility_test.sh||"
 )
 
 PASS=0; FAIL=0; SOFTFAIL=0

--- a/tests/unit/test_interface_protocol.cpp
+++ b/tests/unit/test_interface_protocol.cpp
@@ -548,18 +548,32 @@ TEST(InterfaceProtocol, RemoveRepoNonexistentEmitsNotFound) {
 
 // ─── plan_install (dry-run) ────────────────────────────────
 
-TEST(InterfaceProtocol, PlanInstallEmitsInstallPlanWithoutSideEffects) {
+TEST(InterfaceProtocol, PlanInstallMissingPackageEmitsStructuredError) {
     auto home = make_sandbox_home_();
 
-    // plan_install for a nonexistent package should still emit a result;
-    // the catalog won't be loaded in a fresh sandbox so resolution exits 1
-    // — that is itself a useful preflight signal for clients. Just verify
-    // the capability is dispatched and produces NDJSON.
+    // #374: plan_install for a resolution that fails (catalog not loadable in
+    // a fresh sandbox, or the explicit-namespace package genuinely absent)
+    // must exit non-zero AND carry a structured error on the wire — never a
+    // bare {"exitCode":1,"kind":"result"} with an empty stream. Both failure
+    // paths map to E_NOT_FOUND. This is the core regression guarantee for the
+    // multi-repo silent-exit bug (mcpp consumed the empty envelope as an
+    // opaque failure).
     auto [out, _rc] = run_xlings_({"interface", "plan_install", "--args",
         R"({"targets":["xim:nonexistent_pkg_xyz"]})"}, home);
     auto events = parse_ndjson_(out);
     ASSERT_FALSE(events.empty()) << out;
     EXPECT_EQ(events.back().value("kind", ""), "result");
+    EXPECT_NE(events.back().value("exitCode", 0), 0) << out;
+
+    bool saw_err = false;
+    for (auto& e : events) {
+        if (e.value("kind", "") == "error") {
+            EXPECT_EQ(e.value("code", std::string{}), "E_NOT_FOUND") << out;
+            saw_err = true;
+        }
+    }
+    EXPECT_TRUE(saw_err)
+        << "non-zero plan_install exit produced no error event (issue #374): " << out;
 
     std::filesystem::remove_all(home);
 }


### PR DESCRIPTION
Fixes #374.

## Symptom

`xlings interface install_packages` / `plan_install` exited **1 with an empty NDJSON stream** whenever a project configured **≥2 `index_repos`** and one of them was degenerate (no `pkgs/`, unreachable URL, empty default-namespace redirect target). Consumers (mcpp, mcpp-community/mcpp#238) saw only:

```json
{"exitCode":1,"kind":"result"}
```

…with zero diagnostics. Single-repo configs worked. Reproduced with a clean single-vs-double comparison (see design doc §3).

## Two root causes (architectural)

1. **Observability gap** — the xim command layer reported failures via the global `log::error()`, which interface mode (`platform::set_tui_mode(true)`) **fully suppresses** (not even stderr). The NDJSON protocol already has a first-class `ErrorEvent` kind that `subos.cppm` uses — `cmd_install` just never did. This affected *every* exit-1 path, not only multi-repo.
2. **Multi-repo all-or-nothing** — `PackageCatalog::rebuild()` and `sync_all_repos()` fail-fast on the first bad repo, so one degenerate `index_repo` collapsed the whole catalog (healthy repos included). Sub-index repos were already best-effort right next to the fatal project-repo path.

## Fix

- **P0 (observability):** `cmd_install` emits a structured `ErrorEvent` (code + hint + searched-repos) at every resolve/build/plan/install failure point instead of a swallowed `log::error`. `interface::run` adds a **backstop invariant**: a non-zero exit that emitted no `ErrorEvent` synthesizes one, so the stream is never empty on failure.
- **P1 (robustness):** `catalog.rebuild()` and `sync_all_repos()` are **best-effort** — a repo that can't load/sync is skipped and recorded, the rest keep working, and the skip is surfaced on the wire as a `warn` `LogEvent`. `rebuild` hard-fails only when *nothing* loaded. Mirrors the existing sub-index precedent.

Result for the reported scenario: healthy repos still resolve packages (exit 0) and the skipped repo is visible on the wire; genuinely-missing targets exit non-zero **with** a structured `E_NOT_FOUND` error naming the searched repos.

## Verification

- New e2e **E2E-29** `interface_multi_repo_error_visibility_test.sh`:
  - **A1** healthy target resolves despite a broken sibling repo → exit 0 + skip surfaced on wire.
  - **A2 / A2b** missing target → non-zero exit **and** `{"kind":"error"}` on the wire (both `plan_install` and `install_packages`).
- **RED** on 0.4.66 (silent `{"exitCode":1}`), **GREEN** on 0.4.67.
- `mcpp test`: **11/11** unit binaries pass (incl. `test_interface_protocol`).
- Offline e2e subset (install/index/resolve/error paths): no regressions.

Bumps version **0.4.66 → 0.4.67**.

Design doc: `.agents/docs/2026-07-19-issue374-multi-repo-silent-exit-design.md`