### PR TITLE
fix(xvm/shim): dedupe shim-injected env values (GIT_SSL_CAINFO x:x corruption)

### DIFF
--- a/src/core/xvm/shim.cppm
+++ b/src/core/xvm/shim.cppm
@@ -267,6 +267,29 @@ std::filesystem::path resolve_executable(const std::string& program_name,
     return {};
 }
 
+// Merge a shim-injected env value into the existing one. PATH-style vars
+// prepend (new first), but a value already present — as the whole value or as
+// one separator-delimited component — must NOT be appended again: the blind
+// re-append corrupted single-value vars (GIT_SSL_CAINFO="x" became "x:x",
+// which curl reads as one nonexistent filename and every HTTPS git transport
+// dies; hit when both compact::git's CA pin (#378) and the xim git.lua envs
+// (xim-pkgindex#406) resolve the same bundle path). Returns the value to set,
+// or nullopt for "leave the env untouched".
+std::optional<std::string> merge_shim_env_value(const std::string& expanded,
+                                                const std::string& existing) {
+    if (existing.empty()) return expanded;
+    std::size_t start = 0;
+    while (start <= existing.size()) {
+        auto end = existing.find(platform::PATH_SEPARATOR, start);
+        auto part = existing.substr(start, end == std::string::npos
+                                           ? std::string::npos : end - start);
+        if (part == expanded) return std::nullopt;  // already present
+        if (end == std::string::npos) break;
+        start = end + 1;
+    }
+    return expanded + platform::PATH_SEPARATOR + existing;
+}
+
 // Set environment variables for a program before exec
 void setup_envs(const VData& vdata,
                 const std::string& resolved_path,
@@ -274,12 +297,9 @@ void setup_envs(const VData& vdata,
     // Set envs from VData
     for (auto& [key, value] : vdata.envs) {
         auto expanded = expand_path(value, xlings_home);
-        // Append to existing env if it exists (PATH-style)
         auto existing = std::string(std::getenv(key.c_str()) ? std::getenv(key.c_str()) : "");
-        if (!existing.empty()) {
-            expanded = expanded + platform::PATH_SEPARATOR + existing;
-        }
-        platform::set_env_variable(key, expanded);
+        if (auto merged = merge_shim_env_value(expanded, existing))
+            platform::set_env_variable(key, *merged);
     }
 
     // Prepend resolved program's directory to PATH

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -1883,6 +1883,32 @@ TEST(XvmJsonTest, FullConfigJsonRoundTrip) {
 // xvm shim tests
 // ============================================================
 
+// ── shim env merge: scalar vars must not be blindly PATH-appended (#378) ──
+TEST(XvmShimEnvTest, EmptyExistingUsesExpanded) {
+    auto v = xlings::xvm::merge_shim_env_value("/etc/ssl/certs/ca.crt", "");
+    ASSERT_TRUE(v.has_value());
+    EXPECT_EQ(*v, "/etc/ssl/certs/ca.crt");
+}
+
+TEST(XvmShimEnvTest, IdenticalExistingIsNoop) {
+    // Both the caller (compact::git CA pin) and the shim's lua envs resolve
+    // the same path; re-appending would corrupt it into "x:x".
+    auto v = xlings::xvm::merge_shim_env_value("/etc/ssl/certs/ca.crt",
+                                               "/etc/ssl/certs/ca.crt");
+    EXPECT_FALSE(v.has_value());
+}
+
+TEST(XvmShimEnvTest, ComponentAlreadyPresentIsNoop) {
+    std::string existing = std::string("/a/lib") + xlings::platform::PATH_SEPARATOR + "/b/lib";
+    EXPECT_FALSE(xlings::xvm::merge_shim_env_value("/b/lib", existing).has_value());
+}
+
+TEST(XvmShimEnvTest, NewComponentPrepends) {
+    auto v = xlings::xvm::merge_shim_env_value("/new/lib", "/old/lib");
+    ASSERT_TRUE(v.has_value());
+    EXPECT_EQ(*v, std::string("/new/lib") + xlings::platform::PATH_SEPARATOR + "/old/lib");
+}
+
 TEST(XvmShimTest, ExtractProgramName) {
     EXPECT_EQ(xlings::xvm::extract_program_name("/usr/bin/gcc"), "gcc");
     EXPECT_EQ(xlings::xvm::extract_program_name("./gcc"), "gcc");


### PR DESCRIPTION
Found during #379's real-machine verification: `setup_envs` blindly PATH-appends every vdata env into the existing value. When both compact::git's CA pin (#378, just merged) and the xim git.lua envs (xim-pkgindex#406) resolve the same bundle path, `GIT_SSL_CAINFO` becomes `/etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt` — curl reads that as ONE nonexistent filename and every HTTPS git transport dies with `error adding trust anchors`. Same corruption hits any user with `GIT_SSL_CAINFO` already exported.

Fix: extract `merge_shim_env_value(expanded, existing)` (pure, unit-tested) — keep the PATH-style prepend for genuinely new components, but no-op when the value is already present (whole value or separator-delimited component).

Verified end-to-end on this Debian-layout host (no `/etc/ssl/cert.pem`): `GIT_SSL_CAINFO=<bundle> git ls-remote https://github.com/...` fails with `x:x` through the released shim, succeeds through the patched one; full `xlings update` of a `source:"git"` custom repo with `env -u GIT_SSL_CAINFO` + compact CA pin + shim git: sync OK.

Follow-up to #379 (release 0.4.68 was cancelled before publishing to include this).