### PR TITLE
feat(xvm): add provider-scoped binding group registration

### DIFF
--- a/.agents/docs/2026-07-26-xvm-provider-binding-group-design.md
+++ b/.agents/docs/2026-07-26-xvm-provider-binding-group-design.md
@@ -1,0 +1,544 @@
+# XVM Provider-Scoped Binding Group Design
+
+> Date: 2026-07-26
+> Status: approved for implementation
+> Target release: xlings 0.4.70
+> Related repositories: `openxlings/libxpkg`, `openxlings/xim-pkgindex`
+
+## TL;DR
+
+`xlings use` must switch a package release's binding group, not one flat
+`target -> version` entry at a time.
+
+The existing graph already intends to provide this behavior, but it has no
+release ownership, permits dangling edges, removes versionless sibling targets
+wholesale, and applies libraries/headers outside the graph transaction. The
+result is the observed state where `gcc` has four versions, `g++` has only one,
+and an attempted switch can write a nonexistent `g++` version into the active
+workspace.
+
+The new contract is:
+
+1. every registered target version records its canonical package provider and
+   release;
+2. every explicit binding component has a stable provider-scoped group id;
+3. `use` resolves and validates the complete group before any mutation;
+4. program workspace entries, libraries, headers, and shims are applied from
+   the same immutable switch plan;
+5. uninstall removes exact provider-owned versions and reciprocal edges;
+6. legacy graphs remain readable, but invalid legacy state fails closed and is
+   repaired by re-running the owning package's config/install path in an
+   isolated or user-selected home.
+
+This preserves multiple providers for the same target (`gcc`, `cc`, `npm`,
+`libatomic.so.1`) and member-specific version keys (`15.1.0`,
+`gcc-15.1.0`, `node-22.17.1`) without inferring ownership from names.
+
+## 1. User-visible requirements
+
+### 1.1 Required behavior
+
+- `xlings use gcc 15` switches every member of the selected GCC binding group,
+  including `g++`, `c++`, `cc`, GCC tools, and registered libraries.
+- `xlings use g++ 15` performs the same switch in reverse: any member is a
+  valid group entry point.
+- `xlings use g++` lists every installed `g++` version in the current SubOS,
+  not only the version most recently re-registered.
+- A library target can be used as an entry point when it is registered in a
+  group; its real SubOS library view changes together with program members.
+- Switching in one SubOS does not alter another SubOS's workspace or materialized
+  library/header view.
+- A corrupt or ambiguous group never causes a partial switch.
+
+### 1.2 Compatibility requirements
+
+- Existing valid `VInfo.bindings` JSON remains readable and switchable.
+- Old xlings binaries can still read the primary `versions` data written by the
+  new release; the legacy bidirectional edge representation remains serialized
+  during the transition.
+- Namespaced version keys continue to work.
+- A group may map different target version strings for one package release.
+- One package may expose multiple independent binding groups.
+- One target name may be supplied by multiple packages, provided the concrete
+  target version keys do not collide.
+
+### 1.3 Safety requirements
+
+- Tests and live verification must use temporary `XLINGS_HOME`, `HOME`, and
+  SubOS roots. They must never execute install/remove/use against the host
+  xlings home.
+- Versionless sibling removal must never erase all versions.
+- A failed plan must leave workspace JSON, shims, libraries, and headers
+  unchanged.
+- Config JSON writes use same-directory staging plus atomic replacement.
+
+## 2. Confirmed failure mechanism
+
+The current database has two independent state layers:
+
+```text
+global VersionDB:
+  target -> VInfo {
+    versions[targetVersion] -> VData
+    bindings[peer][thisVersion] -> peerVersion
+  }
+
+per-SubOS workspace:
+  target -> { active, installed[] }
+```
+
+`add_version()` creates both sides of a binding edge, but:
+
+- it creates a missing peer through `db[peer]`, producing placeholder nodes;
+- it does not require the peer version to exist;
+- `remove_version()` removes only `VData`, never reciprocal edges;
+- uninstall falls back to the outer package version only when
+  `op.name == detachTarget`;
+- a versionless sibling op executes `db.erase(op.name)` and returns before
+  `installed[]` cleanup.
+
+GCC's recipe emits versionless removes for ordinary programs, the virtual root,
+and `cc`. Removing one GCC release can therefore erase every `g++` and root
+version, while the requested `gcc` release alone is removed exactly. Reinstalling
+16 reconstructs only the 16 component. Stale edges and `installed[]` entries
+remain.
+
+The current `cmd_use()` then:
+
+1. changes headers/libs for the starting target only;
+2. recursively follows whatever edges remain;
+3. does not verify that a reached `(target, version)` has `VData`;
+4. writes every reached pair to workspace.
+
+This explains both observed modes:
+
+- `gcc@15 -> root@15` stops at the damaged root, so `g++` remains 16;
+- another flavor reaches `g++@15-musl` through a stale edge, writes it active,
+  and the shim later fails because only `g++@16` exists.
+
+## 3. Ecosystem constraints discovered by audit
+
+The official index currently contains 37 recipes with explicit bindings.
+
+- There are no real multi-level trees; valid components are stars.
+- Some packages expose multiple stars.
+- Member versions often differ from root versions:
+  `gcc-<v>`, `glibc-<v>`, `node-<v>`, `openssl-<v>`,
+  `python-<v>`, and flavor-suffixed GCC versions.
+- The same alias is intentionally supplied by multiple providers:
+  GCC/LLVM/musl/mingw for compiler names, binutils/LLVM for tools,
+  Node/standalone npm for `npm`, and multiple packages for shared libraries.
+- Current recipe defects include:
+  - e2fsprogs root registered after members;
+  - syslinux self-binding;
+  - musl and aarch64 flavor roots registered under a different version than
+    their members reference;
+  - openssl registering the same exact target/version twice;
+  - several declared sibling executables left outside the intended group.
+
+Therefore neither `target` nor a version naming convention is a safe owner
+identity. Registration must receive provider identity from the resolved
+`PlanNode`.
+
+## 4. Alternatives considered
+
+### A. Patch traversal and versionless removal only
+
+Add missing edge cleanup, infer sibling versions, and validate `cmd_use`.
+
+This is necessary compatibility work but insufficient architecture: ownership
+remains implicit, alias collisions are ambiguous, and another malformed recipe
+can recreate the same class of corruption.
+
+### B. Provider-scoped binding groups with legacy graph compatibility
+
+Add provider/group metadata to each `VData`, build a production switch plan,
+retain validated legacy bindings for downgrade and migration, and make removal
+provider-aware.
+
+This is the selected design. It fixes the present failure without replacing
+shim dispatch or the entire VersionDB and provides a migration path for existing
+homes.
+
+### C. Replace VersionDB with a separate normalized bundle database
+
+Store packages, releases, members, providers, and active selections in new
+tables and migrate all consumers at once.
+
+This is theoretically cleaner but unnecessarily risks shim dispatch,
+project-mode overrides, SubOS ref-counting, and cross-platform release paths.
+Option B establishes the same identity and transaction boundaries incrementally;
+a future normalized store can consume those explicit identities.
+
+## 5. Data model
+
+### 5.1 Provider and group identity
+
+`VData` gains optional, backward-compatible group metadata:
+
+```cpp
+struct BindingGroupRef {
+    std::string provider;         // canonical package name, including namespace
+    std::string providerVersion;  // resolved package release version
+    std::string group;            // stable label inside that provider release
+    std::string rootTarget;        // exact manifest-bearing target
+    std::string rootVersion;       // exact manifest-bearing target version
+};
+
+struct VData {
+    // existing fields...
+    std::optional<BindingGroupRef> bindingGroup;
+    // Populated only on bindingGroup.rootTarget@rootVersion.
+    std::map<std::string, std::string> bindingMembers;
+};
+```
+
+Every member stores the same `BindingGroupRef`. The exact root additionally
+stores the complete member manifest. This is intentionally more than an owner
+tag: scanning only surviving `VData` cannot detect that a member was deleted,
+whereas a manifest makes both a missing root and a missing member observable.
+
+Root JSON shape:
+
+```json
+{
+  "path": ".../gcc/15.1.0",
+  "bindingGroup": {
+    "provider": "xim:gcc",
+    "version": "15.1.0",
+    "group": "xim-gnu-gcc",
+    "rootTarget": "xim-gnu-gcc",
+    "rootVersion": "15.1.0"
+  },
+  "bindingMembers": {
+    "xim-gnu-gcc": "15.1.0",
+    "gcc": "15.1.0",
+    "g++": "15.1.0",
+    "gcc-ar": "gcc-15.1.0",
+    "libstdc++.so.6": "gcc-15.1.0"
+  }
+}
+```
+
+The identity tuple is:
+
+```text
+(provider, providerVersion, group)
+```
+
+It is independent of:
+
+- target name (`gcc`, `g++`, `libstdc++.so.6`);
+- member version key (`15.1.0`, `gcc-15.1.0`);
+- package-index alias;
+- `VData.alias`, which remains an execution command/argument mapping.
+
+### 5.2 Group assignment
+
+Registration processes one config hook's XVM operations as a batch:
+
+1. materialize every add node without edges;
+2. reject duplicate exact `(target, version, provider)` writes;
+3. build components from structured/legacy binding references;
+4. validate every referenced exact root after all nodes exist;
+5. assign each component a stable group label:
+   - explicit `group` from a future/new libxpkg operation wins;
+   - otherwise the component's binding-root target is used;
+   - an unbound node forms a single-node group named after its target;
+6. choose one exact root, write its full member manifest, write the same root
+   reference to every member, and retain compatible bidirectional bindings.
+
+Batching removes the current order dependency while still rejecting phantom
+roots, self-bindings, conflicting target versions in one group, and
+cross-provider binding references.
+
+### 5.3 Canonical group manifest
+
+The canonical member set is the exact root's persisted `bindingMembers` map.
+Resolution validates:
+
+- the referenced root VData exists;
+- the root reference points to itself;
+- root provider/version/group matches the member reference;
+- every manifest member VData exists and points back to the same root;
+- the starting member occurs in the manifest under its requested version;
+- no target is assigned more than one version.
+
+The serialized `VInfo.bindings` map is compatibility metadata, not the canonical
+source for provider-aware entries. A missing member is therefore a hard
+integrity error rather than a silently smaller group.
+
+For legacy entries without owner metadata, the resolver uses a strictly
+validated binding graph.
+
+## 6. Switch architecture
+
+### 6.1 Pure planning
+
+A new production helper returns either a complete plan or structured errors:
+
+```cpp
+struct BindingSelection {
+    std::map<std::string, std::string> members;
+    BindingSource source; // ProviderGroup | LegacyGraph
+};
+
+std::expected<BindingSelection, BindingError>
+resolve_binding_selection(const VersionDB&, target, version);
+```
+
+Provider-group resolution:
+
+- reads the start `VData.bindingGroup`;
+- loads the exact root's persisted member manifest;
+- validates every member and its back-reference;
+- verifies one version per target and supported target types.
+
+Legacy resolution:
+
+- traverses by `(target, version)`, not target alone;
+- verifies source and destination VData;
+- verifies the reciprocal edge;
+- rejects a cycle only when it produces a conflicting target version;
+- rejects asymmetric, dangling, or conflicting paths.
+
+No filesystem or Config mutation occurs during planning.
+
+### 6.2 Preflight and apply
+
+`cmd_use()` becomes:
+
+```text
+resolve requested member version
+    -> build BindingSelection
+    -> preflight every program/lib/header source
+    -> stage materialized-view changes
+    -> update an in-memory workspace copy for every member
+    -> atomically persist workspace once
+    -> finalize staged views / ensure generic shims
+```
+
+The command-level guarantee is all-or-nothing for expected errors. Staged
+filesystem operations retain rollback information. Workspace JSON is written
+through a same-directory temporary file and atomic rename/replace.
+
+Full crash-atomicity across JSON plus many independent header/library paths
+would require a generation-based sysroot; that is outside this release. A crash
+journal/generation design remains a possible follow-up. The current release
+does not claim stronger durability than it implements.
+
+### 6.3 Programs and shims
+
+Program shims are version-independent xlings launchers. Installation creates
+them; `use` only ensures missing shims exist after successful preflight. Version
+selection is entirely the committed workspace map.
+
+### 6.4 Libraries
+
+For every selected `type == "lib"` member:
+
+- source is `VData.path / (VInfo.filename or target)`;
+- destination is the active SubOS library directory;
+- the old selected member's file is removed only if it is owned by that target;
+- the new file is linked/copied through the existing cross-platform link
+  abstraction;
+- failures roll back before workspace commit.
+
+Installing an additional version without `--use` must not silently repoint an
+already-active library.
+
+### 6.5 Headers
+
+Header directories recorded in selected members are switched for the whole
+selection, not only the CLI starting target. The old view is removed and the new
+view staged before commit. Existing recipes that manage headers themselves keep
+working; group-managed headers use the common materializer.
+
+### 6.6 Installed sets and listing
+
+Every registered member type, including binding roots and libraries, is added to
+the current SubOS `installed[]` set. Therefore:
+
+- `xlings use <program>` lists all locally installed member versions;
+- `xlings use <lib>` can list and select library versions;
+- switching a globally available group into a fresh SubOS atomically adds every
+  selected member to that SubOS's installed sets.
+
+## 7. Removal architecture
+
+### 7.1 Provider-aware removal
+
+When uninstalling a resolved package release, xlings knows its canonical
+provider and version from `PlanNode`/catalog resolution. Before mutating state it
+collects and validates every group manifest owned by that provider release.
+
+Those exact target versions are authoritative. Recipe `xvm.remove` operations
+are validated against them but do not define ownership.
+
+Removal:
+
+- deletes only exact owned versions;
+- removes both sides of all binding edges for those exact versions;
+- prunes empty binding maps and empty target entries;
+- updates `installed[]`;
+- removes a shim only when no usable program version remains;
+- switches an active group to a complete surviving group when possible,
+  otherwise clears all removed members coherently;
+- rematerializes libraries/headers for the fallback group.
+
+### 7.2 Legacy versionless operations
+
+For old provider-less entries, uninstall snapshots the validated legacy
+selection before deletion and maps each versionless sibling op through that
+selection.
+
+If no unique exact version can be derived, uninstall fails before mutation.
+The old `db.erase(op.name)` fallback is removed. Deliberate all-version removal
+must use an explicit API/operation.
+
+## 8. Legacy integrity and repair
+
+### 8.1 Read compatibility
+
+Entries without group metadata are legacy. Valid legacy groups continue to
+switch through strict graph validation.
+
+### 8.2 Invalid legacy state
+
+If validation finds a dangling/asymmetric/conflicting graph:
+
+- `use` exits nonzero;
+- no workspace or filesystem state changes;
+- the diagnostic names the exact invalid pair;
+- it recommends re-running the owning package/version install/config when that
+  owner can be inferred, otherwise reports the affected targets.
+
+Re-running an already-installed package config writes group references and
+manifests and rebuilds compatible edges without re-downloading a valid payload.
+
+### 8.3 Doctor integration
+
+`xlings self doctor` gains XVM checks for:
+
+- active/installed versions missing from VersionDB;
+- dangling/asymmetric legacy edges;
+- provider group conflicts;
+- missing program/library payloads.
+
+`--fix` may repair mechanical metadata and generic shims, but must not execute
+package hooks or download payloads. Missing registrations receive explicit
+install/reconfigure guidance.
+
+## 9. Cross-repository contract
+
+### 9.1 libxpkg
+
+The Lua operation API becomes symmetric:
+
+- `xvm.add(name, opt)` and `xvm.remove(name, version)` both default to the
+  current runtime package version;
+- `xvm.remove_all(name)` is the only explicit all-version operation;
+- `xvm.setup()` propagates its resolved version to root, programs, and libs;
+- `xvm.teardown()` removes the same exact version;
+- a structured optional group label can be transported without parsing target
+  ownership from strings.
+
+The current official index does not call `setup/teardown`, so direct operation
+tests are required.
+
+### 9.2 xim-pkgindex
+
+The GCC-family and audited malformed recipes are corrected:
+
+- exact add/remove root versions;
+- no self-binding;
+- no phantom root;
+- no duplicate exact registration;
+- intended siblings included in their group;
+- explicit versions on teardown.
+
+These recipe changes remain compatible with the previous xlings release, so
+they can merge before the stricter validator.
+
+## 10. Test strategy
+
+### 10.1 Unit tests
+
+- owner JSON round trip and legacy JSON compatibility;
+- provider-group planning from root and leaf;
+- different root/member versions;
+- multiple groups per provider and multiple providers per target;
+- namespace handling;
+- valid legacy cycles;
+- missing VData, asymmetric edge, conflicting target version;
+- exact version removal and reciprocal edge cleanup;
+- no mutation on plan/preflight failure;
+- library/header materialization and rollback.
+
+Tests call production helpers. The existing copied traversal lambda is removed.
+
+### 10.2 Hermetic E2E
+
+A two-version GCC-like fixture contains:
+
+- package/root target;
+- two executable members with real shims;
+- a transformed member version;
+- a library file;
+- a header file;
+- versionless legacy teardown operations.
+
+Scenarios:
+
+1. install v1 and v2;
+2. list from a non-package executable;
+3. switch root -> v1 and execute every shim;
+4. switch leaf -> v2 and execute every shim;
+5. switch from a library target;
+6. verify workspace, installed sets, library, and header views;
+7. corrupt one peer and prove the failed switch changes nothing;
+8. remove non-active v1 and preserve v2;
+9. remove active v2 and apply a coherent fallback;
+10. run different selections in two SubOS instances.
+
+Shell coverage runs on Linux and macOS. PowerShell coverage runs on Windows and
+executes real `.exe` shims; file content is used where Windows symlink privilege
+is unavailable.
+
+### 10.3 Live isolated GCC verification
+
+On Linux, use a temporary xlings home and the modified local package index:
+
+```text
+install gcc@15.1.0
+install gcc@16.1.0
+use gcc 15
+execute gcc and g++
+use g++ 16
+execute gcc and g++
+verify registered lib links
+remove one version
+repeat both directions
+```
+
+The host `.xlings.json`, host SubOS workspace, and host shims are hashed before
+and after to prove they were untouched.
+
+## 11. Rollout and success gates
+
+1. Merge compatible recipe corrections.
+2. Land/release the libxpkg operation-contract fix.
+3. Land xlings 0.4.70 with provider metadata, strict planner, materializer, and
+   legacy fallback.
+4. Keep writing legacy edges through at least the next minor compatibility
+   window.
+5. Consider removing legacy traversal only after field migration evidence.
+
+Completion requires:
+
+- xlings unit tests pass with GCC 16;
+- hermetic Linux/macOS/Windows E2E passes;
+- isolated real GCC 15/16 bidirectional switching passes;
+- libxpkg and pkgindex tests pass;
+- every PR's required CI checks are green;
+- no host xlings state changes.

--- a/.agents/docs/2026-07-26-xvm-provider-binding-group-design.md
+++ b/.agents/docs/2026-07-26-xvm-provider-binding-group-design.md
@@ -186,10 +186,14 @@ struct BindingGroupRef {
 };
 
 struct VData {
-    // existing fields...
+    // Existing per-version fields: path, alias, envs, includedir/libdir.
+    std::string kind;             // program | lib | group
+    std::string sourceName;       // payload entry; empty for group
+    std::string destinationName;  // shim/sysroot name
     std::optional<BindingGroupRef> bindingGroup;
     // Populated only on bindingGroup.rootTarget@rootVersion.
     std::map<std::string, std::string> bindingMembers;
+    std::vector<HeaderAsset> bindingHeaders; // populated on the exact root
 };
 ```
 
@@ -197,12 +201,17 @@ Every member stores the same `BindingGroupRef`. The exact root additionally
 stores the complete member manifest. This is intentionally more than an owner
 tag: scanning only surviving `VData` cannot detect that a member was deleted,
 whereas a manifest makes both a missing root and a missing member observable.
+`kind`, source, and destination are deliberately version-scoped. The legacy
+`VInfo.type` and `VInfo.filename` fields remain read fallbacks only: target-level
+metadata cannot represent two providers whose same target has different kinds
+or filenames.
 
 Root JSON shape:
 
 ```json
 {
   "path": ".../gcc/15.1.0",
+  "kind": "group",
   "bindingGroup": {
     "provider": "xim:gcc",
     "version": "15.1.0",
@@ -248,6 +257,16 @@ Registration processes one config hook's XVM operations as a batch:
 6. choose one exact root, write its full member manifest, write the same root
    reference to every member, and retain compatible bidirectional bindings.
 
+Batch processing also defines safe reconfiguration:
+
+- an exact registration owned by the same provider release is an idempotent
+  upsert;
+- an owner-less legacy exact node can be adopted only when its payload metadata
+  matches the current package registration;
+- an exact node owned by another provider is a conflict and fails closed;
+- old edges/manifests are replaced only for exact nodes in the validated batch,
+  never by target-wide erase.
+
 Batching removes the current order dependency while still rejecting phantom
 roots, self-bindings, conflicting target versions in one group, and
 cross-provider binding references.
@@ -268,8 +287,33 @@ The serialized `VInfo.bindings` map is compatibility metadata, not the canonical
 source for provider-aware entries. A missing member is therefore a hard
 integrity error rather than a silently smaller group.
 
-For legacy entries without owner metadata, the resolver uses a strictly
+For legacy entries without group metadata, the resolver uses a strictly
 validated binding graph.
+
+### 5.4 Header assets and materialized-view ownership
+
+Headers are group assets, not phantom target versions. A `HeaderAsset` records
+its source directory and optional destination prefix in the root manifest. The
+cross-repository XVM operation carries a group label; when omitted it is
+accepted only if the config batch has one unambiguous group. No `headers`
+operation may create `db[node.name].versions[...]` implicitly.
+
+Each SubOS config persists a materialized-view ownership ledger beside
+`workspace`:
+
+```text
+materialized[path] = {
+    bindingGroupRef,
+    memberTarget,
+    memberVersion,
+    source
+}
+```
+
+It covers individual library and header destinations. Ownership must never be
+inferred from symlink targets because Windows may use hardlinks or copies. The
+ledger makes replacement, conflict detection, rollback, and later removal
+deterministic even when different providers expose the same filename.
 
 ## 6. Switch architecture
 
@@ -309,18 +353,28 @@ No filesystem or Config mutation occurs during planning.
 `cmd_use()` becomes:
 
 ```text
+acquire per-home/SubOS XVM state lock
+    -> reload versions/workspace/materialized ledger while holding the lock
 resolve requested member version
     -> build BindingSelection
     -> preflight every program/lib/header source
-    -> stage materialized-view changes
+    -> stage every materialized-view and shim change beside its destination
     -> update an in-memory workspace copy for every member
-    -> atomically persist workspace once
-    -> finalize staged views / ensure generic shims
+    -> replace staged filesystem destinations while retaining backups
+    -> atomically persist workspace + materialized ledger once (commit point)
+    -> delete backups and release the lock
 ```
 
-The command-level guarantee is all-or-nothing for expected errors. Staged
-filesystem operations retain rollback information. Workspace JSON is written
-through a same-directory temporary file and atomic rename/replace.
+Every fallible filesystem creation occurs before the commit point. A failed
+destination replacement or JSON commit restores filesystem backups and leaves
+the old workspace/ledger. Fault-injection tests cover each stage. Generic shims
+are staged exactly like other destinations; they are not a fallible
+post-commit action.
+
+The per-home/SubOS lock is shared by `use`, registration, and removal. State is
+reloaded after lock acquisition so two processes cannot overwrite changes
+loaded before either acquired the lock. Workspace JSON is written through a
+same-directory temporary file and atomic rename/replace.
 
 Full crash-atomicity across JSON plus many independent header/library paths
 would require a generation-based sysroot; that is outside this release. A crash
@@ -333,13 +387,20 @@ Program shims are version-independent xlings launchers. Installation creates
 them; `use` only ensures missing shims exist after successful preflight. Version
 selection is entirely the committed workspace map.
 
+`VData.kind == "group"` is a selectable virtual root: it participates in list,
+use, installed sets, manifests, and diagnostics, but has no executable payload
+and never creates a shim. This replaces the current accidental behavior where a
+default-program marker such as `xim-gnu-gcc` produces a bogus shim.
+
 ### 6.4 Libraries
 
-For every selected `type == "lib"` member:
+For every selected `VData.kind == "lib"` member:
 
-- source is `VData.path / (VInfo.filename or target)`;
-- destination is the active SubOS library directory;
-- the old selected member's file is removed only if it is owned by that target;
+- source is `VData.path / VData.sourceName`;
+- destination is the SubOS library directory plus
+  `VData.destinationName`;
+- the old destination is replaced only through its materialized-view ledger
+  entry and is retained as a transaction backup;
 - the new file is linked/copied through the existing cross-platform link
   abstraction;
 - failures roll back before workspace commit.
@@ -349,10 +410,11 @@ already-active library.
 
 ### 6.5 Headers
 
-Header directories recorded in selected members are switched for the whole
-selection, not only the CLI starting target. The old view is removed and the new
-view staged before commit. Existing recipes that manage headers themselves keep
-working; group-managed headers use the common materializer.
+Header assets recorded in the root manifest are expanded into individual staged
+destinations and recorded in the materialized-view ledger. They switch for the
+whole selection, not only the CLI starting target. Existing recipe-managed
+headers remain outside this ownership model until explicitly migrated and are
+not claimed as transactionally switched.
 
 ### 6.6 Installed sets and listing
 
@@ -368,9 +430,15 @@ the current SubOS `installed[]` set. Therefore:
 
 ### 7.1 Provider-aware removal
 
-When uninstalling a resolved package release, xlings knows its canonical
-provider and version from `PlanNode`/catalog resolution. Before mutating state it
-collects and validates every group manifest owned by that provider release.
+Removal is explicitly two-phase:
+
+1. resolve every group owned by the requested provider release and atomically
+   detach all members/assets from the current SubOS, applying a coherent
+   surviving-group fallback where available;
+2. scan every SubOS/project installed set for the exact owner tuples. If another
+   environment still references the release, retain global VersionDB entries
+   and payload. Otherwise run the uninstall hook and globally purge the exact
+   owned registrations and payload.
 
 Those exact target versions are authoritative. Recipe `xvm.remove` operations
 are validated against them but do not define ownership.
@@ -386,6 +454,10 @@ Removal:
   otherwise clears all removed members coherently;
 - rematerializes libraries/headers for the fallback group.
 
+The reference check operates on every group member, not only the package/root
+target. Removing a release from SubOS A must leave SubOS B's workspace,
+materialized view, and global payload usable.
+
 ### 7.2 Legacy versionless operations
 
 For old provider-less entries, uninstall snapshots the validated legacy
@@ -395,6 +467,11 @@ selection.
 If no unique exact version can be derived, uninstall fails before mutation.
 The old `db.erase(op.name)` fallback is removed. Deliberate all-version removal
 must use an explicit API/operation.
+
+`remove_all` is transported as a distinct `op = "remove_all"` operation. It is
+scoped to target versions owned by the currently executing provider; it cannot
+erase owner-less or other-provider entries. Provider-less legacy all-version
+removal is rejected.
 
 ## 8. Legacy integrity and repair
 
@@ -413,8 +490,9 @@ If validation finds a dangling/asymmetric/conflicting graph:
 - it recommends re-running the owning package/version install/config when that
   owner can be inferred, otherwise reports the affected targets.
 
-Re-running an already-installed package config writes group references and
-manifests and rebuilds compatible edges without re-downloading a valid payload.
+Re-running an already-installed package config performs the idempotent/adoption
+rules in §5.2, writes group references/manifests, and atomically replaces only
+the batch's compatible old edges without re-downloading a valid payload.
 
 ### 8.3 Doctor integration
 
@@ -441,10 +519,15 @@ The Lua operation API becomes symmetric:
 - `xvm.setup()` propagates its resolved version to root, programs, and libs;
 - `xvm.teardown()` removes the same exact version;
 - a structured optional group label can be transported without parsing target
-  ownership from strings.
+  ownership from strings;
+- header operations carry group identity instead of relying on the package name.
 
 The current official index does not call `setup/teardown`, so direct operation
 tests are required.
+
+The libxpkg change is released first. The xlings integration then updates both
+`mcpp.toml` and `mcpp.lock` to that exact patch release; CI must not silently
+continue using 0.0.46.
 
 ### 9.2 xim-pkgindex
 
@@ -464,16 +547,27 @@ they can merge before the stricter validator.
 
 ### 10.1 Unit tests
 
-- owner JSON round trip and legacy JSON compatibility;
+- group reference, exact-root manifest, per-version kind/source/destination,
+  header-asset, and materialized-ledger JSON round trips;
+- legacy JSON compatibility and `VInfo` materialization fallback;
 - provider-group planning from root and leaf;
 - different root/member versions;
-- multiple groups per provider and multiple providers per target;
+- multiple groups per provider, multiple providers per target, and same target
+  with provider-specific kind/source metadata;
 - namespace handling;
+- virtual group roots never create program shims;
 - valid legacy cycles;
 - missing VData, asymmetric edge, conflicting target version;
+- idempotent same-owner reconfiguration, compatible owner-less adoption, and
+  other-owner conflict;
 - exact version removal and reciprocal edge cleanup;
+- raw empty legacy remove normalization and explicit provider-scoped
+  `remove_all`;
 - no mutation on plan/preflight failure;
-- library/header materialization and rollback.
+- library/header materialization, ownership collision, Windows copy/hardlink
+  behavior, and rollback at every injected failure point;
+- lock-then-reload behavior under concurrent stale readers;
+- current-SubOS detach followed by all-SubOS reference accounting.
 
 Tests call production helpers. The existing copied traversal lambda is removed.
 
@@ -499,7 +593,12 @@ Scenarios:
 7. corrupt one peer and prove the failed switch changes nothing;
 8. remove non-active v1 and preserve v2;
 9. remove active v2 and apply a coherent fallback;
-10. run different selections in two SubOS instances.
+10. run different selections in two SubOS instances, detach from one, and prove
+    the other keeps its workspace, materialized view, and global payload;
+11. reconfigure the same provider idempotently, adopt a compatible legacy
+    entry, and reject a conflicting provider without mutation;
+12. exercise explicit provider-scoped `remove_all` without touching another
+    provider's same-named target.
 
 Shell coverage runs on Linux and macOS. PowerShell coverage runs on Windows and
 executes real `.exe` shims; file content is used where Windows symlink privilege
@@ -521,8 +620,9 @@ remove one version
 repeat both directions
 ```
 
-The host `.xlings.json`, host SubOS workspace, and host shims are hashed before
-and after to prove they were untouched.
+The host `.xlings.json`, host SubOS workspace, host executable/shim directories,
+and relevant host package payload metadata are hashed before and after to prove
+they were untouched.
 
 ## 11. Rollout and success gates
 

--- a/.agents/docs/2026-07-26-xvm-provider-binding-group-plan.md
+++ b/.agents/docs/2026-07-26-xvm-provider-binding-group-plan.md
@@ -48,13 +48,17 @@ legacy compatibility; release xlings 0.4.70 with all platform CI green.
 
 - [ ] Add failing group-reference/manifest JSON round-trip and legacy-absence
       tests.
+- [ ] Add failing per-version kind/source/destination and header-manifest JSON
+      tests; retain `VInfo` only as a legacy read fallback.
 - [ ] Add failing production resolver tests for root/leaf, transformed member
       versions, multiple providers, namespace, and multiple groups.
+- [ ] Cover the same target with provider-specific materialization metadata and
+      prove a virtual `kind = group` root never creates a program shim.
 - [ ] Add failing invalid-graph tests: missing target/version, asymmetric edge,
       conflicting target version, self-edge.
-- [ ] Implement `BindingGroupRef`, root member manifests, serialization,
-      `BindingSelection`, structured errors, provider-group resolver, and
-      strict legacy resolver.
+- [ ] Implement `BindingGroupRef`, per-version materialization metadata, root
+      member/header manifests, serialization, `BindingSelection`, structured
+      errors, provider-group resolver, and strict legacy resolver.
 - [ ] Delete the unit test's copied traversal lambda and call production code.
 - [ ] Run focused XVM tests, then full `mcpp test`.
 - [ ] Commit: `feat(xvm): add provider-scoped binding selection model`
@@ -74,11 +78,16 @@ legacy compatibility; release xlings 0.4.70 with all platform CI green.
 - [ ] Cover transformed and namespaced member versions.
 - [ ] Add failing test proving ambiguous versionless sibling removal cannot
       erase the target.
+- [ ] Add a raw empty-operation unit test independent of libxpkg defaults.
+- [ ] Add failing tests for explicit provider-scoped `remove_all`, including a
+      same-named target owned by another provider.
 - [ ] Make `remove_version()` prune both sides and empty maps.
 - [ ] Snapshot provider/legacy selections before uninstall mutation.
 - [ ] Prefer provider-owned exact members; use validated legacy selection only
       as compatibility fallback.
 - [ ] Remove the versionless `db.erase(op.name)` branch.
+- [ ] Handle `remove_all` as a distinct operation scoped to the executing
+      provider; reject owner-less legacy all-version removal.
 - [ ] Run focused and full tests.
 - [ ] Commit: `fix(xvm): remove binding members by exact owned version`
 
@@ -95,9 +104,14 @@ legacy compatibility; release xlings 0.4.70 with all platform CI green.
 - [ ] Add tests for root-after-child operation order.
 - [ ] Add tests rejecting phantom roots, self-binding, duplicate exact nodes,
       cross-provider edges, and two versions of one target in one group.
+- [ ] Test idempotent same-owner registration, compatible owner-less legacy
+      adoption, and conflicting-owner rejection without mutation.
+- [ ] Test grouped header operations and ambiguous ungrouped headers.
 - [ ] Split add processing into node and binding/ownership passes.
 - [ ] Populate provider identity from `PlanNode.canonicalName/version`.
-- [ ] Assign stable group labels and retain compatible bidirectional edges.
+- [ ] Assign stable group labels, carry header group identity, and retain
+      compatible bidirectional edges.
+- [ ] Replace stale manifests/edges only for exact nodes in the validated batch.
 - [ ] Add every member type to current SubOS `installed[]`.
 - [ ] Run focused and full tests.
 - [ ] Commit: `feat(xim): register xvm groups as validated provider batches`
@@ -117,13 +131,21 @@ legacy compatibility; release xlings 0.4.70 with all platform CI green.
 - [ ] Add failing tests proving no workspace mutation on planner/preflight
       errors.
 - [ ] Add library and header switch tests for every member in a selection.
-- [ ] Add rollback test for an unavailable library/header source.
+- [ ] Add ownership-collision and Windows copy/hardlink materialization tests.
+- [ ] Add rollback/fault-injection tests for each staging, replace, and JSON
+      commit failure point.
+- [ ] Add stale-reader concurrency test proving lock acquisition is followed by
+      state reload.
 - [ ] Replace local traversal with `resolve_binding_selection()`.
 - [ ] Preflight the complete selection before changes.
-- [ ] Stage library/header changes and keep rollback records.
+- [ ] Persist a per-SubOS materialized-view ownership ledger.
+- [ ] Acquire the shared XVM state lock and reload DB/workspace/ledger under it.
+- [ ] Stage program shim/library/header changes and keep rollback records.
 - [ ] Update active/installed entries from one in-memory selection.
-- [ ] Atomically replace workspace JSON through a same-directory staged file.
-- [ ] Ensure generic program shims only after successful preflight.
+- [ ] Atomically replace workspace and ledger JSON through same-directory staged
+      files as the transaction commit point.
+- [ ] Treat generic program shims as staged changes; virtual group roots never
+      create shims.
 - [ ] Run focused and full tests.
 - [ ] Commit: `fix(xvm): apply binding group switches transactionally`
 
@@ -142,7 +164,12 @@ legacy compatibility; release xlings 0.4.70 with all platform CI green.
 - [ ] Test removing a non-active group preserves the active group.
 - [ ] Test removing an active group selects one complete surviving group or
       clears all removed members.
+- [ ] Test two SubOS instances: detach the provider release from one, preserve
+      the other's view and global payload, then globally purge only after the
+      final exact owner reference is gone.
 - [ ] Route activation/fallback through the common switch plan.
+- [ ] Separate current-SubOS detach from all-SubOS reference scan and global
+      payload/registration purge.
 - [ ] Run full tests.
 - [ ] Commit: `fix(xim): keep install and remove binding groups coherent`
 
@@ -211,7 +238,8 @@ checkouts.
 - [ ] Test add/remove default to the same runtime version.
 - [ ] Test `setup/teardown` propagate explicit versions to root/program/lib.
 - [ ] Test `remove_all` is the only empty/all-version operation.
-- [ ] Test optional group label round trip if shipped in this slice.
+- [ ] Transport `remove_all` as a distinct operation with provider scope.
+- [ ] Test structured group labels and header group identity round trips.
 - [ ] Build/test all supported libxpkg paths.
 - [ ] Commit, push, open PR, and wait for required CI.
 
@@ -246,18 +274,22 @@ feature checkout.
 
 - [ ] Create a temporary OS home and `XLINGS_HOME`.
 - [ ] Copy only the built test xlings bootstrap and a local modified index.
-- [ ] Hash host global/workspace config before the test.
+- [ ] Hash host global/workspace config, executable/shim directories, and
+      relevant package payload metadata before the test.
 - [ ] Install GCC 15.1.0 and 16.1.0 in the temporary home.
 - [ ] Switch with `gcc`, execute both `gcc` and `g++`.
 - [ ] Switch back with `g++`, execute both again.
 - [ ] Verify registered library links and exact versions.
 - [ ] Remove/reinstall one version and repeat both directions.
-- [ ] Hash host global/workspace config after the test and prove equality.
+- [ ] Hash the same host config, bin/shim, and payload paths after the test and
+      prove equality.
 - [ ] Preserve concise logs under `.agents/docs` or PR evidence.
 
 ## Task 11: Version, documentation, and xlings PR
 
-- [ ] Update VERSION and `mcpp.toml` to xlings 0.4.70.
+- [ ] After the libxpkg release is published, update the xpkg dependency in both
+      `mcpp.toml` and `mcpp.lock` to that exact patch.
+- [ ] Update VERSION and the xlings package version to 0.4.70.
 - [ ] Update user-facing docs/changelog only where the repository convention
       requires it.
 - [ ] Run formatting/style checks.
@@ -276,6 +308,6 @@ feature checkout.
 - [ ] Fix failures by reproducing root cause; do not bypass checks.
 - [ ] Confirm every cross-repository PR is green.
 - [ ] Re-read the user requirements and map each to current evidence.
-- [ ] Confirm host xlings config/workspace hashes did not change.
+- [ ] Confirm host config/workspace, bin/shim, and payload hashes did not change.
 - [ ] Record final PR URLs, commits, versions, tests, runtime proof, and any
       migration action in the comprehensive report.

--- a/.agents/docs/2026-07-26-xvm-provider-binding-group-plan.md
+++ b/.agents/docs/2026-07-26-xvm-provider-binding-group-plan.md
@@ -1,0 +1,281 @@
+# XVM Provider-Scoped Binding Group Implementation Plan
+
+> **For agentic workers:** use `superpowers:test-driven-development` for each
+> behavior slice, `superpowers:subagent-driven-development` for independent
+> repository slices, and `superpowers:verification-before-completion` before
+> any completion claim.
+
+**Goal:** Make `xlings use` switch a validated binding group from any package,
+program, or library member; make uninstall exact and provider-aware; preserve
+legacy compatibility; release xlings 0.4.70 with all platform CI green.
+
+**Architecture:** `.agents/docs/2026-07-26-xvm-provider-binding-group-design.md`
+
+**Repositories:** `openxlings/xlings`, `openxlings/libxpkg`,
+`openxlings/xim-pkgindex`
+
+## Global constraints
+
+- Never run install/remove/use against the host xlings home.
+- Every mutable CLI/E2E invocation must set a temporary `HOME`,
+  `XLINGS_HOME`, and neutral working directory.
+- Build only through mcpp with GCC 16 on Linux.
+- Preserve existing user worktrees and dirty files.
+- Write tests before implementation for every behavior slice.
+- Keep normal additive git history; no amend/rebase/force-push.
+- Commit convention: `<type>(<scope>): <description>`.
+- Target versions: xlings `0.4.70`; libxpkg next patch version.
+
+## Task 0: Isolation and baseline
+
+- [x] Create `fix/xvm-binding-groups` worktree from `origin/main`.
+- [x] Run `mcpp build`.
+- [x] Run `mcpp test`.
+- [x] Confirm 11/11 test binaries pass after the required main-binary build.
+- [x] Confirm no host `xlings use/install/remove` command was executed.
+
+## Task 1: Production binding-selection model
+
+**Files:**
+
+- Add: `src/core/xvm/bindings.cppm`
+- Modify: `src/core/xvm.cppm`
+- Modify: `src/core/xvm/types.cppm`
+- Modify: `src/core/xvm/db.cppm`
+- Test: `tests/unit/test_main.cpp`
+
+**TDD steps:**
+
+- [ ] Add failing group-reference/manifest JSON round-trip and legacy-absence
+      tests.
+- [ ] Add failing production resolver tests for root/leaf, transformed member
+      versions, multiple providers, namespace, and multiple groups.
+- [ ] Add failing invalid-graph tests: missing target/version, asymmetric edge,
+      conflicting target version, self-edge.
+- [ ] Implement `BindingGroupRef`, root member manifests, serialization,
+      `BindingSelection`, structured errors, provider-group resolver, and
+      strict legacy resolver.
+- [ ] Delete the unit test's copied traversal lambda and call production code.
+- [ ] Run focused XVM tests, then full `mcpp test`.
+- [ ] Commit: `feat(xvm): add provider-scoped binding selection model`
+
+## Task 2: Exact edge-aware removal
+
+**Files:**
+
+- Modify: `src/core/xvm/db.cppm`
+- Modify: `src/core/xim/installer.cppm`
+- Test: `tests/unit/test_main.cpp`
+
+**TDD steps:**
+
+- [ ] Add failing tests for removing one version from a two-version tree while
+      preserving the other version's reciprocal edges.
+- [ ] Cover transformed and namespaced member versions.
+- [ ] Add failing test proving ambiguous versionless sibling removal cannot
+      erase the target.
+- [ ] Make `remove_version()` prune both sides and empty maps.
+- [ ] Snapshot provider/legacy selections before uninstall mutation.
+- [ ] Prefer provider-owned exact members; use validated legacy selection only
+      as compatibility fallback.
+- [ ] Remove the versionless `db.erase(op.name)` branch.
+- [ ] Run focused and full tests.
+- [ ] Commit: `fix(xvm): remove binding members by exact owned version`
+
+## Task 3: Batched registration and provider ownership
+
+**Files:**
+
+- Modify: `src/core/xim/installer.cppm`
+- Modify: `src/core/xvm/db.cppm`
+- Test: `tests/unit/test_main.cpp`
+
+**TDD steps:**
+
+- [ ] Add tests for root-after-child operation order.
+- [ ] Add tests rejecting phantom roots, self-binding, duplicate exact nodes,
+      cross-provider edges, and two versions of one target in one group.
+- [ ] Split add processing into node and binding/ownership passes.
+- [ ] Populate provider identity from `PlanNode.canonicalName/version`.
+- [ ] Assign stable group labels and retain compatible bidirectional edges.
+- [ ] Add every member type to current SubOS `installed[]`.
+- [ ] Run focused and full tests.
+- [ ] Commit: `feat(xim): register xvm groups as validated provider batches`
+
+## Task 4: Transactional switch and materialized views
+
+**Files:**
+
+- Modify: `src/core/xvm/commands.cppm`
+- Modify: `src/core/config.cppm`
+- Modify: `src/platform.cppm`
+- Modify platform partitions as needed
+- Test: `tests/unit/test_main.cpp`
+
+**TDD steps:**
+
+- [ ] Add failing tests proving no workspace mutation on planner/preflight
+      errors.
+- [ ] Add library and header switch tests for every member in a selection.
+- [ ] Add rollback test for an unavailable library/header source.
+- [ ] Replace local traversal with `resolve_binding_selection()`.
+- [ ] Preflight the complete selection before changes.
+- [ ] Stage library/header changes and keep rollback records.
+- [ ] Update active/installed entries from one in-memory selection.
+- [ ] Atomically replace workspace JSON through a same-directory staged file.
+- [ ] Ensure generic program shims only after successful preflight.
+- [ ] Run focused and full tests.
+- [ ] Commit: `fix(xvm): apply binding group switches transactionally`
+
+## Task 5: Group-aware install/remove fallback
+
+**Files:**
+
+- Modify: `src/core/xim/installer.cppm`
+- Modify: `src/core/xvm/commands.cppm`
+- Test: `tests/unit/test_main.cpp`
+
+**TDD steps:**
+
+- [ ] Test that installing v2 without `--use` does not repoint a v1 library.
+- [ ] Test `--use` activates the complete new group.
+- [ ] Test removing a non-active group preserves the active group.
+- [ ] Test removing an active group selects one complete surviving group or
+      clears all removed members.
+- [ ] Route activation/fallback through the common switch plan.
+- [ ] Run full tests.
+- [ ] Commit: `fix(xim): keep install and remove binding groups coherent`
+
+## Task 6: Integrity diagnostics
+
+**Files:**
+
+- Modify: `src/core/xself/doctor.cppm`
+- Test: `tests/e2e/self_doctor_test.sh`
+
+**TDD steps:**
+
+- [ ] Add corrupt owner-group and corrupt legacy-edge fixtures.
+- [ ] Assert doctor reports exact target/version pairs and exits nonzero.
+- [ ] Assert `--fix` never executes package hooks or removes payloads.
+- [ ] Add safe stale workspace/edge repair where unambiguous.
+- [ ] Add reinstall/reconfigure hints for unrecoverable registrations.
+- [ ] Run doctor E2E in a temporary home.
+- [ ] Commit: `feat(xvm): diagnose corrupt binding registrations`
+
+## Task 7: Hermetic binding-tree E2E
+
+**Files:**
+
+- Add: `tests/e2e/binding_tree_use_test.sh`
+- Add: `tests/e2e/binding_tree_use_test.ps1`
+- Add fixture recipes/files under `tests/e2e/fixtures/`
+- Modify: `tests/e2e/run_all.sh`
+- Modify macOS/Windows workflows that enumerate E2E tests
+
+**Scenarios:**
+
+- [ ] two-version install;
+- [ ] non-package member list;
+- [ ] root-to-leaf and leaf-to-root switch;
+- [ ] actual execution of every program shim;
+- [ ] transformed member version;
+- [ ] library/header materialization;
+- [ ] library as switch entry point;
+- [ ] corrupt graph fails without state changes;
+- [ ] non-active and active removal;
+- [ ] reinstallation without stale edges;
+- [ ] two SubOS instances with independent views.
+
+**Verification:**
+
+- [ ] Linux shell test passes.
+- [ ] Windows PowerShell test passes locally where available or through CI.
+- [ ] macOS shell path is wired into CI.
+- [ ] Commit: `test(xvm): cover bidirectional binding group lifecycle`
+
+## Task 8: libxpkg operation contract
+
+**Worktree:** create a clean libxpkg worktree; do not touch existing dirty
+checkouts.
+
+**Files:**
+
+- Modify: `src/lua-stdlib/xim/libxpkg/xvm.lua`
+- Modify XVM operation transport if a structured group label is included
+- Add/update libxpkg tests
+- Bump libxpkg patch version
+
+**TDD steps:**
+
+- [ ] Test add/remove default to the same runtime version.
+- [ ] Test `setup/teardown` propagate explicit versions to root/program/lib.
+- [ ] Test `remove_all` is the only empty/all-version operation.
+- [ ] Test optional group label round trip if shipped in this slice.
+- [ ] Build/test all supported libxpkg paths.
+- [ ] Commit, push, open PR, and wait for required CI.
+
+## Task 9: xim-pkgindex recipe integrity
+
+**Worktree:** create a clean pkgindex worktree; preserve its current dirty
+feature checkout.
+
+**Files:**
+
+- Modify affected recipes and matching snapshots/tests:
+  - GCC;
+  - musl GCC;
+  - aarch64 musl GCC;
+  - e2fsprogs;
+  - syslinux;
+  - openssl;
+  - other audited detached members where the intended group is clear.
+
+**TDD steps:**
+
+- [ ] Add static validator/tests for exact binding roots, self-edges, duplicate
+      exact registrations, and exact remove versions.
+- [ ] Make roots and children use matching exact versions.
+- [ ] Remove self-binding and duplicate registration.
+- [ ] Include intended sibling executables.
+- [ ] Make teardown versions explicit.
+- [ ] Run focused and full pkgindex validation.
+- [ ] Commit, push, open PR, and wait for required CI.
+
+## Task 10: Isolated real GCC proof
+
+- [ ] Create a temporary OS home and `XLINGS_HOME`.
+- [ ] Copy only the built test xlings bootstrap and a local modified index.
+- [ ] Hash host global/workspace config before the test.
+- [ ] Install GCC 15.1.0 and 16.1.0 in the temporary home.
+- [ ] Switch with `gcc`, execute both `gcc` and `g++`.
+- [ ] Switch back with `g++`, execute both again.
+- [ ] Verify registered library links and exact versions.
+- [ ] Remove/reinstall one version and repeat both directions.
+- [ ] Hash host global/workspace config after the test and prove equality.
+- [ ] Preserve concise logs under `.agents/docs` or PR evidence.
+
+## Task 11: Version, documentation, and xlings PR
+
+- [ ] Update VERSION and `mcpp.toml` to xlings 0.4.70.
+- [ ] Update user-facing docs/changelog only where the repository convention
+      requires it.
+- [ ] Run formatting/style checks.
+- [ ] Run `mcpp build` and `mcpp test` from a clean state.
+- [ ] Run all relevant shell E2E in isolated homes.
+- [ ] Use `superpowers:requesting-code-review`.
+- [ ] Address verified findings.
+- [ ] Commit: `fix(xvm): switch provider binding groups atomically (0.4.70)`
+- [ ] Push normally and open a draft PR.
+
+## Task 12: CI and completion audit
+
+- [ ] Verify Linux required checks.
+- [ ] Verify macOS required checks.
+- [ ] Verify Windows required checks.
+- [ ] Fix failures by reproducing root cause; do not bypass checks.
+- [ ] Confirm every cross-repository PR is green.
+- [ ] Re-read the user requirements and map each to current evidence.
+- [ ] Confirm host xlings config/workspace hashes did not change.
+- [ ] Record final PR URLs, commits, versions, tests, runtime proof, and any
+      migration action in the comprehensive report.

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -351,6 +351,15 @@ private:
         return {};
     }
 
+    [[nodiscard]] std::filesystem::path global_subos_dir_() const {
+        auto activeSubos = utils::get_env_or_default(
+            "XLINGS_ACTIVE_SUBOS");
+        if (activeSubos.empty()) {
+            activeSubos = globalActiveSubos_;
+        }
+        return paths_.homeDir / "subos" / activeSubos;
+    }
+
     [[nodiscard]] static std::vector<std::string>
     lookup_resource_servers_in_(const MirrorServerMap& source, std::string_view mirror) {
         auto key = effective_mirror_name_(mirror, "GLOBAL");
@@ -971,9 +980,27 @@ public:
         return instance_().paths_.homeDir / "subos" / name;
     }
 
+    [[nodiscard]] static std::filesystem::path global_subos_dir() {
+        return instance_().global_subos_dir_();
+    }
+
     [[nodiscard]] static std::filesystem::path global_subos_bin_dir() {
+        return global_subos_dir() / "bin";
+    }
+
+    [[nodiscard]] static std::filesystem::path
+    xvm_artifact_subos_dir() {
         auto& self = instance_();
-        return self.paths_.homeDir / "subos" / self.globalActiveSubos_ / "bin";
+        const bool useProject =
+            self.hasProjectConfig_ && !self.forceGlobalScope_;
+        if (useProject
+            && (self.projectSubosMode_
+                    == ProjectSubosMode::Named
+                || self.projectSubosMode_
+                    == ProjectSubosMode::Anonymous)) {
+            return self.project_subos_dir_();
+        }
+        return self.global_subos_dir_();
     }
 
     static std::vector<std::string> list_subos_names() {
@@ -1064,18 +1091,10 @@ public:
             // spawns `xlings install -g`) when the user happens to run
             // self install from inside an xlings repo / project tree.
             //
-            // Compose the global-scope path from XLINGS_ACTIVE_SUBOS env
-            // (per-shell override) or globalActiveSubos_ (~/.xlings.json
-            // snapshot) — both are valid global-scope subos names whose
-            // directories exist on disk.
-            std::string global_name;
-            if (auto env = utils::get_env_or_default("XLINGS_ACTIVE_SUBOS");
-                !env.empty()) {
-                global_name = env;
-            } else {
-                global_name = self.globalActiveSubos_;
-            }
-            subosConfigPath = self.paths_.homeDir / "subos" / global_name / ".xlings.json";
+            // Resolve the same global-scope subos root used by XVM
+            // filesystem effects.
+            subosConfigPath =
+                self.global_subos_dir_() / ".xlings.json";
         }
 
         nlohmann::json json;

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -36,9 +36,7 @@ snapshot_xpkg_removal_context(
         const std::string& executingProviderVersion,
         const std::string& preferredTarget = {},
         const std::string& preferredVersion = {}) {
-    xvm::RemovalContext legacyContext{
-        .provider = executingProvider,
-    };
+    xvm::RemovalContext legacyContext;
     std::optional<xvm::RemovalContext> providerContext;
     std::set<std::pair<std::string, std::string>> seeds;
 
@@ -115,9 +113,6 @@ snapshot_xpkg_removal_context(
             }
             if (!providerContext) {
                 providerContext = std::move(*selection);
-                if (!executingProvider.empty()) {
-                    providerContext->provider = executingProvider;
-                }
             }
             return {};
         }
@@ -161,6 +156,7 @@ snapshot_xpkg_removal_context(
     }
 
     if (!providerContext
+        && !legacyContext.hasSelection
         && !executingProvider.empty()
         && !executingProviderVersion.empty()) {
         bool foundProviderRelease = false;
@@ -193,7 +189,8 @@ apply_xpkg_removal_operations(
         xvm::Workspace& workspace,
         xvm::WorkspaceInstalled& installed,
         const std::vector<mcpplibs::xpkg::XvmOp>& operations,
-        const xvm::RemovalContext& context) {
+        const xvm::RemovalContext& context,
+        const xvm::RemovalBatchOptions& options = {}) {
     std::vector<xvm::RemovalOperation> removals;
     for (const auto& operation : operations) {
         if (operation.op != "remove" && operation.op != "remove_all") {
@@ -206,7 +203,121 @@ apply_xpkg_removal_operations(
         });
     }
     return xvm::apply_removal_batch(
-        db, workspace, installed, removals, context);
+        db, workspace, installed, removals, context, options);
+}
+
+void cleanup_removed_xvm_library_artifacts(
+        const std::filesystem::path& libDir,
+        const xvm::VersionDB& dbBeforeRemoval,
+        const xvm::VersionDB& currentDb,
+        const xvm::RemovalBatchResult& removalResult) {
+    auto destinationName = [](
+            const std::string& target,
+            const xvm::VInfo& info,
+            const xvm::VData& data) {
+        if (!data.destinationName.empty()) {
+            return data.destinationName;
+        }
+        if (!info.filename.empty()) return info.filename;
+        return target;
+    };
+
+    std::set<std::string> destinations;
+    for (const auto& removed : removalResult.removed) {
+        auto targetIt = dbBeforeRemoval.find(removed.target);
+        if (targetIt == dbBeforeRemoval.end()) continue;
+        auto versionIt =
+            targetIt->second.versions.find(removed.version);
+        if (versionIt == targetIt->second.versions.end()) continue;
+        const auto& data = versionIt->second;
+        const auto kind = data.kind.empty()
+            ? targetIt->second.type
+            : data.kind;
+        if (kind != "lib") continue;
+        destinations.insert(destinationName(
+            removed.target, targetIt->second, data));
+    }
+
+    for (const auto& name : destinations) {
+        const auto hasSurvivingOwner = std::ranges::any_of(
+            currentDb,
+            [&](const auto& targetEntry) {
+                return std::ranges::any_of(
+                    targetEntry.second.versions,
+                    [&](const auto& versionEntry) {
+                        const auto& data = versionEntry.second;
+                        const auto kind = data.kind.empty()
+                            ? targetEntry.second.type
+                            : data.kind;
+                        return kind == "lib"
+                            && destinationName(
+                                targetEntry.first,
+                                targetEntry.second,
+                                data) == name;
+                    });
+            });
+        if (hasSurvivingOwner) continue;
+
+        const auto destination = libDir / name;
+        std::error_code ec;
+        if (std::filesystem::exists(destination, ec)
+            || std::filesystem::is_symlink(destination, ec)) {
+            ec.clear();
+            std::filesystem::remove(destination, ec);
+        }
+    }
+}
+
+void cleanup_removed_xvm_program_artifacts(
+        const std::filesystem::path& binDir,
+        const xvm::VersionDB& dbBeforeRemoval,
+        const xvm::VersionDB& currentDb,
+        const xvm::WorkspaceInstalled& installed,
+        const xvm::RemovalBatchResult& removalResult) {
+    std::set<std::string> removedPrograms;
+    for (const auto& removed : removalResult.removed) {
+        auto targetIt = dbBeforeRemoval.find(removed.target);
+        if (targetIt == dbBeforeRemoval.end()) continue;
+        auto versionIt =
+            targetIt->second.versions.find(removed.version);
+        if (versionIt == targetIt->second.versions.end()) continue;
+        const auto kind = versionIt->second.kind.empty()
+            ? targetIt->second.type
+            : versionIt->second.kind;
+        if (kind == "program") {
+            removedPrograms.insert(removed.target);
+        }
+    }
+
+    for (const auto& target : removedPrograms) {
+        if (xvm::has_usable_workspace_version(
+                currentDb, installed, target)) {
+            continue;
+        }
+#ifdef _WIN32
+        constexpr std::string_view shimExtension = ".exe";
+#else
+        constexpr std::string_view shimExtension = "";
+#endif
+        std::string shimName = target;
+        if (!shimExtension.empty()
+            && !shimName.ends_with(shimExtension)) {
+            shimName += shimExtension;
+        }
+        const auto shimPath = binDir / shimName;
+        std::error_code ec;
+        if (!std::filesystem::exists(shimPath, ec)
+            && !std::filesystem::is_symlink(shimPath, ec)) {
+            continue;
+        }
+        ec.clear();
+        std::filesystem::remove(shimPath, ec);
+        if (ec) {
+            log::warn("could not remove shim {}: {}; will be replaced "
+                      "on next install/use",
+                      shimPath.string(), ec.message());
+        }
+    }
 }
 
 bool evict_invalid_archive_cache_(
@@ -786,75 +897,6 @@ void detach_current_subos_(const std::string& target,
     }
 }
 
-void remove_xvm_target_artifacts_(const std::string& target,
-                                  bool removeProgramShim,
-                                  bool removeLibraryLink) {
-    namespace fs = std::filesystem;
-    const auto& paths = Config::paths();
-    if (removeLibraryLink) {
-        auto libraryPath = paths.libDir / target;
-        std::error_code ec;
-        if (fs::is_symlink(libraryPath, ec)) {
-            fs::remove(libraryPath, ec);
-        }
-    }
-    if (!removeProgramShim) return;
-
-#ifdef _WIN32
-    constexpr std::string_view shim_ext = ".exe";
-#else
-    constexpr std::string_view shim_ext = "";
-#endif
-    std::string shimName = target;
-    if (!shim_ext.empty() && !shimName.ends_with(shim_ext)) {
-        shimName += shim_ext;
-    }
-    auto shimPath = paths.binDir / shimName;
-    std::error_code ec;
-    if (!fs::exists(shimPath, ec)) return;
-    ec.clear();
-    fs::remove(shimPath, ec);
-    if (ec) {
-        log::warn("could not remove shim {}: {}; will be replaced "
-                  "on next install/use",
-                  shimPath.string(), ec.message());
-    }
-}
-
-void cleanup_removed_xvm_artifacts_(
-        const xvm::VersionDB& dbBeforeRemoval,
-        const xvm::RemovalBatchResult& removalResult) {
-    std::map<std::string, std::pair<bool, bool>> removedKinds;
-    for (const auto& removed : removalResult.removed) {
-        auto& [program, library] = removedKinds[removed.target];
-        auto targetIt = dbBeforeRemoval.find(removed.target);
-        if (targetIt == dbBeforeRemoval.end()) {
-            program = true;
-            continue;
-        }
-        auto versionIt = targetIt->second.versions.find(removed.version);
-        auto kind = versionIt == targetIt->second.versions.end()
-            || versionIt->second.kind.empty()
-            ? targetIt->second.type
-            : versionIt->second.kind;
-        if (kind == "lib") {
-            library = true;
-        } else {
-            program = true;
-        }
-    }
-    for (const auto& [target, kinds] : removedKinds) {
-        if (xvm::has_usable_workspace_version(
-                Config::versions_mut(),
-                Config::workspace_installed(),
-                target)) {
-            continue;
-        }
-        remove_xvm_target_artifacts_(
-            target, kinds.first, kinds.second);
-    }
-}
-
 bool process_xvm_operations_(const PlanNode& node,
                              const std::filesystem::path& dataDir,
                              mcpplibs::xpkg::PackageExecutor& executor,
@@ -921,6 +963,12 @@ bool process_xvm_operations_(const PlanNode& node,
             removalResult.error().version);
         return false;
     }
+
+    cleanup_removed_xvm_library_artifacts(
+        sysroot_lib,
+        dbBeforeRemoval,
+        Config::versions_mut(),
+        *removalResult);
 
     for (auto& op : xvm_ops) {
         if (op.op == "add") {
@@ -1027,8 +1075,12 @@ bool process_xvm_operations_(const PlanNode& node,
         }
     }
 
-    cleanup_removed_xvm_artifacts_(
-        dbBeforeRemoval, *removalResult);
+    cleanup_removed_xvm_program_artifacts(
+        Config::paths().binDir,
+        dbBeforeRemoval,
+        Config::versions_mut(),
+        Config::workspace_installed(),
+        *removalResult);
 
     Config::save_versions();
     Config::save_workspace();
@@ -1853,7 +1905,10 @@ public:
             Config::workspace_mut(),
             Config::workspace_installed_mut(),
             xvm_ops,
-            *removalContext);
+            *removalContext,
+            xvm::RemovalBatchOptions{
+                .purgeSelection = true,
+            });
         if (!removalResult) {
             return std::unexpected(std::format(
                 "xvm removal batch failed for {}@{}: {} "
@@ -1877,8 +1932,17 @@ public:
                 detachedByBatch = true;
             }
         }
-        detail_::cleanup_removed_xvm_artifacts_(
-            dbBeforeRemoval, *removalResult);
+        cleanup_removed_xvm_library_artifacts(
+            Config::paths().libDir,
+            dbBeforeRemoval,
+            Config::versions_mut(),
+            *removalResult);
+        cleanup_removed_xvm_program_artifacts(
+            Config::paths().binDir,
+            dbBeforeRemoval,
+            Config::versions_mut(),
+            Config::workspace_installed(),
+            *removalResult);
         if (!detachedByBatch && !detachVersion.empty()) {
             detail_::detach_current_subos_(
                 detachTarget, detachVersion, false);

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -18,6 +18,7 @@ import xlings.core.common;
 import xlings.core.xself;
 import xlings.core.xvm.types;
 import xlings.core.xvm.db;
+import xlings.core.xvm.removal;
 import xlings.core.xvm.commands;
 import xlings.core.xvm.shim;
 import xlings.core.xim.libxpkg.types.script;
@@ -25,6 +26,188 @@ import xlings.core.xim.libxpkg.types.subos;
 import xlings.runtime.cancellation;
 
 export namespace xlings::xim {
+
+std::expected<xvm::RemovalContext, xvm::RemovalError>
+snapshot_xpkg_removal_context(
+        const xvm::VersionDB& db,
+        const xvm::Workspace& workspace,
+        const std::vector<mcpplibs::xpkg::XvmOp>& operations,
+        const std::string& executingProvider,
+        const std::string& executingProviderVersion,
+        const std::string& preferredTarget = {},
+        const std::string& preferredVersion = {}) {
+    xvm::RemovalContext legacyContext{
+        .provider = executingProvider,
+    };
+    std::optional<xvm::RemovalContext> providerContext;
+    std::set<std::pair<std::string, std::string>> seeds;
+
+    auto mergeSeed = [&](const std::string& target,
+                         const std::string& version)
+        -> std::expected<void, xvm::RemovalError> {
+        if (target.empty() || version.empty()
+            || !seeds.emplace(target, version).second) {
+            return {};
+        }
+        auto exactVersion =
+            xvm::resolve_exact_version_key(db, target, version);
+        if (!exactVersion) {
+            return std::unexpected(std::move(exactVersion.error()));
+        }
+        const auto& info = db.at(target);
+        const auto& data = info.versions.at(*exactVersion);
+        const auto hasOutgoingEdge = std::ranges::any_of(
+            info.bindings,
+            [&](const auto& peer) {
+                return peer.second.contains(*exactVersion);
+            });
+        const auto hasIncomingEdge = std::ranges::any_of(
+            db,
+            [&](const auto& peer) {
+                auto edgeIt = peer.second.bindings.find(target);
+                if (edgeIt == peer.second.bindings.end()) return false;
+                return std::ranges::any_of(
+                    edgeIt->second,
+                    [&](const auto& edge) {
+                        return edge.second == *exactVersion;
+                    });
+            });
+        const auto isUnboundLegacySingleton =
+            !data.bindingGroup
+            && !data.bindingMembersDeclared
+            && data.bindingMembers.empty()
+            && !data.bindingHeadersDeclared
+            && data.bindingHeaders.empty()
+            && data.bindingIntegrityIssues.empty()
+            && !hasOutgoingEdge
+            && !hasIncomingEdge;
+        if (isUnboundLegacySingleton) {
+            auto [it, inserted] =
+                legacyContext.members.emplace(target, *exactVersion);
+            if (!inserted && it->second != *exactVersion) {
+                return std::unexpected(xvm::RemovalError{
+                    .kind = xvm::RemovalErrorKind::SelectionInvalid,
+                    .target = target,
+                    .version = *exactVersion,
+                    .message =
+                        "legacy removal selections conflict on target version",
+                });
+            }
+            legacyContext.hasSelection = true;
+            return {};
+        }
+        auto selection =
+            xvm::snapshot_removal_context(db, target, *exactVersion);
+        if (!selection) {
+            return std::unexpected(std::move(selection.error()));
+        }
+        if (!selection->provider.empty()) {
+            if (!executingProvider.empty()
+                && selection->provider != executingProvider) {
+                return std::unexpected(xvm::RemovalError{
+                    .kind = xvm::RemovalErrorKind::ProviderMismatch,
+                    .target = target,
+                    .version = version,
+                    .message = std::format(
+                        "selected version is owned by provider '{}', not '{}'",
+                        selection->provider, executingProvider),
+                });
+            }
+            if (!providerContext) {
+                providerContext = std::move(*selection);
+                if (!executingProvider.empty()) {
+                    providerContext->provider = executingProvider;
+                }
+            }
+            return {};
+        }
+        if (providerContext) return {};
+
+        for (const auto& [memberTarget, memberVersion] :
+             selection->members) {
+            auto [it, inserted] =
+                legacyContext.members.emplace(memberTarget, memberVersion);
+            if (!inserted && it->second != memberVersion) {
+                return std::unexpected(xvm::RemovalError{
+                    .kind = xvm::RemovalErrorKind::SelectionInvalid,
+                    .target = memberTarget,
+                    .version = memberVersion,
+                    .message =
+                        "legacy removal selections conflict on target version",
+                });
+            }
+        }
+        legacyContext.hasSelection = true;
+        return {};
+    };
+
+    if (!preferredTarget.empty() && db.contains(preferredTarget)) {
+        auto merged = mergeSeed(preferredTarget, preferredVersion);
+        if (!merged) return std::unexpected(std::move(merged.error()));
+    }
+
+    for (const auto& operation : operations) {
+        if (operation.op != "remove") continue;
+        std::string version = operation.version;
+        if (version.empty()) {
+            auto activeIt = workspace.find(operation.name);
+            if (activeIt != workspace.end()) {
+                version = activeIt->second;
+            }
+        }
+        if (version.empty() || !db.contains(operation.name)) continue;
+        auto merged = mergeSeed(operation.name, version);
+        if (!merged) return std::unexpected(std::move(merged.error()));
+    }
+
+    if (!providerContext
+        && !executingProvider.empty()
+        && !executingProviderVersion.empty()) {
+        bool foundProviderRelease = false;
+        for (const auto& [target, info] : db) {
+            for (const auto& [version, data] : info.versions) {
+                if (!data.bindingGroup
+                    || data.bindingGroup->provider != executingProvider
+                    || data.bindingGroup->providerVersion
+                        != executingProviderVersion) {
+                    continue;
+                }
+                foundProviderRelease = true;
+                auto merged = mergeSeed(target, version);
+                if (!merged) {
+                    return std::unexpected(std::move(merged.error()));
+                }
+                break;
+            }
+            if (foundProviderRelease) break;
+        }
+    }
+
+    if (providerContext) return std::move(*providerContext);
+    return legacyContext;
+}
+
+std::expected<xvm::RemovalBatchResult, xvm::RemovalError>
+apply_xpkg_removal_operations(
+        xvm::VersionDB& db,
+        xvm::Workspace& workspace,
+        xvm::WorkspaceInstalled& installed,
+        const std::vector<mcpplibs::xpkg::XvmOp>& operations,
+        const xvm::RemovalContext& context) {
+    std::vector<xvm::RemovalOperation> removals;
+    for (const auto& operation : operations) {
+        if (operation.op != "remove" && operation.op != "remove_all") {
+            continue;
+        }
+        removals.push_back({
+            .op = operation.op,
+            .name = operation.name,
+            .version = operation.version,
+        });
+    }
+    return xvm::apply_removal_batch(
+        db, workspace, installed, removals, context);
+}
 
 bool evict_invalid_archive_cache_(
         const std::filesystem::path& archive,
@@ -459,8 +642,8 @@ bool is_version_referenced_anywhere_(PackageScope scope,
         // pin its xpkgs/ directory against GC.
         //
         // Stored values are namespaced (`ns:1.0` for non-primary repos,
-        // bare for primary), but `version` from the caller is bare —
-        // accept either form, same as detach_current_subos_.
+        // bare for primary). New removal callers pass the exact stored key;
+        // retain bare matching here for legacy workspace files.
         auto matches = [&](std::string_view stored) {
             return stored == version
                 || xvm::strip_namespace(std::string(stored)) == version;
@@ -533,19 +716,14 @@ void remove_target_shims_(const std::string& target, const std::string& version)
     }
 }
 
-void detach_current_subos_(const std::string& target, const std::string& version) {
+void detach_current_subos_(const std::string& target,
+                           const std::string& version,
+                           bool persist = true) {
     auto& ws = Config::workspace_mut();
     auto& wsi = Config::workspace_installed_mut();
 
-    // Stored ver-key in workspace/installed[] is namespaced
-    // (`make_ns_version(version_ns, ver)`) — for the primary repo this
-    // is bare, but for `fromsource:` / `myrepo:` packages it carries the
-    // `ns:` prefix. Callers (uninstall) pass us a bare `version` (the
-    // user's typed value, or PackageMatch.version which is always bare).
-    // Match either form so non-primary-namespace removes don't silently
-    // leave stale active+installed entries.
     auto matches = [&](std::string_view stored) {
-        return stored == version || xvm::strip_namespace(std::string(stored)) == version;
+        return stored == version;
     };
 
     // Step 1 (0.4.19+): always drop `version` from this subos's
@@ -603,10 +781,81 @@ void detach_current_subos_(const std::string& target, const std::string& version
         }
     }
 
-    if (wasActive || installedChanged) Config::save_workspace();
+    if (persist && (wasActive || installedChanged)) {
+        Config::save_workspace();
+    }
 }
 
-void process_xvm_operations_(const PlanNode& node,
+void remove_xvm_target_artifacts_(const std::string& target,
+                                  bool removeProgramShim,
+                                  bool removeLibraryLink) {
+    namespace fs = std::filesystem;
+    const auto& paths = Config::paths();
+    if (removeLibraryLink) {
+        auto libraryPath = paths.libDir / target;
+        std::error_code ec;
+        if (fs::is_symlink(libraryPath, ec)) {
+            fs::remove(libraryPath, ec);
+        }
+    }
+    if (!removeProgramShim) return;
+
+#ifdef _WIN32
+    constexpr std::string_view shim_ext = ".exe";
+#else
+    constexpr std::string_view shim_ext = "";
+#endif
+    std::string shimName = target;
+    if (!shim_ext.empty() && !shimName.ends_with(shim_ext)) {
+        shimName += shim_ext;
+    }
+    auto shimPath = paths.binDir / shimName;
+    std::error_code ec;
+    if (!fs::exists(shimPath, ec)) return;
+    ec.clear();
+    fs::remove(shimPath, ec);
+    if (ec) {
+        log::warn("could not remove shim {}: {}; will be replaced "
+                  "on next install/use",
+                  shimPath.string(), ec.message());
+    }
+}
+
+void cleanup_removed_xvm_artifacts_(
+        const xvm::VersionDB& dbBeforeRemoval,
+        const xvm::RemovalBatchResult& removalResult) {
+    std::map<std::string, std::pair<bool, bool>> removedKinds;
+    for (const auto& removed : removalResult.removed) {
+        auto& [program, library] = removedKinds[removed.target];
+        auto targetIt = dbBeforeRemoval.find(removed.target);
+        if (targetIt == dbBeforeRemoval.end()) {
+            program = true;
+            continue;
+        }
+        auto versionIt = targetIt->second.versions.find(removed.version);
+        auto kind = versionIt == targetIt->second.versions.end()
+            || versionIt->second.kind.empty()
+            ? targetIt->second.type
+            : versionIt->second.kind;
+        if (kind == "lib") {
+            library = true;
+        } else {
+            program = true;
+        }
+    }
+    for (const auto& [target, kinds] : removedKinds) {
+        if (xvm::has_usable_workspace_version(
+                Config::versions_mut(),
+                Config::workspace_installed(),
+                target)) {
+            continue;
+        }
+        remove_xvm_target_artifacts_(
+            target, kinds.first, kinds.second);
+    }
+}
+
+bool process_xvm_operations_(const PlanNode& node,
                              const std::filesystem::path& dataDir,
                              mcpplibs::xpkg::PackageExecutor& executor,
                              bool useAfterInstall) {
@@ -636,6 +885,41 @@ void process_xvm_operations_(const PlanNode& node,
         if (!isPrimary && !node.namespaceName.empty()) {
             version_ns = node.namespaceName;
         }
+    }
+
+    auto executingProvider = node.canonicalName.empty()
+        ? canonical_package_name(node.namespaceName, node.name)
+        : node.canonicalName;
+    auto removalContext = snapshot_xpkg_removal_context(
+        Config::versions_mut(), Config::workspace(), xvm_ops,
+        executingProvider, node.version);
+    if (!removalContext) {
+        log::warn(
+            "xvm removal selection failed for {}@{}: {} "
+            "(target='{}', version='{}')",
+            executingProvider, node.version,
+            removalContext.error().message,
+            removalContext.error().target,
+            removalContext.error().version);
+        return false;
+    }
+
+    const auto dbBeforeRemoval = Config::versions_mut();
+    auto removalResult = apply_xpkg_removal_operations(
+        Config::versions_mut(),
+        Config::workspace_mut(),
+        Config::workspace_installed_mut(),
+        xvm_ops,
+        *removalContext);
+    if (!removalResult) {
+        log::warn(
+            "xvm removal batch failed for {}@{}: {} "
+            "(target='{}', version='{}')",
+            executingProvider, node.version,
+            removalResult.error().message,
+            removalResult.error().target,
+            removalResult.error().version);
+        return false;
     }
 
     for (auto& op : xvm_ops) {
@@ -740,80 +1024,15 @@ void process_xvm_operations_(const PlanNode& node,
             vdata.includedir = op.includedir;
         } else if (op.op == "remove_headers") {
             xvm::remove_headers(op.includedir, sysroot_include);
-        } else if (op.op == "remove") {
-            auto& db = Config::versions_mut();
-            auto it = db.find(op.name);
-            bool isLib = (it != db.end() && it->second.type == "lib");
-
-            if (isLib) {
-                // Remove lib symlink from subos lib dir
-                auto dst = sysroot_lib / op.name;
-                std::error_code ec;
-                if (std::filesystem::is_symlink(dst, ec))
-                    std::filesystem::remove(dst, ec);
-            } else {
-                // Remove shim for uninstalled program. Use the error_code
-                // overload: on Windows the shim may be the running xlings.exe
-                // (when an install hook indirectly emits a remove for xlings),
-                // and DeleteFile on a running executable raises
-                // ERROR_SHARING_VIOLATION. Throwing here would escape main()
-                // (no top-level catch on the cmd_install path) and terminate
-                // the process — silent non-zero exit on CI. The next install
-                // / use cycle re-creates the shim via xself::create_shim, so
-                // a failure here is benign: warn and continue.
-                std::string shim_name = op.name;
-                if (!shim_ext.empty() && !shim_name.ends_with(shim_ext))
-                    shim_name += shim_ext;
-                auto shim_path = paths.binDir / shim_name;
-                std::error_code shim_ec;
-                if (std::filesystem::exists(shim_path, shim_ec)) {
-                    shim_ec.clear();
-                    std::filesystem::remove(shim_path, shim_ec);
-                    if (shim_ec) {
-                        log::warn("could not remove shim {}: {}; will be replaced "
-                                  "on next install/use",
-                                  shim_path.string(), shim_ec.message());
-                    }
-                }
-            }
-            Config::workspace_mut().erase(op.name);
-
-            // 0.4.19+: keep installed[] in sync with the versions DB
-            // wipe. detach_current_subos_ usually pruned `op.version`
-            // already (in the user-initiated remove flow), but
-            // install-time upgrades (recipe emits xvm:remove for the
-            // old version before xvm:add for the new) reach this op
-            // without going through detach. The version key inside
-            // installed[] is the namespaced form (`ns:ver` or bare —
-            // see `add` path above for derivation). Match either form
-            // so we don't leave stale entries when op.version arrives
-            // as a bare string from a recipe even though storage is
-            // namespaced.
-            auto& wsi = Config::workspace_installed_mut();
-            if (op.version.empty()) {
-                wsi.erase(op.name);
-            } else {
-                if (auto it = wsi.find(op.name); it != wsi.end()) {
-                    auto& list = it->second;
-                    auto erased = std::remove_if(list.begin(), list.end(),
-                        [&](const std::string& v) {
-                            return v == op.version
-                                || xvm::strip_namespace(v) == op.version;
-                        });
-                    list.erase(erased, list.end());
-                    if (list.empty()) wsi.erase(it);
-                }
-            }
-
-            if (op.version.empty()) {
-                db.erase(op.name);
-            } else {
-                xvm::remove_version(db, op.name, op.version);
-            }
         }
     }
+
+    cleanup_removed_xvm_artifacts_(
+        dbBeforeRemoval, *removalResult);
+
     Config::save_versions();
     Config::save_workspace();
+    return true;
 }
 
 bool run_config_hook_(const PlanNode& node,
@@ -832,8 +1051,8 @@ bool run_config_hook_(const PlanNode& node,
         log::warn("config hook failed for {}: {}", node.name, hookResult.error);
         return false;
     }
-    process_xvm_operations_(node, dataDir, executor, useAfterInstall);
-    return true;
+    return process_xvm_operations_(
+        node, dataDir, executor, useAfterInstall);
 }
 
 }  // namespace detail_
@@ -1510,6 +1729,45 @@ public:
 
         auto detachTarget = resolvedMatch ? resolvedMatch->name : targetName;
         auto detachVersion = resolvedMatch ? resolvedMatch->version : requestedVersion;
+        if (resolvedMatch) {
+            auto& globalRepos = Config::global_index_repos();
+            const bool isPrimary = !globalRepos.empty()
+                && resolvedMatch->namespaceName == globalRepos[0].name;
+            if (!isPrimary && !resolvedMatch->namespaceName.empty()) {
+                detachVersion = xvm::make_ns_version(
+                    resolvedMatch->namespaceName,
+                    resolvedMatch->version);
+            }
+        }
+        auto executingProvider = resolvedMatch
+            ? (resolvedMatch->canonicalName.empty()
+                ? canonical_package_name(
+                    resolvedMatch->namespaceName,
+                    resolvedMatch->name)
+                : resolvedMatch->canonicalName)
+            : targetName;
+        auto executingProviderVersion = resolvedMatch
+            ? resolvedMatch->version
+            : xvm::strip_namespace(detachVersion);
+
+        auto removalContext = snapshot_xpkg_removal_context(
+            Config::versions_mut(), Config::workspace(), {},
+            executingProvider, executingProviderVersion,
+            detachTarget, detachVersion);
+        if (!removalContext) {
+            return std::unexpected(std::format(
+                "xvm removal selection failed for {}@{}: {} "
+                "(target='{}', version='{}')",
+                executingProvider, executingProviderVersion,
+                removalContext.error().message,
+                removalContext.error().target,
+                removalContext.error().version));
+        }
+        if (auto memberIt = removalContext->members.find(detachTarget);
+            memberIt != removalContext->members.end()) {
+            detachVersion = memberIt->second;
+        }
+
         auto stillReferenced = !detachVersion.empty()
             && detail_::is_version_referenced_anywhere_(
                 resolvedMatch ? resolvedMatch->scope : PackageScope::Global,
@@ -1517,11 +1775,8 @@ public:
                 detachVersion,
                 currentWorkspacePath);
 
-        if (!detachVersion.empty()) {
-            detail_::detach_current_subos_(detachTarget, detachVersion);
-        }
-
         if (stillReferenced) {
+            detail_::detach_current_subos_(detachTarget, detachVersion);
             log::debug("{}@{} detached from current subos; payload retained",
                       detachTarget, detachVersion);
             return {};
@@ -1552,6 +1807,7 @@ public:
                                   .parent_path()
                                   .parent_path().string();
 
+        bool useDefaultRemoval = false;
         if (executor.has_hook(mcpplibs::xpkg::HookType::Uninstall)) {
             log::debug("uninstalling {}...", name);
             auto result = executor.run_hook(
@@ -1577,174 +1833,57 @@ public:
                     isSubosType  = (entry->type == mcpplibs::xpkg::PackageType::Subos);
                 }
             }
-            std::string ver = resolvedMatch ? resolvedMatch->version : std::string{};
-            if (isScriptType) {
-                script::default_uninstall(ctx.pkg_name, ver);
-            } else if (isSubosType) {
-                subos::default_uninstall(ctx.pkg_name, ver);
-            }
+            useDefaultRemoval = isScriptType || isSubosType;
         }
 
         // Process xvm operations collected by uninstall hook
         auto xvm_ops = executor.xvm_operations();
+        if (useDefaultRemoval) {
+            xvm_ops.push_back({
+                .op = "remove",
+                .name = detachTarget,
+                .version = detachVersion,
+            });
+        }
         auto sysroot_include = Config::paths().subosDir / "usr" / "include";
 
-        for (auto& op : xvm_ops) {
-            if (op.op == "remove") {
-                // Compute shim path now; we only delete the shim once we
-                // know there are no surviving versions of this program.
-                // Removing it eagerly (as the previous code did) leaves
-                // the workspace pointing at the highest-remaining version
-                // but the PATH entry is gone — `command not found`.
-#ifdef _WIN32
-                constexpr std::string_view shim_ext = ".exe";
-#else
-                constexpr std::string_view shim_ext = "";
-#endif
-                std::string shim_name = op.name;
-                if (!shim_ext.empty() && !shim_name.ends_with(shim_ext))
-                    shim_name += shim_ext;
-                auto shim_path = Config::paths().binDir / shim_name;
-                auto remove_shim_if_present = [&]() {
-                    // error_code overload only — on Windows the shim may be
-                    // the running xlings.exe (e.g. user runs
-                    // `xlings remove xim:xlings` and that's the only version
-                    // installed, so this branch fires). DeleteFile on a
-                    // running .exe raises ERROR_SHARING_VIOLATION, the
-                    // throwing overload would escape main() and silently
-                    // terminate the process (CI sees non-zero exit, no
-                    // diagnostic). The shim is repointed to whatever
-                    // bootstrap exists on the next install/use cycle, so
-                    // failing to remove it now is benign — log and move on.
-                    std::error_code ec;
-                    if (!std::filesystem::exists(shim_path, ec)) return;
-                    ec.clear();
-                    std::filesystem::remove(shim_path, ec);
-                    if (ec) {
-                        log::warn("could not remove shim {}: {}; will be replaced "
-                                  "on next install/use",
-                                  shim_path.string(), ec.message());
-                    }
-                };
+        const auto dbBeforeRemoval = Config::versions_mut();
+        auto removalResult = apply_xpkg_removal_operations(
+            Config::versions_mut(),
+            Config::workspace_mut(),
+            Config::workspace_installed_mut(),
+            xvm_ops,
+            *removalContext);
+        if (!removalResult) {
+            return std::unexpected(std::format(
+                "xvm removal batch failed for {}@{}: {} "
+                "(target='{}', version='{}')",
+                executingProvider, executingProviderVersion,
+                removalResult.error().message,
+                removalResult.error().target,
+                removalResult.error().version));
+        }
 
-                // Resolve the authoritative version to drop from the DB.
-                // Prefer what the hook sent; fall back to the outer resolve only when the
-                // op is for the same package as the top-level uninstall target.
-                std::string effective_version = op.version;
-                if (effective_version.empty() && op.name == detachTarget) {
-                    effective_version = detachVersion;
-                }
-
-                // Snapshot the active binding before we mutate anything. For detachTarget
-                // this was already cleared by detach_current_subos_ above; for sibling
-                // ops (npm/npx when removing node) it still reflects the pre-remove state.
-                std::string prev_active;
-                if (auto wit = Config::workspace().find(op.name);
-                    wit != Config::workspace().end()) {
-                    prev_active = wit->second;
-                }
-
-                if (effective_version.empty()) {
-                    // No version information anywhere — legacy fallback: clear the whole
-                    // entry. Should only happen for packages whose hook emits versionless
-                    // ops for sibling names that were never registered with a version.
-                    Config::versions_mut().erase(op.name);
-                    Config::workspace_mut().erase(op.name);
-                    remove_shim_if_present();
-                    continue;
-                }
-
-                xvm::remove_version(Config::versions_mut(), op.name, effective_version);
-
-                // 0.4.19+: also drop `effective_version` from this subos's
-                // installed[] (detach_current_subos_ already pruned it for
-                // op.name == detachTarget, but sibling ops emitted by the
-                // recipe — e.g. xvm.remove("npm") when uninstalling node —
-                // never went through detach).
-                {
-                    auto& wsi_mut = Config::workspace_installed_mut();
-                    if (auto it = wsi_mut.find(op.name); it != wsi_mut.end()) {
-                        auto erased = std::remove_if(it->second.begin(),
-                                                     it->second.end(),
-                            [&](const std::string& v) {
-                                return v == effective_version
-                                    || xvm::strip_namespace(v) == effective_version;
-                            });
-                        it->second.erase(erased, it->second.end());
-                        if (it->second.empty()) wsi_mut.erase(it);
-                    }
-                }
-
-                auto dit = Config::versions_mut().find(op.name);
-
-                // Decide the new active binding for this op.name.
-                //
-                // 0.4.19+: fallback candidates come from the **current subos's
-                // installed[]** set, not the global versions DB. Pre-fix the
-                // auto-switch picked the highest remaining version across
-                // ALL subos (`pick_highest_version(dit->second.versions)`) —
-                // which leaked another subos's choices into this one. Concrete
-                // case: subos A has rm-fixture@1.0.0, subos B has rm-fixture@2.0.0.
-                // `xlings remove rm-fixture` in B would auto-set B.workspace[rm-fixture]
-                // to "1.0.0" — a version B never opted into. With C2 schema
-                // each subos has its own opt-in set, so the fallback must
-                // come from the same set; if it's empty, clear the pointer
-                // (and drop the shim) instead of inventing one.
-                const auto& wsi_view = Config::workspace_installed();
-                auto subos_pick_highest = [&](const std::string& name) -> std::string {
-                    auto wit = wsi_view.find(name);
-                    if (wit == wsi_view.end() || wit->second.empty()) return {};
-                    // installed[] is stored sorted ascending → back() is highest
-                    return wit->second.back();
-                };
-
-                bool survivors = (dit != Config::versions_mut().end()
-                                  && !dit->second.versions.empty());
-                if (!survivors) {
-                    // Package fully gone from the global DB — clear workspace
-                    // binding and drop the PATH shim with it. (subos's
-                    // installed[] is already empty by construction.)
-                    Config::workspace_mut().erase(op.name);
-                    remove_shim_if_present();
-                } else if (prev_active.empty() || prev_active == effective_version) {
-                    // We just removed the active version (or detach already cleared
-                    // the slot for detachTarget). Auto-switch to highest version
-                    // this subos has opted into; if none, clear pointer + shim.
-                    auto fallback = subos_pick_highest(op.name);
-                    if (!fallback.empty()) {
-                        Config::workspace_mut()[op.name] = fallback;
-                    } else {
-                        Config::workspace_mut().erase(op.name);
-                        remove_shim_if_present();
-                    }
-                } else {
-                    // A non-active version was removed; keep the previous active
-                    // if it's still in this subos's installed[], otherwise pick
-                    // highest remaining (or clear).
-                    auto fallback = subos_pick_highest(op.name);
-                    bool prev_still_in_subos = false;
-                    if (auto wit = wsi_view.find(op.name); wit != wsi_view.end()) {
-                        for (auto& v : wit->second) {
-                            if (v == prev_active
-                                || xvm::strip_namespace(v) == xvm::strip_namespace(prev_active)) {
-                                prev_still_in_subos = true;
-                                break;
-                            }
-                        }
-                    }
-                    if (prev_still_in_subos) {
-                        Config::workspace_mut()[op.name] = prev_active;
-                    } else if (!fallback.empty()) {
-                        Config::workspace_mut()[op.name] = fallback;
-                    } else {
-                        Config::workspace_mut().erase(op.name);
-                        remove_shim_if_present();
-                    }
-                }
-            } else if (op.op == "remove_headers") {
+        for (const auto& op : xvm_ops) {
+            if (op.op == "remove_headers") {
                 xvm::remove_headers(op.includedir, sysroot_include);
             }
         }
+
+        bool detachedByBatch = false;
+        for (const auto& removed : removalResult->removed) {
+            if (removed.target == detachTarget
+                && removed.version == detachVersion) {
+                detachedByBatch = true;
+            }
+        }
+        detail_::cleanup_removed_xvm_artifacts_(
+            dbBeforeRemoval, *removalResult);
+        if (!detachedByBatch && !detachVersion.empty()) {
+            detail_::detach_current_subos_(
+                detachTarget, detachVersion, false);
+        }
+
         Config::save_versions();
         Config::save_workspace();
 

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -19,6 +19,7 @@ import xlings.core.xself;
 import xlings.core.xvm.types;
 import xlings.core.xvm.db;
 import xlings.core.xvm.removal;
+import xlings.core.xvm.registration;
 import xlings.core.xvm.commands;
 import xlings.core.xvm.shim;
 import xlings.core.xim.libxpkg.types.script;
@@ -26,6 +27,286 @@ import xlings.core.xim.libxpkg.types.subos;
 import xlings.runtime.cancellation;
 
 export namespace xlings::xim {
+
+enum class XpkgRegistrationErrorKind {
+    InvalidVersion,
+    InvalidBinding,
+    ConflictingEnvironment,
+};
+
+struct XpkgRegistrationError {
+    XpkgRegistrationErrorKind kind {
+        XpkgRegistrationErrorKind::InvalidVersion
+    };
+    std::size_t operationIndex { 0 };
+    std::string target;
+    std::string version;
+    std::string message;
+};
+
+enum class XpkgFilesystemEffectKind {
+    ProgramShim,
+    Library,
+    InstallHeaders,
+    RemoveHeaders,
+};
+
+struct XpkgFilesystemEffect {
+    XpkgFilesystemEffectKind kind {
+        XpkgFilesystemEffectKind::ProgramShim
+    };
+    std::string target;
+    std::string version;
+    std::string sourceDir;
+};
+
+struct XpkgResolvedFilesystemEffect {
+    XpkgFilesystemEffectKind kind {
+        XpkgFilesystemEffectKind::ProgramShim
+    };
+    std::string target;
+    std::string version;
+    std::string sourceDir;
+    std::string path;
+    std::string sourceName;
+    std::string destinationName;
+    bool active { false };
+};
+
+struct XpkgRegistrationPlan {
+    xvm::RegistrationBatch batch;
+    std::vector<XpkgFilesystemEffect> effects;
+};
+
+std::optional<XpkgResolvedFilesystemEffect>
+resolve_xpkg_filesystem_effect(
+        const xvm::VersionDB& db,
+        const xvm::Workspace& workspace,
+        const XpkgFilesystemEffect& effect) {
+    XpkgResolvedFilesystemEffect resolved{
+        .kind = effect.kind,
+        .target = effect.target,
+        .version = effect.version,
+        .sourceDir = effect.sourceDir,
+    };
+    if (effect.kind == XpkgFilesystemEffectKind::InstallHeaders
+        || effect.kind == XpkgFilesystemEffectKind::RemoveHeaders) {
+        return resolved;
+    }
+
+    auto targetIt = db.find(effect.target);
+    if (targetIt == db.end()) return std::nullopt;
+    auto versionIt =
+        targetIt->second.versions.find(effect.version);
+    if (versionIt == targetIt->second.versions.end()) {
+        return std::nullopt;
+    }
+    const auto& data = versionIt->second;
+    const auto kind =
+        data.kind.empty() ? targetIt->second.type : data.kind;
+    const auto expectedKind =
+        effect.kind == XpkgFilesystemEffectKind::ProgramShim
+        ? std::string_view{"program"}
+        : std::string_view{"lib"};
+    if (kind != expectedKind) return std::nullopt;
+
+    resolved.path = data.path;
+    resolved.sourceName = !data.sourceName.empty()
+        ? data.sourceName
+        : (!targetIt->second.filename.empty()
+            ? targetIt->second.filename
+            : effect.target);
+    resolved.destinationName = !data.destinationName.empty()
+        ? data.destinationName
+        : (effect.kind == XpkgFilesystemEffectKind::ProgramShim
+            ? effect.target
+            : resolved.sourceName);
+    auto activeIt = workspace.find(effect.target);
+    resolved.active =
+        activeIt != workspace.end()
+        && activeIt->second == effect.version;
+    return resolved;
+}
+
+using XpkgXvmMetadataError = std::variant<
+    xvm::RemovalError,
+    xvm::RegistrationError>;
+
+struct XpkgXvmMetadataResult {
+    xvm::RemovalBatchResult removal;
+    std::vector<xvm::RegisteredMember> registered;
+    std::vector<XpkgFilesystemEffect> effects;
+};
+
+std::expected<XpkgRegistrationPlan, XpkgRegistrationError>
+normalize_xpkg_registration_plan(
+        const PlanNode& node,
+        const std::vector<mcpplibs::xpkg::XvmOp>& operations,
+        const std::string& versionNamespace,
+        const std::filesystem::path& dataDir,
+        bool useAfterInstall) {
+    auto normalizeVersion = [&](
+            const std::string& version,
+            std::size_t operationIndex,
+            const std::string& target)
+        -> std::expected<std::string, XpkgRegistrationError> {
+        if (version.empty()) {
+            return std::unexpected(XpkgRegistrationError{
+                .kind = XpkgRegistrationErrorKind::InvalidVersion,
+                .operationIndex = operationIndex,
+                .target = target,
+                .version = version,
+                .message = "xvm registration version is empty",
+            });
+        }
+        const auto separator = version.find(':');
+        if (separator == std::string::npos) {
+            return xvm::make_ns_version(versionNamespace, version);
+        }
+        const auto actualNamespace = version.substr(0, separator);
+        const auto bareVersion = version.substr(separator + 1);
+        if (actualNamespace.empty()
+            || bareVersion.empty()
+            || bareVersion.contains(':')
+            || actualNamespace != versionNamespace) {
+            return std::unexpected(XpkgRegistrationError{
+                .kind = XpkgRegistrationErrorKind::InvalidVersion,
+                .operationIndex = operationIndex,
+                .target = target,
+                .version = version,
+                .message = std::format(
+                    "xvm registration version namespace '{}' "
+                    "does not match expected namespace '{}'",
+                    actualNamespace, versionNamespace),
+            });
+        }
+        return version;
+    };
+    const auto fallbackPath =
+        (node.storeRoot.empty() ? dataDir / "xpkgs" : node.storeRoot)
+        / package_store_name(node.namespaceName, node.name)
+        / node.version;
+    XpkgRegistrationPlan plan{
+        .batch = {
+            .provider = node.canonicalName.empty()
+                ? canonical_package_name(node.namespaceName, node.name)
+                : node.canonicalName,
+            .providerVersion = node.version,
+            .useAfterInstall = useAfterInstall,
+        },
+    };
+
+    for (std::size_t index = 0; index < operations.size(); ++index) {
+        const auto& operation = operations[index];
+        if (operation.op == "headers") {
+            plan.batch.headers.push_back({
+                .sourceDir = operation.includedir,
+            });
+            plan.effects.push_back({
+                .kind = XpkgFilesystemEffectKind::InstallHeaders,
+                .sourceDir = operation.includedir,
+            });
+            continue;
+        }
+        if (operation.op == "remove_headers") {
+            plan.effects.push_back({
+                .kind = XpkgFilesystemEffectKind::RemoveHeaders,
+                .sourceDir = operation.includedir,
+            });
+            continue;
+        }
+        if (operation.op != "add") continue;
+        const auto rawVersion = operation.version.empty()
+            ? node.version
+            : operation.version;
+        const auto kind =
+            operation.type.empty() ? std::string{"program"} : operation.type;
+        const auto sourceName = kind == "group"
+            ? std::string{}
+            : (operation.filename.empty()
+                ? operation.name
+                : operation.filename);
+        xvm::RegistrationNode registrationNode{
+            .target = operation.name,
+            .version = {},
+            .path = operation.bindir.empty()
+                ? fallbackPath.string()
+                : operation.bindir,
+            .kind = kind,
+            .sourceName = sourceName,
+            .destinationName = kind == "group"
+                ? std::string{}
+                : (kind == "program"
+                    ? operation.name
+                    : sourceName),
+        };
+        auto exactVersion =
+            normalizeVersion(rawVersion, index, operation.name);
+        if (!exactVersion) {
+            return std::unexpected(std::move(exactVersion.error()));
+        }
+        registrationNode.version = std::move(*exactVersion);
+        if (!operation.alias.empty()) {
+            registrationNode.alias.push_back(operation.alias);
+        }
+        for (const auto& [key, value] : operation.envs) {
+            auto [environmentIt, inserted] =
+                registrationNode.envs.emplace(key, value);
+            if (!inserted && environmentIt->second != value) {
+                return std::unexpected(XpkgRegistrationError{
+                    .kind = XpkgRegistrationErrorKind::ConflictingEnvironment,
+                    .operationIndex = index,
+                    .target = operation.name,
+                    .version = key,
+                    .message = std::format(
+                        "xvm registration environment '{}' has "
+                        "conflicting values",
+                        key),
+                });
+            }
+        }
+        if (!operation.binding.empty()) {
+            const auto separator = operation.binding.find('@');
+            if (separator == std::string::npos
+                || separator == 0
+                || separator + 1 == operation.binding.size()
+                || operation.binding.find('@', separator + 1)
+                    != std::string::npos) {
+                return std::unexpected(XpkgRegistrationError{
+                    .kind = XpkgRegistrationErrorKind::InvalidBinding,
+                    .operationIndex = index,
+                    .target = operation.name,
+                    .version = operation.binding,
+                    .message =
+                        "xvm registration binding must be '<root>@<version>'",
+                });
+            }
+            const auto rootTarget =
+                operation.binding.substr(0, separator);
+            auto rootVersion = normalizeVersion(
+                operation.binding.substr(separator + 1),
+                index, rootTarget);
+            if (!rootVersion) {
+                return std::unexpected(std::move(rootVersion.error()));
+            }
+            registrationNode.binding = xvm::RegistrationBinding{
+                .rootTarget = rootTarget,
+                .rootVersion = std::move(*rootVersion),
+            };
+        }
+        if (kind == "program" || kind == "lib") {
+            plan.effects.push_back({
+                .kind = kind == "program"
+                    ? XpkgFilesystemEffectKind::ProgramShim
+                    : XpkgFilesystemEffectKind::Library,
+                .target = operation.name,
+                .version = registrationNode.version,
+            });
+        }
+        plan.batch.nodes.push_back(std::move(registrationNode));
+    }
+    return plan;
+}
 
 std::expected<xvm::RemovalContext, xvm::RemovalError>
 snapshot_xpkg_removal_context(
@@ -206,6 +487,60 @@ apply_xpkg_removal_operations(
         db, workspace, installed, removals, context, options);
 }
 
+std::expected<XpkgXvmMetadataResult, XpkgXvmMetadataError>
+apply_xpkg_xvm_metadata_batch(
+        xvm::VersionDB& db,
+        xvm::Workspace& workspace,
+        xvm::WorkspaceInstalled& installed,
+        const std::vector<mcpplibs::xpkg::XvmOp>& operations,
+        const xvm::RemovalContext& removalContext,
+        const XpkgRegistrationPlan& registration,
+        const xvm::RemovalBatchOptions& removalOptions = {}) {
+    auto candidateDb = db;
+    auto candidateWorkspace = workspace;
+    auto candidateInstalled = installed;
+
+    auto removal = apply_xpkg_removal_operations(
+        candidateDb,
+        candidateWorkspace,
+        candidateInstalled,
+        operations,
+        removalContext,
+        removalOptions);
+    if (!removal) {
+        return std::unexpected(XpkgXvmMetadataError{
+            std::in_place_type<xvm::RemovalError>,
+            std::move(removal.error()),
+        });
+    }
+
+    std::vector<xvm::RegisteredMember> registered;
+    if (!registration.batch.nodes.empty()
+        || !registration.batch.headers.empty()) {
+        auto registrationResult = xvm::apply_registration_batch(
+            candidateDb,
+            candidateWorkspace,
+            candidateInstalled,
+            registration.batch);
+        if (!registrationResult) {
+            return std::unexpected(XpkgXvmMetadataError{
+                std::in_place_type<xvm::RegistrationError>,
+                std::move(registrationResult.error()),
+            });
+        }
+        registered = std::move(*registrationResult);
+    }
+
+    db.swap(candidateDb);
+    workspace.swap(candidateWorkspace);
+    installed.swap(candidateInstalled);
+    return XpkgXvmMetadataResult{
+        .removal = std::move(*removal),
+        .registered = std::move(registered),
+        .effects = registration.effects,
+    };
+}
+
 void cleanup_removed_xvm_library_artifacts(
         const std::filesystem::path& libDir,
         const xvm::VersionDB& dbBeforeRemoval,
@@ -334,6 +669,15 @@ bool evict_invalid_archive_cache_(
 }
 
 namespace detail_ {
+
+std::filesystem::path
+configure_xpkg_execution_artifact_paths_(
+        mcpplibs::xpkg::ExecutionContext& context) {
+    auto subosDir = Config::xvm_artifact_subos_dir();
+    context.bin_dir = subosDir / "bin";
+    context.subos_sysrootdir = subosDir.string();
+    return subosDir;
+}
 
 std::string effective_store_name_(std::string_view namespaceName, std::string_view name) {
     return package_store_name(namespaceName, name);
@@ -902,9 +1246,16 @@ bool process_xvm_operations_(const PlanNode& node,
                              mcpplibs::xpkg::PackageExecutor& executor,
                              bool useAfterInstall) {
     auto xvm_ops = executor.xvm_operations();
-    auto sysroot_include = Config::paths().subosDir / "usr" / "include";
-    auto sysroot_lib = Config::paths().libDir;
     auto& paths = Config::paths();
+    auto& scopedDb = Config::versions_mut();
+    auto& scopedWorkspace = Config::workspace_mut();
+    auto& scopedInstalled = Config::workspace_installed_mut();
+    const auto artifactSubosDir =
+        Config::xvm_artifact_subos_dir();
+    const auto artifactBinDir = artifactSubosDir / "bin";
+    const auto sysroot_lib = artifactSubosDir / "lib";
+    const auto sysroot_include =
+        artifactSubosDir / "usr" / "include";
 
     // Locate xlings binary for shim creation
 #ifdef _WIN32
@@ -929,161 +1280,202 @@ bool process_xvm_operations_(const PlanNode& node,
         }
     }
 
-    auto executingProvider = node.canonicalName.empty()
-        ? canonical_package_name(node.namespaceName, node.name)
-        : node.canonicalName;
-    auto removalContext = snapshot_xpkg_removal_context(
-        Config::versions_mut(), Config::workspace(), xvm_ops,
-        executingProvider, node.version);
-    if (!removalContext) {
+    auto registration = normalize_xpkg_registration_plan(
+        node, xvm_ops, version_ns, dataDir, useAfterInstall);
+    if (!registration) {
         log::warn(
-            "xvm removal selection failed for {}@{}: {} "
-            "(target='{}', version='{}')",
-            executingProvider, node.version,
-            removalContext.error().message,
-            removalContext.error().target,
-            removalContext.error().version);
+            "xvm registration normalization failed for {}@{}: {} "
+            "(operation={}, target='{}', version='{}')",
+            node.canonicalName.empty()
+                ? canonical_package_name(node.namespaceName, node.name)
+                : node.canonicalName,
+            node.version,
+            registration.error().message,
+            registration.error().operationIndex,
+            registration.error().target,
+            registration.error().version);
         return false;
     }
-
-    const auto dbBeforeRemoval = Config::versions_mut();
-    auto removalResult = apply_xpkg_removal_operations(
-        Config::versions_mut(),
-        Config::workspace_mut(),
-        Config::workspace_installed_mut(),
+    const bool hasRemoval = std::ranges::any_of(
         xvm_ops,
-        *removalContext);
-    if (!removalResult) {
-        log::warn(
-            "xvm removal batch failed for {}@{}: {} "
-            "(target='{}', version='{}')",
-            executingProvider, node.version,
-            removalResult.error().message,
-            removalResult.error().target,
-            removalResult.error().version);
+        [](const auto& operation) {
+            return operation.op == "remove"
+                || operation.op == "remove_all";
+        });
+    if (!hasRemoval
+        && registration->batch.nodes.empty()
+        && registration->batch.headers.empty()
+        && registration->effects.empty()) {
+        return true;
+    }
+
+    xvm::RemovalContext removalContext;
+    if (hasRemoval) {
+        auto snapshot = snapshot_xpkg_removal_context(
+            scopedDb, scopedWorkspace, xvm_ops,
+            registration->batch.provider,
+            registration->batch.providerVersion);
+        if (!snapshot) {
+            log::warn(
+                "xvm removal selection failed for {}@{}: {} "
+                "(target='{}', version='{}')",
+                registration->batch.provider,
+                registration->batch.providerVersion,
+                snapshot.error().message,
+                snapshot.error().target,
+                snapshot.error().version);
+            return false;
+        }
+        removalContext = std::move(*snapshot);
+    }
+
+    const auto dbBeforeRemoval = scopedDb;
+    auto metadata = apply_xpkg_xvm_metadata_batch(
+        scopedDb,
+        scopedWorkspace,
+        scopedInstalled,
+        xvm_ops,
+        removalContext,
+        *registration);
+    if (!metadata) {
+        if (std::holds_alternative<xvm::RemovalError>(
+                metadata.error())) {
+            const auto& error =
+                std::get<xvm::RemovalError>(metadata.error());
+            log::warn(
+                "xvm removal batch failed for {}@{}: {} "
+                "(target='{}', version='{}')",
+                registration->batch.provider,
+                registration->batch.providerVersion,
+                error.message,
+                error.target,
+                error.version);
+        } else {
+            const auto& error =
+                std::get<xvm::RegistrationError>(metadata.error());
+            log::warn(
+                "xvm registration batch failed for {}@{}: {} "
+                "(path='{}', target='{}', version='{}')",
+                registration->batch.provider,
+                registration->batch.providerVersion,
+                error.message,
+                error.path,
+                error.target,
+                error.version);
+        }
         return false;
     }
 
     cleanup_removed_xvm_library_artifacts(
         sysroot_lib,
         dbBeforeRemoval,
-        Config::versions_mut(),
-        *removalResult);
+        scopedDb,
+        metadata->removal);
 
-    for (auto& op : xvm_ops) {
-        if (op.op == "add") {
-            std::string ver = op.version.empty() ? node.version : op.version;
-            std::string p = op.bindir.empty()
-                ? ((node.storeRoot.empty() ? (dataDir / "xpkgs") : node.storeRoot)
-                    / detail_::effective_store_name_(node)
-                    / node.version).string()
-                : op.bindir;
-            std::string type = op.type.empty() ? "program" : op.type;
-            xvm::add_version(Config::versions_mut(),
-                             op.name, ver, p, type, op.filename, op.alias,
-                             version_ns, op.binding);
-
-            // Write envs from XvmOp into VData
-            auto ver_key = xvm::make_ns_version(version_ns, ver);
-            if (!op.envs.empty()) {
-                auto& vdata = Config::versions_mut()[op.name].versions[ver_key];
-                for (auto& [key, val] : op.envs) {
-                    vdata.envs[key] = val;
+    for (const auto& effect : metadata->effects) {
+        auto resolved = resolve_xpkg_filesystem_effect(
+            scopedDb, scopedWorkspace, effect);
+        if (!resolved) {
+            log::warn(
+                "validated xvm effect target disappeared or changed kind: "
+                "{}@{}",
+                effect.target, effect.version);
+            continue;
+        }
+        if (resolved->kind
+            == XpkgFilesystemEffectKind::InstallHeaders) {
+            xvm::install_headers(
+                resolved->sourceDir, sysroot_include);
+            continue;
+        }
+        if (resolved->kind
+            == XpkgFilesystemEffectKind::RemoveHeaders) {
+            xvm::remove_headers(
+                resolved->sourceDir, sysroot_include);
+            continue;
+        }
+        if (resolved->kind
+            == XpkgFilesystemEffectKind::ProgramShim) {
+            if (std::filesystem::exists(xlings_bin)) {
+                std::string shimName = resolved->target;
+                if (!shim_ext.empty() && !shimName.ends_with(shim_ext)) {
+                    shimName += shim_ext;
+                }
+                std::filesystem::create_directories(artifactBinDir);
+                xself::create_shim(
+                    xlings_bin, artifactBinDir / shimName);
+                if (artifactBinDir
+                    != Config::global_subos_bin_dir()) {
+                    common::mirror_shim_to_global_bin(
+                        xlings_bin, shimName);
                 }
             }
 
-            // Activate and create shim for each added program.
-            // Auto-activate only when no version is currently active for this
-            // program OR the caller passed useAfterInstall (`--use`). Otherwise
-            // preserve the user's existing choice. The shim is always
-            // (re-)created so the program is reachable on PATH once activated.
-            if (type == "program") {
-                auto& ws = Config::workspace();
-                bool hasActive = ws.contains(op.name) && !ws.at(op.name).empty();
-                bool didActivate = !hasActive || useAfterInstall;
-                if (didActivate) {
-                    Config::workspace_mut()[op.name] = ver_key;
+            if (resolved->active
+                && xvm::is_xlings_binary(resolved->target)
+                && std::filesystem::exists(xlings_bin)
+                && !resolved->path.empty()
+                && !resolved->sourceName.empty()) {
+                auto activeName = resolved->sourceName;
+                if (!shim_ext.empty()
+                    && !activeName.ends_with(shim_ext)) {
+                    activeName += shim_ext;
                 }
-
-                // 0.4.19+: track ver_key in this subos's installed[] set.
-                // Independent of the active-pointer decision above — a
-                // version is "installed in this subos" once the package
-                // recipe has been run for it, regardless of whether it's
-                // the currently selected one. The set is what powers
-                // subos-aware list/use/update in the next PR.
-                {
-                    auto& list = Config::workspace_installed_mut()[op.name];
-                    if (std::find(list.begin(), list.end(), ver_key) == list.end()) {
-                        list.push_back(ver_key);
+                const auto activeBin =
+                    std::filesystem::path(resolved->path)
+                    / activeName;
+                if (std::filesystem::exists(activeBin)) {
+                    if (platform::atomic_replace_executable(
+                            activeBin, xlings_bin)) {
+                        log::debug(
+                            "[self-replace] bootstrap {} <- {}",
+                            xlings_bin.string(), activeBin.string());
+                    } else {
+                        log::warn(
+                            "[self-replace] failed: bootstrap {} <- {}",
+                            xlings_bin.string(), activeBin.string());
                     }
                 }
-                if (std::filesystem::exists(xlings_bin)) {
-                    std::string shim_name = op.name;
-                    if (!shim_ext.empty() && !shim_name.ends_with(shim_ext))
-                        shim_name += shim_ext;
-                    std::filesystem::create_directories(paths.binDir);
-                    xself::create_shim(xlings_bin, paths.binDir / shim_name);
-                    common::mirror_shim_to_global_bin(xlings_bin, shim_name);
-                }
-
-                // Self-replace bootstrap when activating xlings/xim/xvm.
-                // main.cpp's multiplexer short-circuits these names to the
-                // local cli::run() — it doesn't consult the workspace at
-                // runtime. So the only way to make "active xlings = X.Y.Z"
-                // visible to the user is to physically replace the bootstrap
-                // binary at xlings_bin with the version we just installed.
-                // Atomic replace (POSIX rename / Windows MoveFileEx-old-then-
-                // copy) is safe even when the running process IS the bootstrap.
-                if (didActivate
-                    && xvm::is_xlings_binary(op.name)
-                    && std::filesystem::exists(xlings_bin)
-                    && !op.bindir.empty()) {
-                    auto active_bin = std::filesystem::path(op.bindir)
-                                    / ("xlings" + std::string(shim_ext));
-                    if (std::filesystem::exists(active_bin)) {
-                        if (platform::atomic_replace_executable(active_bin, xlings_bin)) {
-                            log::debug("[self-replace] bootstrap {} <- {}",
-                                      xlings_bin.string(), active_bin.string());
-                        } else {
-                            log::warn("[self-replace] failed: bootstrap {} <- {}",
-                                     xlings_bin.string(), active_bin.string());
-                        }
-                    }
-                    // COMPAT(0.4.8 → drop in 0.6.0): opportunistic legacy
-                    // alias cleanup, alongside the bootstrap replacement.
-                    xself::compat::v0_4_8::cleanup_legacy_alias_shims(paths.binDir, xlings_bin);
-                }
-            } else if (type == "lib" && !op.bindir.empty()) {
-                // Install lib symlink to subos lib dir
-                std::string fname = op.filename.empty() ? op.name : op.filename;
-                auto src = std::filesystem::path(op.bindir) / fname;
-                std::filesystem::create_directories(sysroot_lib);
-                auto dst = sysroot_lib / fname;
-                std::error_code ec;
-                if (std::filesystem::exists(dst, ec) || std::filesystem::is_symlink(dst, ec))
-                    std::filesystem::remove(dst, ec);
-                if (std::filesystem::exists(src, ec))
-                    std::filesystem::create_symlink(src, dst, ec);
+                xself::compat::v0_4_8::cleanup_legacy_alias_shims(
+                    artifactBinDir, xlings_bin);
             }
-        } else if (op.op == "headers") {
-            xvm::install_headers(op.includedir, sysroot_include);
-            auto hdr_ver_key = xvm::make_ns_version(version_ns, node.version);
-            auto& vdata = Config::versions_mut()[node.name].versions[hdr_ver_key];
-            vdata.includedir = op.includedir;
-        } else if (op.op == "remove_headers") {
-            xvm::remove_headers(op.includedir, sysroot_include);
+            continue;
+        }
+        if (resolved->kind != XpkgFilesystemEffectKind::Library
+            || resolved->path.empty()) {
+            continue;
+        }
+
+        const auto source =
+            std::filesystem::path(resolved->path)
+            / resolved->sourceName;
+        const auto destination =
+            sysroot_lib / resolved->destinationName;
+        std::filesystem::create_directories(sysroot_lib);
+        std::error_code ec;
+        if (std::filesystem::exists(destination, ec)
+            || std::filesystem::is_symlink(destination, ec)) {
+            std::filesystem::remove(destination, ec);
+        }
+        ec.clear();
+        if (std::filesystem::exists(source, ec)) {
+            std::filesystem::create_symlink(
+                source, destination, ec);
         }
     }
 
     cleanup_removed_xvm_program_artifacts(
-        Config::paths().binDir,
+        artifactBinDir,
         dbBeforeRemoval,
-        Config::versions_mut(),
-        Config::workspace_installed(),
-        *removalResult);
+        scopedDb,
+        scopedInstalled,
+        metadata->removal);
 
-    Config::save_versions();
-    Config::save_workspace();
+    if (!metadata->removal.removed.empty()
+        || !metadata->registered.empty()) {
+        Config::save_versions();
+        Config::save_workspace();
+    }
     return true;
 }
 
@@ -1304,10 +1696,10 @@ public:
             ctx.platform = platform;
             auto targetRoot = node.storeRoot.empty() ? (dataDir / "xpkgs") : node.storeRoot;
             ctx.install_dir = targetRoot / detail_::effective_store_name_(node) / node.version;
-            ctx.bin_dir = Config::paths().binDir;
+            detail_::configure_xpkg_execution_artifact_paths_(
+                ctx);
             ctx.xpkg_dir = node.pkgFile.parent_path();
             ctx.project_data_dir = Config::project_data_dir();
-            ctx.subos_sysrootdir = Config::paths().subosDir.string();
             // pkgindex_dir: package index repo root (for custom module loading).
             // pkgFile layout: <pkgindex>/pkgs/<letter>/<name>.lua → 3 levels up.
             ctx.pkgindex_dir = node.pkgFile.parent_path()
@@ -1623,7 +2015,7 @@ public:
             // Apply elfpatch auto-patching if the install hook enabled it
             if (!payloadInstalled) {
                 // Ensure binDir is in PATH so elfpatch can find patchelf
-                auto binDir = Config::paths().binDir.string();
+                auto binDir = ctx.bin_dir.string();
                 auto curPath = std::string(std::getenv("PATH") ? std::getenv("PATH") : "");
                 if (!binDir.empty() && curPath.find(binDir) == std::string::npos) {
                     platform::set_env_variable("PATH",
@@ -1851,10 +2243,11 @@ public:
         ctx.pkg_name = resolvedMatch ? resolvedMatch->name : name;
         ctx.version = resolvedMatch ? resolvedMatch->version : std::string{};
         ctx.platform = platform;
-        ctx.bin_dir = Config::paths().binDir;
+        const auto artifactSubosDir =
+            detail_::configure_xpkg_execution_artifact_paths_(
+                ctx);
         ctx.install_dir = installDir;
         ctx.xpkg_dir = pkgFile.parent_path();
-        ctx.subos_sysrootdir = Config::paths().subosDir.string();
         ctx.pkgindex_dir = pkgFile.parent_path()
                                   .parent_path()
                                   .parent_path().string();
@@ -1897,7 +2290,8 @@ public:
                 .version = detachVersion,
             });
         }
-        auto sysroot_include = Config::paths().subosDir / "usr" / "include";
+        auto sysroot_include =
+            artifactSubosDir / "usr" / "include";
 
         const auto dbBeforeRemoval = Config::versions_mut();
         auto removalResult = apply_xpkg_removal_operations(
@@ -1933,12 +2327,12 @@ public:
             }
         }
         cleanup_removed_xvm_library_artifacts(
-            Config::paths().libDir,
+            artifactSubosDir / "lib",
             dbBeforeRemoval,
             Config::versions_mut(),
             *removalResult);
         cleanup_removed_xvm_program_artifacts(
-            Config::paths().binDir,
+            artifactSubosDir / "bin",
             dbBeforeRemoval,
             Config::versions_mut(),
             Config::workspace_installed(),

--- a/src/core/xim/libxpkg/types/script.cppm
+++ b/src/core/xim/libxpkg/types/script.cppm
@@ -8,6 +8,7 @@ import xlings.core.config;
 import xlings.core.log;
 import xlings.core.xself;
 import xlings.core.xvm.db;
+import xlings.core.xvm.removal;
 import mcpplibs.xpkg.executor;
 
 export namespace xlings::xim::script {
@@ -77,6 +78,29 @@ bool default_config(const PlanNode& node,
 }
 
 bool default_uninstall(const std::string& name, const std::string& version) {
+    if (version.empty()) return false;
+
+    auto exactVersion = xvm::resolve_exact_version_key(
+        Config::versions_mut(), name, version);
+    if (!exactVersion) return false;
+    const auto wasActive =
+        Config::workspace().contains(name)
+        && Config::workspace().at(name) == *exactVersion;
+    const std::vector<xvm::RemovalOperation> operations{
+        {
+            .op = "remove",
+            .name = name,
+            .version = *exactVersion,
+        },
+    };
+    auto removal = xvm::apply_removal_batch(
+        Config::versions_mut(),
+        Config::workspace_mut(),
+        Config::workspace_installed_mut(),
+        operations,
+        {});
+    if (!removal) return false;
+
     auto paths = Config::paths();
 #ifdef _WIN32
     constexpr std::string_view shim_ext = ".exe";
@@ -87,15 +111,16 @@ bool default_uninstall(const std::string& name, const std::string& version) {
     if (!shim_ext.empty() && !shim_name.ends_with(shim_ext))
         shim_name += std::string(shim_ext);
     auto shim_path = paths.binDir / shim_name;
-    if (std::filesystem::exists(shim_path)) {
-        std::filesystem::remove(shim_path);
-    }
-
-    Config::workspace_mut().erase(name);
-    if (version.empty()) {
-        Config::versions_mut().erase(name);
-    } else {
-        xvm::remove_version(Config::versions_mut(), name, version);
+    if (wasActive
+        && !xvm::has_usable_workspace_version(
+            Config::versions_mut(),
+            Config::workspace_installed(),
+            name)) {
+        std::error_code ec;
+        if (std::filesystem::exists(shim_path, ec)) {
+            ec.clear();
+            std::filesystem::remove(shim_path, ec);
+        }
     }
 
     Config::save_versions();

--- a/src/core/xim/libxpkg/types/subos.cppm
+++ b/src/core/xim/libxpkg/types/subos.cppm
@@ -7,6 +7,7 @@ import xlings.core.common;
 import xlings.core.config;
 import xlings.core.log;
 import xlings.core.xvm.db;
+import xlings.core.xvm.removal;
 import xlings.libs.json;
 import mcpplibs.xpkg.executor;
 
@@ -102,12 +103,21 @@ bool default_uninstall(const std::string& name, const std::string& version) {
     // payload at xpkgs/<name>/<ver>/. Forks already in subos/ are independent
     // and not touched by this — their .xlings.json points to xpkgs they
     // reference directly (deps), and those deps are independent xpkgs.
-    Config::workspace_mut().erase(name);
-    if (version.empty()) {
-        Config::versions_mut().erase(name);
-    } else {
-        xvm::remove_version(Config::versions_mut(), name, version);
-    }
+    if (version.empty()) return false;
+    const std::vector<xvm::RemovalOperation> operations{
+        {
+            .op = "remove",
+            .name = name,
+            .version = version,
+        },
+    };
+    auto removal = xvm::apply_removal_batch(
+        Config::versions_mut(),
+        Config::workspace_mut(),
+        Config::workspace_installed_mut(),
+        operations,
+        {});
+    if (!removal) return false;
 
     Config::save_versions();
     Config::save_workspace();

--- a/src/core/xvm.cppm
+++ b/src/core/xvm.cppm
@@ -3,5 +3,6 @@ export module xlings.core.xvm;
 export import xlings.core.xvm.types;
 export import xlings.core.xvm.db;
 export import xlings.core.xvm.bindings;
+export import xlings.core.xvm.registration;
 export import xlings.core.xvm.shim;
 export import xlings.core.xvm.commands;

--- a/src/core/xvm.cppm
+++ b/src/core/xvm.cppm
@@ -2,5 +2,6 @@ export module xlings.core.xvm;
 
 export import xlings.core.xvm.types;
 export import xlings.core.xvm.db;
+export import xlings.core.xvm.bindings;
 export import xlings.core.xvm.shim;
 export import xlings.core.xvm.commands;

--- a/src/core/xvm/bindings.cppm
+++ b/src/core/xvm/bindings.cppm
@@ -79,8 +79,31 @@ bool supported_kind_(std::string_view kind) {
     return kind == "program" || kind == "lib" || kind == "group";
 }
 
+std::optional<std::string_view>
+canonical_manifest_path_(const VData& data) {
+    if (data.bindingMembersDeclared || !data.bindingMembers.empty()) {
+        return "/bindingMembers";
+    }
+    if (data.bindingHeadersDeclared || !data.bindingHeaders.empty()) {
+        return "/bindingHeaders";
+    }
+    return std::nullopt;
+}
+
 bool has_canonical_manifest_(const VData& data) {
-    return !data.bindingMembers.empty() || !data.bindingHeaders.empty();
+    return canonical_manifest_path_(data).has_value();
+}
+
+BindingError metadata_integrity_error_(
+    const std::string& target,
+    const std::string& version,
+    std::string_view code,
+    std::string_view path) {
+    return binding_error_(
+        BindingErrorKind::MetadataIntegrityIssue,
+        target, version,
+        std::format("binding metadata integrity issue '{}' at '{}'",
+                    code, path));
 }
 
 std::optional<BindingError>
@@ -89,11 +112,42 @@ binding_integrity_error_(const VData& data,
                          const std::string& version) {
     if (data.bindingIntegrityIssues.empty()) return std::nullopt;
     const auto& issue = data.bindingIntegrityIssues.front();
-    return binding_error_(
-        BindingErrorKind::MetadataIntegrityIssue,
-        target, version,
-        std::format("binding metadata integrity issue '{}' at '{}'",
-                    issue.code, issue.path));
+    return metadata_integrity_error_(
+        target, version, issue.code, issue.path);
+}
+
+std::optional<std::string_view>
+invalid_group_identity_path_(const BindingGroupRef& group) {
+    if (group.provider.empty()) return "/bindingGroup/provider";
+    if (group.providerVersion.empty()) return "/bindingGroup/version";
+    if (group.group.empty()) return "/bindingGroup/group";
+    if (group.rootTarget.empty()) return "/bindingGroup/rootTarget";
+    if (group.rootVersion.empty()) return "/bindingGroup/rootVersion";
+    return std::nullopt;
+}
+
+std::optional<BindingError>
+group_identity_integrity_error_(const BindingGroupRef& group,
+                                const std::string& target,
+                                const std::string& version) {
+    const auto invalidPath = invalid_group_identity_path_(group);
+    if (!invalidPath) return std::nullopt;
+    return metadata_integrity_error_(
+        target, version, "binding-group-field-invalid", *invalidPath);
+}
+
+std::optional<BindingError>
+non_root_metadata_error_(const VData& data,
+                         const std::string& target,
+                         const std::string& version,
+                         const BindingGroupRef& group) {
+    if (target == group.rootTarget && version == group.rootVersion) {
+        return std::nullopt;
+    }
+    const auto metadataPath = canonical_manifest_path_(data);
+    if (!metadataPath) return std::nullopt;
+    return metadata_integrity_error_(
+        target, version, "binding-metadata-on-non-root", *metadataPath);
 }
 
 std::expected<BindingSelection, BindingError>
@@ -120,6 +174,13 @@ resolve_provider_group_(const VersionDB& db,
     if (auto error = binding_integrity_error_(
             root, group.rootTarget, group.rootVersion)) {
         return std::unexpected(std::move(*error));
+    }
+    if (root.bindingGroup) {
+        if (auto error = group_identity_integrity_error_(
+                *root.bindingGroup,
+                group.rootTarget, group.rootVersion)) {
+            return std::unexpected(std::move(*error));
+        }
     }
     if (!root.bindingGroup
         || root.bindingGroup->rootTarget != group.rootTarget
@@ -170,12 +231,23 @@ resolve_provider_group_(const VersionDB& db,
                 memberIt->second, memberTarget, memberVersion)) {
             return std::unexpected(std::move(*error));
         }
+        if (memberIt->second.bindingGroup) {
+            if (auto error = group_identity_integrity_error_(
+                    *memberIt->second.bindingGroup,
+                    memberTarget, memberVersion)) {
+                return std::unexpected(std::move(*error));
+            }
+        }
         if (!memberIt->second.bindingGroup
             || !same_group_(*memberIt->second.bindingGroup, group)) {
             return std::unexpected(binding_error_(
                 BindingErrorKind::MemberReferenceMismatch,
                 memberTarget, memberVersion,
                 "binding member back-reference is inconsistent"));
+        }
+        if (auto error = non_root_metadata_error_(
+                memberIt->second, memberTarget, memberVersion, group)) {
+            return std::unexpected(std::move(*error));
         }
         if (!supported_kind_(memberIt->second.kind)) {
             return std::unexpected(binding_error_(
@@ -228,6 +300,11 @@ resolve_legacy_graph_(const VersionDB& db,
             return std::unexpected(std::move(*error));
         }
         if (dataIt->second.bindingGroup) {
+            if (auto error = group_identity_integrity_error_(
+                    *dataIt->second.bindingGroup,
+                    currentTarget, currentVersion)) {
+                return std::unexpected(std::move(*error));
+            }
             return std::unexpected(binding_error_(
                 BindingErrorKind::ProviderMetadataInLegacyGraph,
                 currentTarget, currentVersion,
@@ -343,6 +420,15 @@ resolve_binding_selection(const VersionDB& db,
             "canonical binding manifest is missing its binding group"));
     }
     if (versionIt->second.bindingGroup) {
+        if (auto error = detail_::group_identity_integrity_error_(
+                *versionIt->second.bindingGroup, target, version)) {
+            return std::unexpected(std::move(*error));
+        }
+        if (auto error = detail_::non_root_metadata_error_(
+                versionIt->second, target, version,
+                *versionIt->second.bindingGroup)) {
+            return std::unexpected(std::move(*error));
+        }
         return detail_::resolve_provider_group_(
             db, target, version, *versionIt->second.bindingGroup);
     }

--- a/src/core/xvm/bindings.cppm
+++ b/src/core/xvm/bindings.cppm
@@ -116,6 +116,50 @@ binding_integrity_error_(const VData& data,
         target, version, issue.code, issue.path);
 }
 
+std::string json_pointer_token_(std::string_view token) {
+    std::string escaped;
+    escaped.reserve(token.size());
+    for (const auto ch : token) {
+        if (ch == '~') {
+            escaped += "~0";
+        } else if (ch == '/') {
+            escaped += "~1";
+        } else {
+            escaped += ch;
+        }
+    }
+    return escaped;
+}
+
+std::optional<BindingError>
+root_content_integrity_error_(const VData& root,
+                              const std::string& target,
+                              const std::string& version) {
+    for (const auto& [memberTarget, memberVersion] : root.bindingMembers) {
+        if (memberTarget.empty()) {
+            return metadata_integrity_error_(
+                target, version,
+                "binding-member-target-empty", "/bindingMembers/");
+        }
+        if (memberVersion.empty()) {
+            return metadata_integrity_error_(
+                target, version,
+                "binding-member-version-empty",
+                "/bindingMembers/" + json_pointer_token_(memberTarget));
+        }
+    }
+    for (std::size_t index = 0;
+         index < root.bindingHeaders.size(); ++index) {
+        if (root.bindingHeaders[index].sourceDir.empty()) {
+            return metadata_integrity_error_(
+                target, version,
+                "binding-header-source-dir-empty",
+                std::format("/bindingHeaders/{}/sourceDir", index));
+        }
+    }
+    return std::nullopt;
+}
+
 std::optional<std::string_view>
 invalid_group_identity_path_(const BindingGroupRef& group) {
     if (group.provider.empty()) return "/bindingGroup/provider";
@@ -195,6 +239,10 @@ resolve_provider_group_(const VersionDB& db,
             BindingErrorKind::GroupIdentityMismatch,
             group.rootTarget, group.rootVersion,
             "binding root group identity is inconsistent"));
+    }
+    if (auto error = root_content_integrity_error_(
+            root, group.rootTarget, group.rootVersion)) {
+        return std::unexpected(std::move(*error));
     }
 
     auto startIt = root.bindingMembers.find(target);

--- a/src/core/xvm/bindings.cppm
+++ b/src/core/xvm/bindings.cppm
@@ -24,6 +24,9 @@ enum class BindingErrorKind {
     SelfEdge,
     AsymmetricEdge,
     ConflictingTargetVersion,
+    PartialProviderMetadata,
+    ProviderMetadataInLegacyGraph,
+    MetadataIntegrityIssue,
 };
 
 struct BindingSelection {
@@ -38,7 +41,14 @@ struct BindingError {
     std::string message;
 };
 
-namespace detail_ {
+std::expected<BindingSelection, BindingError>
+resolve_binding_selection(const VersionDB& db,
+                          const std::string& target,
+                          const std::string& version);
+
+}  // namespace xlings::xvm
+
+namespace xlings::xvm::detail_ {
 
 BindingError binding_error_(BindingErrorKind kind,
                             const std::string& target,
@@ -69,6 +79,23 @@ bool supported_kind_(std::string_view kind) {
     return kind == "program" || kind == "lib" || kind == "group";
 }
 
+bool has_canonical_manifest_(const VData& data) {
+    return !data.bindingMembers.empty() || !data.bindingHeaders.empty();
+}
+
+std::optional<BindingError>
+binding_integrity_error_(const VData& data,
+                         const std::string& target,
+                         const std::string& version) {
+    if (data.bindingIntegrityIssues.empty()) return std::nullopt;
+    const auto& issue = data.bindingIntegrityIssues.front();
+    return binding_error_(
+        BindingErrorKind::MetadataIntegrityIssue,
+        target, version,
+        std::format("binding metadata integrity issue '{}' at '{}'",
+                    issue.code, issue.path));
+}
+
 std::expected<BindingSelection, BindingError>
 resolve_provider_group_(const VersionDB& db,
                         const std::string& target,
@@ -90,6 +117,10 @@ resolve_provider_group_(const VersionDB& db,
     }
 
     const auto& root = rootIt->second;
+    if (auto error = binding_integrity_error_(
+            root, group.rootTarget, group.rootVersion)) {
+        return std::unexpected(std::move(*error));
+    }
     if (!root.bindingGroup
         || root.bindingGroup->rootTarget != group.rootTarget
         || root.bindingGroup->rootVersion != group.rootVersion) {
@@ -134,6 +165,10 @@ resolve_provider_group_(const VersionDB& db,
                 BindingErrorKind::VersionNotFound,
                 memberTarget, memberVersion,
                 "binding member version is missing"));
+        }
+        if (auto error = binding_integrity_error_(
+                memberIt->second, memberTarget, memberVersion)) {
+            return std::unexpected(std::move(*error));
         }
         if (!memberIt->second.bindingGroup
             || !same_group_(*memberIt->second.bindingGroup, group)) {
@@ -187,6 +222,22 @@ resolve_legacy_graph_(const VersionDB& db,
                 BindingErrorKind::VersionNotFound,
                 currentTarget, currentVersion,
                 "legacy version is missing"));
+        }
+        if (auto error = binding_integrity_error_(
+                dataIt->second, currentTarget, currentVersion)) {
+            return std::unexpected(std::move(*error));
+        }
+        if (dataIt->second.bindingGroup) {
+            return std::unexpected(binding_error_(
+                BindingErrorKind::ProviderMetadataInLegacyGraph,
+                currentTarget, currentVersion,
+                "provider-aware version cannot participate in a legacy graph"));
+        }
+        if (has_canonical_manifest_(dataIt->second)) {
+            return std::unexpected(binding_error_(
+                BindingErrorKind::PartialProviderMetadata,
+                currentTarget, currentVersion,
+                "canonical binding manifest is missing its binding group"));
         }
         const auto kind = dataIt->second.kind.empty()
             ? std::string_view{infoIt->second.type}
@@ -260,7 +311,9 @@ resolve_legacy_graph_(const VersionDB& db,
     return selection;
 }
 
-}  // namespace detail_
+}  // namespace xlings::xvm::detail_
+
+namespace xlings::xvm {
 
 std::expected<BindingSelection, BindingError>
 resolve_binding_selection(const VersionDB& db,
@@ -277,6 +330,17 @@ resolve_binding_selection(const VersionDB& db,
         return std::unexpected(detail_::binding_error_(
             BindingErrorKind::VersionNotFound,
             target, version, "binding version is missing"));
+    }
+    if (auto error = detail_::binding_integrity_error_(
+            versionIt->second, target, version)) {
+        return std::unexpected(std::move(*error));
+    }
+    if (!versionIt->second.bindingGroup
+        && detail_::has_canonical_manifest_(versionIt->second)) {
+        return std::unexpected(detail_::binding_error_(
+            BindingErrorKind::PartialProviderMetadata,
+            target, version,
+            "canonical binding manifest is missing its binding group"));
     }
     if (versionIt->second.bindingGroup) {
         return detail_::resolve_provider_group_(

--- a/src/core/xvm/bindings.cppm
+++ b/src/core/xvm/bindings.cppm
@@ -1,0 +1,288 @@
+export module xlings.core.xvm.bindings;
+
+import std;
+
+import xlings.core.xvm.types;
+
+export namespace xlings::xvm {
+
+enum class BindingSource {
+    ProviderGroup,
+    LegacyGraph,
+};
+
+enum class BindingErrorKind {
+    InvalidGraph,
+    TargetNotFound,
+    VersionNotFound,
+    RootReferenceMismatch,
+    GroupIdentityMismatch,
+    RootMissingFromManifest,
+    StartMemberMissing,
+    MemberReferenceMismatch,
+    UnsupportedKind,
+    SelfEdge,
+    AsymmetricEdge,
+    ConflictingTargetVersion,
+};
+
+struct BindingSelection {
+    std::map<std::string, std::string> members;
+    BindingSource source { BindingSource::LegacyGraph };
+};
+
+struct BindingError {
+    BindingErrorKind kind { BindingErrorKind::InvalidGraph };
+    std::string target;
+    std::string version;
+    std::string message;
+};
+
+namespace detail_ {
+
+BindingError binding_error_(BindingErrorKind kind,
+                            const std::string& target,
+                            const std::string& version,
+                            std::string message) {
+    return {
+        .kind = kind,
+        .target = target,
+        .version = version,
+        .message = std::move(message),
+    };
+}
+
+bool same_group_identity_(const BindingGroupRef& lhs,
+                          const BindingGroupRef& rhs) {
+    return lhs.provider == rhs.provider
+        && lhs.providerVersion == rhs.providerVersion
+        && lhs.group == rhs.group;
+}
+
+bool same_group_(const BindingGroupRef& lhs, const BindingGroupRef& rhs) {
+    return same_group_identity_(lhs, rhs)
+        && lhs.rootTarget == rhs.rootTarget
+        && lhs.rootVersion == rhs.rootVersion;
+}
+
+bool supported_kind_(std::string_view kind) {
+    return kind == "program" || kind == "lib" || kind == "group";
+}
+
+std::expected<BindingSelection, BindingError>
+resolve_provider_group_(const VersionDB& db,
+                        const std::string& target,
+                        const std::string& version,
+                        const BindingGroupRef& group) {
+    auto rootInfoIt = db.find(group.rootTarget);
+    if (rootInfoIt == db.end()) {
+        return std::unexpected(binding_error_(
+            BindingErrorKind::TargetNotFound,
+            group.rootTarget, group.rootVersion,
+            "binding root target is missing"));
+    }
+    auto rootIt = rootInfoIt->second.versions.find(group.rootVersion);
+    if (rootIt == rootInfoIt->second.versions.end()) {
+        return std::unexpected(binding_error_(
+            BindingErrorKind::VersionNotFound,
+            group.rootTarget, group.rootVersion,
+            "binding root version is missing"));
+    }
+
+    const auto& root = rootIt->second;
+    if (!root.bindingGroup
+        || root.bindingGroup->rootTarget != group.rootTarget
+        || root.bindingGroup->rootVersion != group.rootVersion) {
+        return std::unexpected(binding_error_(
+            BindingErrorKind::RootReferenceMismatch,
+            group.rootTarget, group.rootVersion,
+            "binding root does not reference itself"));
+    }
+    if (!same_group_identity_(*root.bindingGroup, group)) {
+        return std::unexpected(binding_error_(
+            BindingErrorKind::GroupIdentityMismatch,
+            group.rootTarget, group.rootVersion,
+            "binding root group identity is inconsistent"));
+    }
+
+    auto startIt = root.bindingMembers.find(target);
+    if (startIt == root.bindingMembers.end() || startIt->second != version) {
+        return std::unexpected(binding_error_(
+            BindingErrorKind::StartMemberMissing,
+            target, version, "starting member is absent from binding manifest"));
+    }
+    auto manifestRootIt = root.bindingMembers.find(group.rootTarget);
+    if (manifestRootIt == root.bindingMembers.end()
+        || manifestRootIt->second != group.rootVersion) {
+        return std::unexpected(binding_error_(
+            BindingErrorKind::RootMissingFromManifest,
+            group.rootTarget, group.rootVersion,
+            "binding root is absent from binding manifest"));
+    }
+
+    for (const auto& [memberTarget, memberVersion] : root.bindingMembers) {
+        auto memberInfoIt = db.find(memberTarget);
+        if (memberInfoIt == db.end()) {
+            return std::unexpected(binding_error_(
+                BindingErrorKind::TargetNotFound,
+                memberTarget, memberVersion,
+                "binding member target is missing"));
+        }
+        auto memberIt = memberInfoIt->second.versions.find(memberVersion);
+        if (memberIt == memberInfoIt->second.versions.end()) {
+            return std::unexpected(binding_error_(
+                BindingErrorKind::VersionNotFound,
+                memberTarget, memberVersion,
+                "binding member version is missing"));
+        }
+        if (!memberIt->second.bindingGroup
+            || !same_group_(*memberIt->second.bindingGroup, group)) {
+            return std::unexpected(binding_error_(
+                BindingErrorKind::MemberReferenceMismatch,
+                memberTarget, memberVersion,
+                "binding member back-reference is inconsistent"));
+        }
+        if (!supported_kind_(memberIt->second.kind)) {
+            return std::unexpected(binding_error_(
+                BindingErrorKind::UnsupportedKind,
+                memberTarget, memberVersion,
+                std::format("unsupported provider-group member kind '{}'",
+                            memberIt->second.kind)));
+        }
+    }
+
+    return BindingSelection{
+        .members = root.bindingMembers,
+        .source = BindingSource::ProviderGroup,
+    };
+}
+
+std::expected<BindingSelection, BindingError>
+resolve_legacy_graph_(const VersionDB& db,
+                      const std::string& target,
+                      const std::string& version) {
+    BindingSelection selection{
+        .source = BindingSource::LegacyGraph,
+    };
+    std::vector<std::pair<std::string, std::string>> pending{
+        {target, version},
+    };
+    std::set<std::pair<std::string, std::string>> visited;
+
+    while (!pending.empty()) {
+        auto [currentTarget, currentVersion] = std::move(pending.back());
+        pending.pop_back();
+        if (!visited.emplace(currentTarget, currentVersion).second) continue;
+
+        auto infoIt = db.find(currentTarget);
+        if (infoIt == db.end()) {
+            return std::unexpected(binding_error_(
+                BindingErrorKind::TargetNotFound,
+                currentTarget, currentVersion,
+                "legacy target is missing"));
+        }
+        auto dataIt = infoIt->second.versions.find(currentVersion);
+        if (dataIt == infoIt->second.versions.end()) {
+            return std::unexpected(binding_error_(
+                BindingErrorKind::VersionNotFound,
+                currentTarget, currentVersion,
+                "legacy version is missing"));
+        }
+        const auto kind = dataIt->second.kind.empty()
+            ? std::string_view{infoIt->second.type}
+            : std::string_view{dataIt->second.kind};
+        if (!supported_kind_(kind)) {
+            return std::unexpected(binding_error_(
+                BindingErrorKind::UnsupportedKind,
+                currentTarget, currentVersion,
+                std::format("unsupported legacy member kind '{}'", kind)));
+        }
+
+        if (auto selectedIt = selection.members.find(currentTarget);
+            selectedIt != selection.members.end()
+            && selectedIt->second != currentVersion) {
+            return std::unexpected(binding_error_(
+                BindingErrorKind::ConflictingTargetVersion,
+                currentTarget, currentVersion,
+                "legacy graph selects conflicting target versions"));
+        }
+        selection.members[currentTarget] = currentVersion;
+
+        for (const auto& [peerTarget, versions] : infoIt->second.bindings) {
+            auto edgeIt = versions.find(currentVersion);
+            if (edgeIt == versions.end()) continue;
+            const auto& peerVersion = edgeIt->second;
+            if (peerTarget == currentTarget) {
+                return std::unexpected(binding_error_(
+                    BindingErrorKind::SelfEdge,
+                    currentTarget, currentVersion,
+                    "legacy binding contains a self-edge"));
+            }
+
+            auto peerInfoIt = db.find(peerTarget);
+            if (peerInfoIt == db.end()) {
+                return std::unexpected(binding_error_(
+                    BindingErrorKind::TargetNotFound,
+                    peerTarget, peerVersion,
+                    "legacy binding destination target is missing"));
+            }
+            if (!peerInfoIt->second.versions.contains(peerVersion)) {
+                return std::unexpected(binding_error_(
+                    BindingErrorKind::VersionNotFound,
+                    peerTarget, peerVersion,
+                    "legacy binding destination version is missing"));
+            }
+            auto reverseIt = peerInfoIt->second.bindings.find(currentTarget);
+            if (reverseIt == peerInfoIt->second.bindings.end()) {
+                return std::unexpected(binding_error_(
+                    BindingErrorKind::AsymmetricEdge,
+                    peerTarget, peerVersion, "legacy binding is asymmetric"));
+            }
+            auto reverseVersionIt = reverseIt->second.find(peerVersion);
+            if (reverseVersionIt == reverseIt->second.end()
+                || reverseVersionIt->second != currentVersion) {
+                return std::unexpected(binding_error_(
+                    BindingErrorKind::AsymmetricEdge,
+                    peerTarget, peerVersion, "legacy binding is asymmetric"));
+            }
+            if (auto selectedIt = selection.members.find(peerTarget);
+                selectedIt != selection.members.end()
+                && selectedIt->second != peerVersion) {
+                return std::unexpected(binding_error_(
+                    BindingErrorKind::ConflictingTargetVersion,
+                    peerTarget, peerVersion,
+                    "legacy graph selects conflicting target versions"));
+            }
+            pending.emplace_back(peerTarget, peerVersion);
+        }
+    }
+
+    return selection;
+}
+
+}  // namespace detail_
+
+std::expected<BindingSelection, BindingError>
+resolve_binding_selection(const VersionDB& db,
+                          const std::string& target,
+                          const std::string& version) {
+    auto infoIt = db.find(target);
+    if (infoIt == db.end()) {
+        return std::unexpected(detail_::binding_error_(
+            BindingErrorKind::TargetNotFound,
+            target, version, "binding target is missing"));
+    }
+    auto versionIt = infoIt->second.versions.find(version);
+    if (versionIt == infoIt->second.versions.end()) {
+        return std::unexpected(detail_::binding_error_(
+            BindingErrorKind::VersionNotFound,
+            target, version, "binding version is missing"));
+    }
+    if (versionIt->second.bindingGroup) {
+        return detail_::resolve_provider_group_(
+            db, target, version, *versionIt->second.bindingGroup);
+    }
+    return detail_::resolve_legacy_graph_(db, target, version);
+}
+
+}  // namespace xlings::xvm

--- a/src/core/xvm/bindings.cppm
+++ b/src/core/xvm/bindings.cppm
@@ -323,6 +323,20 @@ resolve_legacy_graph_(const VersionDB& db,
         {target, version},
     };
     std::set<std::pair<std::string, std::string>> visited;
+    std::map<
+        std::pair<std::string, std::string>,
+        std::vector<std::pair<std::string, std::string>>> incomingEdges;
+    for (const auto& [sourceTarget, sourceInfo] : db) {
+        for (const auto& [destinationTarget, versions] :
+             sourceInfo.bindings) {
+            for (const auto& [sourceVersion, destinationVersion] :
+                 versions) {
+                incomingEdges[
+                    {destinationTarget, destinationVersion}]
+                    .emplace_back(sourceTarget, sourceVersion);
+            }
+        }
+    }
 
     while (!pending.empty()) {
         auto [currentTarget, currentVersion] = std::move(pending.back());
@@ -372,6 +386,45 @@ resolve_legacy_graph_(const VersionDB& db,
                 BindingErrorKind::UnsupportedKind,
                 currentTarget, currentVersion,
                 std::format("unsupported legacy member kind '{}'", kind)));
+        }
+
+        const auto incomingIt =
+            incomingEdges.find({currentTarget, currentVersion});
+        if (incomingIt != incomingEdges.end()) {
+            for (const auto& [sourceTarget, sourceVersion] :
+                 incomingIt->second) {
+                if (sourceTarget == currentTarget) {
+                    return std::unexpected(binding_error_(
+                        BindingErrorKind::SelfEdge,
+                        currentTarget, currentVersion,
+                        "legacy binding contains a self-edge"));
+                }
+                const auto& sourceInfo = db.at(sourceTarget);
+                if (!sourceInfo.versions.contains(sourceVersion)) {
+                    return std::unexpected(binding_error_(
+                        BindingErrorKind::VersionNotFound,
+                        sourceTarget, sourceVersion,
+                        "legacy binding source version is missing"));
+                }
+
+                const auto reciprocalIt =
+                    infoIt->second.bindings.find(sourceTarget);
+                if (reciprocalIt == infoIt->second.bindings.end()) {
+                    return std::unexpected(binding_error_(
+                        BindingErrorKind::AsymmetricEdge,
+                        sourceTarget, sourceVersion,
+                        "legacy binding is asymmetric"));
+                }
+                const auto reciprocalVersionIt =
+                    reciprocalIt->second.find(currentVersion);
+                if (reciprocalVersionIt == reciprocalIt->second.end()
+                    || reciprocalVersionIt->second != sourceVersion) {
+                    return std::unexpected(binding_error_(
+                        BindingErrorKind::AsymmetricEdge,
+                        sourceTarget, sourceVersion,
+                        "legacy binding is asymmetric"));
+                }
+            }
         }
 
         if (auto selectedIt = selection.members.find(currentTarget);

--- a/src/core/xvm/db.cppm
+++ b/src/core/xvm/db.cppm
@@ -331,14 +331,14 @@ nlohmann::json vdata_to_json(const VData& vdata) {
             {"rootVersion", vdata.bindingGroup->rootVersion},
         };
     }
-    if (!vdata.bindingMembers.empty()) {
+    if (vdata.bindingMembersDeclared || !vdata.bindingMembers.empty()) {
         nlohmann::json members = nlohmann::json::object();
         for (const auto& [target, version] : vdata.bindingMembers) {
             members[target] = version;
         }
         j["bindingMembers"] = std::move(members);
     }
-    if (!vdata.bindingHeaders.empty()) {
+    if (vdata.bindingHeadersDeclared || !vdata.bindingHeaders.empty()) {
         nlohmann::json headers = nlohmann::json::array();
         for (const auto& header : vdata.bindingHeaders) {
             headers.push_back({
@@ -365,6 +365,12 @@ VData vdata_from_json(const nlohmann::json& j) {
     VData vdata;
     const auto recordIssue =
         [&vdata](std::string code, std::string path) {
+            const auto duplicate = std::ranges::any_of(
+                vdata.bindingIntegrityIssues,
+                [&](const BindingIntegrityIssue& issue) {
+                    return issue.code == code && issue.path == path;
+                });
+            if (duplicate) return;
             vdata.bindingIntegrityIssues.push_back({
                 .code = std::move(code),
                 .path = std::move(path),
@@ -409,56 +415,112 @@ VData vdata_from_json(const nlohmann::json& j) {
                 vdata.envs[it.key()] = it.value().get<std::string>();
         }
     }
-    if (j.contains("bindingIntegrityIssues")
-        && j["bindingIntegrityIssues"].is_array()) {
-        for (const auto& issueJson : j["bindingIntegrityIssues"]) {
-            if (!issueJson.is_object()
-                || !issueJson.contains("code")
-                || !issueJson["code"].is_string()
-                || !issueJson.contains("path")
-                || !issueJson["path"].is_string()) {
-                continue;
+    if (j.contains("bindingIntegrityIssues")) {
+        if (!j["bindingIntegrityIssues"].is_array()) {
+            recordIssue(
+                "binding-integrity-issues-not-array",
+                "/bindingIntegrityIssues");
+        } else {
+            std::size_t index = 0;
+            for (const auto& issueJson : j["bindingIntegrityIssues"]) {
+                const auto issuePath =
+                    "/bindingIntegrityIssues/" + std::to_string(index++);
+                if (!issueJson.is_object()) {
+                    recordIssue(
+                        "binding-integrity-issue-not-object",
+                        issuePath);
+                    continue;
+                }
+
+                const auto validCode =
+                    issueJson.contains("code")
+                    && issueJson["code"].is_string()
+                    && !issueJson["code"].get_ref<
+                        const std::string&>().empty();
+                const auto validPath =
+                    issueJson.contains("path")
+                    && issueJson["path"].is_string()
+                    && !issueJson["path"].get_ref<
+                        const std::string&>().empty();
+                if (!validCode) {
+                    recordIssue(
+                        "binding-integrity-issue-field-invalid",
+                        issuePath + "/code");
+                }
+                if (!validPath) {
+                    recordIssue(
+                        "binding-integrity-issue-field-invalid",
+                        issuePath + "/path");
+                }
+                if (validCode && validPath) {
+                    recordIssue(
+                        issueJson["code"].get<std::string>(),
+                        issueJson["path"].get<std::string>());
+                }
             }
-            vdata.bindingIntegrityIssues.push_back({
-                .code = issueJson["code"].get<std::string>(),
-                .path = issueJson["path"].get<std::string>(),
-            });
         }
     }
-    if (j.contains("bindingGroup") && j["bindingGroup"].is_object()) {
-        const auto& group = j["bindingGroup"];
-        BindingGroupRef ref;
-        if (group.contains("provider") && group["provider"].is_string())
-            ref.provider = group["provider"].get<std::string>();
-        if (group.contains("version") && group["version"].is_string())
-            ref.providerVersion = group["version"].get<std::string>();
-        if (group.contains("group") && group["group"].is_string())
-            ref.group = group["group"].get<std::string>();
-        if (group.contains("rootTarget") && group["rootTarget"].is_string())
-            ref.rootTarget = group["rootTarget"].get<std::string>();
-        if (group.contains("rootVersion") && group["rootVersion"].is_string())
-            ref.rootVersion = group["rootVersion"].get<std::string>();
-        vdata.bindingGroup = std::move(ref);
+    if (j.contains("bindingGroup")) {
+        if (!j["bindingGroup"].is_object()) {
+            recordIssue(
+                "binding-group-not-object", "/bindingGroup");
+        } else {
+            const auto& group = j["bindingGroup"];
+            BindingGroupRef ref;
+            const auto parseGroupField =
+                [&](std::string_view name, std::string& destination) {
+                    const auto key = std::string(name);
+                    if (group.contains(key)
+                        && group[key].is_string()
+                        && !group[key].get_ref<
+                            const std::string&>().empty()) {
+                        destination = group[key].get<std::string>();
+                    } else {
+                        recordIssue(
+                            "binding-group-field-invalid",
+                            "/bindingGroup/" + key);
+                    }
+                };
+            parseGroupField("provider", ref.provider);
+            parseGroupField("version", ref.providerVersion);
+            parseGroupField("group", ref.group);
+            parseGroupField("rootTarget", ref.rootTarget);
+            parseGroupField("rootVersion", ref.rootVersion);
+            vdata.bindingGroup = std::move(ref);
+        }
     }
     if (j.contains("bindingMembers")) {
+        vdata.bindingMembersDeclared = true;
         if (!j["bindingMembers"].is_object()) {
             recordIssue(
                 "binding-members-not-object", "/bindingMembers");
         } else {
             const auto& members = j["bindingMembers"];
             for (auto it = members.begin(); it != members.end(); ++it) {
-                if (it.value().is_string()) {
-                    vdata.bindingMembers[it.key()] =
-                        it.value().get<std::string>();
-                } else {
+                const auto validTarget = !it.key().empty();
+                if (!validTarget) {
+                    recordIssue(
+                        "binding-member-target-empty",
+                        "/bindingMembers/");
+                }
+                if (!it.value().is_string()) {
                     recordIssue(
                         "binding-member-version-not-string",
                         "/bindingMembers/" + pointerToken(it.key()));
+                } else if (it.value().get_ref<
+                               const std::string&>().empty()) {
+                    recordIssue(
+                        "binding-member-version-empty",
+                        "/bindingMembers/" + pointerToken(it.key()));
+                } else if (validTarget) {
+                    vdata.bindingMembers[it.key()] =
+                        it.value().get<std::string>();
                 }
             }
         }
     }
     if (j.contains("bindingHeaders")) {
+        vdata.bindingHeadersDeclared = true;
         if (!j["bindingHeaders"].is_array()) {
             recordIssue(
                 "binding-headers-not-array", "/bindingHeaders");
@@ -475,6 +537,13 @@ VData vdata_from_json(const nlohmann::json& j) {
                     || !headerJson["sourceDir"].is_string()) {
                     recordIssue(
                         "binding-header-source-dir-not-string",
+                        headerPath + "/sourceDir");
+                    continue;
+                }
+                if (headerJson["sourceDir"].get_ref<
+                        const std::string&>().empty()) {
+                    recordIssue(
+                        "binding-header-source-dir-empty",
                         headerPath + "/sourceDir");
                     continue;
                 }

--- a/src/core/xvm/db.cppm
+++ b/src/core/xvm/db.cppm
@@ -72,30 +72,164 @@ void add_version(VersionDB& db,
 }
 
 // Remove a version from the database.
-// Matches exact key first, then tries "ns:version" patterns for bare version input.
-void remove_version(VersionDB& db,
-                    const std::string& target,
-                    const std::string& version) {
-    auto it = db.find(target);
-    if (it == db.end()) return;
-    auto& vers = it->second.versions;
+// Namespaced input must match exactly. Bare input resolves only when exactly
+// one stored key has that bare version.
+enum class RemovalErrorKind {
+    VersionNotFound,
+    AmbiguousVersion,
+    AsymmetricEdge,
+    SelectionInvalid,
+    ProviderRequired,
+    ProviderMismatch,
+    ProviderVersionNotFound,
+    VersionMismatch,
+};
 
-    // Exact match
-    if (vers.erase(version)) {
-        if (vers.empty()) db.erase(it);
-        return;
+struct RemovalError {
+    RemovalErrorKind kind { RemovalErrorKind::VersionNotFound };
+    std::string target;
+    std::string version;
+    std::string peerTarget;
+    std::string peerVersion;
+    std::string message;
+};
+
+std::expected<std::string, RemovalError>
+resolve_exact_version_key(const VersionDB& db,
+                          const std::string& target,
+                          const std::string& version) {
+    auto it = db.find(target);
+    if (it == db.end() || version.empty()) {
+        return std::unexpected(RemovalError{
+            .kind = RemovalErrorKind::VersionNotFound,
+            .target = target,
+            .version = version,
+            .message = "removal version is missing",
+        });
     }
 
-    // If bare version given, try removing any "ns:version" that matches
-    if (version.find(':') == std::string::npos) {
-        for (auto vit = vers.begin(); vit != vers.end(); ++vit) {
-            if (strip_namespace(vit->first) == version) {
-                vers.erase(vit);
-                if (vers.empty()) db.erase(it);
-                return;
+    if (version.find(':') != std::string::npos) {
+        if (it->second.versions.contains(version)) return version;
+        return std::unexpected(RemovalError{
+            .kind = RemovalErrorKind::VersionNotFound,
+            .target = target,
+            .version = version,
+            .message = "exact removal version is not registered",
+        });
+    }
+
+    std::vector<std::string> matches;
+    for (const auto& [storedVersion, _] : it->second.versions) {
+        if (strip_namespace(storedVersion) == version) {
+            matches.push_back(storedVersion);
+        }
+    }
+    if (matches.size() == 1) return matches.front();
+    if (matches.empty()) {
+        return std::unexpected(RemovalError{
+            .kind = RemovalErrorKind::VersionNotFound,
+            .target = target,
+            .version = version,
+            .message = "removal version is not registered",
+        });
+    }
+    return std::unexpected(RemovalError{
+        .kind = RemovalErrorKind::AmbiguousVersion,
+        .target = target,
+        .version = version,
+        .message = std::format(
+            "bare removal version '{}' matches {} stored versions",
+            version, matches.size()),
+    });
+}
+
+std::expected<std::string, RemovalError>
+remove_version(VersionDB& db,
+               const std::string& target,
+               const std::string& version) {
+    auto exactVersionResult =
+        resolve_exact_version_key(db, target, version);
+    if (!exactVersionResult) {
+        return std::unexpected(std::move(exactVersionResult.error()));
+    }
+    const auto& exactVersion = *exactVersionResult;
+
+    auto it = db.find(target);
+    auto& vers = it->second.versions;
+
+    std::vector<std::pair<std::string, std::string>> edges;
+    for (const auto& [peerTarget, versions] : it->second.bindings) {
+        if (auto edgeIt = versions.find(exactVersion);
+            edgeIt != versions.end()) {
+            edges.emplace_back(peerTarget, edgeIt->second);
+        }
+    }
+
+    for (const auto& [peerTarget, peerVersion] : edges) {
+        auto peerIt = db.find(peerTarget);
+        const auto reciprocal =
+            peerIt != db.end()
+            && peerIt->second.versions.contains(peerVersion)
+            && peerIt->second.bindings.contains(target)
+            && peerIt->second.bindings.at(target).contains(peerVersion)
+            && peerIt->second.bindings.at(target).at(peerVersion)
+                == exactVersion;
+        if (!reciprocal) {
+            return std::unexpected(RemovalError{
+                .kind = RemovalErrorKind::AsymmetricEdge,
+                .target = target,
+                .version = exactVersion,
+                .peerTarget = peerTarget,
+                .peerVersion = peerVersion,
+                .message = "removal binding edge is not reciprocal",
+            });
+        }
+    }
+
+    for (const auto& [peerTarget, peerInfo] : db) {
+        auto incomingIt = peerInfo.bindings.find(target);
+        if (incomingIt == peerInfo.bindings.end()) continue;
+        for (const auto& [peerVersion, targetVersion] : incomingIt->second) {
+            if (targetVersion != exactVersion) continue;
+            const auto reciprocal =
+                peerInfo.versions.contains(peerVersion)
+                && it->second.bindings.contains(peerTarget)
+                && it->second.bindings.at(peerTarget).contains(exactVersion)
+                && it->second.bindings.at(peerTarget).at(exactVersion)
+                    == peerVersion;
+            if (!reciprocal) {
+                return std::unexpected(RemovalError{
+                    .kind = RemovalErrorKind::AsymmetricEdge,
+                    .target = target,
+                    .version = exactVersion,
+                    .peerTarget = peerTarget,
+                    .peerVersion = peerVersion,
+                    .message = "incoming removal binding edge is not reciprocal",
+                });
             }
         }
     }
+
+    for (const auto& [peerTarget, peerVersion] : edges) {
+        auto bindingIt = it->second.bindings.find(peerTarget);
+        bindingIt->second.erase(exactVersion);
+        if (bindingIt->second.empty()) {
+            it->second.bindings.erase(bindingIt);
+        }
+
+        auto peerIt = db.find(peerTarget);
+        if (peerIt == db.end()) continue;
+        auto reverseIt = peerIt->second.bindings.find(target);
+        if (reverseIt == peerIt->second.bindings.end()) continue;
+        reverseIt->second.erase(peerVersion);
+        if (reverseIt->second.empty()) {
+            peerIt->second.bindings.erase(reverseIt);
+        }
+    }
+
+    vers.erase(exactVersion);
+    if (vers.empty() && it->second.bindings.empty()) db.erase(it);
+    return exactVersion;
 }
 
 // Pick the highest semver key from a version map (descending by dotted numeric components,

--- a/src/core/xvm/db.cppm
+++ b/src/core/xvm/db.cppm
@@ -49,6 +49,12 @@ void add_version(VersionDB& db,
     auto ver_key = make_ns_version(ns, version);
     VData vdata;
     vdata.path = path;
+    vdata.kind = type;
+    if (type != "group") {
+        vdata.sourceName = filename.empty() ? target : filename;
+        vdata.destinationName =
+            type == "program" ? target : vdata.sourceName;
+    }
     if (!alias.empty()) vdata.alias.push_back(alias);
     info.versions[ver_key] = std::move(vdata);
 
@@ -300,6 +306,10 @@ std::string expand_path(const std::string& path, const std::string& xlings_home)
 nlohmann::json vdata_to_json(const VData& vdata) {
     nlohmann::json j;
     j["path"] = vdata.path;
+    if (!vdata.kind.empty()) j["kind"] = vdata.kind;
+    if (!vdata.sourceName.empty()) j["sourceName"] = vdata.sourceName;
+    if (!vdata.destinationName.empty())
+        j["destinationName"] = vdata.destinationName;
     if (!vdata.includedir.empty()) j["includedir"] = vdata.includedir;
     if (!vdata.libdir.empty()) j["libdir"] = vdata.libdir;
     if (!vdata.alias.empty()) {
@@ -312,6 +322,32 @@ nlohmann::json vdata_to_json(const VData& vdata) {
         }
         j["envs"] = envs_j;
     }
+    if (vdata.bindingGroup) {
+        j["bindingGroup"] = {
+            {"provider", vdata.bindingGroup->provider},
+            {"version", vdata.bindingGroup->providerVersion},
+            {"group", vdata.bindingGroup->group},
+            {"rootTarget", vdata.bindingGroup->rootTarget},
+            {"rootVersion", vdata.bindingGroup->rootVersion},
+        };
+    }
+    if (!vdata.bindingMembers.empty()) {
+        nlohmann::json members = nlohmann::json::object();
+        for (const auto& [target, version] : vdata.bindingMembers) {
+            members[target] = version;
+        }
+        j["bindingMembers"] = std::move(members);
+    }
+    if (!vdata.bindingHeaders.empty()) {
+        nlohmann::json headers = nlohmann::json::array();
+        for (const auto& header : vdata.bindingHeaders) {
+            headers.push_back({
+                {"sourceDir", header.sourceDir},
+                {"destinationPrefix", header.destinationPrefix},
+            });
+        }
+        j["bindingHeaders"] = std::move(headers);
+    }
     return j;
 }
 
@@ -319,6 +355,12 @@ VData vdata_from_json(const nlohmann::json& j) {
     VData vdata;
     if (j.contains("path") && j["path"].is_string())
         vdata.path = j["path"].get<std::string>();
+    if (j.contains("kind") && j["kind"].is_string())
+        vdata.kind = j["kind"].get<std::string>();
+    if (j.contains("sourceName") && j["sourceName"].is_string())
+        vdata.sourceName = j["sourceName"].get<std::string>();
+    if (j.contains("destinationName") && j["destinationName"].is_string())
+        vdata.destinationName = j["destinationName"].get<std::string>();
     if (j.contains("includedir") && j["includedir"].is_string())
         vdata.includedir = j["includedir"].get<std::string>();
     if (j.contains("libdir") && j["libdir"].is_string())
@@ -333,6 +375,47 @@ VData vdata_from_json(const nlohmann::json& j) {
         for (auto it = envs.begin(); it != envs.end(); ++it) {
             if (it.value().is_string())
                 vdata.envs[it.key()] = it.value().get<std::string>();
+        }
+    }
+    if (j.contains("bindingGroup") && j["bindingGroup"].is_object()) {
+        const auto& group = j["bindingGroup"];
+        BindingGroupRef ref;
+        if (group.contains("provider") && group["provider"].is_string())
+            ref.provider = group["provider"].get<std::string>();
+        if (group.contains("version") && group["version"].is_string())
+            ref.providerVersion = group["version"].get<std::string>();
+        if (group.contains("group") && group["group"].is_string())
+            ref.group = group["group"].get<std::string>();
+        if (group.contains("rootTarget") && group["rootTarget"].is_string())
+            ref.rootTarget = group["rootTarget"].get<std::string>();
+        if (group.contains("rootVersion") && group["rootVersion"].is_string())
+            ref.rootVersion = group["rootVersion"].get<std::string>();
+        vdata.bindingGroup = std::move(ref);
+    }
+    if (j.contains("bindingMembers") && j["bindingMembers"].is_object()) {
+        const auto& members = j["bindingMembers"];
+        for (auto it = members.begin(); it != members.end(); ++it) {
+            if (it.value().is_string()) {
+                vdata.bindingMembers[it.key()] =
+                    it.value().get<std::string>();
+            }
+        }
+    }
+    if (j.contains("bindingHeaders") && j["bindingHeaders"].is_array()) {
+        for (const auto& headerJson : j["bindingHeaders"]) {
+            if (!headerJson.is_object()) continue;
+            HeaderAsset header;
+            if (headerJson.contains("sourceDir") &&
+                headerJson["sourceDir"].is_string()) {
+                header.sourceDir =
+                    headerJson["sourceDir"].get<std::string>();
+            }
+            if (headerJson.contains("destinationPrefix") &&
+                headerJson["destinationPrefix"].is_string()) {
+                header.destinationPrefix =
+                    headerJson["destinationPrefix"].get<std::string>();
+            }
+            vdata.bindingHeaders.push_back(std::move(header));
         }
     }
     return vdata;

--- a/src/core/xvm/db.cppm
+++ b/src/core/xvm/db.cppm
@@ -348,11 +348,43 @@ nlohmann::json vdata_to_json(const VData& vdata) {
         }
         j["bindingHeaders"] = std::move(headers);
     }
+    if (!vdata.bindingIntegrityIssues.empty()) {
+        nlohmann::json issues = nlohmann::json::array();
+        for (const auto& issue : vdata.bindingIntegrityIssues) {
+            issues.push_back({
+                {"code", issue.code},
+                {"path", issue.path},
+            });
+        }
+        j["bindingIntegrityIssues"] = std::move(issues);
+    }
     return j;
 }
 
 VData vdata_from_json(const nlohmann::json& j) {
     VData vdata;
+    const auto recordIssue =
+        [&vdata](std::string code, std::string path) {
+            vdata.bindingIntegrityIssues.push_back({
+                .code = std::move(code),
+                .path = std::move(path),
+            });
+        };
+    const auto pointerToken = [](std::string_view token) {
+        std::string escaped;
+        escaped.reserve(token.size());
+        for (char ch : token) {
+            if (ch == '~') {
+                escaped += "~0";
+            } else if (ch == '/') {
+                escaped += "~1";
+            } else {
+                escaped += ch;
+            }
+        }
+        return escaped;
+    };
+
     if (j.contains("path") && j["path"].is_string())
         vdata.path = j["path"].get<std::string>();
     if (j.contains("kind") && j["kind"].is_string())
@@ -377,6 +409,22 @@ VData vdata_from_json(const nlohmann::json& j) {
                 vdata.envs[it.key()] = it.value().get<std::string>();
         }
     }
+    if (j.contains("bindingIntegrityIssues")
+        && j["bindingIntegrityIssues"].is_array()) {
+        for (const auto& issueJson : j["bindingIntegrityIssues"]) {
+            if (!issueJson.is_object()
+                || !issueJson.contains("code")
+                || !issueJson["code"].is_string()
+                || !issueJson.contains("path")
+                || !issueJson["path"].is_string()) {
+                continue;
+            }
+            vdata.bindingIntegrityIssues.push_back({
+                .code = issueJson["code"].get<std::string>(),
+                .path = issueJson["path"].get<std::string>(),
+            });
+        }
+    }
     if (j.contains("bindingGroup") && j["bindingGroup"].is_object()) {
         const auto& group = j["bindingGroup"];
         BindingGroupRef ref;
@@ -392,31 +440,67 @@ VData vdata_from_json(const nlohmann::json& j) {
             ref.rootVersion = group["rootVersion"].get<std::string>();
         vdata.bindingGroup = std::move(ref);
     }
-    if (j.contains("bindingMembers") && j["bindingMembers"].is_object()) {
-        const auto& members = j["bindingMembers"];
-        for (auto it = members.begin(); it != members.end(); ++it) {
-            if (it.value().is_string()) {
-                vdata.bindingMembers[it.key()] =
-                    it.value().get<std::string>();
+    if (j.contains("bindingMembers")) {
+        if (!j["bindingMembers"].is_object()) {
+            recordIssue(
+                "binding-members-not-object", "/bindingMembers");
+        } else {
+            const auto& members = j["bindingMembers"];
+            for (auto it = members.begin(); it != members.end(); ++it) {
+                if (it.value().is_string()) {
+                    vdata.bindingMembers[it.key()] =
+                        it.value().get<std::string>();
+                } else {
+                    recordIssue(
+                        "binding-member-version-not-string",
+                        "/bindingMembers/" + pointerToken(it.key()));
+                }
             }
         }
     }
-    if (j.contains("bindingHeaders") && j["bindingHeaders"].is_array()) {
-        for (const auto& headerJson : j["bindingHeaders"]) {
-            if (!headerJson.is_object()) continue;
-            HeaderAsset header;
-            if (headerJson.contains("sourceDir") &&
-                headerJson["sourceDir"].is_string()) {
-                header.sourceDir =
-                    headerJson["sourceDir"].get<std::string>();
+    if (j.contains("bindingHeaders")) {
+        if (!j["bindingHeaders"].is_array()) {
+            recordIssue(
+                "binding-headers-not-array", "/bindingHeaders");
+        } else {
+            std::size_t index = 0;
+            for (const auto& headerJson : j["bindingHeaders"]) {
+                const auto headerPath =
+                    "/bindingHeaders/" + std::to_string(index++);
+                if (!headerJson.is_object()) {
+                    recordIssue("binding-header-not-object", headerPath);
+                    continue;
+                }
+                if (!headerJson.contains("sourceDir")
+                    || !headerJson["sourceDir"].is_string()) {
+                    recordIssue(
+                        "binding-header-source-dir-not-string",
+                        headerPath + "/sourceDir");
+                    continue;
+                }
+                if (headerJson.contains("destinationPrefix")
+                    && !headerJson["destinationPrefix"].is_string()) {
+                    recordIssue(
+                        "binding-header-destination-prefix-not-string",
+                        headerPath + "/destinationPrefix");
+                    continue;
+                }
+
+                HeaderAsset header{
+                    .sourceDir =
+                        headerJson["sourceDir"].get<std::string>(),
+                };
+                if (headerJson.contains("destinationPrefix")) {
+                    header.destinationPrefix =
+                        headerJson["destinationPrefix"].get<std::string>();
+                }
+                vdata.bindingHeaders.push_back(std::move(header));
             }
-            if (headerJson.contains("destinationPrefix") &&
-                headerJson["destinationPrefix"].is_string()) {
-                header.destinationPrefix =
-                    headerJson["destinationPrefix"].get<std::string>();
-            }
-            vdata.bindingHeaders.push_back(std::move(header));
         }
+    }
+    if ((j.contains("bindingMembers") || j.contains("bindingHeaders"))
+        && !vdata.bindingGroup) {
+        recordIssue("binding-group-missing", "/bindingGroup");
     }
     return vdata;
 }

--- a/src/core/xvm/registration.cppm
+++ b/src/core/xvm/registration.cppm
@@ -87,6 +87,12 @@ apply_registration_batch(
 namespace xlings::xvm::detail_ {
 
 using RegistrationExactKey = std::pair<std::string, std::string>;
+using RegistrationGroupIdentity = std::tuple<
+    std::string,
+    std::string,
+    std::string,
+    std::string,
+    std::string>;
 
 struct RegistrationGroup {
     std::string label;
@@ -120,6 +126,17 @@ bool same_registration_group_(
         && lhs.group == rhs.group
         && lhs.rootTarget == rhs.rootTarget
         && lhs.rootVersion == rhs.rootVersion;
+}
+
+RegistrationGroupIdentity registration_group_identity_(
+    const BindingGroupRef& group) {
+    return {
+        group.provider,
+        group.providerVersion,
+        group.group,
+        group.rootTarget,
+        group.rootVersion,
+    };
 }
 
 std::string effective_kind_(
@@ -753,16 +770,39 @@ apply_registration_batch(
             candidateDb.at(target)
                 .bindings[group.root.first][version] = group.root.second;
         }
+    }
 
+    std::map<
+        detail_::RegistrationGroupIdentity,
+        detail_::RegistrationExactKey> candidateGroups;
+    for (const auto& [target, info] : candidateDb) {
+        for (const auto& [version, data] : info.versions) {
+            if (!data.bindingGroup) continue;
+            const auto& ref = *data.bindingGroup;
+            if (ref.provider != batch.provider
+                || ref.providerVersion != batch.providerVersion) {
+                continue;
+            }
+            candidateGroups.try_emplace(
+                detail_::registration_group_identity_(ref),
+                target, version);
+        }
+    }
+    for (const auto& [_, representative] : candidateGroups) {
+        const auto& ref =
+            *candidateDb.at(representative.first)
+                 .versions.at(representative.second)
+                 .bindingGroup;
         auto selection = resolve_binding_selection(
-            candidateDb, group.root.first, group.root.second);
+            candidateDb, representative.first, representative.second);
         if (!selection) {
-            return std::unexpected(RegistrationError{
-                .kind = RegistrationErrorKind::BindingValidationFailed,
-                .target = selection.error().target,
-                .version = selection.error().version,
-                .message = selection.error().message,
-            });
+            return std::unexpected(detail_::registration_error_(
+                RegistrationErrorKind::BindingValidationFailed,
+                "/bindingGroups/"
+                    + detail_::registration_path_token_(ref.group),
+                selection.error().target,
+                selection.error().version,
+                selection.error().message));
         }
     }
 

--- a/src/core/xvm/registration.cppm
+++ b/src/core/xvm/registration.cppm
@@ -48,6 +48,7 @@ struct RegisteredMember {
 enum class RegistrationErrorKind {
     InvalidBatchIdentity,
     InvalidNodeIdentity,
+    InvalidNodePayload,
     InvalidBindingIdentity,
     DuplicateNode,
     RootNotInBatch,
@@ -90,6 +91,8 @@ using RegistrationExactKey = std::pair<std::string, std::string>;
 struct RegistrationGroup {
     std::string label;
     RegistrationExactKey root;
+    RegistrationExactKey identityNode;
+    std::string identityPath;
     std::map<std::string, std::string> members;
     std::vector<HeaderAsset> headers;
 };
@@ -155,15 +158,36 @@ std::optional<std::string> legacy_payload_mismatch_(
         node.target, info, data, kind);
     const auto destinationName = effective_destination_name_(
         node.target, data, kind, sourceName);
+    const auto expectedSourceName = node.kind == "group"
+        ? std::string_view{}
+        : std::string_view{node.sourceName};
+    const auto expectedDestinationName = node.kind == "group"
+        ? std::string_view{}
+        : std::string_view{node.destinationName};
     if (data.path != node.path) return "path";
     if (kind != node.kind) return "kind";
-    if (sourceName != node.sourceName) return "sourceName";
-    if (destinationName != node.destinationName) {
+    if (sourceName != expectedSourceName) return "sourceName";
+    if (destinationName != expectedDestinationName) {
         return "destinationName";
     }
     if (data.alias != node.alias) return "alias";
     if (data.envs != node.envs) return "envs";
     return std::nullopt;
+}
+
+std::string registration_path_token_(std::string_view token) {
+    std::string escaped;
+    escaped.reserve(token.size());
+    for (const auto ch : token) {
+        if (ch == '~') {
+            escaped += "~0";
+        } else if (ch == '/') {
+            escaped += "~1";
+        } else {
+            escaped += ch;
+        }
+    }
+    return escaped;
 }
 
 void erase_exact_registration_edges_(
@@ -230,6 +254,28 @@ apply_registration_batch(
                 RegistrationErrorKind::InvalidNodeIdentity,
                 nodePath + "/version", node.target, node.version,
                 "registration version is empty"));
+        }
+        if (node.kind != "program"
+            && node.kind != "lib"
+            && node.kind != "group") {
+            return std::unexpected(detail_::registration_error_(
+                RegistrationErrorKind::InvalidNodePayload,
+                nodePath + "/kind", node.target, node.version,
+                std::format(
+                    "unsupported registration node kind '{}'",
+                    node.kind)));
+        }
+        if (node.kind != "group" && node.sourceName.empty()) {
+            return std::unexpected(detail_::registration_error_(
+                RegistrationErrorKind::InvalidNodePayload,
+                nodePath + "/sourceName", node.target, node.version,
+                "materialized registration source name is empty"));
+        }
+        if (node.kind != "group" && node.destinationName.empty()) {
+            return std::unexpected(detail_::registration_error_(
+                RegistrationErrorKind::InvalidNodePayload,
+                nodePath + "/destinationName", node.target, node.version,
+                "materialized registration destination name is empty"));
         }
         if (node.binding && node.binding->rootTarget.empty()) {
             return std::unexpected(detail_::registration_error_(
@@ -351,6 +397,10 @@ apply_registration_batch(
             detail_::RegistrationGroup{
                 .label = label,
                 .root = root,
+                .identityNode = key,
+                .identityPath = node.binding->group.empty()
+                    ? nodePath + "/binding/rootTarget"
+                    : nodePath + "/binding/group",
             });
         rootGroups[root] = label;
         nodeGroups[key] = label;
@@ -388,11 +438,77 @@ apply_registration_batch(
             detail_::RegistrationGroup{
                 .label = label,
                 .root = key,
+                .identityNode = key,
+                .identityPath =
+                    std::format("/nodes/{}/target", index),
             });
         nodeGroups[key] = label;
         rootGroups[key] = label;
         if (auto error = addMember(groupIt->second, node, index)) {
             return std::unexpected(std::move(*error));
+        }
+    }
+
+    struct PersistedRegistrationGroup {
+        detail_::RegistrationExactKey root;
+        std::set<detail_::RegistrationExactKey> members;
+    };
+    std::map<std::string, PersistedRegistrationGroup> persistedGroups;
+    for (const auto& [target, info] : db) {
+        for (const auto& [version, data] : info.versions) {
+            if (!data.bindingGroup) continue;
+            const auto& ref = *data.bindingGroup;
+            if (ref.provider != batch.provider
+                || ref.providerVersion != batch.providerVersion) {
+                continue;
+            }
+            const detail_::RegistrationExactKey root{
+                ref.rootTarget,
+                ref.rootVersion,
+            };
+            auto [groupIt, inserted] = persistedGroups.try_emplace(
+                ref.group,
+                PersistedRegistrationGroup{
+                    .root = root,
+                });
+            if (!inserted && groupIt->second.root != root) {
+                return std::unexpected(detail_::registration_error_(
+                    RegistrationErrorKind::GroupConflict,
+                    "/bindingGroups/"
+                        + detail_::registration_path_token_(ref.group),
+                    target, version,
+                    std::format(
+                        "persisted registration group '{}' has multiple roots",
+                        ref.group)));
+            }
+            groupIt->second.members.emplace(target, version);
+        }
+    }
+    for (const auto& [label, group] : groups) {
+        const auto persistedIt = persistedGroups.find(label);
+        if (persistedIt == persistedGroups.end()) continue;
+        if (persistedIt->second.root != group.root) {
+            return std::unexpected(detail_::registration_error_(
+                RegistrationErrorKind::GroupConflict,
+                group.identityPath,
+                group.identityNode.first,
+                group.identityNode.second,
+                std::format(
+                    "registration group '{}' conflicts with persisted root '{}@{}'",
+                    label,
+                    persistedIt->second.root.first,
+                    persistedIt->second.root.second)));
+        }
+        for (const auto& member : persistedIt->second.members) {
+            if (nodeIndexes.contains(member)) continue;
+            return std::unexpected(detail_::registration_error_(
+                RegistrationErrorKind::IncompleteOwnedGroup,
+                group.identityPath,
+                member.first,
+                member.second,
+                std::format(
+                    "same-owner registration omits an existing member of group '{}'",
+                    label)));
         }
     }
 

--- a/src/core/xvm/registration.cppm
+++ b/src/core/xvm/registration.cppm
@@ -1,0 +1,659 @@
+export module xlings.core.xvm.registration;
+
+import std;
+
+import xlings.core.xvm.types;
+import xlings.core.xvm.bindings;
+
+export namespace xlings::xvm {
+
+struct RegistrationBinding {
+    std::string rootTarget;
+    std::string rootVersion;
+    std::string group;
+};
+
+struct RegistrationNode {
+    std::string target;
+    std::string version;
+    std::string path;
+    std::string kind;
+    std::string sourceName;
+    std::string destinationName;
+    std::vector<std::string> alias;
+    std::map<std::string, std::string> envs;
+    std::optional<RegistrationBinding> binding;
+};
+
+struct RegistrationHeader {
+    std::string sourceDir;
+    std::string destinationPrefix;
+    std::string group;
+};
+
+struct RegistrationBatch {
+    std::string provider;
+    std::string providerVersion;
+    std::vector<RegistrationNode> nodes;
+    std::vector<RegistrationHeader> headers;
+    bool useAfterInstall { false };
+};
+
+struct RegisteredMember {
+    std::string target;
+    std::string version;
+    std::string kind;
+};
+
+enum class RegistrationErrorKind {
+    InvalidBatchIdentity,
+    InvalidNodeIdentity,
+    InvalidBindingIdentity,
+    DuplicateNode,
+    RootNotInBatch,
+    SelfBinding,
+    GroupConflict,
+    TargetVersionConflict,
+    OwnershipConflict,
+    LegacyPayloadMismatch,
+    IncompleteLegacyComponent,
+    IncompleteOwnedGroup,
+    InvalidHeader,
+    HeaderGroupNotFound,
+    HeaderAmbiguous,
+    BindingValidationFailed,
+};
+
+struct RegistrationError {
+    RegistrationErrorKind kind {
+        RegistrationErrorKind::InvalidBatchIdentity
+    };
+    std::string path;
+    std::string target;
+    std::string version;
+    std::string message;
+};
+
+std::expected<std::vector<RegisteredMember>, RegistrationError>
+apply_registration_batch(
+    VersionDB& db,
+    Workspace& workspace,
+    WorkspaceInstalled& installed,
+    const RegistrationBatch& batch);
+
+}  // namespace xlings::xvm
+
+namespace xlings::xvm::detail_ {
+
+using RegistrationExactKey = std::pair<std::string, std::string>;
+
+struct RegistrationGroup {
+    std::string label;
+    RegistrationExactKey root;
+    std::map<std::string, std::string> members;
+    std::vector<HeaderAsset> headers;
+};
+
+RegistrationError registration_error_(
+    RegistrationErrorKind kind,
+    std::string path,
+    std::string target,
+    std::string version,
+    std::string message) {
+    return {
+        .kind = kind,
+        .path = std::move(path),
+        .target = std::move(target),
+        .version = std::move(version),
+        .message = std::move(message),
+    };
+}
+
+bool same_registration_group_(
+    const BindingGroupRef& lhs,
+    const BindingGroupRef& rhs) {
+    return lhs.provider == rhs.provider
+        && lhs.providerVersion == rhs.providerVersion
+        && lhs.group == rhs.group
+        && lhs.rootTarget == rhs.rootTarget
+        && lhs.rootVersion == rhs.rootVersion;
+}
+
+std::string effective_kind_(
+    const VInfo& info,
+    const VData& data) {
+    return data.kind.empty() ? info.type : data.kind;
+}
+
+std::string effective_source_name_(
+    const std::string& target,
+    const VInfo& info,
+    const VData& data,
+    std::string_view kind) {
+    if (kind == "group") return {};
+    if (!data.sourceName.empty()) return data.sourceName;
+    return info.filename.empty() ? target : info.filename;
+}
+
+std::string effective_destination_name_(
+    const std::string& target,
+    const VData& data,
+    std::string_view kind,
+    std::string_view sourceName) {
+    if (kind == "group") return {};
+    if (!data.destinationName.empty()) return data.destinationName;
+    if (kind == "program") return target;
+    return std::string(sourceName);
+}
+
+std::optional<std::string> legacy_payload_mismatch_(
+    const RegistrationNode& node,
+    const VInfo& info,
+    const VData& data) {
+    const auto kind = effective_kind_(info, data);
+    const auto sourceName = effective_source_name_(
+        node.target, info, data, kind);
+    const auto destinationName = effective_destination_name_(
+        node.target, data, kind, sourceName);
+    if (data.path != node.path) return "path";
+    if (kind != node.kind) return "kind";
+    if (sourceName != node.sourceName) return "sourceName";
+    if (destinationName != node.destinationName) {
+        return "destinationName";
+    }
+    if (data.alias != node.alias) return "alias";
+    if (data.envs != node.envs) return "envs";
+    return std::nullopt;
+}
+
+void erase_exact_registration_edges_(
+    VersionDB& db,
+    const std::set<RegistrationExactKey>& exactNodes) {
+    for (auto& [sourceTarget, info] : db) {
+        for (auto bindingIt = info.bindings.begin();
+             bindingIt != info.bindings.end();) {
+            const auto& peerTarget = bindingIt->first;
+            std::erase_if(
+                bindingIt->second,
+                [&](const auto& edge) {
+                    const auto& [sourceVersion, peerVersion] = edge;
+                    return exactNodes.contains(
+                               RegistrationExactKey{
+                                   sourceTarget, sourceVersion})
+                        || exactNodes.contains(
+                               RegistrationExactKey{
+                                   peerTarget, peerVersion});
+                });
+            if (bindingIt->second.empty()) {
+                bindingIt = info.bindings.erase(bindingIt);
+            } else {
+                ++bindingIt;
+            }
+        }
+    }
+}
+
+}  // namespace xlings::xvm::detail_
+
+namespace xlings::xvm {
+
+std::expected<std::vector<RegisteredMember>, RegistrationError>
+apply_registration_batch(
+    VersionDB& db,
+    Workspace& workspace,
+    WorkspaceInstalled& installed,
+    const RegistrationBatch& batch) {
+    if (batch.provider.empty()) {
+        return std::unexpected(detail_::registration_error_(
+            RegistrationErrorKind::InvalidBatchIdentity,
+            "/provider", {}, {}, "registration provider is empty"));
+    }
+    if (batch.providerVersion.empty()) {
+        return std::unexpected(detail_::registration_error_(
+            RegistrationErrorKind::InvalidBatchIdentity,
+            "/providerVersion", {}, {},
+            "registration provider release is empty"));
+    }
+
+    std::map<detail_::RegistrationExactKey, std::size_t> nodeIndexes;
+    for (std::size_t index = 0; index < batch.nodes.size(); ++index) {
+        const auto& node = batch.nodes[index];
+        const auto nodePath = std::format("/nodes/{}", index);
+        if (node.target.empty()) {
+            return std::unexpected(detail_::registration_error_(
+                RegistrationErrorKind::InvalidNodeIdentity,
+                nodePath + "/target", node.target, node.version,
+                "registration target is empty"));
+        }
+        if (node.version.empty()) {
+            return std::unexpected(detail_::registration_error_(
+                RegistrationErrorKind::InvalidNodeIdentity,
+                nodePath + "/version", node.target, node.version,
+                "registration version is empty"));
+        }
+        if (node.binding && node.binding->rootTarget.empty()) {
+            return std::unexpected(detail_::registration_error_(
+                RegistrationErrorKind::InvalidBindingIdentity,
+                nodePath + "/binding/rootTarget",
+                node.target, node.version,
+                "registration binding root target is empty"));
+        }
+        if (node.binding && node.binding->rootVersion.empty()) {
+            return std::unexpected(detail_::registration_error_(
+                RegistrationErrorKind::InvalidBindingIdentity,
+                nodePath + "/binding/rootVersion",
+                node.target, node.version,
+                "registration binding root version is empty"));
+        }
+
+        const detail_::RegistrationExactKey key{
+            node.target,
+            node.version,
+        };
+        if (const auto [_, inserted] =
+                nodeIndexes.emplace(key, index);
+            !inserted) {
+            return std::unexpected(detail_::registration_error_(
+                RegistrationErrorKind::DuplicateNode,
+                nodePath, node.target, node.version,
+                "duplicate exact registration node"));
+        }
+    }
+
+    std::map<std::string, detail_::RegistrationGroup> groups;
+    std::map<detail_::RegistrationExactKey, std::string> rootGroups;
+    std::map<detail_::RegistrationExactKey, std::string> nodeGroups;
+    const auto addMember = [&](
+        detail_::RegistrationGroup& group,
+        const RegistrationNode& node,
+        std::size_t index)
+        -> std::optional<RegistrationError> {
+        auto [memberIt, inserted] =
+            group.members.emplace(node.target, node.version);
+        if (!inserted && memberIt->second != node.version) {
+            return detail_::registration_error_(
+                RegistrationErrorKind::TargetVersionConflict,
+                std::format("/nodes/{}", index),
+                node.target, node.version,
+                std::format(
+                    "group '{}' selects two versions of target '{}'",
+                    group.label, node.target));
+        }
+        return std::nullopt;
+    };
+
+    for (std::size_t index = 0; index < batch.nodes.size(); ++index) {
+        const auto& node = batch.nodes[index];
+        if (!node.binding) continue;
+        const auto nodePath = std::format("/nodes/{}", index);
+        const detail_::RegistrationExactKey key{
+            node.target,
+            node.version,
+        };
+        const detail_::RegistrationExactKey root{
+            node.binding->rootTarget,
+            node.binding->rootVersion,
+        };
+        if (key == root) {
+            return std::unexpected(detail_::registration_error_(
+                RegistrationErrorKind::SelfBinding,
+                nodePath + "/binding", node.target, node.version,
+                "registration node cannot bind to itself"));
+        }
+        if (!nodeIndexes.contains(root)) {
+            return std::unexpected(detail_::registration_error_(
+                RegistrationErrorKind::RootNotInBatch,
+                nodePath + "/binding",
+                root.first, root.second,
+                "registration binding root is not an exact batch node"));
+        }
+
+        const auto label = node.binding->group.empty()
+            ? node.binding->rootTarget
+            : node.binding->group;
+        if (auto groupIt = groups.find(label);
+            groupIt != groups.end() && groupIt->second.root != root) {
+            return std::unexpected(detail_::registration_error_(
+                RegistrationErrorKind::GroupConflict,
+                nodePath + "/binding/group",
+                node.target, node.version,
+                std::format(
+                    "registration group '{}' has multiple roots", label)));
+        }
+        if (auto rootIt = rootGroups.find(root);
+            rootIt != rootGroups.end() && rootIt->second != label) {
+            return std::unexpected(detail_::registration_error_(
+                RegistrationErrorKind::GroupConflict,
+                nodePath + "/binding/group",
+                node.target, node.version,
+                "registration root is assigned to multiple groups"));
+        }
+        if (auto nodeIt = nodeGroups.find(key);
+            nodeIt != nodeGroups.end() && nodeIt->second != label) {
+            return std::unexpected(detail_::registration_error_(
+                RegistrationErrorKind::GroupConflict,
+                nodePath + "/binding/group",
+                node.target, node.version,
+                "registration node is assigned to multiple groups"));
+        }
+        if (auto rootNodeIt = nodeGroups.find(root);
+            rootNodeIt != nodeGroups.end()
+            && rootNodeIt->second != label) {
+            return std::unexpected(detail_::registration_error_(
+                RegistrationErrorKind::GroupConflict,
+                nodePath + "/binding/group",
+                node.target, node.version,
+                "registration root is assigned to multiple groups"));
+        }
+
+        auto [groupIt, _] = groups.try_emplace(
+            label,
+            detail_::RegistrationGroup{
+                .label = label,
+                .root = root,
+            });
+        rootGroups[root] = label;
+        nodeGroups[key] = label;
+        nodeGroups[root] = label;
+        if (auto error = addMember(groupIt->second, node, index)) {
+            return std::unexpected(std::move(*error));
+        }
+        const auto& rootNode =
+            batch.nodes[nodeIndexes.at(root)];
+        if (auto error = addMember(
+                groupIt->second, rootNode, nodeIndexes.at(root))) {
+            return std::unexpected(std::move(*error));
+        }
+    }
+
+    for (std::size_t index = 0; index < batch.nodes.size(); ++index) {
+        const auto& node = batch.nodes[index];
+        const detail_::RegistrationExactKey key{
+            node.target,
+            node.version,
+        };
+        if (nodeGroups.contains(key)) continue;
+        const auto label = node.target;
+        if (auto groupIt = groups.find(label);
+            groupIt != groups.end() && groupIt->second.root != key) {
+            return std::unexpected(detail_::registration_error_(
+                RegistrationErrorKind::GroupConflict,
+                std::format("/nodes/{}", index),
+                node.target, node.version,
+                std::format(
+                    "registration group '{}' has multiple roots", label)));
+        }
+        auto [groupIt, _] = groups.try_emplace(
+            label,
+            detail_::RegistrationGroup{
+                .label = label,
+                .root = key,
+            });
+        nodeGroups[key] = label;
+        rootGroups[key] = label;
+        if (auto error = addMember(groupIt->second, node, index)) {
+            return std::unexpected(std::move(*error));
+        }
+    }
+
+    for (std::size_t index = 0; index < batch.headers.size(); ++index) {
+        const auto& header = batch.headers[index];
+        const auto headerPath = std::format("/headers/{}", index);
+        if (header.sourceDir.empty()) {
+            return std::unexpected(detail_::registration_error_(
+                RegistrationErrorKind::InvalidHeader,
+                headerPath + "/sourceDir", {}, {},
+                "registration header source directory is empty"));
+        }
+
+        auto groupIt = groups.end();
+        if (!header.group.empty()) {
+            groupIt = groups.find(header.group);
+            if (groupIt == groups.end()) {
+                return std::unexpected(detail_::registration_error_(
+                    RegistrationErrorKind::HeaderGroupNotFound,
+                    headerPath + "/group", header.group, {},
+                    std::format(
+                        "registration header group '{}' does not exist",
+                        header.group)));
+            }
+        } else {
+            if (groups.size() != 1) {
+                return std::unexpected(detail_::registration_error_(
+                    RegistrationErrorKind::HeaderAmbiguous,
+                    headerPath + "/group", {}, {},
+                    std::format(
+                        "ungrouped registration header has {} candidate groups",
+                        groups.size())));
+            }
+            groupIt = groups.begin();
+        }
+        groupIt->second.headers.push_back({
+            .sourceDir = header.sourceDir,
+            .destinationPrefix = header.destinationPrefix,
+        });
+    }
+    for (auto& [_, group] : groups) {
+        std::ranges::sort(
+            group.headers,
+            [](const HeaderAsset& lhs, const HeaderAsset& rhs) {
+                return std::tie(lhs.sourceDir, lhs.destinationPrefix)
+                    < std::tie(rhs.sourceDir, rhs.destinationPrefix);
+            });
+        group.headers.erase(
+            std::unique(
+                group.headers.begin(),
+                group.headers.end(),
+                [](const HeaderAsset& lhs, const HeaderAsset& rhs) {
+                    return lhs.sourceDir == rhs.sourceDir
+                        && lhs.destinationPrefix
+                            == rhs.destinationPrefix;
+                }),
+            group.headers.end());
+    }
+
+    for (std::size_t index = 0; index < batch.nodes.size(); ++index) {
+        const auto& node = batch.nodes[index];
+        const auto infoIt = db.find(node.target);
+        if (infoIt == db.end()) continue;
+        const auto dataIt = infoIt->second.versions.find(node.version);
+        if (dataIt == infoIt->second.versions.end()) continue;
+        const auto& data = dataIt->second;
+        const auto nodePath = std::format("/nodes/{}", index);
+
+        if (data.bindingGroup) {
+            const auto& owner = *data.bindingGroup;
+            if (owner.provider != batch.provider
+                || owner.providerVersion != batch.providerVersion) {
+                return std::unexpected(detail_::registration_error_(
+                    RegistrationErrorKind::OwnershipConflict,
+                    nodePath, node.target, node.version,
+                    std::format(
+                        "exact registration is owned by '{}@{}'",
+                        owner.provider, owner.providerVersion)));
+            }
+
+            std::set<detail_::RegistrationExactKey> oldMembers;
+            for (const auto& [target, info] : db) {
+                for (const auto& [version, member] : info.versions) {
+                    if (member.bindingGroup
+                        && detail_::same_registration_group_(
+                            *member.bindingGroup, owner)) {
+                        oldMembers.emplace(target, version);
+                    }
+                }
+            }
+            const auto rootInfoIt = db.find(owner.rootTarget);
+            if (rootInfoIt != db.end()) {
+                const auto rootIt = rootInfoIt->second.versions.find(
+                    owner.rootVersion);
+                if (rootIt != rootInfoIt->second.versions.end()
+                    && rootIt->second.bindingGroup
+                    && detail_::same_registration_group_(
+                        *rootIt->second.bindingGroup, owner)) {
+                    for (const auto& [target, version] :
+                         rootIt->second.bindingMembers) {
+                        const auto memberInfoIt = db.find(target);
+                        if (memberInfoIt != db.end()
+                            && memberInfoIt->second.versions.contains(
+                                version)) {
+                            oldMembers.emplace(target, version);
+                        }
+                    }
+                }
+            }
+            for (const auto& oldMember : oldMembers) {
+                if (nodeIndexes.contains(oldMember)) continue;
+                return std::unexpected(detail_::registration_error_(
+                    RegistrationErrorKind::IncompleteOwnedGroup,
+                    nodePath, oldMember.first, oldMember.second,
+                    "same-owner registration omits an existing group member"));
+            }
+            continue;
+        }
+
+        if (auto field = detail_::legacy_payload_mismatch_(
+                node, infoIt->second, data)) {
+            return std::unexpected(detail_::registration_error_(
+                RegistrationErrorKind::LegacyPayloadMismatch,
+                nodePath + "/" + *field,
+                node.target, node.version,
+                std::format(
+                    "owner-less legacy payload field '{}' is incompatible",
+                    *field)));
+        }
+        auto selection = resolve_binding_selection(
+            db, node.target, node.version);
+        if (!selection) {
+            return std::unexpected(detail_::registration_error_(
+                RegistrationErrorKind::BindingValidationFailed,
+                nodePath, selection.error().target,
+                selection.error().version,
+                selection.error().message));
+        }
+        for (const auto& [target, version] : selection->members) {
+            if (nodeIndexes.contains(
+                    detail_::RegistrationExactKey{target, version})) {
+                continue;
+            }
+            return std::unexpected(detail_::registration_error_(
+                RegistrationErrorKind::IncompleteLegacyComponent,
+                nodePath, target, version,
+                "legacy component is not completely represented in batch"));
+        }
+    }
+
+    auto candidateDb = db;
+    auto candidateWorkspace = workspace;
+    auto candidateInstalled = installed;
+
+    for (const auto& [_, index] : nodeIndexes) {
+        const auto& node = batch.nodes[index];
+        auto& info = candidateDb[node.target];
+        if (info.type.empty()) info.type = node.kind;
+        if (info.filename.empty() && node.kind != "group") {
+            info.filename = node.sourceName;
+        }
+        auto& data = info.versions[node.version];
+        data.path = node.path;
+        data.kind = node.kind;
+        data.sourceName =
+            node.kind == "group" ? std::string{} : node.sourceName;
+        data.destinationName =
+            node.kind == "group" ? std::string{} : node.destinationName;
+        data.alias = node.alias;
+        data.envs = node.envs;
+        data.bindingGroup.reset();
+        data.bindingMembers.clear();
+        data.bindingMembersDeclared = false;
+        data.bindingHeaders.clear();
+        data.bindingHeadersDeclared = false;
+        data.bindingIntegrityIssues.clear();
+    }
+    std::set<detail_::RegistrationExactKey> exactNodes;
+    for (const auto& [key, _] : nodeIndexes) {
+        exactNodes.insert(key);
+    }
+    detail_::erase_exact_registration_edges_(
+        candidateDb, exactNodes);
+
+    std::vector<RegisteredMember> registered;
+    for (const auto& [_, group] : groups) {
+        const BindingGroupRef ref{
+            .provider = batch.provider,
+            .providerVersion = batch.providerVersion,
+            .group = group.label,
+            .rootTarget = group.root.first,
+            .rootVersion = group.root.second,
+        };
+        for (const auto& [target, version] : group.members) {
+            auto& data =
+                candidateDb.at(target).versions.at(version);
+            data.bindingGroup = ref;
+            data.bindingMembers.clear();
+            data.bindingMembersDeclared = false;
+            data.bindingHeaders.clear();
+            data.bindingHeadersDeclared = false;
+            registered.push_back({
+                .target = target,
+                .version = version,
+                .kind = data.kind,
+            });
+            auto& versions = candidateInstalled[target];
+            bool foundVersion = false;
+            std::erase_if(
+                versions,
+                [&](const std::string& installedVersion) {
+                    if (installedVersion != version) return false;
+                    if (!foundVersion) {
+                        foundVersion = true;
+                        return false;
+                    }
+                    return true;
+                });
+            if (!foundVersion) {
+                versions.push_back(version);
+            }
+            if (!candidateWorkspace.contains(target)
+                || batch.useAfterInstall) {
+                candidateWorkspace[target] = version;
+            }
+        }
+
+        auto& root =
+            candidateDb.at(group.root.first)
+                .versions.at(group.root.second);
+        root.bindingMembers = group.members;
+        root.bindingMembersDeclared = true;
+        root.bindingHeaders = group.headers;
+        root.bindingHeadersDeclared = !group.headers.empty();
+        for (const auto& [target, version] : group.members) {
+            if (target == group.root.first
+                && version == group.root.second) {
+                continue;
+            }
+            candidateDb.at(group.root.first)
+                .bindings[target][group.root.second] = version;
+            candidateDb.at(target)
+                .bindings[group.root.first][version] = group.root.second;
+        }
+
+        auto selection = resolve_binding_selection(
+            candidateDb, group.root.first, group.root.second);
+        if (!selection) {
+            return std::unexpected(RegistrationError{
+                .kind = RegistrationErrorKind::BindingValidationFailed,
+                .target = selection.error().target,
+                .version = selection.error().version,
+                .message = selection.error().message,
+            });
+        }
+    }
+
+    db.swap(candidateDb);
+    workspace.swap(candidateWorkspace);
+    installed.swap(candidateInstalled);
+    return registered;
+}
+
+}  // namespace xlings::xvm

--- a/src/core/xvm/registration.cppm
+++ b/src/core/xvm/registration.cppm
@@ -504,7 +504,16 @@ apply_registration_batch(
     for (const auto& [label, group] : groups) {
         const auto persistedIt = persistedGroups.find(label);
         if (persistedIt == persistedGroups.end()) continue;
+        const auto missingMemberIt = std::ranges::find_if(
+            persistedIt->second.members,
+            [&](const auto& member) {
+                return !nodeIndexes.contains(member);
+            });
         if (persistedIt->second.root != group.root) {
+            if (missingMemberIt
+                == persistedIt->second.members.end()) {
+                continue;
+            }
             return std::unexpected(detail_::registration_error_(
                 RegistrationErrorKind::GroupConflict,
                 group.identityPath,
@@ -516,17 +525,18 @@ apply_registration_batch(
                     persistedIt->second.root.first,
                     persistedIt->second.root.second)));
         }
-        for (const auto& member : persistedIt->second.members) {
-            if (nodeIndexes.contains(member)) continue;
-            return std::unexpected(detail_::registration_error_(
-                RegistrationErrorKind::IncompleteOwnedGroup,
-                group.identityPath,
-                member.first,
-                member.second,
-                std::format(
-                    "same-owner registration omits an existing member of group '{}'",
-                    label)));
+        if (missingMemberIt
+            == persistedIt->second.members.end()) {
+            continue;
         }
+        return std::unexpected(detail_::registration_error_(
+            RegistrationErrorKind::IncompleteOwnedGroup,
+            group.identityPath,
+            missingMemberIt->first,
+            missingMemberIt->second,
+            std::format(
+                "same-owner registration omits an existing member of group '{}'",
+                label)));
     }
 
     for (std::size_t index = 0; index < batch.headers.size(); ++index) {

--- a/src/core/xvm/removal.cppm
+++ b/src/core/xvm/removal.cppm
@@ -29,6 +29,10 @@ struct RemovalBatchResult {
     std::vector<RemovedVersion> removed;
 };
 
+struct RemovalBatchOptions {
+    bool purgeSelection { false };
+};
+
 bool has_usable_workspace_version(
         const VersionDB& db,
         const WorkspaceInstalled& installed,
@@ -133,7 +137,8 @@ apply_removal_batch(VersionDB& db,
                     Workspace& workspace,
                     WorkspaceInstalled& installed,
                     const std::vector<RemovalOperation>& operations,
-                    const RemovalContext& context) {
+                    const RemovalContext& context,
+                    const RemovalBatchOptions& options = {}) {
     std::vector<RemovedVersion> removals;
     std::vector<RemovedVersion> selectedRecipeMembers;
     std::set<std::pair<std::string, std::string>> seen;
@@ -260,7 +265,7 @@ apply_removal_batch(VersionDB& db,
             removals.push_back(removal);
         }
     }
-    if (!selectedRecipeMembers.empty()) {
+    if (options.purgeSelection || !selectedRecipeMembers.empty()) {
         for (const auto& [target, version] : context.members) {
             auto exactVersion =
                 resolve_exact_version_key(db, target, version);

--- a/src/core/xvm/removal.cppm
+++ b/src/core/xvm/removal.cppm
@@ -1,0 +1,330 @@
+export module xlings.core.xvm.removal;
+
+import std;
+
+import xlings.core.xvm.types;
+import xlings.core.xvm.bindings;
+import xlings.core.xvm.db;
+
+export namespace xlings::xvm {
+
+struct RemovalOperation {
+    std::string op;
+    std::string name;
+    std::string version;
+};
+
+struct RemovalContext {
+    std::map<std::string, std::string> members;
+    std::string provider;
+    bool hasSelection { false };
+};
+
+struct RemovedVersion {
+    std::string target;
+    std::string version;
+};
+
+struct RemovalBatchResult {
+    std::vector<RemovedVersion> removed;
+};
+
+bool has_usable_workspace_version(
+        const VersionDB& db,
+        const WorkspaceInstalled& installed,
+        const std::string& target) {
+    auto installedIt = installed.find(target);
+    auto targetIt = db.find(target);
+    if (installedIt == installed.end() || targetIt == db.end()) {
+        return false;
+    }
+    return std::ranges::any_of(
+        installedIt->second,
+        [&](const std::string& version) {
+            return targetIt->second.versions.contains(version);
+        });
+}
+
+std::expected<RemovalContext, RemovalError>
+snapshot_removal_context(const VersionDB& db,
+                         const std::string& target,
+                         const std::string& version) {
+    auto exactVersion =
+        resolve_exact_version_key(db, target, version);
+    if (!exactVersion) {
+        return std::unexpected(std::move(exactVersion.error()));
+    }
+    const auto& data = db.at(target).versions.at(*exactVersion);
+    auto resolveSelection = [&](const std::string& memberTarget,
+                                const std::string& memberVersion)
+        -> std::expected<BindingSelection, RemovalError> {
+        auto selection = resolve_binding_selection(
+            db, memberTarget, memberVersion);
+        if (!selection) {
+            return std::unexpected(RemovalError{
+                .kind = RemovalErrorKind::SelectionInvalid,
+                .target = selection.error().target,
+                .version = selection.error().version,
+                .message = selection.error().message,
+            });
+        }
+        return std::move(*selection);
+    };
+
+    auto firstSelection = resolveSelection(target, *exactVersion);
+    if (!firstSelection) {
+        return std::unexpected(std::move(firstSelection.error()));
+    }
+    if (!data.bindingGroup) {
+        return RemovalContext{
+            .members = std::move(firstSelection->members),
+            .hasSelection = true,
+        };
+    }
+
+    const auto& owner = *data.bindingGroup;
+    std::set<std::tuple<std::string, std::string, std::string>> groups;
+    for (const auto& [_, info] : db) {
+        for (const auto& [__, member] : info.versions) {
+            if (!member.bindingGroup
+                || member.bindingGroup->provider != owner.provider
+                || member.bindingGroup->providerVersion
+                    != owner.providerVersion) {
+                continue;
+            }
+            groups.emplace(
+                member.bindingGroup->group,
+                member.bindingGroup->rootTarget,
+                member.bindingGroup->rootVersion);
+        }
+    }
+
+    std::map<std::string, std::string> members;
+    for (const auto& [_, rootTarget, rootVersion] : groups) {
+        auto selection = resolveSelection(rootTarget, rootVersion);
+        if (!selection) {
+            return std::unexpected(std::move(selection.error()));
+        }
+        for (const auto& [memberTarget, memberVersion] :
+             selection->members) {
+            auto [it, inserted] =
+                members.emplace(memberTarget, memberVersion);
+            if (!inserted && it->second != memberVersion) {
+                return std::unexpected(RemovalError{
+                    .kind = RemovalErrorKind::SelectionInvalid,
+                    .target = memberTarget,
+                    .version = memberVersion,
+                    .message =
+                        "provider release selects conflicting member versions",
+                });
+            }
+        }
+    }
+
+    return RemovalContext{
+        .members = std::move(members),
+        .provider = owner.provider,
+        .hasSelection = true,
+    };
+}
+
+std::expected<RemovalBatchResult, RemovalError>
+apply_removal_batch(VersionDB& db,
+                    Workspace& workspace,
+                    WorkspaceInstalled& installed,
+                    const std::vector<RemovalOperation>& operations,
+                    const RemovalContext& context) {
+    std::vector<RemovedVersion> removals;
+    std::vector<RemovedVersion> selectedRecipeMembers;
+    std::set<std::pair<std::string, std::string>> seen;
+
+    for (const auto& operation : operations) {
+        if (operation.op == "remove_all") {
+            if (context.provider.empty()) {
+                return std::unexpected(RemovalError{
+                    .kind = RemovalErrorKind::ProviderRequired,
+                    .target = operation.name,
+                    .version = operation.version,
+                    .message =
+                        "remove_all requires a canonical provider context",
+                });
+            }
+            auto targetIt = db.find(operation.name);
+            bool matched = false;
+            if (targetIt != db.end()) {
+                for (const auto& [version, data] : targetIt->second.versions) {
+                    if (!data.bindingGroup
+                        || data.bindingGroup->provider != context.provider) {
+                        continue;
+                    }
+                    matched = true;
+                    if (seen.emplace(operation.name, version).second) {
+                        removals.push_back({
+                            .target = operation.name,
+                            .version = version,
+                        });
+                    }
+                }
+            }
+            if (!matched) {
+                return std::unexpected(RemovalError{
+                    .kind = RemovalErrorKind::ProviderVersionNotFound,
+                    .target = operation.name,
+                    .version = operation.version,
+                    .message = std::format(
+                        "target has no version owned by provider '{}'",
+                        context.provider),
+                });
+            }
+            continue;
+        }
+        if (operation.op != "remove") continue;
+
+        if (context.hasSelection) {
+            auto memberIt = context.members.find(operation.name);
+            if (memberIt == context.members.end()) {
+                return std::unexpected(RemovalError{
+                    .kind = RemovalErrorKind::SelectionInvalid,
+                    .target = operation.name,
+                    .version = operation.version,
+                    .message =
+                        "recipe removal target is outside the owned selection",
+                });
+            }
+            auto selectedVersion = resolve_exact_version_key(
+                db, operation.name, memberIt->second);
+            if (!selectedVersion) {
+                return std::unexpected(
+                    std::move(selectedVersion.error()));
+            }
+            if (!operation.version.empty()) {
+                auto recipeVersion = resolve_exact_version_key(
+                    db, operation.name, operation.version);
+                if (!recipeVersion) {
+                    return std::unexpected(
+                        std::move(recipeVersion.error()));
+                }
+                if (*recipeVersion != *selectedVersion) {
+                    return std::unexpected(RemovalError{
+                        .kind = RemovalErrorKind::VersionMismatch,
+                        .target = operation.name,
+                        .version = operation.version,
+                        .message = std::format(
+                            "recipe removal version does not match "
+                            "selected owned version '{}'",
+                            *selectedVersion),
+                    });
+                }
+            }
+            selectedRecipeMembers.push_back({
+                .target = operation.name,
+                .version = *selectedVersion,
+            });
+            continue;
+        }
+
+        std::expected<std::string, RemovalError> exactVersion =
+            std::unexpected(RemovalError{
+                .kind = RemovalErrorKind::VersionNotFound,
+                .target = operation.name,
+                .version = operation.version,
+                .message = "removal operation has no exact version",
+            });
+        if (!operation.version.empty()) {
+            exactVersion = resolve_exact_version_key(
+                db, operation.name, operation.version);
+        } else if (auto targetIt = db.find(operation.name);
+                   targetIt != db.end()
+                   && targetIt->second.versions.size() > 1) {
+            exactVersion = std::unexpected(RemovalError{
+                .kind = RemovalErrorKind::AmbiguousVersion,
+                .target = operation.name,
+                .version = operation.version,
+                .message =
+                    "versionless removal has no unique validated selection",
+            });
+        }
+        if (!exactVersion) {
+            return std::unexpected(std::move(exactVersion.error()));
+        }
+        if (seen.emplace(operation.name, *exactVersion).second) {
+            removals.push_back({
+                .target = operation.name,
+                .version = *exactVersion,
+            });
+        }
+    }
+
+    for (const auto& removal : selectedRecipeMembers) {
+        if (seen.emplace(removal.target, removal.version).second) {
+            removals.push_back(removal);
+        }
+    }
+    if (!selectedRecipeMembers.empty()) {
+        for (const auto& [target, version] : context.members) {
+            auto exactVersion =
+                resolve_exact_version_key(db, target, version);
+            if (!exactVersion) {
+                return std::unexpected(
+                    std::move(exactVersion.error()));
+            }
+            if (seen.emplace(target, *exactVersion).second) {
+                removals.push_back({
+                    .target = target,
+                    .version = *exactVersion,
+                });
+            }
+        }
+    }
+
+    auto candidateDb = db;
+    auto candidateWorkspace = workspace;
+    auto candidateInstalled = installed;
+    std::set<std::string> touchedTargets;
+
+    for (const auto& removal : removals) {
+        auto result =
+            remove_version(candidateDb, removal.target, removal.version);
+        if (!result) {
+            return std::unexpected(std::move(result.error()));
+        }
+        touchedTargets.insert(removal.target);
+
+        if (auto installedIt = candidateInstalled.find(removal.target);
+            installedIt != candidateInstalled.end()) {
+            std::erase(installedIt->second, removal.version);
+            if (installedIt->second.empty()) {
+                candidateInstalled.erase(installedIt);
+            }
+        }
+        if (auto activeIt = candidateWorkspace.find(removal.target);
+            activeIt != candidateWorkspace.end()
+            && activeIt->second == removal.version) {
+            candidateWorkspace.erase(activeIt);
+        }
+    }
+
+    for (const auto& target : touchedTargets) {
+        if (candidateWorkspace.contains(target)) continue;
+        auto installedIt = candidateInstalled.find(target);
+        if (installedIt == candidateInstalled.end()) continue;
+        for (auto versionIt = installedIt->second.rbegin();
+             versionIt != installedIt->second.rend(); ++versionIt) {
+            auto targetIt = candidateDb.find(target);
+            if (targetIt != candidateDb.end()
+                && targetIt->second.versions.contains(*versionIt)) {
+                candidateWorkspace[target] = *versionIt;
+                break;
+            }
+        }
+    }
+
+    db.swap(candidateDb);
+    workspace.swap(candidateWorkspace);
+    installed.swap(candidateInstalled);
+    return RemovalBatchResult{
+        .removed = std::move(removals),
+    };
+}
+
+}  // namespace xlings::xvm

--- a/src/core/xvm/types.cppm
+++ b/src/core/xvm/types.cppm
@@ -4,12 +4,31 @@ import std;
 
 export namespace xlings::xvm {
 
+struct BindingGroupRef {
+    std::string provider;
+    std::string providerVersion;
+    std::string group;
+    std::string rootTarget;
+    std::string rootVersion;
+};
+
+struct HeaderAsset {
+    std::string sourceDir;
+    std::string destinationPrefix;
+};
+
 struct VData {
     std::string path;
+    std::string kind;
+    std::string sourceName;
+    std::string destinationName;
     std::string includedir;  // source header directory (e.g., xpkgs/openssl/3.1.5/include)
     std::string libdir;      // source library directory (e.g., xpkgs/glibc/2.39/lib64)
     std::vector<std::string> alias;
     std::map<std::string, std::string> envs;
+    std::optional<BindingGroupRef> bindingGroup;
+    std::map<std::string, std::string> bindingMembers;
+    std::vector<HeaderAsset> bindingHeaders;
 
 #if defined(_MSC_VER)
     VData() = default;

--- a/src/core/xvm/types.cppm
+++ b/src/core/xvm/types.cppm
@@ -34,6 +34,8 @@ struct VData {
     std::optional<BindingGroupRef> bindingGroup;
     std::map<std::string, std::string> bindingMembers;
     std::vector<HeaderAsset> bindingHeaders;
+    bool bindingMembersDeclared { false };
+    bool bindingHeadersDeclared { false };
     std::vector<BindingIntegrityIssue> bindingIntegrityIssues;
 
 #if defined(_MSC_VER)

--- a/src/core/xvm/types.cppm
+++ b/src/core/xvm/types.cppm
@@ -17,6 +17,11 @@ struct HeaderAsset {
     std::string destinationPrefix;
 };
 
+struct BindingIntegrityIssue {
+    std::string code;
+    std::string path;
+};
+
 struct VData {
     std::string path;
     std::string kind;
@@ -29,6 +34,7 @@ struct VData {
     std::optional<BindingGroupRef> bindingGroup;
     std::map<std::string, std::string> bindingMembers;
     std::vector<HeaderAsset> bindingHeaders;
+    std::vector<BindingIntegrityIssue> bindingIntegrityIssues;
 
 #if defined(_MSC_VER)
     VData() = default;

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -1794,6 +1794,54 @@ TEST(XvmDbTest, ExpandPath) {
 // xvm JSON serialization tests
 // ============================================================
 
+namespace {
+
+nlohmann::json valid_binding_group_json() {
+    return {
+        {"provider", "repo:provider"},
+        {"version", "1.0.0"},
+        {"group", "provider-group"},
+        {"rootTarget", "provider-root"},
+        {"rootVersion", "1.0.0"},
+    };
+}
+
+xlings::xvm::VData reload_vdata(const xlings::xvm::VData& data) {
+    return xlings::xvm::vdata_from_json(
+        xlings::xvm::vdata_to_json(data));
+}
+
+void expect_single_binding_integrity_issue(
+    const xlings::xvm::VData& data,
+    std::string_view code,
+    std::string_view path) {
+    ASSERT_EQ(data.bindingIntegrityIssues.size(), 1u);
+    EXPECT_EQ(data.bindingIntegrityIssues[0].code, code);
+    EXPECT_EQ(data.bindingIntegrityIssues[0].path, path);
+}
+
+void expect_metadata_integrity_failure(
+    const xlings::xvm::VData& data,
+    std::string_view code,
+    std::string_view path) {
+    xlings::xvm::VersionDB db;
+    db["subject"].type = "program";
+    db["subject"].versions["1.0.0"] = data;
+
+    auto result =
+        xlings::xvm::resolve_binding_selection(db, "subject", "1.0.0");
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().kind,
+              xlings::xvm::BindingErrorKind::MetadataIntegrityIssue);
+    EXPECT_EQ(result.error().target, "subject");
+    EXPECT_EQ(result.error().version, "1.0.0");
+    EXPECT_NE(result.error().message.find(code), std::string::npos);
+    EXPECT_NE(result.error().message.find(path), std::string::npos);
+}
+
+}  // namespace
+
 TEST(XvmJsonTest, VDataRoundTrip) {
     xlings::xvm::VData original;
     original.path = "/usr/bin";
@@ -2008,6 +2056,326 @@ TEST(XvmJsonTest, MalformedCanonicalContainersRecordIntegrityIssues) {
     EXPECT_EQ(parsed.bindingIntegrityIssues[2].code,
               "binding-group-missing");
     EXPECT_EQ(parsed.bindingIntegrityIssues[2].path, "/bindingGroup");
+}
+
+TEST(XvmJsonTest, NonObjectBindingGroupPersistsIntegrityFailure) {
+    nlohmann::json malformed{
+        {"path", "/subject"},
+        {"kind", "program"},
+        {"bindingGroup", false},
+    };
+
+    auto parsed = xlings::xvm::vdata_from_json(malformed);
+    expect_single_binding_integrity_issue(
+        parsed, "binding-group-not-object", "/bindingGroup");
+    expect_metadata_integrity_failure(
+        parsed, "binding-group-not-object", "/bindingGroup");
+
+    for (int cycle = 0; cycle < 3; ++cycle) {
+        SCOPED_TRACE(cycle);
+        parsed = reload_vdata(parsed);
+        expect_single_binding_integrity_issue(
+            parsed, "binding-group-not-object", "/bindingGroup");
+        expect_metadata_integrity_failure(
+            parsed, "binding-group-not-object", "/bindingGroup");
+    }
+}
+
+TEST(XvmJsonTest, EveryInvalidBindingGroupFieldPersistsIntegrityFailure) {
+    const std::array<std::string_view, 5> fields{
+        "provider",
+        "version",
+        "group",
+        "rootTarget",
+        "rootVersion",
+    };
+    const std::array<std::string_view, 3> invalidClasses{
+        "missing",
+        "wrong-type",
+        "empty",
+    };
+
+    for (const auto field : fields) {
+        for (const auto invalidClass : invalidClasses) {
+            SCOPED_TRACE(std::string(field) + ":" + std::string(invalidClass));
+            nlohmann::json malformed{
+                {"path", "/subject"},
+                {"kind", "program"},
+                {"bindingGroup", valid_binding_group_json()},
+            };
+            auto& group = malformed["bindingGroup"];
+            if (invalidClass == "missing") {
+                group.erase(std::string(field));
+            } else if (invalidClass == "wrong-type") {
+                group[std::string(field)] = false;
+            } else {
+                group[std::string(field)] = "";
+            }
+            const auto path = "/bindingGroup/" + std::string(field);
+
+            auto parsed = xlings::xvm::vdata_from_json(malformed);
+            expect_single_binding_integrity_issue(
+                parsed, "binding-group-field-invalid", path);
+            expect_metadata_integrity_failure(
+                parsed, "binding-group-field-invalid", path);
+
+            for (int cycle = 0; cycle < 3; ++cycle) {
+                SCOPED_TRACE(cycle);
+                parsed = reload_vdata(parsed);
+                expect_single_binding_integrity_issue(
+                    parsed, "binding-group-field-invalid", path);
+                expect_metadata_integrity_failure(
+                    parsed, "binding-group-field-invalid", path);
+            }
+        }
+    }
+}
+
+TEST(XvmJsonTest, MalformedPersistedIssueStateBecomesDurableFailure) {
+    struct Case {
+        std::string_view name;
+        nlohmann::json issueState;
+        std::string_view code;
+        std::string_view path;
+    };
+    const std::vector<Case> cases{
+        {
+            "container-not-array",
+            nlohmann::json::object(),
+            "binding-integrity-issues-not-array",
+            "/bindingIntegrityIssues",
+        },
+        {
+            "item-not-object",
+            nlohmann::json::array({false}),
+            "binding-integrity-issue-not-object",
+            "/bindingIntegrityIssues/0",
+        },
+        {
+            "code-missing",
+            nlohmann::json::array({
+                {{"path", "/bindingGroup/provider"}},
+            }),
+            "binding-integrity-issue-field-invalid",
+            "/bindingIntegrityIssues/0/code",
+        },
+        {
+            "code-wrong-type",
+            nlohmann::json::array({
+                {
+                    {"code", false},
+                    {"path", "/bindingGroup/provider"},
+                },
+            }),
+            "binding-integrity-issue-field-invalid",
+            "/bindingIntegrityIssues/0/code",
+        },
+        {
+            "code-empty",
+            nlohmann::json::array({
+                {
+                    {"code", ""},
+                    {"path", "/bindingGroup/provider"},
+                },
+            }),
+            "binding-integrity-issue-field-invalid",
+            "/bindingIntegrityIssues/0/code",
+        },
+        {
+            "path-missing",
+            nlohmann::json::array({
+                {{"code", "existing-integrity-issue"}},
+            }),
+            "binding-integrity-issue-field-invalid",
+            "/bindingIntegrityIssues/0/path",
+        },
+        {
+            "path-wrong-type",
+            nlohmann::json::array({
+                {
+                    {"code", "existing-integrity-issue"},
+                    {"path", false},
+                },
+            }),
+            "binding-integrity-issue-field-invalid",
+            "/bindingIntegrityIssues/0/path",
+        },
+        {
+            "path-empty",
+            nlohmann::json::array({
+                {
+                    {"code", "existing-integrity-issue"},
+                    {"path", ""},
+                },
+            }),
+            "binding-integrity-issue-field-invalid",
+            "/bindingIntegrityIssues/0/path",
+        },
+    };
+
+    for (const auto& testCase : cases) {
+        SCOPED_TRACE(testCase.name);
+        nlohmann::json malformed{
+            {"path", "/subject"},
+            {"kind", "program"},
+            {"bindingIntegrityIssues", testCase.issueState},
+        };
+
+        auto parsed = xlings::xvm::vdata_from_json(malformed);
+        expect_single_binding_integrity_issue(
+            parsed, testCase.code, testCase.path);
+        expect_metadata_integrity_failure(
+            parsed, testCase.code, testCase.path);
+
+        for (int cycle = 0; cycle < 3; ++cycle) {
+            SCOPED_TRACE(cycle);
+            parsed = reload_vdata(parsed);
+            expect_single_binding_integrity_issue(
+                parsed, testCase.code, testCase.path);
+            expect_metadata_integrity_failure(
+                parsed, testCase.code, testCase.path);
+        }
+    }
+}
+
+TEST(XvmJsonTest, DuplicateDerivedIntegrityIssuesCollapseAcrossReloads) {
+    nlohmann::json malformed{
+        {"path", "/subject"},
+        {"kind", "program"},
+        {"bindingGroup", valid_binding_group_json()},
+        {
+            "bindingIntegrityIssues",
+            nlohmann::json::array({
+                {
+                    {"code", "binding-group-field-invalid"},
+                    {"path", "/bindingGroup/provider"},
+                },
+                {
+                    {"code", "binding-group-field-invalid"},
+                    {"path", "/bindingGroup/provider"},
+                },
+            }),
+        },
+    };
+    malformed["bindingGroup"]["provider"] = "";
+
+    auto parsed = xlings::xvm::vdata_from_json(malformed);
+    for (int cycle = 0; cycle < 4; ++cycle) {
+        SCOPED_TRACE(cycle);
+        expect_single_binding_integrity_issue(
+            parsed,
+            "binding-group-field-invalid",
+            "/bindingGroup/provider");
+        expect_metadata_integrity_failure(
+            parsed,
+            "binding-group-field-invalid",
+            "/bindingGroup/provider");
+        parsed = reload_vdata(parsed);
+    }
+}
+
+TEST(XvmJsonTest, EmptyBindingMemberTargetAndVersionPersistFailures) {
+    struct Case {
+        std::string_view name;
+        std::string target;
+        std::string version;
+        std::string_view code;
+        std::string_view path;
+    };
+    const std::vector<Case> cases{
+        {
+            "empty-target",
+            "",
+            "1.0.0",
+            "binding-member-target-empty",
+            "/bindingMembers/",
+        },
+        {
+            "empty-version",
+            "tool",
+            "",
+            "binding-member-version-empty",
+            "/bindingMembers/tool",
+        },
+    };
+
+    for (const auto& testCase : cases) {
+        SCOPED_TRACE(testCase.name);
+        nlohmann::json members = nlohmann::json::object();
+        members[testCase.target] = testCase.version;
+        nlohmann::json malformed{
+            {"path", "/subject"},
+            {"kind", "group"},
+            {"bindingGroup", valid_binding_group_json()},
+            {"bindingMembers", std::move(members)},
+        };
+
+        auto parsed = xlings::xvm::vdata_from_json(malformed);
+        expect_single_binding_integrity_issue(
+            parsed, testCase.code, testCase.path);
+        expect_metadata_integrity_failure(
+            parsed, testCase.code, testCase.path);
+        EXPECT_TRUE(parsed.bindingMembers.empty());
+
+        for (int cycle = 0; cycle < 3; ++cycle) {
+            SCOPED_TRACE(cycle);
+            parsed = reload_vdata(parsed);
+            expect_single_binding_integrity_issue(
+                parsed, testCase.code, testCase.path);
+            expect_metadata_integrity_failure(
+                parsed, testCase.code, testCase.path);
+            EXPECT_TRUE(parsed.bindingMembers.empty());
+        }
+    }
+}
+
+TEST(XvmJsonTest, EmptyHeaderSourcePersistsWhileEmptyDestinationIsValid) {
+    nlohmann::json malformed{
+        {"path", "/subject"},
+        {"kind", "group"},
+        {"bindingGroup", valid_binding_group_json()},
+        {
+            "bindingHeaders",
+            nlohmann::json::array({
+                {
+                    {"sourceDir", ""},
+                    {"destinationPrefix", ""},
+                },
+            }),
+        },
+    };
+
+    auto parsed = xlings::xvm::vdata_from_json(malformed);
+    expect_single_binding_integrity_issue(
+        parsed,
+        "binding-header-source-dir-empty",
+        "/bindingHeaders/0/sourceDir");
+    expect_metadata_integrity_failure(
+        parsed,
+        "binding-header-source-dir-empty",
+        "/bindingHeaders/0/sourceDir");
+    EXPECT_TRUE(parsed.bindingHeaders.empty());
+
+    for (int cycle = 0; cycle < 3; ++cycle) {
+        SCOPED_TRACE(cycle);
+        parsed = reload_vdata(parsed);
+        expect_single_binding_integrity_issue(
+            parsed,
+            "binding-header-source-dir-empty",
+            "/bindingHeaders/0/sourceDir");
+        expect_metadata_integrity_failure(
+            parsed,
+            "binding-header-source-dir-empty",
+            "/bindingHeaders/0/sourceDir");
+        EXPECT_TRUE(parsed.bindingHeaders.empty());
+    }
+
+    malformed["bindingHeaders"][0]["sourceDir"] = "include";
+    auto valid = xlings::xvm::vdata_from_json(malformed);
+    EXPECT_TRUE(valid.bindingIntegrityIssues.empty());
+    ASSERT_EQ(valid.bindingHeaders.size(), 1u);
+    EXPECT_EQ(valid.bindingHeaders[0].sourceDir, "include");
+    EXPECT_TRUE(valid.bindingHeaders[0].destinationPrefix.empty());
 }
 
 TEST(XvmJsonTest, PerVersionMetadataSupportsDifferentProvidersForOneTarget) {
@@ -3190,6 +3558,51 @@ void expect_binding_error(
     EXPECT_FALSE(result.error().message.empty());
 }
 
+struct BindingGroupIdentityFieldCase {
+    std::string_view path;
+    std::string xlings::xvm::BindingGroupRef::* member;
+};
+
+const std::array<BindingGroupIdentityFieldCase, 5>
+    binding_group_identity_fields{
+        BindingGroupIdentityFieldCase{
+            "/bindingGroup/provider",
+            &xlings::xvm::BindingGroupRef::provider,
+        },
+        BindingGroupIdentityFieldCase{
+            "/bindingGroup/version",
+            &xlings::xvm::BindingGroupRef::providerVersion,
+        },
+        BindingGroupIdentityFieldCase{
+            "/bindingGroup/group",
+            &xlings::xvm::BindingGroupRef::group,
+        },
+        BindingGroupIdentityFieldCase{
+            "/bindingGroup/rootTarget",
+            &xlings::xvm::BindingGroupRef::rootTarget,
+        },
+        BindingGroupIdentityFieldCase{
+            "/bindingGroup/rootVersion",
+            &xlings::xvm::BindingGroupRef::rootVersion,
+        },
+    };
+
+void expect_binding_metadata_error(
+    const std::expected<xlings::xvm::BindingSelection,
+                        xlings::xvm::BindingError>& result,
+    std::string_view target,
+    std::string_view version,
+    std::string_view code,
+    std::string_view path) {
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().kind,
+              xlings::xvm::BindingErrorKind::MetadataIntegrityIssue);
+    EXPECT_EQ(result.error().target, target);
+    EXPECT_EQ(result.error().version, version);
+    EXPECT_NE(result.error().message.find(code), std::string::npos);
+    EXPECT_NE(result.error().message.find(path), std::string::npos);
+}
+
 }  // namespace
 
 TEST(XvmBindingSelectionTest, ProviderGroupResolvesRootAndLeafExactly) {
@@ -3208,6 +3621,12 @@ TEST(XvmBindingSelectionTest, ProviderGroupResolvesRootAndLeafExactly) {
     auto& root = add_provider_group_member(
         db, "xim-gnu-gcc", "xim:15.1.0", group, "group");
     root.bindingMembers = expected;
+    root.bindingHeaders = {
+        {
+            .sourceDir = "include",
+            .destinationPrefix = "",
+        },
+    };
     add_provider_group_member(
         db, "gcc", "xim:15.1.0", group, "program", "gcc-15", "gcc");
     add_provider_group_member(
@@ -3372,6 +3791,188 @@ TEST(XvmBindingSelectionErrorTest, RejectsBindingHeadersWithoutGroup) {
     expect_binding_error(
         result, xlings::xvm::BindingErrorKind::PartialProviderMetadata,
         "tool", "1.0.0");
+}
+
+TEST(XvmBindingSelectionErrorTest,
+     ProviderGroupRejectsBindingMembersOnNonRoot) {
+    xlings::xvm::VersionDB db;
+    const auto group = make_binding_group_ref(
+        "repo:provider", "1.0.0", "provider-group",
+        "provider-root", "1.0.0");
+    auto& root = add_provider_group_member(
+        db, "provider-root", "1.0.0", group, "group");
+    root.bindingMembers = {
+        {"provider-root", "1.0.0"},
+        {"tool", "1.0.0"},
+    };
+    auto& member = add_provider_group_member(
+        db, "tool", "1.0.0", group, "program");
+    member.bindingMembers = {
+        {"nested-tool", "1.0.0"},
+    };
+
+    auto result = xlings::xvm::resolve_binding_selection(
+        db, "provider-root", "1.0.0");
+
+    expect_binding_metadata_error(
+        result, "tool", "1.0.0",
+        "binding-metadata-on-non-root", "/bindingMembers");
+}
+
+TEST(XvmBindingSelectionErrorTest,
+     ProviderGroupRejectsBindingHeadersOnNonRoot) {
+    xlings::xvm::VersionDB db;
+    const auto group = make_binding_group_ref(
+        "repo:provider", "1.0.0", "provider-group",
+        "provider-root", "1.0.0");
+    auto& root = add_provider_group_member(
+        db, "provider-root", "1.0.0", group, "group");
+    root.bindingMembers = {
+        {"provider-root", "1.0.0"},
+        {"tool", "1.0.0"},
+    };
+    auto& member = add_provider_group_member(
+        db, "tool", "1.0.0", group, "program");
+    member.bindingHeaders = {
+        {
+            .sourceDir = "include",
+            .destinationPrefix = "",
+        },
+    };
+
+    auto result = xlings::xvm::resolve_binding_selection(
+        db, "provider-root", "1.0.0");
+
+    expect_binding_metadata_error(
+        result, "tool", "1.0.0",
+        "binding-metadata-on-non-root", "/bindingHeaders");
+}
+
+TEST(XvmBindingSelectionErrorTest,
+     ProviderGroupRejectsPersistedEmptyNonRootMetadataFields) {
+    struct Case {
+        std::string_view field;
+        nlohmann::json emptyValue;
+    };
+    const std::array<Case, 2> cases{
+        Case{"bindingMembers", nlohmann::json::object()},
+        Case{"bindingHeaders", nlohmann::json::array()},
+    };
+
+    for (const auto& testCase : cases) {
+        SCOPED_TRACE(testCase.field);
+        nlohmann::json memberJson{
+            {"path", "/pkg/1.0.0"},
+            {"kind", "program"},
+            {"bindingGroup", valid_binding_group_json()},
+            {std::string(testCase.field), testCase.emptyValue},
+        };
+        auto member = xlings::xvm::vdata_from_json(memberJson);
+        auto persisted = xlings::xvm::vdata_to_json(member);
+        ASSERT_TRUE(persisted.contains(testCase.field));
+        member = reload_vdata(member);
+
+        xlings::xvm::VersionDB db;
+        const auto group = make_binding_group_ref(
+            "repo:provider", "1.0.0", "provider-group",
+            "provider-root", "1.0.0");
+        auto& root = add_provider_group_member(
+            db, "provider-root", "1.0.0", group, "group");
+        root.bindingMembers = {
+            {"provider-root", "1.0.0"},
+            {"tool", "1.0.0"},
+        };
+        db["tool"].versions["1.0.0"] = std::move(member);
+
+        auto result = xlings::xvm::resolve_binding_selection(
+            db, "provider-root", "1.0.0");
+
+        expect_binding_metadata_error(
+            result, "tool", "1.0.0",
+            "binding-metadata-on-non-root",
+            "/" + std::string(testCase.field));
+    }
+}
+
+TEST(XvmBindingSelectionErrorTest,
+     RejectsEveryEmptyStartingGroupIdentityField) {
+    for (const auto& testCase : binding_group_identity_fields) {
+        SCOPED_TRACE(testCase.path);
+        xlings::xvm::VersionDB db;
+        const auto group = make_binding_group_ref(
+            "repo:provider", "1.0.0", "provider-group",
+            "provider-root", "1.0.0");
+        auto& root = add_provider_group_member(
+            db, "provider-root", "1.0.0", group, "group");
+        root.bindingMembers = {
+            {"provider-root", "1.0.0"},
+            {"tool", "1.0.0"},
+        };
+        auto& start = add_provider_group_member(
+            db, "tool", "1.0.0", group, "program");
+        ((*start.bindingGroup).*testCase.member).clear();
+
+        auto result = xlings::xvm::resolve_binding_selection(
+            db, "tool", "1.0.0");
+
+        expect_binding_metadata_error(
+            result, "tool", "1.0.0",
+            "binding-group-field-invalid", testCase.path);
+    }
+}
+
+TEST(XvmBindingSelectionErrorTest,
+     RejectsEveryEmptyRootGroupIdentityField) {
+    for (const auto& testCase : binding_group_identity_fields) {
+        SCOPED_TRACE(testCase.path);
+        xlings::xvm::VersionDB db;
+        const auto group = make_binding_group_ref(
+            "repo:provider", "1.0.0", "provider-group",
+            "provider-root", "1.0.0");
+        auto& root = add_provider_group_member(
+            db, "provider-root", "1.0.0", group, "group");
+        root.bindingMembers = {
+            {"provider-root", "1.0.0"},
+            {"tool", "1.0.0"},
+        };
+        ((*root.bindingGroup).*testCase.member).clear();
+        add_provider_group_member(
+            db, "tool", "1.0.0", group, "program");
+
+        auto result = xlings::xvm::resolve_binding_selection(
+            db, "tool", "1.0.0");
+
+        expect_binding_metadata_error(
+            result, "provider-root", "1.0.0",
+            "binding-group-field-invalid", testCase.path);
+    }
+}
+
+TEST(XvmBindingSelectionErrorTest,
+     RejectsEveryEmptyMemberGroupIdentityField) {
+    for (const auto& testCase : binding_group_identity_fields) {
+        SCOPED_TRACE(testCase.path);
+        xlings::xvm::VersionDB db;
+        const auto group = make_binding_group_ref(
+            "repo:provider", "1.0.0", "provider-group",
+            "provider-root", "1.0.0");
+        auto& root = add_provider_group_member(
+            db, "provider-root", "1.0.0", group, "group");
+        root.bindingMembers = {
+            {"provider-root", "1.0.0"},
+            {"tool", "1.0.0"},
+        };
+        auto& member = add_provider_group_member(
+            db, "tool", "1.0.0", group, "program");
+        ((*member.bindingGroup).*testCase.member).clear();
+
+        auto result = xlings::xvm::resolve_binding_selection(
+            db, "provider-root", "1.0.0");
+
+        expect_binding_metadata_error(
+            result, "tool", "1.0.0",
+            "binding-group-field-invalid", testCase.path);
+    }
 }
 
 TEST(XvmBindingSelectionErrorTest,

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -4289,6 +4289,209 @@ TEST(XvmRegistrationOwnershipTest,
 }
 
 TEST(XvmRegistrationOwnershipTest,
+     CompleteSameOwnerRootMigrationIsAtomicAndOrderIndependent) {
+    const auto oldGroup = make_binding_group_ref(
+        "repo:provider", "1.0.0", "shared",
+        "old-root", "repo:old-root");
+    xlings::xvm::VersionDB initialDb;
+    auto& oldRoot = add_provider_group_member(
+        initialDb, "old-root", "repo:old-root", oldGroup, "group");
+    oldRoot.bindingMembers = {
+        {"old-a", "repo:old-a"},
+        {"old-b", "repo:old-b"},
+        {"old-root", "repo:old-root"},
+    };
+    oldRoot.bindingMembersDeclared = true;
+    oldRoot.bindingHeaders = {
+        {
+            .sourceDir = "/pkg/old/include",
+            .destinationPrefix = "old",
+        },
+    };
+    oldRoot.bindingHeadersDeclared = true;
+    add_provider_group_member(
+        initialDb, "old-a", "repo:old-a", oldGroup,
+        "program", "old-a", "old-a");
+    add_provider_group_member(
+        initialDb, "old-b", "repo:old-b", oldGroup,
+        "program", "old-b", "old-b");
+    initialDb["old-root"].bindings["old-a"]["repo:old-root"] =
+        "repo:old-a";
+    initialDb["old-a"].bindings["old-root"]["repo:old-a"] =
+        "repo:old-root";
+    initialDb["old-root"].bindings["old-b"]["repo:old-root"] =
+        "repo:old-b";
+    initialDb["old-b"].bindings["old-root"]["repo:old-b"] =
+        "repo:old-root";
+    const xlings::xvm::Workspace initialWorkspace{
+        {"old-a", "repo:old-a"},
+        {"old-b", "repo:old-b"},
+        {"old-root", "repo:old-root"},
+    };
+    const xlings::xvm::WorkspaceInstalled initialInstalled{
+        {"old-a", {"repo:old-a"}},
+        {"old-b", {"repo:old-b"}},
+        {"old-root", {"repo:old-root"}},
+    };
+
+    auto newRoot =
+        make_registration_node("new-root", "repo:new-root", "group");
+    auto migratedOldRoot =
+        make_registration_node("old-root", "repo:old-root", "group");
+    migratedOldRoot.binding = make_registration_binding(
+        "new-root", "repo:new-root", "shared");
+    auto migratedA =
+        make_registration_node("old-a", "repo:old-a");
+    migratedA.binding = make_registration_binding(
+        "new-root", "repo:new-root", "shared");
+    auto migratedB =
+        make_registration_node("old-b", "repo:old-b");
+    migratedB.binding = make_registration_binding(
+        "new-root", "repo:new-root", "shared");
+    auto forwardBatch = make_registration_batch({
+        migratedA,
+        newRoot,
+        migratedOldRoot,
+        migratedB,
+    });
+    auto reverseBatch = forwardBatch;
+    std::ranges::reverse(reverseBatch.nodes);
+
+    auto forwardDb = initialDb;
+    auto forwardWorkspace = initialWorkspace;
+    auto forwardInstalled = initialInstalled;
+    auto forward = xlings::xvm::apply_registration_batch(
+        forwardDb, forwardWorkspace, forwardInstalled, forwardBatch);
+    auto reverseDb = initialDb;
+    auto reverseWorkspace = initialWorkspace;
+    auto reverseInstalled = initialInstalled;
+    auto reverse = xlings::xvm::apply_registration_batch(
+        reverseDb, reverseWorkspace, reverseInstalled, reverseBatch);
+
+    ASSERT_TRUE(forward.has_value()) << forward.error().message;
+    ASSERT_TRUE(reverse.has_value()) << reverse.error().message;
+    EXPECT_EQ(
+        xlings::xvm::versions_to_json(forwardDb),
+        xlings::xvm::versions_to_json(reverseDb));
+    EXPECT_EQ(forwardWorkspace, reverseWorkspace);
+    EXPECT_EQ(forwardInstalled, reverseInstalled);
+
+    const std::map<std::string, std::string> expectedMembers{
+        {"new-root", "repo:new-root"},
+        {"old-a", "repo:old-a"},
+        {"old-b", "repo:old-b"},
+        {"old-root", "repo:old-root"},
+    };
+    const auto& migratedRoot =
+        forwardDb.at("new-root").versions.at("repo:new-root");
+    EXPECT_EQ(migratedRoot.bindingMembers, expectedMembers);
+    EXPECT_TRUE(migratedRoot.bindingHeaders.empty());
+
+    for (const auto& [target, version] : expectedMembers) {
+        const auto& member = forwardDb.at(target).versions.at(version);
+        ASSERT_TRUE(member.bindingGroup.has_value());
+        EXPECT_EQ(member.bindingGroup->group, "shared");
+        EXPECT_EQ(member.bindingGroup->rootTarget, "new-root");
+        EXPECT_EQ(member.bindingGroup->rootVersion, "repo:new-root");
+    }
+    std::size_t sharedRefCount = 0;
+    std::set<std::pair<std::string, std::string>> sharedRoots;
+    for (const auto& [_, info] : forwardDb) {
+        for (const auto& versionEntry : info.versions) {
+            const auto& data = versionEntry.second;
+            if (!data.bindingGroup
+                || data.bindingGroup->provider != "repo:provider"
+                || data.bindingGroup->providerVersion != "1.0.0"
+                || data.bindingGroup->group != "shared") {
+                continue;
+            }
+            ++sharedRefCount;
+            sharedRoots.emplace(
+                data.bindingGroup->rootTarget,
+                data.bindingGroup->rootVersion);
+        }
+    }
+    EXPECT_EQ(sharedRefCount, expectedMembers.size());
+    EXPECT_EQ(
+        sharedRoots,
+        (std::set<std::pair<std::string, std::string>>{
+            {"new-root", "repo:new-root"},
+        }));
+
+    const auto& migratedOldRootData =
+        forwardDb.at("old-root").versions.at("repo:old-root");
+    EXPECT_TRUE(migratedOldRootData.bindingMembers.empty());
+    EXPECT_FALSE(migratedOldRootData.bindingMembersDeclared);
+    EXPECT_TRUE(migratedOldRootData.bindingHeaders.empty());
+    EXPECT_FALSE(migratedOldRootData.bindingHeadersDeclared);
+    EXPECT_FALSE(forwardDb.at("old-root").bindings.contains("old-a"));
+    EXPECT_FALSE(forwardDb.at("old-root").bindings.contains("old-b"));
+    EXPECT_FALSE(forwardDb.at("old-a").bindings.contains("old-root"));
+    EXPECT_FALSE(forwardDb.at("old-b").bindings.contains("old-root"));
+    EXPECT_EQ(
+        forwardDb.at("old-root")
+            .bindings.at("new-root").at("repo:old-root"),
+        "repo:new-root");
+}
+
+TEST(XvmRegistrationOwnershipTest,
+     RootMigrationRejectsOmittedManifestOnlyMemberWithoutMutation) {
+    const auto oldGroup = make_binding_group_ref(
+        "repo:provider", "1.0.0", "shared",
+        "old-root", "repo:old-root");
+    xlings::xvm::VersionDB db;
+    auto& oldRoot = add_provider_group_member(
+        db, "old-root", "repo:old-root", oldGroup, "group");
+    oldRoot.bindingMembers = {
+        {"manifest-only", "repo:manifest-only"},
+        {"old-member", "repo:old-member"},
+        {"old-root", "repo:old-root"},
+    };
+    oldRoot.bindingMembersDeclared = true;
+    add_provider_group_member(
+        db, "old-member", "repo:old-member", oldGroup,
+        "program", "old-member", "old-member");
+    auto& manifestOnly =
+        db["manifest-only"].versions["repo:manifest-only"];
+    manifestOnly.path = "/pkg/provider/1.0.0";
+    manifestOnly.kind = "program";
+    manifestOnly.sourceName = "manifest-only";
+    manifestOnly.destinationName = "manifest-only";
+
+    auto newRoot =
+        make_registration_node("new-root", "repo:new-root", "group");
+    auto migratedOldRoot =
+        make_registration_node("old-root", "repo:old-root", "group");
+    migratedOldRoot.binding = make_registration_binding(
+        "new-root", "repo:new-root", "shared");
+    auto migratedMember =
+        make_registration_node("old-member", "repo:old-member");
+    migratedMember.binding = make_registration_binding(
+        "new-root", "repo:new-root", "shared");
+    xlings::xvm::Workspace workspace{{"sentinel", "0"}};
+    xlings::xvm::WorkspaceInstalled installed{{"sentinel", {"0"}}};
+    const auto dbBefore = xlings::xvm::versions_to_json(db);
+    const auto workspaceBefore = workspace;
+    const auto installedBefore = installed;
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed,
+        make_registration_batch({
+            migratedOldRoot,
+            migratedMember,
+            newRoot,
+        }));
+
+    expect_registration_error(
+        result,
+        xlings::xvm::RegistrationErrorKind::IncompleteOwnedGroup,
+        "/nodes/0", "manifest-only", "repo:manifest-only");
+    expect_registration_state_unchanged(
+        db, workspace, installed,
+        dbBefore, workspaceBefore, installedBefore);
+}
+
+TEST(XvmRegistrationOwnershipTest,
      RejectsOtherProviderExactCollisionWithoutMutation) {
     xlings::xvm::VersionDB db;
     auto& existing = db["tool"].versions["repo:1.0.0"];

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -5128,6 +5128,88 @@ TEST(XimXvmRemovalAdapterTest,
 }
 
 TEST(XimXvmRemovalAdapterTest,
+     AuthoritativePurgeRemovesSnapshotWhenHookHasNoRemoveOps) {
+    xlings::xvm::VersionDB db;
+    xlings::xvm::add_version(
+        db, "toolchain", "15.1.0", "/pkg/toolchain",
+        "program", "", "", "repo-a");
+    xlings::xvm::add_version(
+        db, "cc", "gcc-15.1.0", "/pkg/toolchain",
+        "program", "cc-15", "cc", "repo-a",
+        "toolchain@15.1.0");
+    xlings::xvm::Workspace workspace{
+        {"toolchain", "repo-a:15.1.0"},
+        {"cc", "repo-a:gcc-15.1.0"},
+    };
+    xlings::xvm::WorkspaceInstalled installed{
+        {"toolchain", {"repo-a:15.1.0"}},
+        {"cc", {"repo-a:gcc-15.1.0"}},
+    };
+    const std::vector<mcpplibs::xpkg::XvmOp> hookOperations;
+    auto context = xlings::xim::snapshot_xpkg_removal_context(
+        db, workspace, hookOperations,
+        "repo-a:toolchain", "15.1.0",
+        "toolchain", "repo-a:15.1.0");
+    ASSERT_TRUE(context.has_value()) << context.error().message;
+
+    auto result = xlings::xim::apply_xpkg_removal_operations(
+        db, workspace, installed, hookOperations, *context,
+        xlings::xvm::RemovalBatchOptions{
+            .purgeSelection = true,
+        });
+
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    EXPECT_EQ(result->removed.size(), 2u);
+    EXPECT_FALSE(db.contains("toolchain"));
+    EXPECT_FALSE(db.contains("cc"));
+    EXPECT_TRUE(workspace.empty());
+    EXPECT_TRUE(installed.empty());
+}
+
+TEST(XimXvmRemovalAdapterTest,
+     OperationsOnlyKeepsProviderSnapshotWhenConfigHookHasNoRemoveOps) {
+    xlings::xvm::VersionDB db;
+    const auto group = make_binding_group_ref(
+        "repo-a:toolchain", "15.1.0", "compiler",
+        "toolchain", "repo-a:15.1.0");
+    auto& root = add_provider_group_member(
+        db, "toolchain", "repo-a:15.1.0", group, "group");
+    root.bindingMembers = {
+        {"cc", "repo-a:gcc-15.1.0"},
+        {"toolchain", "repo-a:15.1.0"},
+    };
+    add_provider_group_member(
+        db, "cc", "repo-a:gcc-15.1.0", group,
+        "program", "cc-15", "cc");
+    xlings::xvm::Workspace workspace{
+        {"toolchain", "repo-a:15.1.0"},
+        {"cc", "repo-a:gcc-15.1.0"},
+    };
+    xlings::xvm::WorkspaceInstalled installed{
+        {"toolchain", {"repo-a:15.1.0"}},
+        {"cc", {"repo-a:gcc-15.1.0"}},
+    };
+    const auto dbBefore = xlings::xvm::versions_to_json(db);
+    const auto workspaceBefore = workspace;
+    const auto installedBefore = installed;
+    const std::vector<mcpplibs::xpkg::XvmOp> configOperations;
+    auto context = xlings::xim::snapshot_xpkg_removal_context(
+        db, workspace, configOperations,
+        "repo-a:toolchain", "15.1.0");
+    ASSERT_TRUE(context.has_value()) << context.error().message;
+    ASSERT_TRUE(context->hasSelection);
+
+    auto result = xlings::xim::apply_xpkg_removal_operations(
+        db, workspace, installed, configOperations, *context);
+
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    EXPECT_TRUE(result->removed.empty());
+    EXPECT_EQ(xlings::xvm::versions_to_json(db), dbBefore);
+    EXPECT_EQ(workspace, workspaceBefore);
+    EXPECT_EQ(installed, installedBefore);
+}
+
+TEST(XimXvmRemovalAdapterTest,
      PreSnapshotsConfigSelectionFromActiveRemovalTarget) {
     xlings::xvm::VersionDB db;
     xlings::xvm::add_version(
@@ -5189,20 +5271,78 @@ TEST(XimXvmRemovalAdapterTest,
         "repo-a:1.0.0");
 }
 
+TEST(XimXvmRemovalAdapterTest,
+     LegacyPreferredSelectionCannotAuthorizeCanonicalRemoveAll) {
+    xlings::xvm::VersionDB db;
+    auto& legacy = db["cc"].versions["legacy:0.9.0"];
+    legacy.path = "/pkg/legacy";
+    legacy.kind = "program";
+    legacy.sourceName = "cc-legacy";
+    legacy.destinationName = "cc";
+
+    const auto canonicalGroup = make_binding_group_ref(
+        "repo-a:provider", "1.0.0", "compiler",
+        "cc", "repo-a:1.0.0");
+    auto& canonical = add_provider_group_member(
+        db, "cc", "repo-a:1.0.0", canonicalGroup, "group");
+    canonical.bindingMembers = {
+        {"cc", "repo-a:1.0.0"},
+    };
+
+    xlings::xvm::Workspace workspace{
+        {"cc", "legacy:0.9.0"},
+    };
+    xlings::xvm::WorkspaceInstalled installed{
+        {"cc", {"legacy:0.9.0", "repo-a:1.0.0"}},
+    };
+    const std::vector<mcpplibs::xpkg::XvmOp> operations{
+        {
+            .op = "remove_all",
+            .name = "cc",
+        },
+    };
+    const auto dbBefore = xlings::xvm::versions_to_json(db);
+    const auto workspaceBefore = workspace;
+    const auto installedBefore = installed;
+
+    auto context = xlings::xim::snapshot_xpkg_removal_context(
+        db, workspace, operations,
+        "repo-a:provider", "1.0.0",
+        "cc", "legacy:0.9.0");
+    ASSERT_TRUE(context.has_value()) << context.error().message;
+    EXPECT_TRUE(context->provider.empty());
+    EXPECT_EQ(context->members.at("cc"), "legacy:0.9.0");
+
+    auto result = xlings::xim::apply_xpkg_removal_operations(
+        db, workspace, installed, operations, *context);
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(
+        result.error().kind,
+        xlings::xvm::RemovalErrorKind::ProviderRequired);
+    EXPECT_EQ(xlings::xvm::versions_to_json(db), dbBefore);
+    EXPECT_EQ(workspace, workspaceBefore);
+    EXPECT_EQ(installed, installedBefore);
+}
+
 TEST(XimXvmRemovalAdapterTest, TransportsRemoveAllAsDistinctOperation) {
     xlings::xvm::VersionDB db;
-    auto& providerA = db["cc"].versions["repo-a:1.0.0"];
-    providerA.path = "/pkg/a";
-    providerA.kind = "program";
-    providerA.bindingGroup = make_binding_group_ref(
+    const auto groupA = make_binding_group_ref(
         "repo-a:provider", "1.0.0", "group-a",
-        "root-a", "repo-a:1.0.0");
-    auto& providerB = db["cc"].versions["repo-b:2.0.0"];
-    providerB.path = "/pkg/b";
-    providerB.kind = "program";
-    providerB.bindingGroup = make_binding_group_ref(
+        "cc", "repo-a:1.0.0");
+    auto& providerA = add_provider_group_member(
+        db, "cc", "repo-a:1.0.0", groupA, "group");
+    providerA.bindingMembers = {
+        {"cc", "repo-a:1.0.0"},
+    };
+    const auto groupB = make_binding_group_ref(
         "repo-b:provider", "2.0.0", "group-b",
-        "root-b", "repo-b:2.0.0");
+        "cc", "repo-b:2.0.0");
+    auto& providerB = add_provider_group_member(
+        db, "cc", "repo-b:2.0.0", groupB, "group");
+    providerB.bindingMembers = {
+        {"cc", "repo-b:2.0.0"},
+    };
     xlings::xvm::Workspace workspace{
         {"cc", "repo-a:1.0.0"},
     };
@@ -5215,12 +5355,15 @@ TEST(XimXvmRemovalAdapterTest, TransportsRemoveAllAsDistinctOperation) {
             .name = "cc",
         },
     };
-    const xlings::xvm::RemovalContext context{
-        .provider = "repo-a:provider",
-    };
+    auto context = xlings::xim::snapshot_xpkg_removal_context(
+        db, workspace, operations,
+        "repo-a:provider", "1.0.0",
+        "cc", "repo-a:1.0.0");
+    ASSERT_TRUE(context.has_value()) << context.error().message;
+    EXPECT_EQ(context->provider, "repo-a:provider");
 
     auto result = xlings::xim::apply_xpkg_removal_operations(
-        db, workspace, installed, operations, context);
+        db, workspace, installed, operations, *context);
 
     ASSERT_TRUE(result.has_value()) << result.error().message;
     ASSERT_EQ(result->removed.size(), 1u);
@@ -5230,6 +5373,265 @@ TEST(XimXvmRemovalAdapterTest, TransportsRemoveAllAsDistinctOperation) {
     EXPECT_EQ(db.at("cc").versions.size(), 1u);
     EXPECT_TRUE(db.at("cc").versions.contains("repo-b:2.0.0"));
     EXPECT_EQ(workspace.at("cc"), "repo-b:2.0.0");
+}
+
+TEST(XimXvmRemovalArtifactTest,
+     RemovesExactLibraryDestinationBeforeReplacement) {
+    namespace fs = std::filesystem;
+    const auto nonce =
+        std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto testRoot = fs::temp_directory_path()
+        / std::format("xlings-xvm-removal-artifact-{}", nonce);
+    const auto binDir = testRoot / "bin";
+    const auto libDir = testRoot / "lib";
+    const auto oldPayload = testRoot / "old";
+    const auto newPayload = testRoot / "new";
+    const auto unrelatedPayload = testRoot / "unrelated";
+    fs::create_directories(binDir);
+    fs::create_directories(libDir);
+    fs::create_directories(oldPayload);
+    fs::create_directories(newPayload);
+    fs::create_directories(unrelatedPayload);
+
+    const auto target = std::string{"compiler-runtime"};
+    const auto destinationName = std::string{"libcompiler.so"};
+    const auto oldSource = oldPayload / destinationName;
+    const auto newSource = newPayload / destinationName;
+    const auto unrelatedSource = unrelatedPayload / target;
+    xlings::platform::write_string_to_file(
+        oldSource.string(), "OLD");
+    xlings::platform::write_string_to_file(
+        newSource.string(), "NEW");
+    xlings::platform::write_string_to_file(
+        unrelatedSource.string(), "SENTINEL");
+    xlings::xvm::install_libs(
+        oldPayload.string(), libDir, {destinationName});
+    xlings::xvm::install_libs(
+        unrelatedPayload.string(), libDir, {target});
+
+    xlings::xvm::VersionDB db;
+    xlings::xvm::add_version(
+        db, target, "repo-a:1.0.0", oldPayload.string(),
+        "lib", destinationName);
+    const auto dbBefore = db;
+    ASSERT_EQ(
+        dbBefore.at(target)
+            .versions.at("repo-a:1.0.0").destinationName,
+        destinationName);
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+    const std::vector<mcpplibs::xpkg::XvmOp> operations{
+        {
+            .op = "remove",
+            .name = target,
+            .version = "repo-a:1.0.0",
+        },
+    };
+    auto removalResult = xlings::xim::apply_xpkg_removal_operations(
+        db, workspace, installed, operations, {});
+    ASSERT_TRUE(removalResult.has_value())
+        << removalResult.error().message;
+
+    xlings::xim::cleanup_removed_xvm_library_artifacts(
+        libDir, dbBefore, db, *removalResult);
+
+    EXPECT_FALSE(fs::exists(libDir / destinationName));
+    ASSERT_TRUE(fs::exists(libDir / target));
+    EXPECT_EQ(
+        xlings::platform::read_file_to_string(
+            (libDir / target).string()),
+        "SENTINEL");
+
+    xlings::xvm::add_version(
+        db, target, "repo-a:2.0.0", newPayload.string(),
+        "lib", destinationName);
+    xlings::xvm::install_libs(
+        newPayload.string(), libDir, {destinationName});
+    ASSERT_TRUE(fs::exists(libDir / destinationName));
+    EXPECT_EQ(
+        xlings::platform::read_file_to_string(
+            (libDir / destinationName).string()),
+        "NEW");
+    EXPECT_EQ(
+        xlings::platform::read_file_to_string(
+            (libDir / target).string()),
+        "SENTINEL");
+
+    std::error_code ec;
+    fs::remove_all(testRoot, ec);
+}
+
+TEST(XimXvmRemovalArtifactTest,
+     UsesLegacyLibraryFilenameWhenVersionDestinationIsMissing) {
+    namespace fs = std::filesystem;
+    const auto nonce =
+        std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto testRoot = fs::temp_directory_path()
+        / std::format("xlings-xvm-removal-legacy-lib-{}", nonce);
+    const auto sourceDir = testRoot / "source";
+    const auto libDir = testRoot / "lib";
+    const auto filename = std::string{"liblegacy.so"};
+    fs::create_directories(sourceDir);
+    xlings::platform::write_string_to_file(
+        (sourceDir / filename).string(), "LEGACY");
+    xlings::xvm::install_libs(
+        sourceDir.string(), libDir, {filename});
+
+    xlings::xvm::VersionDB dbBefore;
+    auto& info = dbBefore["legacy-runtime"];
+    info.type = "lib";
+    info.filename = filename;
+    auto& version = info.versions["1.0.0"];
+    version.path = sourceDir.string();
+    const xlings::xvm::RemovalBatchResult removalResult{
+        .removed = {
+            {
+                .target = "legacy-runtime",
+                .version = "1.0.0",
+            },
+        },
+    };
+
+    xlings::xim::cleanup_removed_xvm_library_artifacts(
+        libDir, dbBefore, {}, removalResult);
+
+    EXPECT_FALSE(fs::exists(libDir / filename));
+    std::error_code ec;
+    fs::remove_all(testRoot, ec);
+}
+
+TEST(XimXvmRemovalArtifactTest,
+     KeepsDestinationOwnedBySurvivingLibraryVersion) {
+    namespace fs = std::filesystem;
+    const auto nonce =
+        std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto testRoot = fs::temp_directory_path()
+        / std::format("xlings-xvm-removal-surviving-lib-{}", nonce);
+    const auto sourceDir = testRoot / "source";
+    const auto libDir = testRoot / "lib";
+    const auto target = std::string{"compiler-runtime"};
+    const auto filename = std::string{"libcompiler.so"};
+    fs::create_directories(sourceDir);
+    xlings::platform::write_string_to_file(
+        (sourceDir / filename).string(), "SURVIVOR");
+    xlings::xvm::install_libs(
+        sourceDir.string(), libDir, {filename});
+
+    xlings::xvm::VersionDB dbBefore;
+    xlings::xvm::add_version(
+        dbBefore, target, "1.0.0", "/old",
+        "lib", filename);
+    xlings::xvm::add_version(
+        dbBefore, target, "2.0.0", sourceDir.string(),
+        "lib", filename);
+    auto currentDb = dbBefore;
+    currentDb.at(target).versions.erase("1.0.0");
+    const xlings::xvm::RemovalBatchResult removalResult{
+        .removed = {
+            {
+                .target = target,
+                .version = "1.0.0",
+            },
+        },
+    };
+
+    xlings::xim::cleanup_removed_xvm_library_artifacts(
+        libDir, dbBefore, currentDb, removalResult);
+
+    ASSERT_TRUE(fs::exists(libDir / filename));
+    EXPECT_EQ(
+        xlings::platform::read_file_to_string(
+            (libDir / filename).string()),
+        "SURVIVOR");
+    std::error_code ec;
+    fs::remove_all(testRoot, ec);
+}
+
+TEST(XimXvmRemovalArtifactTest,
+     KeepsProgramShimWhenUsableVersionSurvives) {
+    namespace fs = std::filesystem;
+    const auto nonce =
+        std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto testRoot = fs::temp_directory_path()
+        / std::format("xlings-xvm-removal-surviving-shim-{}", nonce);
+    const auto binDir = testRoot / "bin";
+    fs::create_directories(binDir);
+#ifdef _WIN32
+    const auto shim = binDir / "cc.exe";
+#else
+    const auto shim = binDir / "cc";
+#endif
+    xlings::platform::write_string_to_file(shim.string(), "SHIM");
+
+    xlings::xvm::VersionDB dbBefore;
+    xlings::xvm::add_version(
+        dbBefore, "cc", "1.0.0", "/old", "program", "cc");
+    xlings::xvm::add_version(
+        dbBefore, "cc", "2.0.0", "/new", "program", "cc");
+    auto currentDb = dbBefore;
+    currentDb.at("cc").versions.erase("1.0.0");
+    const xlings::xvm::WorkspaceInstalled installed{
+        {"cc", {"2.0.0"}},
+    };
+    const xlings::xvm::RemovalBatchResult removalResult{
+        .removed = {
+            {
+                .target = "cc",
+                .version = "1.0.0",
+            },
+        },
+    };
+
+    xlings::xim::cleanup_removed_xvm_program_artifacts(
+        binDir, dbBefore, currentDb, installed, removalResult);
+
+    EXPECT_TRUE(fs::exists(shim));
+    EXPECT_EQ(
+        xlings::platform::read_file_to_string(shim.string()),
+        "SHIM");
+    std::error_code ec;
+    fs::remove_all(testRoot, ec);
+}
+
+TEST(XimXvmRemovalArtifactTest,
+     VirtualGroupNeverOwnsSameNamedProgramShim) {
+    namespace fs = std::filesystem;
+    const auto nonce =
+        std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto testRoot = fs::temp_directory_path()
+        / std::format("xlings-xvm-removal-group-shim-{}", nonce);
+    const auto binDir = testRoot / "bin";
+    fs::create_directories(binDir);
+#ifdef _WIN32
+    const auto shim = binDir / "toolchain.exe";
+#else
+    const auto shim = binDir / "toolchain";
+#endif
+    xlings::platform::write_string_to_file(shim.string(), "UNRELATED");
+
+    xlings::xvm::VersionDB dbBefore;
+    auto& info = dbBefore["toolchain"];
+    info.type = "program";
+    auto& version = info.versions["1.0.0"];
+    version.kind = "group";
+    const xlings::xvm::RemovalBatchResult removalResult{
+        .removed = {
+            {
+                .target = "toolchain",
+                .version = "1.0.0",
+            },
+        },
+    };
+
+    xlings::xim::cleanup_removed_xvm_program_artifacts(
+        binDir, dbBefore, {}, {}, removalResult);
+
+    EXPECT_TRUE(fs::exists(shim));
+    EXPECT_EQ(
+        xlings::platform::read_file_to_string(shim.string()),
+        "UNRELATED");
+    std::error_code ec;
+    fs::remove_all(testRoot, ec);
 }
 
 TEST(XvmDbTest, AddVersionWithBindingNamespaced) {

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -3895,6 +3895,84 @@ TEST(XvmBindingSelectionErrorTest,
 }
 
 TEST(XvmBindingSelectionErrorTest,
+     ProviderGroupRejectsEmptyRootManifestTargetBeforeLookup) {
+    xlings::xvm::VersionDB db;
+    const auto group = make_binding_group_ref(
+        "repo:provider", "1.0.0", "provider-group",
+        "provider-root", "1.0.0");
+    auto& root = add_provider_group_member(
+        db, "provider-root", "1.0.0", group, "group");
+    root.bindingMembers = {
+        {"", "existing-empty-target-version"},
+        {"provider-root", "1.0.0"},
+    };
+    add_provider_group_member(
+        db, "", "existing-empty-target-version", group, "program");
+
+    auto result = xlings::xvm::resolve_binding_selection(
+        db, "provider-root", "1.0.0");
+
+    expect_binding_metadata_error(
+        result, "provider-root", "1.0.0",
+        "binding-member-target-empty", "/bindingMembers/");
+}
+
+TEST(XvmBindingSelectionErrorTest,
+     ProviderGroupRejectsEmptyRootManifestVersionBeforeLookup) {
+    xlings::xvm::VersionDB db;
+    const auto group = make_binding_group_ref(
+        "repo:provider", "1.0.0", "provider-group",
+        "provider-root", "1.0.0");
+    auto& root = add_provider_group_member(
+        db, "provider-root", "1.0.0", group, "group");
+    root.bindingMembers = {
+        {"provider-root", "1.0.0"},
+        {"tool/member~alias", ""},
+    };
+    add_provider_group_member(
+        db, "tool/member~alias", "", group, "program");
+
+    auto result = xlings::xvm::resolve_binding_selection(
+        db, "provider-root", "1.0.0");
+
+    expect_binding_metadata_error(
+        result, "provider-root", "1.0.0",
+        "binding-member-version-empty",
+        "/bindingMembers/tool~1member~0alias");
+}
+
+TEST(XvmBindingSelectionErrorTest,
+     ProviderGroupRejectsEmptyRootHeaderSource) {
+    xlings::xvm::VersionDB db;
+    const auto group = make_binding_group_ref(
+        "repo:provider", "1.0.0", "provider-group",
+        "provider-root", "1.0.0");
+    auto& root = add_provider_group_member(
+        db, "provider-root", "1.0.0", group, "group");
+    root.bindingMembers = {
+        {"provider-root", "1.0.0"},
+    };
+    root.bindingHeaders = {
+        {
+            .sourceDir = "include",
+            .destinationPrefix = "",
+        },
+        {
+            .sourceDir = "",
+            .destinationPrefix = "",
+        },
+    };
+
+    auto result = xlings::xvm::resolve_binding_selection(
+        db, "provider-root", "1.0.0");
+
+    expect_binding_metadata_error(
+        result, "provider-root", "1.0.0",
+        "binding-header-source-dir-empty",
+        "/bindingHeaders/1/sourceDir");
+}
+
+TEST(XvmBindingSelectionErrorTest,
      RejectsEveryEmptyStartingGroupIdentityField) {
     for (const auto& testCase : binding_group_identity_fields) {
         SCOPED_TRACE(testCase.path);

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -1868,6 +1868,7 @@ TEST(XvmJsonTest, BindingGroupManifestAndMaterializationRoundTrip) {
     EXPECT_EQ(j["bindingHeaders"][0]["destinationPrefix"], "c++/15.1.0");
     EXPECT_EQ(j["bindingHeaders"][1]["sourceDir"], "include-fixed");
     EXPECT_EQ(j["bindingHeaders"][1]["destinationPrefix"], "");
+    EXPECT_FALSE(j.contains("bindingIntegrityIssues"));
 
     auto restored = xlings::xvm::vdata_from_json(j);
     ASSERT_TRUE(restored.bindingGroup.has_value());
@@ -1885,6 +1886,7 @@ TEST(XvmJsonTest, BindingGroupManifestAndMaterializationRoundTrip) {
     EXPECT_EQ(restored.bindingHeaders[0].destinationPrefix, "c++/15.1.0");
     EXPECT_EQ(restored.bindingHeaders[1].sourceDir, "include-fixed");
     EXPECT_TRUE(restored.bindingHeaders[1].destinationPrefix.empty());
+    EXPECT_TRUE(restored.bindingIntegrityIssues.empty());
 }
 
 TEST(XvmJsonTest, LegacyVDataOmitsProviderAndMaterializationMetadata) {
@@ -1900,6 +1902,7 @@ TEST(XvmJsonTest, LegacyVDataOmitsProviderAndMaterializationMetadata) {
     EXPECT_TRUE(restored.sourceName.empty());
     EXPECT_TRUE(restored.destinationName.empty());
     EXPECT_TRUE(restored.bindingHeaders.empty());
+    EXPECT_TRUE(restored.bindingIntegrityIssues.empty());
 
     auto serialized = xlings::xvm::vdata_to_json(restored);
     EXPECT_FALSE(serialized.contains("bindingGroup"));
@@ -1908,6 +1911,103 @@ TEST(XvmJsonTest, LegacyVDataOmitsProviderAndMaterializationMetadata) {
     EXPECT_FALSE(serialized.contains("sourceName"));
     EXPECT_FALSE(serialized.contains("destinationName"));
     EXPECT_FALSE(serialized.contains("bindingHeaders"));
+    EXPECT_FALSE(serialized.contains("bindingIntegrityIssues"));
+}
+
+TEST(XvmJsonTest,
+     MalformedCanonicalEntriesRecordAndPersistIntegrityIssues) {
+    auto corrupt = nlohmann::json::parse(R"({
+        "path": "/pkg/provider",
+        "bindingGroup": {
+            "provider": "repo:provider",
+            "version": "1.0.0",
+            "group": "provider-group",
+            "rootTarget": "provider-root",
+            "rootVersion": "1.0.0"
+        },
+        "bindingMembers": {
+            "provider-root": "1.0.0",
+            "bad/member~name": 7
+        },
+        "bindingHeaders": [
+            {
+                "sourceDir": "include",
+                "destinationPrefix": ""
+            },
+            {
+                "sourceDir": false,
+                "destinationPrefix": "broken"
+            },
+            {
+                "sourceDir": "include-valid",
+                "destinationPrefix": 9
+            }
+        ]
+    })");
+
+    auto parsed = xlings::xvm::vdata_from_json(corrupt);
+
+    ASSERT_EQ(parsed.bindingMembers.size(), 1u);
+    EXPECT_EQ(parsed.bindingMembers.at("provider-root"), "1.0.0");
+    ASSERT_EQ(parsed.bindingHeaders.size(), 1u);
+    EXPECT_EQ(parsed.bindingHeaders.front().sourceDir, "include");
+    ASSERT_EQ(parsed.bindingIntegrityIssues.size(), 3u);
+    EXPECT_EQ(parsed.bindingIntegrityIssues[0].code,
+              "binding-member-version-not-string");
+    EXPECT_EQ(parsed.bindingIntegrityIssues[0].path,
+              "/bindingMembers/bad~1member~0name");
+    EXPECT_EQ(parsed.bindingIntegrityIssues[1].code,
+              "binding-header-source-dir-not-string");
+    EXPECT_EQ(parsed.bindingIntegrityIssues[1].path,
+              "/bindingHeaders/1/sourceDir");
+    EXPECT_EQ(parsed.bindingIntegrityIssues[2].code,
+              "binding-header-destination-prefix-not-string");
+    EXPECT_EQ(parsed.bindingIntegrityIssues[2].path,
+              "/bindingHeaders/2/destinationPrefix");
+
+    auto serialized = xlings::xvm::vdata_to_json(parsed);
+    ASSERT_TRUE(serialized.contains("bindingIntegrityIssues"));
+    ASSERT_EQ(serialized["bindingIntegrityIssues"].size(), 3u);
+    EXPECT_EQ(serialized["bindingIntegrityIssues"][0]["code"],
+              "binding-member-version-not-string");
+    EXPECT_EQ(serialized["bindingIntegrityIssues"][0]["path"],
+              "/bindingMembers/bad~1member~0name");
+
+    auto restored = xlings::xvm::vdata_from_json(serialized);
+    ASSERT_EQ(restored.bindingIntegrityIssues.size(), 3u);
+    EXPECT_EQ(restored.bindingIntegrityIssues[0].code,
+              "binding-member-version-not-string");
+    EXPECT_EQ(restored.bindingIntegrityIssues[0].path,
+              "/bindingMembers/bad~1member~0name");
+    EXPECT_EQ(restored.bindingIntegrityIssues[1].code,
+              "binding-header-source-dir-not-string");
+    EXPECT_EQ(restored.bindingIntegrityIssues[1].path,
+              "/bindingHeaders/1/sourceDir");
+    EXPECT_EQ(restored.bindingIntegrityIssues[2].code,
+              "binding-header-destination-prefix-not-string");
+    EXPECT_EQ(restored.bindingIntegrityIssues[2].path,
+              "/bindingHeaders/2/destinationPrefix");
+}
+
+TEST(XvmJsonTest, MalformedCanonicalContainersRecordIntegrityIssues) {
+    auto corrupt = nlohmann::json::parse(R"({
+        "path": "/pkg/provider",
+        "bindingMembers": [],
+        "bindingHeaders": {}
+    })");
+
+    auto parsed = xlings::xvm::vdata_from_json(corrupt);
+
+    ASSERT_EQ(parsed.bindingIntegrityIssues.size(), 3u);
+    EXPECT_EQ(parsed.bindingIntegrityIssues[0].code,
+              "binding-members-not-object");
+    EXPECT_EQ(parsed.bindingIntegrityIssues[0].path, "/bindingMembers");
+    EXPECT_EQ(parsed.bindingIntegrityIssues[1].code,
+              "binding-headers-not-array");
+    EXPECT_EQ(parsed.bindingIntegrityIssues[1].path, "/bindingHeaders");
+    EXPECT_EQ(parsed.bindingIntegrityIssues[2].code,
+              "binding-group-missing");
+    EXPECT_EQ(parsed.bindingIntegrityIssues[2].path, "/bindingGroup");
 }
 
 TEST(XvmJsonTest, PerVersionMetadataSupportsDifferentProvidersForOneTarget) {
@@ -3184,6 +3284,180 @@ TEST(XvmBindingSelectionTest, ProviderScopeSeparatesGroupsForSameTarget) {
                   {"cc", "repo-b:2.0.0"},
                   {"repo-b:root", "repo-b:2.0.0"},
               }));
+}
+
+TEST(XvmBindingSelectionTest,
+     SameProviderVersionSeparatesGroupRootsAndMembers) {
+    xlings::xvm::VersionDB db;
+    const auto groupA = make_binding_group_ref(
+        "repo:toolchain", "1.0.0", "c-tools",
+        "c-root", "repo:c-root");
+    auto& rootA = add_provider_group_member(
+        db, "c-root", "repo:c-root", groupA, "group");
+    rootA.bindingMembers = {
+        {"c-root", "repo:c-root"},
+        {"cc", "repo:cc"},
+    };
+    add_provider_group_member(
+        db, "cc", "repo:cc", groupA, "program", "cc", "cc");
+
+    const auto groupB = make_binding_group_ref(
+        "repo:toolchain", "1.0.0", "fortran-tools",
+        "fortran-root", "repo:fortran-root");
+    auto& rootB = add_provider_group_member(
+        db, "fortran-root", "repo:fortran-root", groupB, "group");
+    rootB.bindingMembers = {
+        {"cc", "repo:fc"},
+        {"fortran-root", "repo:fortran-root"},
+    };
+    add_provider_group_member(
+        db, "cc", "repo:fc", groupB, "program", "fc", "fc");
+
+    auto selectedA =
+        xlings::xvm::resolve_binding_selection(db, "cc", "repo:cc");
+    ASSERT_TRUE(selectedA.has_value()) << selectedA.error().message;
+    EXPECT_EQ(selectedA->members,
+              (std::map<std::string, std::string>{
+                  {"c-root", "repo:c-root"},
+                  {"cc", "repo:cc"},
+              }));
+
+    auto selectedB =
+        xlings::xvm::resolve_binding_selection(db, "cc", "repo:fc");
+    ASSERT_TRUE(selectedB.has_value()) << selectedB.error().message;
+    EXPECT_EQ(selectedB->members,
+              (std::map<std::string, std::string>{
+                  {"cc", "repo:fc"},
+                  {"fortran-root", "repo:fortran-root"},
+              }));
+
+    rootA.bindingMembers["cc"] = "repo:fc";
+    auto crossGroup =
+        xlings::xvm::resolve_binding_selection(db, "c-root", "repo:c-root");
+    expect_binding_error(
+        crossGroup, xlings::xvm::BindingErrorKind::MemberReferenceMismatch,
+        "cc", "repo:fc");
+}
+
+TEST(XvmBindingSelectionErrorTest, RejectsBindingMembersWithoutGroup) {
+    xlings::xvm::VersionDB db;
+    auto& data = db["tool"].versions["1.0.0"];
+    data.kind = "program";
+    data.bindingMembers = {
+        {"tool", "1.0.0"},
+    };
+
+    auto result =
+        xlings::xvm::resolve_binding_selection(db, "tool", "1.0.0");
+
+    expect_binding_error(
+        result, xlings::xvm::BindingErrorKind::PartialProviderMetadata,
+        "tool", "1.0.0");
+}
+
+TEST(XvmBindingSelectionErrorTest, RejectsBindingHeadersWithoutGroup) {
+    xlings::xvm::VersionDB db;
+    auto& data = db["tool"].versions["1.0.0"];
+    data.kind = "program";
+    data.bindingHeaders = {
+        {
+            .sourceDir = "include",
+            .destinationPrefix = "",
+        },
+    };
+
+    auto result =
+        xlings::xvm::resolve_binding_selection(db, "tool", "1.0.0");
+
+    expect_binding_error(
+        result, xlings::xvm::BindingErrorKind::PartialProviderMetadata,
+        "tool", "1.0.0");
+}
+
+TEST(XvmBindingSelectionErrorTest,
+     LegacyRejectsProviderAwareNodeReachedByTraversal) {
+    xlings::xvm::VersionDB db;
+    db["legacy"].type = "program";
+    db["legacy"].versions["1.0.0"].path = "/legacy";
+    db["provider"].type = "program";
+    auto& provider = db["provider"].versions["1.0.0"];
+    provider.path = "/provider";
+    provider.bindingGroup = make_binding_group_ref(
+        "repo:provider", "1.0.0", "provider-group",
+        "provider", "1.0.0");
+    db["legacy"].bindings["provider"]["1.0.0"] = "1.0.0";
+    db["provider"].bindings["legacy"]["1.0.0"] = "1.0.0";
+
+    auto result =
+        xlings::xvm::resolve_binding_selection(db, "legacy", "1.0.0");
+
+    expect_binding_error(
+        result,
+        xlings::xvm::BindingErrorKind::ProviderMetadataInLegacyGraph,
+        "provider", "1.0.0");
+}
+
+TEST(XvmBindingSelectionErrorTest,
+     ProviderResolutionRejectsPersistedIntegrityIssue) {
+    auto corruptRoot = nlohmann::json::parse(R"({
+        "path": "/provider",
+        "kind": "group",
+        "bindingGroup": {
+            "provider": "repo:provider",
+            "version": "1.0.0",
+            "group": "provider-group",
+            "rootTarget": "provider-root",
+            "rootVersion": "1.0.0"
+        },
+        "bindingMembers": {
+            "provider-root": "1.0.0",
+            "tool": false
+        }
+    })");
+    auto persisted = xlings::xvm::vdata_to_json(
+        xlings::xvm::vdata_from_json(corruptRoot));
+    xlings::xvm::VersionDB db;
+    db["provider-root"].versions["1.0.0"] =
+        xlings::xvm::vdata_from_json(persisted);
+
+    auto result = xlings::xvm::resolve_binding_selection(
+        db, "provider-root", "1.0.0");
+
+    ASSERT_FALSE(result.has_value());
+    expect_binding_error(
+        result, xlings::xvm::BindingErrorKind::MetadataIntegrityIssue,
+        "provider-root", "1.0.0");
+    EXPECT_NE(result.error().message.find(
+                  "binding-member-version-not-string"),
+              std::string::npos);
+    EXPECT_NE(result.error().message.find("/bindingMembers/tool"),
+              std::string::npos);
+}
+
+TEST(XvmBindingSelectionErrorTest,
+     LegacyResolutionRejectsPersistedIntegrityIssue) {
+    auto corruptLegacy = nlohmann::json::parse(R"({
+        "path": "/legacy",
+        "bindingHeaders": [false]
+    })");
+    auto persisted = xlings::xvm::vdata_to_json(
+        xlings::xvm::vdata_from_json(corruptLegacy));
+    xlings::xvm::VersionDB db;
+    db["legacy"].type = "program";
+    db["legacy"].versions["1.0.0"] =
+        xlings::xvm::vdata_from_json(persisted);
+
+    auto result =
+        xlings::xvm::resolve_binding_selection(db, "legacy", "1.0.0");
+
+    ASSERT_FALSE(result.has_value());
+    expect_binding_error(
+        result, xlings::xvm::BindingErrorKind::MetadataIntegrityIssue,
+        "legacy", "1.0.0");
+    EXPECT_NE(result.error().message.find("binding-header-not-object"),
+              std::string::npos);
+    EXPECT_NE(result.error().message.find("/bindingHeaders/0"),
+              std::string::npos);
 }
 
 TEST(XvmBindingSelectionErrorTest, RejectsMissingStartingTarget) {

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -4215,6 +4215,80 @@ TEST(XvmRegistrationOwnershipTest,
 }
 
 TEST(XvmRegistrationOwnershipTest,
+     MissingPersistedRootRejectsDifferentIncomingGroupWithoutMutation) {
+    xlings::xvm::VersionDB db;
+    const auto oldGroup = make_binding_group_ref(
+        "repo:provider", "1.0.0", "old-group",
+        "shared-root", "repo:root");
+    add_provider_group_member(
+        db, "old-member", "repo:old-member", oldGroup,
+        "program", "old-member", "old-member");
+    xlings::xvm::Workspace workspace{{"sentinel", "0"}};
+    xlings::xvm::WorkspaceInstalled installed{{"sentinel", {"0"}}};
+    const auto dbBefore = xlings::xvm::versions_to_json(db);
+    const auto workspaceBefore = workspace;
+    const auto installedBefore = installed;
+
+    auto root =
+        make_registration_node("shared-root", "repo:root", "group");
+    auto newMember =
+        make_registration_node("new-member", "repo:new-member");
+    newMember.binding = make_registration_binding(
+        "shared-root", "repo:root", "new-group");
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed,
+        make_registration_batch({root, newMember}));
+
+    expect_registration_error(
+        result,
+        xlings::xvm::RegistrationErrorKind::BindingValidationFailed,
+        "/bindingGroups/old-group", "shared-root", "repo:root");
+    expect_registration_state_unchanged(
+        db, workspace, installed,
+        dbBefore, workspaceBefore, installedBefore);
+}
+
+TEST(XvmRegistrationOwnershipTest,
+     RejectsPersistedTwoLabelsForOneRootWithoutMutation) {
+    xlings::xvm::VersionDB db;
+    const auto alphaGroup = make_binding_group_ref(
+        "repo:provider", "1.0.0", "alpha",
+        "shared-root", "repo:root");
+    auto& root = add_provider_group_member(
+        db, "shared-root", "repo:root", alphaGroup, "group");
+    root.bindingMembers = {
+        {"shared-root", "repo:root"},
+    };
+    root.bindingMembersDeclared = true;
+    const auto betaGroup = make_binding_group_ref(
+        "repo:provider", "1.0.0", "beta",
+        "shared-root", "repo:root");
+    add_provider_group_member(
+        db, "beta-member", "repo:beta", betaGroup,
+        "program", "beta-member", "beta-member");
+    xlings::xvm::Workspace workspace{{"sentinel", "0"}};
+    xlings::xvm::WorkspaceInstalled installed{{"sentinel", {"0"}}};
+    const auto dbBefore = xlings::xvm::versions_to_json(db);
+    const auto workspaceBefore = workspace;
+    const auto installedBefore = installed;
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed,
+        make_registration_batch({
+            make_registration_node("fresh", "repo:fresh"),
+        }));
+
+    expect_registration_error(
+        result,
+        xlings::xvm::RegistrationErrorKind::BindingValidationFailed,
+        "/bindingGroups/beta", "shared-root", "repo:root");
+    expect_registration_state_unchanged(
+        db, workspace, installed,
+        dbBefore, workspaceBefore, installedBefore);
+}
+
+TEST(XvmRegistrationOwnershipTest,
      RejectsOtherProviderExactCollisionWithoutMutation) {
     xlings::xvm::VersionDB db;
     auto& existing = db["tool"].versions["repo:1.0.0"];
@@ -5034,27 +5108,43 @@ TEST(XvmRegistrationStateTest,
 }
 
 TEST(XvmRegistrationStateTest,
-     InvalidPayloadInFinalNodePreservesEveryStateObject) {
+     FinalComponentValidationFailurePreservesEveryStateObject) {
     xlings::xvm::VersionDB db;
     db["sentinel"].versions["0"].path = "/sentinel";
-    xlings::xvm::Workspace workspace{{"sentinel", "0"}};
-    xlings::xvm::WorkspaceInstalled installed{{"sentinel", {"0"}}};
+    const auto staleGroup = make_binding_group_ref(
+        "repo:provider", "1.0.0", "stale-group",
+        "future-root", "repo:root");
+    add_provider_group_member(
+        db, "stale-member", "repo:stale-member", staleGroup,
+        "program", "stale-member", "stale-member");
+    xlings::xvm::Workspace workspace{
+        {"future-root", "repo:previous"},
+        {"sentinel", "0"},
+    };
+    xlings::xvm::WorkspaceInstalled installed{
+        {"future-root", {"repo:previous"}},
+        {"sentinel", {"0"}},
+    };
     const auto dbBefore = xlings::xvm::versions_to_json(db);
     const auto workspaceBefore = workspace;
     const auto installedBefore = installed;
-    auto valid =
-        make_registration_node("a-valid", "repo:valid");
-    auto invalid =
-        make_registration_node("z-invalid", "repo:invalid", "archive");
+
+    auto root =
+        make_registration_node("future-root", "repo:root", "group");
+    auto freshMember =
+        make_registration_node("fresh-member", "repo:fresh-member");
+    freshMember.binding = make_registration_binding(
+        "future-root", "repo:root", "replacement-group");
+    auto batch = make_registration_batch({root, freshMember});
+    batch.useAfterInstall = true;
 
     auto result = xlings::xvm::apply_registration_batch(
-        db, workspace, installed,
-        make_registration_batch({valid, invalid}));
+        db, workspace, installed, batch);
 
     expect_registration_error(
         result,
-        xlings::xvm::RegistrationErrorKind::InvalidNodePayload,
-        "/nodes/1/kind", "z-invalid", "repo:invalid");
+        xlings::xvm::RegistrationErrorKind::BindingValidationFailed,
+        "/bindingGroups/stale-group", "future-root", "repo:root");
     expect_registration_state_unchanged(
         db, workspace, installed,
         dbBefore, workspaceBefore, installedBefore);

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -6878,6 +6878,1455 @@ TEST(XvmRemovalBatchTest,
         }));
 }
 
+TEST(XimXvmRegistrationAdapterTest,
+     RootAfterChildProducesOneExactProviderGroup) {
+    xlings::xim::PlanNode provider;
+    provider.name = "toolchain";
+    provider.version = "15.1.0";
+    provider.namespaceName = "repo-a";
+    provider.canonicalName = "repo-a:toolchain";
+    provider.storeRoot = "/store";
+    const std::vector<mcpplibs::xpkg::XvmOp> operations{
+        {
+            .op = "add",
+            .name = "cc",
+            .version = "gcc-15.1.0",
+            .bindir = "/payload/bin",
+            .type = "program",
+            .filename = "cc-real",
+            .binding = "toolchain@15.1.0",
+        },
+        {
+            .op = "add",
+            .name = "toolchain",
+            .version = "15.1.0",
+            .type = "group",
+        },
+    };
+
+    auto plan = xlings::xim::normalize_xpkg_registration_plan(
+        provider, operations, "repo-a", "/data", false);
+
+    ASSERT_TRUE(plan.has_value()) << plan.error().message;
+    EXPECT_EQ(plan->batch.provider, "repo-a:toolchain");
+    EXPECT_EQ(plan->batch.providerVersion, "15.1.0");
+    ASSERT_EQ(plan->batch.nodes.size(), 2u);
+    EXPECT_EQ(plan->batch.nodes[0].target, "cc");
+    EXPECT_EQ(plan->batch.nodes[0].version, "repo-a:gcc-15.1.0");
+    ASSERT_TRUE(plan->batch.nodes[0].binding.has_value());
+    EXPECT_EQ(
+        plan->batch.nodes[0].binding->rootTarget,
+        "toolchain");
+    EXPECT_EQ(
+        plan->batch.nodes[0].binding->rootVersion,
+        "repo-a:15.1.0");
+    EXPECT_EQ(plan->batch.nodes[1].target, "toolchain");
+    EXPECT_EQ(plan->batch.nodes[1].version, "repo-a:15.1.0");
+
+    xlings::xvm::VersionDB db;
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, plan->batch);
+
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    const auto& root =
+        db.at("toolchain").versions.at("repo-a:15.1.0");
+    const auto& child =
+        db.at("cc").versions.at("repo-a:gcc-15.1.0");
+    ASSERT_TRUE(root.bindingGroup.has_value());
+    ASSERT_TRUE(child.bindingGroup.has_value());
+    EXPECT_EQ(root.bindingGroup->provider, "repo-a:toolchain");
+    EXPECT_EQ(root.bindingGroup->providerVersion, "15.1.0");
+    EXPECT_EQ(root.bindingGroup->group, "toolchain");
+    EXPECT_EQ(
+        child.bindingGroup->provider,
+        root.bindingGroup->provider);
+    EXPECT_EQ(
+        child.bindingGroup->providerVersion,
+        root.bindingGroup->providerVersion);
+    EXPECT_EQ(
+        child.bindingGroup->group,
+        root.bindingGroup->group);
+    EXPECT_EQ(
+        child.bindingGroup->rootTarget,
+        root.bindingGroup->rootTarget);
+    EXPECT_EQ(
+        child.bindingGroup->rootVersion,
+        root.bindingGroup->rootVersion);
+    EXPECT_EQ(
+        root.bindingMembers,
+        (std::map<std::string, std::string>{
+            {"cc", "repo-a:gcc-15.1.0"},
+            {"toolchain", "repo-a:15.1.0"},
+        }));
+    EXPECT_EQ(
+        installed.at("cc"),
+        (std::vector<std::string>{"repo-a:gcc-15.1.0"}));
+    EXPECT_EQ(
+        installed.at("toolchain"),
+        (std::vector<std::string>{"repo-a:15.1.0"}));
+}
+
+TEST(XimXvmRegistrationAdapterTest,
+     NormalizesVersionNamespaceExactlyOnceAndRejectsConflicts) {
+    xlings::xim::PlanNode provider;
+    provider.name = "provider";
+    provider.version = "1.0.0";
+    provider.namespaceName = "repo-a";
+    const auto makeAdd = [](std::string version) {
+        return std::vector<mcpplibs::xpkg::XvmOp>{
+            {
+                .op = "add",
+                .name = "tool",
+                .version = std::move(version),
+            },
+        };
+    };
+
+    auto matching = xlings::xim::normalize_xpkg_registration_plan(
+        provider, makeAdd("repo-a:tool-1.0.0"),
+        "repo-a", "/data", false);
+    ASSERT_TRUE(matching.has_value()) << matching.error().message;
+    ASSERT_EQ(matching->batch.nodes.size(), 1u);
+    EXPECT_EQ(
+        matching->batch.nodes[0].version,
+        "repo-a:tool-1.0.0");
+
+    struct InvalidCase {
+        std::string expectedNamespace;
+        std::string version;
+    };
+    const std::array<InvalidCase, 3> invalidCases{
+        InvalidCase{"repo-a", "repo-b:tool-1.0.0"},
+        InvalidCase{"", "repo-a:tool-1.0.0"},
+        InvalidCase{"repo-a", "repo-a:repo-a:tool-1.0.0"},
+    };
+    for (const auto& testCase : invalidCases) {
+        SCOPED_TRACE(testCase.version);
+        auto result = xlings::xim::normalize_xpkg_registration_plan(
+            provider, makeAdd(testCase.version),
+            testCase.expectedNamespace, "/data", false);
+
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(
+            result.error().kind,
+            xlings::xim::XpkgRegistrationErrorKind::InvalidVersion);
+        EXPECT_EQ(result.error().operationIndex, 0u);
+        EXPECT_EQ(result.error().target, "tool");
+        EXPECT_EQ(result.error().version, testCase.version);
+        EXPECT_FALSE(result.error().message.empty());
+    }
+}
+
+TEST(XimXvmRegistrationAdapterTest,
+     RejectsMalformedLegacyBindingBeforeRegistration) {
+    xlings::xim::PlanNode provider;
+    provider.name = "provider";
+    provider.version = "1.0.0";
+    provider.namespaceName = "repo-a";
+    const std::array<std::string, 4> invalidBindings{
+        "root",
+        "@1.0.0",
+        "root@",
+        "root@1.0.0@extra",
+    };
+
+    for (const auto& binding : invalidBindings) {
+        SCOPED_TRACE(binding);
+        const std::vector<mcpplibs::xpkg::XvmOp> operations{
+            {
+                .op = "add",
+                .name = "child",
+                .binding = binding,
+            },
+        };
+        auto result = xlings::xim::normalize_xpkg_registration_plan(
+            provider, operations, "repo-a", "/data", false);
+
+        ASSERT_FALSE(result.has_value());
+        EXPECT_EQ(
+            result.error().kind,
+            xlings::xim::XpkgRegistrationErrorKind::InvalidBinding);
+        EXPECT_EQ(result.error().operationIndex, 0u);
+        EXPECT_EQ(result.error().target, "child");
+        EXPECT_EQ(result.error().version, binding);
+        EXPECT_FALSE(result.error().message.empty());
+    }
+}
+
+TEST(XimXvmRegistrationAdapterTest,
+     DeduplicatesEqualEnvironmentAndRejectsConflictingDuplicate) {
+    xlings::xim::PlanNode provider;
+    provider.name = "provider";
+    provider.version = "1.0.0";
+    const std::vector<mcpplibs::xpkg::XvmOp> equalOperations{
+        {
+            .op = "add",
+            .name = "tool",
+            .envs = {
+                {"MODE", "release"},
+                {"MODE", "release"},
+            },
+        },
+    };
+    auto equal = xlings::xim::normalize_xpkg_registration_plan(
+        provider, equalOperations, "", "/data", false);
+
+    ASSERT_TRUE(equal.has_value()) << equal.error().message;
+    ASSERT_EQ(equal->batch.nodes.size(), 1u);
+    EXPECT_EQ(
+        equal->batch.nodes[0].envs,
+        (std::map<std::string, std::string>{
+            {"MODE", "release"},
+        }));
+
+    const std::vector<mcpplibs::xpkg::XvmOp> conflictOperations{
+        {
+            .op = "add",
+            .name = "tool",
+            .envs = {
+                {"MODE", "release"},
+                {"MODE", "debug"},
+            },
+        },
+    };
+    auto conflict = xlings::xim::normalize_xpkg_registration_plan(
+        provider, conflictOperations, "", "/data", false);
+
+    ASSERT_FALSE(conflict.has_value());
+    EXPECT_EQ(
+        conflict.error().kind,
+        xlings::xim::XpkgRegistrationErrorKind::ConflictingEnvironment);
+    EXPECT_EQ(conflict.error().operationIndex, 0u);
+    EXPECT_EQ(conflict.error().target, "tool");
+    EXPECT_EQ(conflict.error().version, "MODE");
+    EXPECT_FALSE(conflict.error().message.empty());
+}
+
+TEST(XimXvmRegistrationAdapterTest,
+     CanonicalProviderAndVersionPayloadDriveDeferredEffects) {
+    xlings::xim::PlanNode provider;
+    provider.name = "recipe-name";
+    provider.version = "2.0.0";
+    provider.namespaceName = "repo-a";
+    provider.canonicalName = "canonical:provider";
+    provider.storeRoot = "/store";
+    const std::vector<mcpplibs::xpkg::XvmOp> operations{
+        {
+            .op = "add",
+            .name = "cc",
+            .alias = "--driver",
+            .envs = {
+                {"CC_MODE", "strict"},
+            },
+        },
+        {
+            .op = "add",
+            .name = "compiler-runtime",
+            .version = "runtime-2.0.0",
+            .bindir = "/payload/lib",
+            .type = "lib",
+            .filename = "libcompiler.so.2",
+        },
+        {
+            .op = "add",
+            .name = "toolchain",
+            .type = "group",
+        },
+    };
+
+    auto plan = xlings::xim::normalize_xpkg_registration_plan(
+        provider, operations, "repo-a", "/data", true);
+
+    ASSERT_TRUE(plan.has_value()) << plan.error().message;
+    EXPECT_EQ(plan->batch.provider, "canonical:provider");
+    EXPECT_EQ(plan->batch.providerVersion, "2.0.0");
+    EXPECT_TRUE(plan->batch.useAfterInstall);
+    ASSERT_EQ(plan->batch.nodes.size(), 3u);
+
+    const auto& program = plan->batch.nodes[0];
+    EXPECT_EQ(program.target, "cc");
+    EXPECT_EQ(program.version, "repo-a:2.0.0");
+    EXPECT_EQ(
+        program.path,
+        "/store/repo-a-x-recipe-name/2.0.0");
+    EXPECT_EQ(program.kind, "program");
+    EXPECT_EQ(program.sourceName, "cc");
+    EXPECT_EQ(program.destinationName, "cc");
+    EXPECT_EQ(
+        program.alias,
+        (std::vector<std::string>{"--driver"}));
+    EXPECT_EQ(
+        program.envs,
+        (std::map<std::string, std::string>{
+            {"CC_MODE", "strict"},
+        }));
+
+    const auto& library = plan->batch.nodes[1];
+    EXPECT_EQ(library.target, "compiler-runtime");
+    EXPECT_EQ(library.version, "repo-a:runtime-2.0.0");
+    EXPECT_EQ(library.path, "/payload/lib");
+    EXPECT_EQ(library.kind, "lib");
+    EXPECT_EQ(library.sourceName, "libcompiler.so.2");
+    EXPECT_EQ(library.destinationName, "libcompiler.so.2");
+
+    const auto& group = plan->batch.nodes[2];
+    EXPECT_EQ(group.target, "toolchain");
+    EXPECT_EQ(group.version, "repo-a:2.0.0");
+    EXPECT_EQ(group.kind, "group");
+    EXPECT_TRUE(group.sourceName.empty());
+    EXPECT_TRUE(group.destinationName.empty());
+
+    ASSERT_EQ(plan->effects.size(), 2u);
+    EXPECT_EQ(
+        plan->effects[0].kind,
+        xlings::xim::XpkgFilesystemEffectKind::ProgramShim);
+    EXPECT_EQ(plan->effects[0].target, "cc");
+    EXPECT_EQ(plan->effects[0].version, "repo-a:2.0.0");
+    EXPECT_EQ(
+        plan->effects[1].kind,
+        xlings::xim::XpkgFilesystemEffectKind::Library);
+    EXPECT_EQ(plan->effects[1].target, "compiler-runtime");
+    EXPECT_EQ(
+        plan->effects[1].version,
+        "repo-a:runtime-2.0.0");
+}
+
+TEST(XimXvmRegistrationAdapterTest,
+     UngroupedHeaderRoutesToOnlyRootWithoutPhantomProviderTarget) {
+    xlings::xim::PlanNode provider;
+    provider.name = "recipe-provider";
+    provider.version = "1.0.0";
+    provider.namespaceName = "repo-a";
+    const std::vector<mcpplibs::xpkg::XvmOp> operations{
+        {
+            .op = "add",
+            .name = "toolchain",
+            .type = "group",
+        },
+        {
+            .op = "headers",
+            .includedir = "/payload/include",
+        },
+    };
+    auto plan = xlings::xim::normalize_xpkg_registration_plan(
+        provider, operations, "repo-a", "/data", false);
+
+    ASSERT_TRUE(plan.has_value()) << plan.error().message;
+    ASSERT_EQ(plan->batch.headers.size(), 1u);
+    EXPECT_EQ(
+        plan->batch.headers[0].sourceDir,
+        "/payload/include");
+    EXPECT_TRUE(plan->batch.headers[0].destinationPrefix.empty());
+    EXPECT_TRUE(plan->batch.headers[0].group.empty());
+    ASSERT_EQ(plan->effects.size(), 1u);
+    EXPECT_EQ(
+        plan->effects[0].kind,
+        xlings::xim::XpkgFilesystemEffectKind::InstallHeaders);
+    EXPECT_EQ(plan->effects[0].sourceDir, "/payload/include");
+
+    xlings::xvm::VersionDB db;
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, plan->batch);
+
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    ASSERT_TRUE(db.contains("toolchain"));
+    EXPECT_FALSE(db.contains("recipe-provider"));
+    const auto& root =
+        db.at("toolchain").versions.at("repo-a:1.0.0");
+    ASSERT_EQ(root.bindingHeaders.size(), 1u);
+    EXPECT_EQ(root.bindingHeaders[0].sourceDir, "/payload/include");
+    EXPECT_TRUE(root.bindingHeaders[0].destinationPrefix.empty());
+}
+
+TEST(XimXvmRegistrationAdapterTest,
+     UngroupedHeaderRejectsMultipleGroupsWithoutMutation) {
+    xlings::xim::PlanNode provider;
+    provider.name = "recipe-provider";
+    provider.version = "1.0.0";
+    const std::vector<mcpplibs::xpkg::XvmOp> operations{
+        {
+            .op = "add",
+            .name = "compiler",
+            .type = "group",
+        },
+        {
+            .op = "add",
+            .name = "tools",
+            .version = "tools-1.0.0",
+            .type = "group",
+        },
+        {
+            .op = "headers",
+            .includedir = "/payload/include",
+        },
+    };
+    auto plan = xlings::xim::normalize_xpkg_registration_plan(
+        provider, operations, "", "/data", false);
+    ASSERT_TRUE(plan.has_value()) << plan.error().message;
+
+    xlings::xvm::VersionDB db;
+    db["sentinel"].versions["0"].path = "/sentinel";
+    xlings::xvm::Workspace workspace{{"sentinel", "0"}};
+    xlings::xvm::WorkspaceInstalled installed{
+        {"sentinel", {"0"}},
+    };
+    const auto dbBefore = xlings::xvm::versions_to_json(db);
+    const auto workspaceBefore = workspace;
+    const auto installedBefore = installed;
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, plan->batch);
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(
+        result.error().kind,
+        xlings::xvm::RegistrationErrorKind::HeaderAmbiguous);
+    EXPECT_EQ(xlings::xvm::versions_to_json(db), dbBefore);
+    EXPECT_EQ(workspace, workspaceBefore);
+    EXPECT_EQ(installed, installedBefore);
+}
+
+TEST(XimXvmRegistrationAdapterTest,
+     RemoveHeadersProducesOnlyADeferredCompatibilityEffect) {
+    xlings::xim::PlanNode provider;
+    provider.name = "recipe-provider";
+    provider.version = "1.0.0";
+    const std::vector<mcpplibs::xpkg::XvmOp> operations{
+        {
+            .op = "remove_headers",
+            .includedir = "/payload/include",
+        },
+    };
+
+    auto plan = xlings::xim::normalize_xpkg_registration_plan(
+        provider, operations, "", "/data", false);
+
+    ASSERT_TRUE(plan.has_value()) << plan.error().message;
+    EXPECT_TRUE(plan->batch.nodes.empty());
+    EXPECT_TRUE(plan->batch.headers.empty());
+    ASSERT_EQ(plan->effects.size(), 1u);
+    EXPECT_EQ(
+        plan->effects[0].kind,
+        xlings::xim::XpkgFilesystemEffectKind::RemoveHeaders);
+    EXPECT_EQ(plan->effects[0].sourceDir, "/payload/include");
+}
+
+TEST(XimXvmMetadataBatchTest,
+     LateRegistrationConflictPreservesCallerStateAndArtifact) {
+    xlings::xvm::VersionDB db;
+    auto& oldVersion = db["old-tool"].versions["repo:old-1.0.0"];
+    oldVersion.path = "/old/tool";
+    oldVersion.kind = "program";
+    oldVersion.sourceName = "old-tool";
+    oldVersion.destinationName = "old-tool";
+
+    auto& conflict = db["new-tool"].versions["repo:new-1.0.0"];
+    conflict.path = "/other/tool";
+    conflict.kind = "program";
+    conflict.sourceName = "other-tool";
+    conflict.destinationName = "new-tool";
+    conflict.bindingGroup = xlings::xvm::BindingGroupRef{
+        .provider = "other:provider",
+        .providerVersion = "1.0.0",
+        .group = "new-tool",
+        .rootTarget = "new-tool",
+        .rootVersion = "repo:new-1.0.0",
+    };
+    conflict.bindingMembers = {
+        {"new-tool", "repo:new-1.0.0"},
+    };
+    conflict.bindingMembersDeclared = true;
+
+    xlings::xvm::Workspace workspace{
+        {"old-tool", "repo:old-1.0.0"},
+        {"new-tool", "repo:new-1.0.0"},
+    };
+    xlings::xvm::WorkspaceInstalled installed{
+        {"old-tool", {"repo:old-1.0.0"}},
+        {"new-tool", {"repo:new-1.0.0"}},
+    };
+    const std::vector<mcpplibs::xpkg::XvmOp> operations{
+        {
+            .op = "remove",
+            .name = "old-tool",
+            .version = "repo:old-1.0.0",
+        },
+        {
+            .op = "add",
+            .name = "new-tool",
+            .version = "repo:new-1.0.0",
+            .bindir = "/new/tool",
+        },
+    };
+    xlings::xim::PlanNode provider;
+    provider.name = "provider";
+    provider.version = "1.0.0";
+    provider.namespaceName = "repo";
+    provider.canonicalName = "repo:provider";
+    auto plan = xlings::xim::normalize_xpkg_registration_plan(
+        provider, operations, "repo", "/data", false);
+    ASSERT_TRUE(plan.has_value()) << plan.error().message;
+    auto context = xlings::xim::snapshot_xpkg_removal_context(
+        db, workspace, operations,
+        provider.canonicalName, provider.version);
+    ASSERT_TRUE(context.has_value()) << context.error().message;
+
+    const auto dbBefore = xlings::xvm::versions_to_json(db);
+    const auto workspaceBefore = workspace;
+    const auto installedBefore = installed;
+    const auto artifactDir =
+        std::filesystem::temp_directory_path()
+        / std::format(
+            "xlings-xvm-metadata-batch-sentinel-{}",
+            std::chrono::steady_clock::now()
+                .time_since_epoch()
+                .count());
+    std::filesystem::create_directories(artifactDir);
+    const auto artifact = artifactDir / "keep";
+    {
+        std::ofstream output(artifact);
+        output << "unchanged";
+    }
+
+    auto result = xlings::xim::apply_xpkg_xvm_metadata_batch(
+        db, workspace, installed, operations, *context, *plan);
+
+    ASSERT_FALSE(result.has_value());
+    ASSERT_TRUE(std::holds_alternative<xlings::xvm::RegistrationError>(
+        result.error()));
+    EXPECT_EQ(
+        std::get<xlings::xvm::RegistrationError>(result.error()).kind,
+        xlings::xvm::RegistrationErrorKind::OwnershipConflict);
+    EXPECT_EQ(xlings::xvm::versions_to_json(db), dbBefore);
+    EXPECT_EQ(workspace, workspaceBefore);
+    EXPECT_EQ(installed, installedBefore);
+    ASSERT_TRUE(std::filesystem::exists(artifact));
+    std::ifstream input(artifact);
+    std::string artifactContents;
+    input >> artifactContents;
+    EXPECT_EQ(artifactContents, "unchanged");
+    std::filesystem::remove_all(artifactDir);
+}
+
+TEST(XimXvmMetadataBatchTest,
+     RemoveOldAddNewCommitsAndPreservesAnotherProviderRelease) {
+    xlings::xvm::VersionDB db;
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+    const auto seedRelease = [&](
+            const std::string& release,
+            bool useAfterInstall) {
+        xlings::xim::PlanNode provider;
+        provider.name = "toolchain";
+        provider.version = release;
+        provider.namespaceName = "repo";
+        provider.canonicalName = "repo:toolchain";
+        const std::vector<mcpplibs::xpkg::XvmOp> operations{
+            {
+                .op = "add",
+                .name = "cc",
+                .version = "cc-" + release,
+                .bindir = "/payload/" + release + "/bin",
+                .binding = "toolchain@" + release,
+            },
+            {
+                .op = "add",
+                .name = "compiler-runtime",
+                .version = "runtime-" + release,
+                .bindir = "/payload/" + release + "/lib",
+                .type = "lib",
+                .filename = "libcompiler.so",
+                .binding = "toolchain@" + release,
+            },
+            {
+                .op = "add",
+                .name = "toolchain",
+                .type = "group",
+            },
+        };
+        auto plan = xlings::xim::normalize_xpkg_registration_plan(
+            provider, operations, "repo", "/data", useAfterInstall);
+        EXPECT_TRUE(plan.has_value());
+        if (!plan) return;
+        auto result = xlings::xvm::apply_registration_batch(
+            db, workspace, installed, plan->batch);
+        EXPECT_TRUE(result.has_value());
+    };
+    seedRelease("0.9.0", false);
+    seedRelease("1.0.0", true);
+    ASSERT_EQ(db.at("toolchain").versions.size(), 2u);
+
+    xlings::xim::PlanNode provider;
+    provider.name = "toolchain";
+    provider.version = "2.0.0";
+    provider.namespaceName = "repo";
+    provider.canonicalName = "repo:toolchain";
+    const std::vector<mcpplibs::xpkg::XvmOp> operations{
+        {
+            .op = "remove",
+            .name = "toolchain",
+            .version = "repo:1.0.0",
+        },
+        {
+            .op = "add",
+            .name = "cc",
+            .version = "cc-2.0.0",
+            .bindir = "/payload/2.0.0/bin",
+            .binding = "toolchain@2.0.0",
+        },
+        {
+            .op = "add",
+            .name = "compiler-runtime",
+            .version = "runtime-2.0.0",
+            .bindir = "/payload/2.0.0/lib",
+            .type = "lib",
+            .filename = "libcompiler.so",
+            .binding = "toolchain@2.0.0",
+        },
+        {
+            .op = "add",
+            .name = "toolchain",
+            .type = "group",
+        },
+    };
+    auto plan = xlings::xim::normalize_xpkg_registration_plan(
+        provider, operations, "repo", "/data", true);
+    ASSERT_TRUE(plan.has_value()) << plan.error().message;
+    auto context = xlings::xim::snapshot_xpkg_removal_context(
+        db, workspace, operations,
+        provider.canonicalName, provider.version);
+    ASSERT_TRUE(context.has_value()) << context.error().message;
+
+    auto result = xlings::xim::apply_xpkg_xvm_metadata_batch(
+        db, workspace, installed, operations, *context, *plan);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->removal.removed.size(), 3u);
+    EXPECT_EQ(result->registered.size(), 3u);
+    ASSERT_EQ(result->effects.size(), 2u);
+    EXPECT_EQ(
+        result->effects[0].kind,
+        xlings::xim::XpkgFilesystemEffectKind::ProgramShim);
+    EXPECT_EQ(
+        result->effects[1].kind,
+        xlings::xim::XpkgFilesystemEffectKind::Library);
+    for (const auto& [target, oldVersion, otherVersion, newVersion] :
+         std::array<std::array<std::string, 4>, 3>{
+             std::array<std::string, 4>{
+                 "toolchain", "repo:1.0.0",
+                 "repo:0.9.0", "repo:2.0.0",
+             },
+             std::array<std::string, 4>{
+                 "cc", "repo:cc-1.0.0",
+                 "repo:cc-0.9.0", "repo:cc-2.0.0",
+             },
+             std::array<std::string, 4>{
+                 "compiler-runtime", "repo:runtime-1.0.0",
+                 "repo:runtime-0.9.0", "repo:runtime-2.0.0",
+             },
+         }) {
+        SCOPED_TRACE(target);
+        ASSERT_TRUE(db.contains(target));
+        EXPECT_FALSE(db.at(target).versions.contains(oldVersion));
+        EXPECT_TRUE(db.at(target).versions.contains(otherVersion));
+        EXPECT_TRUE(db.at(target).versions.contains(newVersion));
+        EXPECT_EQ(workspace.at(target), newVersion);
+        EXPECT_EQ(
+            installed.at(target),
+            (std::vector<std::string>{otherVersion, newVersion}));
+    }
+    const auto& newRoot =
+        db.at("toolchain").versions.at("repo:2.0.0");
+    ASSERT_TRUE(newRoot.bindingGroup.has_value());
+    EXPECT_EQ(newRoot.bindingGroup->provider, "repo:toolchain");
+    EXPECT_EQ(newRoot.bindingGroup->providerVersion, "2.0.0");
+    EXPECT_EQ(newRoot.bindingMembers.size(), 3u);
+}
+
+TEST(XimXvmMetadataBatchTest,
+     EmptyMetadataOperationsDoNotPurgeDiscoveredProviderSelection) {
+    xlings::xvm::VersionDB db;
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+    xlings::xim::PlanNode provider;
+    provider.name = "provider";
+    provider.version = "1.0.0";
+    provider.namespaceName = "repo";
+    provider.canonicalName = "repo:provider";
+    const std::vector<mcpplibs::xpkg::XvmOp> seedOperations{
+        {
+            .op = "add",
+            .name = "provider-root",
+            .type = "group",
+        },
+    };
+    auto seedPlan = xlings::xim::normalize_xpkg_registration_plan(
+        provider, seedOperations, "repo", "/data", true);
+    ASSERT_TRUE(seedPlan.has_value()) << seedPlan.error().message;
+    auto seeded = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, seedPlan->batch);
+    ASSERT_TRUE(seeded.has_value()) << seeded.error().message;
+
+    const std::vector<mcpplibs::xpkg::XvmOp> operations;
+    auto emptyPlan = xlings::xim::normalize_xpkg_registration_plan(
+        provider, operations, "repo", "/data", false);
+    ASSERT_TRUE(emptyPlan.has_value()) << emptyPlan.error().message;
+    auto context = xlings::xim::snapshot_xpkg_removal_context(
+        db, workspace, operations,
+        provider.canonicalName, provider.version);
+    ASSERT_TRUE(context.has_value()) << context.error().message;
+    ASSERT_TRUE(context->hasSelection);
+    const auto dbBefore = xlings::xvm::versions_to_json(db);
+    const auto workspaceBefore = workspace;
+    const auto installedBefore = installed;
+
+    auto result = xlings::xim::apply_xpkg_xvm_metadata_batch(
+        db, workspace, installed,
+        operations, *context, *emptyPlan);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_TRUE(result->removal.removed.empty());
+    EXPECT_TRUE(result->registered.empty());
+    EXPECT_TRUE(result->effects.empty());
+    EXPECT_EQ(xlings::xvm::versions_to_json(db), dbBefore);
+    EXPECT_EQ(workspace, workspaceBefore);
+    EXPECT_EQ(installed, installedBefore);
+}
+
+TEST(XimXvmMetadataBatchTest,
+     RootOrderPermutationsSerializeIdenticallyThroughAdapter) {
+    xlings::xim::PlanNode provider;
+    provider.name = "toolchain";
+    provider.version = "1.0.0";
+    provider.namespaceName = "repo";
+    provider.canonicalName = "repo:toolchain";
+    const mcpplibs::xpkg::XvmOp root{
+        .op = "add",
+        .name = "toolchain",
+        .type = "group",
+    };
+    const mcpplibs::xpkg::XvmOp child{
+        .op = "add",
+        .name = "cc",
+        .version = "cc-1.0.0",
+        .bindir = "/payload/bin",
+        .filename = "cc-real",
+        .binding = "toolchain@1.0.0",
+    };
+    const auto apply = [&](
+            const std::vector<mcpplibs::xpkg::XvmOp>& operations) {
+        xlings::xvm::VersionDB db;
+        xlings::xvm::Workspace workspace;
+        xlings::xvm::WorkspaceInstalled installed;
+        auto plan = xlings::xim::normalize_xpkg_registration_plan(
+            provider, operations, "repo", "/data", false);
+        EXPECT_TRUE(plan.has_value());
+        if (!plan) {
+            return std::tuple{
+                nlohmann::json{},
+                xlings::xvm::Workspace{},
+                xlings::xvm::WorkspaceInstalled{},
+            };
+        }
+        auto result = xlings::xim::apply_xpkg_xvm_metadata_batch(
+            db, workspace, installed, operations,
+            xlings::xvm::RemovalContext{}, *plan);
+        EXPECT_TRUE(result.has_value());
+        return std::tuple{
+            xlings::xvm::versions_to_json(db),
+            std::move(workspace),
+            std::move(installed),
+        };
+    };
+
+    const auto rootFirst = apply({root, child});
+    const auto rootLast = apply({child, root});
+
+    EXPECT_EQ(rootFirst, rootLast);
+}
+
+TEST(XimXvmMetadataBatchTest,
+     PhantomAndSelfBindingsPropagateWithoutStateMutation) {
+    struct InvalidCase {
+        std::string binding;
+        xlings::xvm::RegistrationErrorKind expected;
+    };
+    const std::array<InvalidCase, 2> invalidCases{
+        InvalidCase{
+            "missing-root@1.0.0",
+            xlings::xvm::RegistrationErrorKind::RootNotInBatch,
+        },
+        InvalidCase{
+            "child@1.0.0",
+            xlings::xvm::RegistrationErrorKind::SelfBinding,
+        },
+    };
+    for (const auto& testCase : invalidCases) {
+        SCOPED_TRACE(testCase.binding);
+        xlings::xim::PlanNode provider;
+        provider.name = "provider";
+        provider.version = "1.0.0";
+        provider.namespaceName = "repo";
+        provider.canonicalName = "repo:provider";
+        const std::vector<mcpplibs::xpkg::XvmOp> operations{
+            {
+                .op = "add",
+                .name = "child",
+                .binding = testCase.binding,
+            },
+        };
+        auto plan = xlings::xim::normalize_xpkg_registration_plan(
+            provider, operations, "repo", "/data", false);
+        ASSERT_TRUE(plan.has_value()) << plan.error().message;
+
+        xlings::xvm::VersionDB db;
+        db["sentinel"].versions["0"].path = "/sentinel";
+        xlings::xvm::Workspace workspace{{"sentinel", "0"}};
+        xlings::xvm::WorkspaceInstalled installed{
+            {"sentinel", {"0"}},
+        };
+        const auto dbBefore = xlings::xvm::versions_to_json(db);
+        const auto workspaceBefore = workspace;
+        const auto installedBefore = installed;
+
+        auto result = xlings::xim::apply_xpkg_xvm_metadata_batch(
+            db, workspace, installed, operations,
+            xlings::xvm::RemovalContext{}, *plan);
+
+        ASSERT_FALSE(result.has_value());
+        ASSERT_TRUE(std::holds_alternative<
+            xlings::xvm::RegistrationError>(result.error()));
+        EXPECT_EQ(
+            std::get<xlings::xvm::RegistrationError>(
+                result.error()).kind,
+            testCase.expected);
+        EXPECT_EQ(xlings::xvm::versions_to_json(db), dbBefore);
+        EXPECT_EQ(workspace, workspaceBefore);
+        EXPECT_EQ(installed, installedBefore);
+    }
+}
+
+TEST(XimXvmMetadataBatchTest,
+     AdoptsCompatibleLegacyStateAndRerunsIdempotentlyThroughAdapter) {
+    xlings::xvm::VersionDB db;
+    seed_complete_legacy_registration_group(db);
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+    xlings::xim::PlanNode provider;
+    provider.name = "provider";
+    provider.version = "1.0.0";
+    provider.namespaceName = "repo";
+    provider.canonicalName = "repo:provider";
+    const std::vector<mcpplibs::xpkg::XvmOp> operations{
+        {
+            .op = "add",
+            .name = "tool",
+            .version = "tool-1.0.0",
+            .bindir = "/pkg/provider/1.0.0",
+            .alias = "tool-alias",
+            .filename = "tool-real",
+            .binding = "legacy-root@1.0.0",
+            .envs = {
+                {"TOOL_ENV", "tool"},
+            },
+        },
+        {
+            .op = "add",
+            .name = "legacy-root",
+            .bindir = "/pkg/provider/1.0.0",
+            .alias = "root-alias",
+            .filename = "legacy-root-real",
+            .envs = {
+                {"ROOT_ENV", "root"},
+            },
+        },
+    };
+    auto plan = xlings::xim::normalize_xpkg_registration_plan(
+        provider, operations, "repo", "/data", false);
+    ASSERT_TRUE(plan.has_value()) << plan.error().message;
+
+    auto first = xlings::xim::apply_xpkg_xvm_metadata_batch(
+        db, workspace, installed, operations,
+        xlings::xvm::RemovalContext{}, *plan);
+
+    ASSERT_TRUE(first.has_value());
+    ASSERT_TRUE(
+        db.at("legacy-root")
+            .versions.at("repo:1.0.0")
+            .bindingGroup.has_value());
+    EXPECT_EQ(
+        db.at("legacy-root")
+            .versions.at("repo:1.0.0")
+            .bindingGroup->provider,
+        "repo:provider");
+    EXPECT_EQ(
+        installed.at("legacy-root"),
+        (std::vector<std::string>{"repo:1.0.0"}));
+    EXPECT_EQ(
+        installed.at("tool"),
+        (std::vector<std::string>{"repo:tool-1.0.0"}));
+    const auto dbAfterFirst = xlings::xvm::versions_to_json(db);
+    const auto workspaceAfterFirst = workspace;
+    const auto installedAfterFirst = installed;
+
+    auto second = xlings::xim::apply_xpkg_xvm_metadata_batch(
+        db, workspace, installed, operations,
+        xlings::xvm::RemovalContext{}, *plan);
+
+    ASSERT_TRUE(second.has_value());
+    EXPECT_EQ(xlings::xvm::versions_to_json(db), dbAfterFirst);
+    EXPECT_EQ(workspace, workspaceAfterFirst);
+    EXPECT_EQ(installed, installedAfterFirst);
+}
+
+TEST(XimXvmMetadataBatchTest,
+     SameProviderDifferentReleaseCollisionPreservesState) {
+    xlings::xvm::VersionDB db;
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+    xlings::xim::PlanNode oldProvider;
+    oldProvider.name = "provider";
+    oldProvider.version = "0.9.0";
+    oldProvider.namespaceName = "repo";
+    oldProvider.canonicalName = "repo:provider";
+    const std::vector<mcpplibs::xpkg::XvmOp> oldOperations{
+        {
+            .op = "add",
+            .name = "tool",
+            .version = "shared-1.0.0",
+            .bindir = "/old/tool",
+        },
+    };
+    auto oldPlan = xlings::xim::normalize_xpkg_registration_plan(
+        oldProvider, oldOperations, "repo", "/data", false);
+    ASSERT_TRUE(oldPlan.has_value()) << oldPlan.error().message;
+    auto seeded = xlings::xim::apply_xpkg_xvm_metadata_batch(
+        db, workspace, installed, oldOperations,
+        xlings::xvm::RemovalContext{}, *oldPlan);
+    ASSERT_TRUE(seeded.has_value());
+
+    xlings::xim::PlanNode newProvider = oldProvider;
+    newProvider.version = "1.0.0";
+    const std::vector<mcpplibs::xpkg::XvmOp> newOperations{
+        {
+            .op = "add",
+            .name = "tool",
+            .version = "shared-1.0.0",
+            .bindir = "/new/tool",
+        },
+    };
+    auto newPlan = xlings::xim::normalize_xpkg_registration_plan(
+        newProvider, newOperations, "repo", "/data", false);
+    ASSERT_TRUE(newPlan.has_value()) << newPlan.error().message;
+    const auto dbBefore = xlings::xvm::versions_to_json(db);
+    const auto workspaceBefore = workspace;
+    const auto installedBefore = installed;
+
+    auto result = xlings::xim::apply_xpkg_xvm_metadata_batch(
+        db, workspace, installed, newOperations,
+        xlings::xvm::RemovalContext{}, *newPlan);
+
+    ASSERT_FALSE(result.has_value());
+    ASSERT_TRUE(std::holds_alternative<
+        xlings::xvm::RegistrationError>(result.error()));
+    EXPECT_EQ(
+        std::get<xlings::xvm::RegistrationError>(
+            result.error()).kind,
+        xlings::xvm::RegistrationErrorKind::OwnershipConflict);
+    EXPECT_EQ(xlings::xvm::versions_to_json(db), dbBefore);
+    EXPECT_EQ(workspace, workspaceBefore);
+    EXPECT_EQ(installed, installedBefore);
+}
+
+TEST(XimXvmMetadataBatchTest,
+     ResolvesDeferredEffectsFromFinalExactMetadata) {
+    xlings::xvm::VersionDB db;
+    auto& oldProgram = db["cc"].versions["repo:cc-1.0.0"];
+    oldProgram.path = "/old/bin";
+    oldProgram.kind = "program";
+    oldProgram.sourceName = "old-cc";
+    oldProgram.destinationName = "cc";
+    auto& oldLibrary =
+        db["compiler-runtime"].versions["repo:runtime-1.0.0"];
+    oldLibrary.path = "/old/lib";
+    oldLibrary.kind = "lib";
+    oldLibrary.sourceName = "libold.so";
+    oldLibrary.destinationName = "libold.so";
+    xlings::xvm::Workspace workspace{
+        {"cc", "repo:cc-1.0.0"},
+        {"compiler-runtime", "repo:runtime-1.0.0"},
+    };
+    xlings::xvm::WorkspaceInstalled installed{
+        {"cc", {"repo:cc-1.0.0"}},
+        {"compiler-runtime", {"repo:runtime-1.0.0"}},
+    };
+    xlings::xim::PlanNode provider;
+    provider.name = "toolchain";
+    provider.version = "2.0.0";
+    provider.namespaceName = "repo";
+    provider.canonicalName = "repo:toolchain";
+    const std::vector<mcpplibs::xpkg::XvmOp> operations{
+        {
+            .op = "add",
+            .name = "cc",
+            .version = "cc-2.0.0",
+            .bindir = "/final/bin",
+            .filename = "cc-real",
+            .binding = "toolchain@2.0.0",
+        },
+        {
+            .op = "add",
+            .name = "compiler-runtime",
+            .version = "runtime-2.0.0",
+            .bindir = "/final/lib",
+            .type = "lib",
+            .filename = "libcompiler.so.2",
+            .binding = "toolchain@2.0.0",
+        },
+        {
+            .op = "add",
+            .name = "toolchain",
+            .type = "group",
+        },
+    };
+    auto plan = xlings::xim::normalize_xpkg_registration_plan(
+        provider, operations, "repo", "/data", true);
+    ASSERT_TRUE(plan.has_value()) << plan.error().message;
+    auto applied = xlings::xim::apply_xpkg_xvm_metadata_batch(
+        db, workspace, installed, operations,
+        xlings::xvm::RemovalContext{}, *plan);
+    ASSERT_TRUE(applied.has_value());
+    ASSERT_EQ(applied->effects.size(), 2u);
+
+    auto program = xlings::xim::resolve_xpkg_filesystem_effect(
+        db, workspace, applied->effects[0]);
+    auto library = xlings::xim::resolve_xpkg_filesystem_effect(
+        db, workspace, applied->effects[1]);
+
+    ASSERT_TRUE(program.has_value());
+    EXPECT_EQ(
+        program->kind,
+        xlings::xim::XpkgFilesystemEffectKind::ProgramShim);
+    EXPECT_EQ(program->target, "cc");
+    EXPECT_EQ(program->version, "repo:cc-2.0.0");
+    EXPECT_EQ(program->path, "/final/bin");
+    EXPECT_EQ(program->sourceName, "cc-real");
+    EXPECT_EQ(program->destinationName, "cc");
+    EXPECT_TRUE(program->active);
+    ASSERT_TRUE(library.has_value());
+    EXPECT_EQ(
+        library->kind,
+        xlings::xim::XpkgFilesystemEffectKind::Library);
+    EXPECT_EQ(library->target, "compiler-runtime");
+    EXPECT_EQ(library->version, "repo:runtime-2.0.0");
+    EXPECT_EQ(library->path, "/final/lib");
+    EXPECT_EQ(library->sourceName, "libcompiler.so.2");
+    EXPECT_EQ(library->destinationName, "libcompiler.so.2");
+    EXPECT_TRUE(library->active);
+    EXPECT_FALSE(std::ranges::any_of(
+        applied->effects,
+        [](const auto& effect) {
+            return effect.target == "toolchain";
+        }));
+}
+
+namespace {
+
+int run_xvm_registration_production_child_(
+        const std::filesystem::path& root) {
+    namespace fs = std::filesystem;
+
+    const auto fail = [](int code, std::string_view message) {
+        std::cerr << "xvm registration production child: "
+                  << message << '\n';
+        return code;
+    };
+    const auto write_text = [&](const fs::path& path,
+                                std::string_view contents) {
+        fs::create_directories(path.parent_path());
+        std::ofstream output(path);
+        output << contents;
+        return output.good();
+    };
+
+    const auto home = root / "home" / ".xlings";
+    const auto project = root / "project";
+    const auto payload = root / "payload";
+    const auto temp = root / "tmp";
+    const auto projectSubos = project / ".xlings" / "subos" / "_";
+    const auto globalSubos = home / "subos" / "env-scope";
+    fs::create_directories(temp);
+    fs::create_directories(project);
+    fs::create_directories(payload / "bin");
+    fs::create_directories(globalSubos);
+    if (!write_text(
+            home / ".xlings.json",
+            R"({"activeSubos":"persisted-scope"})")
+        || !write_text(
+            globalSubos / ".xlings.json",
+            R"({"workspace":{}})")
+        || !write_text(
+            project / ".xlings.json",
+            R"({"workspace":{}})")) {
+        return fail(2, "failed to create isolated Config fixtures");
+    }
+
+    xlings::platform::set_env_variable("HOME", (root / "home").string());
+    xlings::platform::set_env_variable("XLINGS_HOME", home.string());
+    xlings::platform::set_env_variable(
+        "XLINGS_ACTIVE_SUBOS", "env-scope");
+    xlings::platform::set_env_variable("XLINGS_PROJECT_DIR", "");
+    xlings::platform::set_env_variable(
+        "XDG_CONFIG_HOME", (root / "config").string());
+    xlings::platform::set_env_variable(
+        "XDG_CACHE_HOME", (root / "cache").string());
+    xlings::platform::set_env_variable(
+        "XDG_DATA_HOME", (root / "data").string());
+    xlings::platform::set_env_variable("TMPDIR", temp.string());
+    fs::current_path(project);
+
+#ifdef _WIN32
+    constexpr std::string_view executableExtension = ".exe";
+#else
+    constexpr std::string_view executableExtension = "";
+#endif
+    const auto bootstrap =
+        home / "bin"
+        / ("xlings" + std::string(executableExtension));
+    if (!write_text(bootstrap, "old-bootstrap")) {
+        return fail(3, "failed to seed isolated bootstrap");
+    }
+    fs::permissions(
+        bootstrap,
+        fs::perms::owner_all
+            | fs::perms::group_read
+            | fs::perms::group_exec
+            | fs::perms::others_read
+            | fs::perms::others_exec,
+        fs::perm_options::replace);
+
+    const auto write_recipe = [&](
+            const fs::path& recipe,
+            std::string_view target,
+            std::string_view filename = {}) {
+        std::ofstream output(recipe);
+        output
+            << "import(\"xim.libxpkg.pkginfo\")\n"
+            << "import(\"xim.libxpkg.xvm\")\n"
+            << "function config()\n"
+            << "  xvm.add(\"" << target
+            << "\", { bindir = path.join("
+               "pkginfo.install_dir(), \"bin\")";
+        if (!filename.empty()) {
+            output << ", filename = \"" << filename << "\"";
+        }
+        output << " })\n  return true\nend\n";
+        return output.good();
+    };
+    const auto run_config = [&](
+            const fs::path& recipe,
+            std::string name,
+            std::string version,
+            const fs::path& installDir,
+            bool useAfterInstall) {
+        auto executor = mcpplibs::xpkg::create_executor(recipe);
+        if (!executor) {
+            std::cerr << executor.error() << '\n';
+            return false;
+        }
+        xlings::xim::PlanNode node;
+        node.name = std::move(name);
+        node.canonicalName = node.name;
+        node.version = std::move(version);
+        mcpplibs::xpkg::ExecutionContext context;
+        context.pkg_name = node.name;
+        context.version = node.version;
+        context.platform = std::string(xlings::platform::OS_NAME);
+        context.arch = "x86_64";
+        context.install_file = recipe;
+        context.install_dir = installDir;
+        context.run_dir = installDir;
+        context.xpkg_dir = root / "data";
+        xlings::xim::detail_::
+            configure_xpkg_execution_artifact_paths_(context);
+        const auto expectedSubos =
+            xlings::Config::xvm_artifact_subos_dir();
+        if (context.bin_dir != expectedSubos / "bin"
+            || context.subos_sysrootdir
+                != expectedSubos.string()) {
+            std::cerr
+                << "execution context does not match write scope\n";
+            return false;
+        }
+        return xlings::xim::detail_::run_config_hook_(
+            node,
+            root / "data",
+            *executor,
+            context,
+            {},
+            useAfterInstall);
+    };
+
+    if (!xlings::Config::has_project_config()) {
+        return fail(4, "temporary project was not selected");
+    }
+    if (xlings::Config::global_subos_dir() != globalSubos) {
+        return fail(
+            5,
+            "global subos root ignored XLINGS_ACTIVE_SUBOS");
+    }
+    if (xlings::Config::xvm_artifact_subos_dir()
+        != projectSubos) {
+        return fail(
+            6,
+            "project metadata and artifact roots disagree");
+    }
+
+    const auto projectRecipe = root / "project-provider.lua";
+    if (!write_recipe(projectRecipe, "task3b-project-tool")) {
+        return fail(7, "failed to write project recipe");
+    }
+    if (!run_config(
+            projectRecipe,
+            "task3b-project-provider",
+            "1.0.0",
+            payload / "project",
+            true)) {
+        return fail(8, "project-scope config hook failed");
+    }
+    if (!xlings::Config::project_versions().contains(
+            "task3b-project-tool")
+        || !xlings::Config::workspace_mut().contains(
+            "task3b-project-tool")
+        || !xlings::Config::workspace_installed_mut().contains(
+            "task3b-project-tool")) {
+        return fail(
+            9,
+            "project registration did not use project metadata");
+    }
+    if (!fs::exists(
+            projectSubos / "bin" / "task3b-project-tool")) {
+        return fail(
+            10,
+            "project registration did not use project artifact root");
+    }
+
+    xlings::Config::set_force_global_scope(true);
+    if (xlings::Config::xvm_artifact_subos_dir()
+        != globalSubos) {
+        return fail(
+            11,
+            "force-global metadata and artifact roots disagree");
+    }
+    const auto selfRecipe = root / "self-provider.lua";
+    if (!write_recipe(
+            selfRecipe, "xlings", "xlings-real")) {
+        return fail(12, "failed to write self-replace recipe");
+    }
+    const auto selfPayload = payload / "self";
+    const auto selfSource =
+        selfPayload / "bin"
+        / ("xlings-real"
+           + std::string(executableExtension));
+    if (!write_text(selfSource, "new-bootstrap")) {
+        return fail(13, "failed to create custom self source");
+    }
+    fs::permissions(
+        selfSource,
+        fs::perms::owner_all
+            | fs::perms::group_read
+            | fs::perms::group_exec
+            | fs::perms::others_read
+            | fs::perms::others_exec,
+        fs::perm_options::replace);
+    if (!run_config(
+            selfRecipe,
+            "task3b-self-provider",
+            "2.0.0",
+            selfPayload,
+            true)) {
+        return fail(14, "force-global self config hook failed");
+    }
+    if (!xlings::Config::global_versions().contains("xlings")
+        || xlings::Config::project_versions().contains("xlings")) {
+        return fail(
+            15,
+            "force-global registration did not use global metadata");
+    }
+    if (!fs::exists(
+            globalSubos / "bin"
+            / ("xlings" + std::string(executableExtension)))
+        || fs::exists(
+            projectSubos / "bin"
+            / ("xlings" + std::string(executableExtension)))) {
+        return fail(
+            16,
+            "force-global shim was written to the wrong artifact root");
+    }
+    {
+        std::ifstream input(bootstrap);
+        std::string contents;
+        input >> contents;
+        if (contents != "new-bootstrap") {
+            return fail(
+                17,
+                "self-replace ignored final exact sourceName");
+        }
+    }
+
+    xlings::Config::set_force_global_scope(false);
+    auto& db = xlings::Config::versions_mut();
+    auto& workspace = xlings::Config::workspace_mut();
+    auto& installed =
+        xlings::Config::workspace_installed_mut();
+    constexpr std::string_view conflictTarget =
+        "task3b-conflict-tool";
+    constexpr std::string_view conflictVersion = "3.0.0";
+    constexpr std::string_view removedTarget =
+        "task3b-removal-sentinel";
+    constexpr std::string_view removedVersion = "0.1.0";
+    auto& removed =
+        db[std::string(removedTarget)]
+            .versions[std::string(removedVersion)];
+    removed.path = "/old/payload";
+    removed.kind = "program";
+    removed.sourceName = std::string(removedTarget);
+    removed.destinationName = std::string(removedTarget);
+    workspace[std::string(removedTarget)] =
+        std::string(removedVersion);
+    installed[std::string(removedTarget)] = {
+        std::string(removedVersion),
+    };
+    auto& conflict =
+        db[std::string(conflictTarget)]
+            .versions[std::string(conflictVersion)];
+    conflict.path = "/other/payload";
+    conflict.kind = "program";
+    conflict.sourceName = "other-tool";
+    conflict.destinationName = std::string(conflictTarget);
+    conflict.bindingGroup = xlings::xvm::BindingGroupRef{
+        .provider = "other-provider",
+        .providerVersion = "9.0.0",
+        .group = std::string(conflictTarget),
+        .rootTarget = std::string(conflictTarget),
+        .rootVersion = std::string(conflictVersion),
+    };
+    conflict.bindingMembers = {
+        {std::string(conflictTarget),
+         std::string(conflictVersion)},
+    };
+    conflict.bindingMembersDeclared = true;
+    workspace[std::string(conflictTarget)] =
+        std::string(conflictVersion);
+    installed[std::string(conflictTarget)] = {
+        std::string(conflictVersion),
+    };
+    const auto dbBefore = xlings::xvm::versions_to_json(db);
+    const auto workspaceBefore = workspace;
+    const auto installedBefore = installed;
+    const auto conflictShim =
+        projectSubos / "bin"
+        / (std::string(conflictTarget)
+           + std::string(executableExtension));
+    const auto removalShim =
+        projectSubos / "bin"
+        / (std::string(removedTarget)
+           + std::string(executableExtension));
+    if (fs::exists(conflictShim)) {
+        return fail(18, "conflict shim unexpectedly pre-exists");
+    }
+    if (!write_text(removalShim, "keep-removal-shim")) {
+        return fail(19, "failed to seed exact removal artifact");
+    }
+    const auto conflictRecipe = root / "conflict-provider.lua";
+    {
+        std::ofstream output(conflictRecipe);
+        output
+            << "import(\"xim.libxpkg.pkginfo\")\n"
+            << "import(\"xim.libxpkg.xvm\")\n"
+            << "function config()\n"
+            << "  xvm.remove(\"" << removedTarget
+            << "\", \"" << removedVersion << "\")\n"
+            << "  xvm.add(\"" << conflictTarget
+            << "\", { bindir = path.join("
+               "pkginfo.install_dir(), \"bin\") })\n"
+            << "  return true\nend\n";
+        if (!output.good()) {
+            return fail(20, "failed to write conflict recipe");
+        }
+    }
+    if (run_config(
+            conflictRecipe,
+            "task3b-conflict-provider",
+            std::string(conflictVersion),
+            payload / "conflict",
+            true)) {
+        return fail(
+            21,
+            "production config hook swallowed registration failure");
+    }
+    if (xlings::xvm::versions_to_json(db) != dbBefore
+        || workspace != workspaceBefore
+        || installed != installedBefore) {
+        return fail(
+            22,
+            "late registration conflict mutated scoped metadata");
+    }
+    if (fs::exists(conflictShim)) {
+        return fail(
+            23,
+            "late registration conflict ran its exact shim effect");
+    }
+    {
+        std::ifstream input(removalShim);
+        std::string contents;
+        input >> contents;
+        if (contents != "keep-removal-shim") {
+            return fail(
+                24,
+                "late conflict ran candidate removal cleanup");
+        }
+    }
+
+    return 0;
+}
+
+}  // namespace
+
+TEST(XimXvmProductionPathTest,
+     UsesMatchingScopedArtifactsAndSuppressesFailedEffects) {
+    namespace fs = std::filesystem;
+    const auto root =
+        fs::temp_directory_path()
+        / std::format(
+            "xlings-task3b-production-{}",
+            std::chrono::steady_clock::now()
+                .time_since_epoch()
+                .count());
+    fs::remove_all(root);
+    fs::create_directories(root);
+    const auto executable =
+        xlings::platform::get_executable_path();
+    ASSERT_FALSE(executable.empty());
+    auto command = std::format(
+        "{} --xvm-registration-production-child {}",
+        xlings::platform::shell_quote(executable.string()),
+        xlings::platform::shell_quote(root.string()));
+#ifdef _WIN32
+    command = "\"" + command + "\"";
+#endif
+    auto child = xlings::platform::spawn_command(command);
+    ASSERT_GT(child.pid, 0);
+    auto [status, output] = xlings::platform::wait_or_kill(
+        child, nullptr, std::chrono::seconds{30});
+    EXPECT_EQ(status, 0) << output;
+    std::error_code ec;
+    fs::remove_all(root, ec);
+}
+
 TEST(XimXvmRemovalAdapterTest,
      PreSnapshotsUninstallSelectionForLaterVersionlessHookOps) {
     xlings::xvm::VersionDB db;
@@ -8875,6 +10324,11 @@ int main(int argc, char** argv) {
         std::ofstream(argv[3]) << "ready";
         std::this_thread::sleep_for(std::chrono::milliseconds{400});
         return 0;
+    }
+    if (argc == 3
+        && std::string_view(argv[1])
+            == "--xvm-registration-production-child") {
+        return run_xvm_registration_production_child_(argv[2]);
     }
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -20,6 +20,7 @@ import xlings.core.xim.repo;
 import xlings.core.xim.extract;
 import xlings.core.xvm.types;
 import xlings.core.xvm.db;
+import xlings.core.xvm.bindings;
 import xlings.core.xvm.shim;
 import xlings.core.xvm.commands;
 import xlings.core.compact;
@@ -1722,6 +1723,51 @@ TEST(XvmDbTest, GetVDataAndVInfo) {
     EXPECT_EQ(xlings::xvm::get_vinfo(db, "nonexistent"), nullptr);
 }
 
+TEST(XvmDbTest, AddVersionStoresMaterializationMetadataPerVersion) {
+    xlings::xvm::VersionDB db;
+    xlings::xvm::add_version(
+        db, "tool", "1.0.0", "/provider-a", "program", "tool-a", "", "repo-a");
+    xlings::xvm::add_version(
+        db, "tool", "2.0.0", "/provider-b", "lib", "libtool-b.so", "", "repo-b");
+
+    const auto* first =
+        xlings::xvm::get_vdata(db, "tool", "repo-a:1.0.0");
+    ASSERT_NE(first, nullptr);
+    EXPECT_EQ(first->kind, "program");
+    EXPECT_EQ(first->sourceName, "tool-a");
+    EXPECT_EQ(first->destinationName, "tool");
+
+    const auto* second =
+        xlings::xvm::get_vdata(db, "tool", "repo-b:2.0.0");
+    ASSERT_NE(second, nullptr);
+    EXPECT_EQ(second->kind, "lib");
+    EXPECT_EQ(second->sourceName, "libtool-b.so");
+    EXPECT_EQ(second->destinationName, "libtool-b.so");
+
+    const auto* legacyInfo = xlings::xvm::get_vinfo(db, "tool");
+    ASSERT_NE(legacyInfo, nullptr);
+    EXPECT_EQ(legacyInfo->type, "program");
+    EXPECT_EQ(legacyInfo->filename, "tool-a");
+}
+
+TEST(XvmDbTest, AddVersionPreservesVirtualGroupWithoutProgramPayload) {
+    xlings::xvm::VersionDB db;
+    xlings::xvm::add_version(
+        db, "provider-root", "1.0.0", "/provider", "group");
+
+    const auto* root =
+        xlings::xvm::get_vdata(db, "provider-root", "1.0.0");
+    ASSERT_NE(root, nullptr);
+    EXPECT_EQ(root->kind, "group");
+    EXPECT_TRUE(root->sourceName.empty());
+    EXPECT_TRUE(root->destinationName.empty());
+
+    const auto* legacyInfo = xlings::xvm::get_vinfo(db, "provider-root");
+    ASSERT_NE(legacyInfo, nullptr);
+    EXPECT_EQ(legacyInfo->type, "group");
+    EXPECT_TRUE(legacyInfo->filename.empty());
+}
+
 TEST(XvmDbTest, GetBinding) {
     xlings::xvm::VersionDB db;
     xlings::xvm::add_version(db, "gcc", "15.1.0", "/usr/bin");
@@ -1776,6 +1822,146 @@ TEST(XvmJsonTest, VDataMinimal) {
     EXPECT_EQ(restored.path, "/usr/bin");
     EXPECT_TRUE(restored.alias.empty());
     EXPECT_TRUE(restored.envs.empty());
+}
+
+TEST(XvmJsonTest, BindingGroupManifestAndMaterializationRoundTrip) {
+    xlings::xvm::VData original;
+    original.path = "/pkg/gcc-15";
+    original.kind = "group";
+    original.bindingGroup = xlings::xvm::BindingGroupRef{
+        .provider = "xim:gcc",
+        .providerVersion = "15.1.0",
+        .group = "xim-gnu-gcc",
+        .rootTarget = "xim-gnu-gcc",
+        .rootVersion = "xim:15.1.0",
+    };
+    original.bindingMembers = {
+        {"g++", "xim:15.1.0"},
+        {"gcc", "xim:15.1.0"},
+        {"gcc-ar", "xim:gcc-15.1.0"},
+        {"xim-gnu-gcc", "xim:15.1.0"},
+    };
+    original.bindingHeaders = {
+        {
+            .sourceDir = "include/c++/15.1.0",
+            .destinationPrefix = "c++/15.1.0",
+        },
+        {
+            .sourceDir = "include-fixed",
+            .destinationPrefix = "",
+        },
+    };
+
+    auto j = xlings::xvm::vdata_to_json(original);
+    ASSERT_TRUE(j.contains("bindingGroup"));
+    EXPECT_EQ(j["bindingGroup"]["provider"], "xim:gcc");
+    EXPECT_EQ(j["bindingGroup"]["version"], "15.1.0");
+    EXPECT_EQ(j["bindingGroup"]["group"], "xim-gnu-gcc");
+    EXPECT_EQ(j["bindingGroup"]["rootTarget"], "xim-gnu-gcc");
+    EXPECT_EQ(j["bindingGroup"]["rootVersion"], "xim:15.1.0");
+    EXPECT_EQ(j["bindingMembers"]["gcc-ar"], "xim:gcc-15.1.0");
+    EXPECT_EQ(j["kind"], "group");
+    EXPECT_FALSE(j.contains("sourceName"));
+    EXPECT_FALSE(j.contains("destinationName"));
+    ASSERT_EQ(j["bindingHeaders"].size(), 2u);
+    EXPECT_EQ(j["bindingHeaders"][0]["sourceDir"], "include/c++/15.1.0");
+    EXPECT_EQ(j["bindingHeaders"][0]["destinationPrefix"], "c++/15.1.0");
+    EXPECT_EQ(j["bindingHeaders"][1]["sourceDir"], "include-fixed");
+    EXPECT_EQ(j["bindingHeaders"][1]["destinationPrefix"], "");
+
+    auto restored = xlings::xvm::vdata_from_json(j);
+    ASSERT_TRUE(restored.bindingGroup.has_value());
+    EXPECT_EQ(restored.bindingGroup->provider, "xim:gcc");
+    EXPECT_EQ(restored.bindingGroup->providerVersion, "15.1.0");
+    EXPECT_EQ(restored.bindingGroup->group, "xim-gnu-gcc");
+    EXPECT_EQ(restored.bindingGroup->rootTarget, "xim-gnu-gcc");
+    EXPECT_EQ(restored.bindingGroup->rootVersion, "xim:15.1.0");
+    EXPECT_EQ(restored.bindingMembers, original.bindingMembers);
+    EXPECT_EQ(restored.kind, "group");
+    EXPECT_TRUE(restored.sourceName.empty());
+    EXPECT_TRUE(restored.destinationName.empty());
+    ASSERT_EQ(restored.bindingHeaders.size(), 2u);
+    EXPECT_EQ(restored.bindingHeaders[0].sourceDir, "include/c++/15.1.0");
+    EXPECT_EQ(restored.bindingHeaders[0].destinationPrefix, "c++/15.1.0");
+    EXPECT_EQ(restored.bindingHeaders[1].sourceDir, "include-fixed");
+    EXPECT_TRUE(restored.bindingHeaders[1].destinationPrefix.empty());
+}
+
+TEST(XvmJsonTest, LegacyVDataOmitsProviderAndMaterializationMetadata) {
+    auto legacy = nlohmann::json::parse(R"({
+        "path": "/usr/bin",
+        "alias": ["15"]
+    })");
+
+    auto restored = xlings::xvm::vdata_from_json(legacy);
+    EXPECT_FALSE(restored.bindingGroup.has_value());
+    EXPECT_TRUE(restored.bindingMembers.empty());
+    EXPECT_TRUE(restored.kind.empty());
+    EXPECT_TRUE(restored.sourceName.empty());
+    EXPECT_TRUE(restored.destinationName.empty());
+    EXPECT_TRUE(restored.bindingHeaders.empty());
+
+    auto serialized = xlings::xvm::vdata_to_json(restored);
+    EXPECT_FALSE(serialized.contains("bindingGroup"));
+    EXPECT_FALSE(serialized.contains("bindingMembers"));
+    EXPECT_FALSE(serialized.contains("kind"));
+    EXPECT_FALSE(serialized.contains("sourceName"));
+    EXPECT_FALSE(serialized.contains("destinationName"));
+    EXPECT_FALSE(serialized.contains("bindingHeaders"));
+}
+
+TEST(XvmJsonTest, PerVersionMetadataSupportsDifferentProvidersForOneTarget) {
+    xlings::xvm::VersionDB original;
+    original["tool"].type = "program";
+    original["tool"].filename = "first-provider-tool";
+
+    auto& first = original["tool"].versions["repo-a:1.0.0"];
+    first.path = "/pkg/provider-a";
+    first.kind = "program";
+    first.sourceName = "tool-a";
+    first.destinationName = "tool";
+    first.bindingGroup = xlings::xvm::BindingGroupRef{
+        .provider = "repo-a:provider",
+        .providerVersion = "1.0.0",
+        .group = "provider-a",
+        .rootTarget = "provider-a",
+        .rootVersion = "repo-a:1.0.0",
+    };
+
+    auto& second = original["tool"].versions["repo-b:2.0.0"];
+    second.path = "/pkg/provider-b";
+    second.kind = "lib";
+    second.sourceName = "libtool-b.so";
+    second.destinationName = "libtool.so";
+    second.bindingGroup = xlings::xvm::BindingGroupRef{
+        .provider = "repo-b:provider",
+        .providerVersion = "2.0.0",
+        .group = "provider-b",
+        .rootTarget = "provider-b",
+        .rootVersion = "repo-b:2.0.0",
+    };
+
+    auto restored =
+        xlings::xvm::versions_from_json(xlings::xvm::versions_to_json(original));
+
+    const auto& firstRestored =
+        restored.at("tool").versions.at("repo-a:1.0.0");
+    EXPECT_EQ(firstRestored.kind, "program");
+    EXPECT_EQ(firstRestored.sourceName, "tool-a");
+    EXPECT_EQ(firstRestored.destinationName, "tool");
+    ASSERT_TRUE(firstRestored.bindingGroup.has_value());
+    EXPECT_EQ(firstRestored.bindingGroup->provider, "repo-a:provider");
+
+    const auto& secondRestored =
+        restored.at("tool").versions.at("repo-b:2.0.0");
+    EXPECT_EQ(secondRestored.kind, "lib");
+    EXPECT_EQ(secondRestored.sourceName, "libtool-b.so");
+    EXPECT_EQ(secondRestored.destinationName, "libtool.so");
+    ASSERT_TRUE(secondRestored.bindingGroup.has_value());
+    EXPECT_EQ(secondRestored.bindingGroup->provider, "repo-b:provider");
+
+    EXPECT_EQ(restored.at("tool").type, "program");
+    EXPECT_EQ(restored.at("tool").filename, "first-provider-tool");
 }
 
 TEST(XvmJsonTest, VInfoRoundTrip) {
@@ -2857,6 +3043,448 @@ TEST(XvmDbTest, NamespacedVersionMatch) {
 // xvm binding tree tests
 // ============================================================
 
+namespace {
+
+xlings::xvm::BindingGroupRef make_binding_group_ref(
+    std::string provider,
+    std::string providerVersion,
+    std::string group,
+    std::string rootTarget,
+    std::string rootVersion) {
+    return {
+        .provider = std::move(provider),
+        .providerVersion = std::move(providerVersion),
+        .group = std::move(group),
+        .rootTarget = std::move(rootTarget),
+        .rootVersion = std::move(rootVersion),
+    };
+}
+
+xlings::xvm::VData& add_provider_group_member(
+    xlings::xvm::VersionDB& db,
+    const std::string& target,
+    const std::string& version,
+    const xlings::xvm::BindingGroupRef& group,
+    const std::string& kind,
+    const std::string& sourceName = "",
+    const std::string& destinationName = "") {
+    auto& data = db[target].versions[version];
+    data.path = "/pkg/" + group.providerVersion;
+    data.kind = kind;
+    data.sourceName = sourceName;
+    data.destinationName = destinationName;
+    data.bindingGroup = group;
+    return data;
+}
+
+void expect_binding_error(
+    const std::expected<xlings::xvm::BindingSelection,
+                        xlings::xvm::BindingError>& result,
+    xlings::xvm::BindingErrorKind kind,
+    std::string_view target,
+    std::string_view version) {
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().kind, kind);
+    EXPECT_EQ(result.error().target, target);
+    EXPECT_EQ(result.error().version, version);
+    EXPECT_FALSE(result.error().message.empty());
+}
+
+}  // namespace
+
+TEST(XvmBindingSelectionTest, ProviderGroupResolvesRootAndLeafExactly) {
+    xlings::xvm::VersionDB db;
+    const auto group = make_binding_group_ref(
+        "xim:gcc", "15.1.0", "xim-gnu-gcc",
+        "xim-gnu-gcc", "xim:15.1.0");
+    const std::map<std::string, std::string> expected{
+        {"g++", "xim:15.1.0"},
+        {"gcc", "xim:15.1.0"},
+        {"gcc-ar", "xim:gcc-15.1.0"},
+        {"libstdc++.so.6", "xim:gcc-15.1.0"},
+        {"xim-gnu-gcc", "xim:15.1.0"},
+    };
+
+    auto& root = add_provider_group_member(
+        db, "xim-gnu-gcc", "xim:15.1.0", group, "group");
+    root.bindingMembers = expected;
+    add_provider_group_member(
+        db, "gcc", "xim:15.1.0", group, "program", "gcc-15", "gcc");
+    add_provider_group_member(
+        db, "g++", "xim:15.1.0", group, "program", "g++-15", "g++");
+    add_provider_group_member(
+        db, "gcc-ar", "xim:gcc-15.1.0", group,
+        "program", "gcc-ar-15", "gcc-ar");
+    add_provider_group_member(
+        db, "libstdc++.so.6", "xim:gcc-15.1.0", group,
+        "lib", "libstdc++.so.6.0.34", "libstdc++.so.6");
+
+    auto fromLeaf = xlings::xvm::resolve_binding_selection(
+        db, "gcc", "xim:15.1.0");
+    ASSERT_TRUE(fromLeaf.has_value()) << fromLeaf.error().message;
+    EXPECT_EQ(fromLeaf->source, xlings::xvm::BindingSource::ProviderGroup);
+    EXPECT_EQ(fromLeaf->members, expected);
+
+    auto fromRoot = xlings::xvm::resolve_binding_selection(
+        db, "xim-gnu-gcc", "xim:15.1.0");
+    ASSERT_TRUE(fromRoot.has_value()) << fromRoot.error().message;
+    EXPECT_EQ(fromRoot->source, xlings::xvm::BindingSource::ProviderGroup);
+    EXPECT_EQ(fromRoot->members, expected);
+}
+
+TEST(XvmBindingSelectionTest, ProviderScopeSeparatesGroupsForSameTarget) {
+    xlings::xvm::VersionDB db;
+    db["cc"].type = "program";
+    db["cc"].filename = "first-writer-cc";
+
+    const auto groupA = make_binding_group_ref(
+        "repo-a:toolchain", "1.0.0", "toolchain-a",
+        "repo-a:root", "repo-a:1.0.0");
+    auto& rootA = add_provider_group_member(
+        db, "repo-a:root", "repo-a:1.0.0", groupA, "group");
+    rootA.bindingMembers = {
+        {"cc", "repo-a:1.0.0"},
+        {"repo-a:root", "repo-a:1.0.0"},
+    };
+    add_provider_group_member(
+        db, "cc", "repo-a:1.0.0", groupA,
+        "program", "cc-a", "cc");
+
+    const auto groupB = make_binding_group_ref(
+        "repo-b:toolchain", "2.0.0", "toolchain-b",
+        "repo-b:root", "repo-b:2.0.0");
+    auto& rootB = add_provider_group_member(
+        db, "repo-b:root", "repo-b:2.0.0", groupB, "group");
+    rootB.bindingMembers = {
+        {"cc", "repo-b:2.0.0"},
+        {"repo-b:root", "repo-b:2.0.0"},
+    };
+    auto& ccB = add_provider_group_member(
+        db, "cc", "repo-b:2.0.0", groupB,
+        "lib", "libcc-b.so.2", "libcc.so");
+
+    ASSERT_EQ(ccB.kind, "lib");
+    EXPECT_EQ(ccB.sourceName, "libcc-b.so.2");
+    EXPECT_EQ(ccB.destinationName, "libcc.so");
+
+    auto selectedA = xlings::xvm::resolve_binding_selection(
+        db, "cc", "repo-a:1.0.0");
+    ASSERT_TRUE(selectedA.has_value()) << selectedA.error().message;
+    EXPECT_EQ(selectedA->members,
+              (std::map<std::string, std::string>{
+                  {"cc", "repo-a:1.0.0"},
+                  {"repo-a:root", "repo-a:1.0.0"},
+              }));
+
+    auto selectedB = xlings::xvm::resolve_binding_selection(
+        db, "cc", "repo-b:2.0.0");
+    ASSERT_TRUE(selectedB.has_value()) << selectedB.error().message;
+    EXPECT_EQ(selectedB->members,
+              (std::map<std::string, std::string>{
+                  {"cc", "repo-b:2.0.0"},
+                  {"repo-b:root", "repo-b:2.0.0"},
+              }));
+}
+
+TEST(XvmBindingSelectionErrorTest, RejectsMissingStartingTarget) {
+    xlings::xvm::VersionDB db;
+
+    auto result =
+        xlings::xvm::resolve_binding_selection(db, "missing", "1.0.0");
+
+    expect_binding_error(
+        result, xlings::xvm::BindingErrorKind::TargetNotFound,
+        "missing", "1.0.0");
+}
+
+TEST(XvmBindingSelectionErrorTest, RejectsMissingStartingVersion) {
+    xlings::xvm::VersionDB db;
+    db["tool"].versions["1.0.0"].path = "/tool";
+
+    auto result =
+        xlings::xvm::resolve_binding_selection(db, "tool", "2.0.0");
+
+    expect_binding_error(
+        result, xlings::xvm::BindingErrorKind::VersionNotFound,
+        "tool", "2.0.0");
+}
+
+TEST(XvmBindingSelectionErrorTest, ProviderGroupRejectsMissingRootVersion) {
+    xlings::xvm::VersionDB db;
+    const auto group = make_binding_group_ref(
+        "xim:gcc", "15.1.0", "gcc", "root", "15.1.0");
+    add_provider_group_member(
+        db, "gcc", "15.1.0", group, "program", "gcc", "gcc");
+    db["root"].versions["14.2.0"].kind = "group";
+
+    auto result =
+        xlings::xvm::resolve_binding_selection(db, "gcc", "15.1.0");
+
+    expect_binding_error(
+        result, xlings::xvm::BindingErrorKind::VersionNotFound,
+        "root", "15.1.0");
+}
+
+TEST(XvmBindingSelectionErrorTest, ProviderGroupRequiresRootSelfReference) {
+    xlings::xvm::VersionDB db;
+    const auto group = make_binding_group_ref(
+        "xim:gcc", "15.1.0", "gcc", "root", "15.1.0");
+    add_provider_group_member(
+        db, "gcc", "15.1.0", group, "program", "gcc", "gcc");
+    auto& root =
+        add_provider_group_member(db, "root", "15.1.0", group, "group");
+    root.bindingGroup->rootTarget = "not-root";
+    root.bindingMembers = {
+        {"gcc", "15.1.0"},
+        {"root", "15.1.0"},
+    };
+
+    auto result =
+        xlings::xvm::resolve_binding_selection(db, "gcc", "15.1.0");
+
+    expect_binding_error(
+        result, xlings::xvm::BindingErrorKind::RootReferenceMismatch,
+        "root", "15.1.0");
+}
+
+TEST(XvmBindingSelectionErrorTest, ProviderGroupRequiresMatchingRootIdentity) {
+    xlings::xvm::VersionDB db;
+    const auto group = make_binding_group_ref(
+        "xim:gcc", "15.1.0", "gcc", "root", "15.1.0");
+    add_provider_group_member(
+        db, "gcc", "15.1.0", group, "program", "gcc", "gcc");
+    auto otherGroup = group;
+    otherGroup.provider = "other:gcc";
+    auto& root =
+        add_provider_group_member(db, "root", "15.1.0", otherGroup, "group");
+    root.bindingMembers = {
+        {"gcc", "15.1.0"},
+        {"root", "15.1.0"},
+    };
+
+    auto result =
+        xlings::xvm::resolve_binding_selection(db, "gcc", "15.1.0");
+
+    expect_binding_error(
+        result, xlings::xvm::BindingErrorKind::GroupIdentityMismatch,
+        "root", "15.1.0");
+}
+
+TEST(XvmBindingSelectionErrorTest, ProviderGroupRequiresRootInManifest) {
+    xlings::xvm::VersionDB db;
+    const auto group = make_binding_group_ref(
+        "xim:gcc", "15.1.0", "gcc", "root", "15.1.0");
+    add_provider_group_member(
+        db, "gcc", "15.1.0", group, "program", "gcc", "gcc");
+    auto& root =
+        add_provider_group_member(db, "root", "15.1.0", group, "group");
+    root.bindingMembers = {
+        {"gcc", "15.1.0"},
+    };
+
+    auto result =
+        xlings::xvm::resolve_binding_selection(db, "gcc", "15.1.0");
+
+    expect_binding_error(
+        result, xlings::xvm::BindingErrorKind::RootMissingFromManifest,
+        "root", "15.1.0");
+}
+
+TEST(XvmBindingSelectionErrorTest, ProviderGroupRequiresStartInManifest) {
+    xlings::xvm::VersionDB db;
+    const auto group = make_binding_group_ref(
+        "xim:gcc", "15.1.0", "gcc", "root", "15.1.0");
+    add_provider_group_member(
+        db, "gcc", "15.1.0", group, "program", "gcc", "gcc");
+    auto& root =
+        add_provider_group_member(db, "root", "15.1.0", group, "group");
+    root.bindingMembers = {
+        {"root", "15.1.0"},
+    };
+
+    auto result =
+        xlings::xvm::resolve_binding_selection(db, "gcc", "15.1.0");
+
+    expect_binding_error(
+        result, xlings::xvm::BindingErrorKind::StartMemberMissing,
+        "gcc", "15.1.0");
+}
+
+TEST(XvmBindingSelectionErrorTest, ProviderGroupRejectsMissingManifestTarget) {
+    xlings::xvm::VersionDB db;
+    const auto group = make_binding_group_ref(
+        "xim:gcc", "15.1.0", "gcc", "root", "15.1.0");
+    auto& root =
+        add_provider_group_member(db, "root", "15.1.0", group, "group");
+    root.bindingMembers = {
+        {"missing", "15.1.0"},
+        {"root", "15.1.0"},
+    };
+
+    auto result =
+        xlings::xvm::resolve_binding_selection(db, "root", "15.1.0");
+
+    expect_binding_error(
+        result, xlings::xvm::BindingErrorKind::TargetNotFound,
+        "missing", "15.1.0");
+}
+
+TEST(XvmBindingSelectionErrorTest, ProviderGroupRejectsMissingManifestVersion) {
+    xlings::xvm::VersionDB db;
+    const auto group = make_binding_group_ref(
+        "xim:gcc", "15.1.0", "gcc", "root", "15.1.0");
+    auto& root =
+        add_provider_group_member(db, "root", "15.1.0", group, "group");
+    root.bindingMembers = {
+        {"gcc", "15.1.0"},
+        {"root", "15.1.0"},
+    };
+    add_provider_group_member(
+        db, "gcc", "14.2.0", group, "program", "gcc", "gcc");
+
+    auto result =
+        xlings::xvm::resolve_binding_selection(db, "root", "15.1.0");
+
+    expect_binding_error(
+        result, xlings::xvm::BindingErrorKind::VersionNotFound,
+        "gcc", "15.1.0");
+}
+
+TEST(XvmBindingSelectionErrorTest, ProviderGroupRejectsMemberBackReference) {
+    xlings::xvm::VersionDB db;
+    const auto group = make_binding_group_ref(
+        "xim:gcc", "15.1.0", "gcc", "root", "15.1.0");
+    auto& root =
+        add_provider_group_member(db, "root", "15.1.0", group, "group");
+    root.bindingMembers = {
+        {"gcc", "15.1.0"},
+        {"root", "15.1.0"},
+    };
+    auto otherGroup = group;
+    otherGroup.group = "other";
+    add_provider_group_member(
+        db, "gcc", "15.1.0", otherGroup, "program", "gcc", "gcc");
+
+    auto result =
+        xlings::xvm::resolve_binding_selection(db, "root", "15.1.0");
+
+    expect_binding_error(
+        result, xlings::xvm::BindingErrorKind::MemberReferenceMismatch,
+        "gcc", "15.1.0");
+}
+
+TEST(XvmBindingSelectionErrorTest, ProviderGroupUsesPerVersionKind) {
+    xlings::xvm::VersionDB db;
+    const auto group = make_binding_group_ref(
+        "xim:gcc", "15.1.0", "gcc", "root", "15.1.0");
+    auto& root =
+        add_provider_group_member(db, "root", "15.1.0", group, "group");
+    root.bindingMembers = {
+        {"gcc", "15.1.0"},
+        {"root", "15.1.0"},
+    };
+    add_provider_group_member(
+        db, "gcc", "15.1.0", group, "archive", "gcc", "gcc");
+    db["gcc"].type = "program";
+
+    auto result =
+        xlings::xvm::resolve_binding_selection(db, "root", "15.1.0");
+
+    expect_binding_error(
+        result, xlings::xvm::BindingErrorKind::UnsupportedKind,
+        "gcc", "15.1.0");
+}
+
+TEST(XvmBindingSelectionErrorTest, LegacyRejectsMissingDestinationVersion) {
+    xlings::xvm::VersionDB db;
+    db["a"].type = "program";
+    db["a"].versions["1"].path = "/a";
+    db["b"].type = "program";
+    db["b"].versions["1"].path = "/b";
+    db["a"].bindings["b"]["1"] = "2";
+    db["b"].bindings["a"]["2"] = "1";
+
+    auto result = xlings::xvm::resolve_binding_selection(db, "a", "1");
+
+    expect_binding_error(
+        result, xlings::xvm::BindingErrorKind::VersionNotFound, "b", "2");
+}
+
+TEST(XvmBindingSelectionErrorTest, LegacyRejectsAsymmetricEdge) {
+    xlings::xvm::VersionDB db;
+    db["a"].type = "program";
+    db["a"].versions["1"].path = "/a";
+    db["b"].type = "program";
+    db["b"].versions["1"].path = "/b";
+    db["a"].bindings["b"]["1"] = "1";
+
+    auto result = xlings::xvm::resolve_binding_selection(db, "a", "1");
+
+    expect_binding_error(
+        result, xlings::xvm::BindingErrorKind::AsymmetricEdge, "b", "1");
+}
+
+TEST(XvmBindingSelectionErrorTest, LegacyRejectsSelfEdge) {
+    xlings::xvm::VersionDB db;
+    db["a"].type = "program";
+    db["a"].versions["1"].path = "/a";
+    db["a"].bindings["a"]["1"] = "1";
+
+    auto result = xlings::xvm::resolve_binding_selection(db, "a", "1");
+
+    expect_binding_error(
+        result, xlings::xvm::BindingErrorKind::SelfEdge, "a", "1");
+}
+
+TEST(XvmBindingSelectionErrorTest, LegacyRejectsTargetVersionConflict) {
+    xlings::xvm::VersionDB db;
+    for (const auto& [target, version] :
+         std::vector<std::pair<std::string, std::string>>{
+             {"a", "1"}, {"a", "2"}, {"b", "1"}, {"c", "1"}}) {
+        db[target].type = "program";
+        db[target].versions[version].path = "/" + target + "/" + version;
+    }
+    db["a"].bindings["b"]["1"] = "1";
+    db["b"].bindings["a"]["1"] = "1";
+    db["b"].bindings["c"]["1"] = "1";
+    db["c"].bindings["b"]["1"] = "1";
+    db["c"].bindings["a"]["1"] = "2";
+    db["a"].bindings["c"]["2"] = "1";
+
+    auto result = xlings::xvm::resolve_binding_selection(db, "a", "1");
+
+    expect_binding_error(
+        result, xlings::xvm::BindingErrorKind::ConflictingTargetVersion,
+        "a", "2");
+}
+
+TEST(XvmBindingSelectionErrorTest, LegacyFallsBackToVInfoKind) {
+    xlings::xvm::VersionDB db;
+    db["tool"].type = "archive";
+    db["tool"].versions["1"].path = "/tool";
+
+    auto result =
+        xlings::xvm::resolve_binding_selection(db, "tool", "1");
+
+    expect_binding_error(
+        result, xlings::xvm::BindingErrorKind::UnsupportedKind,
+        "tool", "1");
+}
+
+TEST(XvmBindingSelectionErrorTest, LegacyPrefersVDataKindOverVInfo) {
+    xlings::xvm::VersionDB db;
+    db["tool"].type = "program";
+    db["tool"].versions["1"].path = "/tool";
+    db["tool"].versions["1"].kind = "archive";
+
+    auto result =
+        xlings::xvm::resolve_binding_selection(db, "tool", "1");
+
+    expect_binding_error(
+        result, xlings::xvm::BindingErrorKind::UnsupportedKind,
+        "tool", "1");
+}
+
 TEST(XvmDbTest, AddVersionWithBinding) {
     xlings::xvm::VersionDB db;
 
@@ -2938,43 +3566,25 @@ TEST(XvmDbTest, AddVersionWithBindingNamespaced) {
 }
 
 TEST(XvmDbTest, BindingTreeTraversal) {
-    // Test the binding tree traversal logic used by cmd_use
     xlings::xvm::VersionDB db;
 
-    // Build a binding tree: xim-gnu-gcc -> gcc, g++, gcc-ar
     xlings::xvm::add_version(db, "xim-gnu-gcc", "15.1.0", "/pkg/gcc-15");
     xlings::xvm::add_version(db, "gcc", "15.1.0", "/pkg/gcc-15", "program", "gcc", "gcc", "", "xim-gnu-gcc@15.1.0");
     xlings::xvm::add_version(db, "g++", "15.1.0", "/pkg/gcc-15", "program", "g++", "g++", "", "xim-gnu-gcc@15.1.0");
     xlings::xvm::add_version(db, "gcc-ar", "gcc-15.1.0", "/pkg/gcc-15", "program", "gcc-ar", "gcc-ar", "", "xim-gnu-gcc@15.1.0");
 
-    // Simulate the collect_bindings traversal starting from "gcc" version "15.1.0"
-    std::map<std::string, std::string> to_switch;
-    std::set<std::string> visited;
+    auto selection =
+        xlings::xvm::resolve_binding_selection(db, "gcc", "15.1.0");
 
-    std::function<void(const std::string&, const std::string&)> collect_bindings;
-    collect_bindings = [&](const std::string& node, const std::string& node_ver) {
-        if (visited.contains(node)) return;
-        visited.insert(node);
-        to_switch[node] = node_ver;
-
-        auto info = xlings::xvm::get_vinfo(db, node);
-        if (!info) return;
-        for (auto& [peer_name, vermap] : info->bindings) {
-            auto it = vermap.find(node_ver);
-            if (it != vermap.end()) {
-                collect_bindings(peer_name, it->second);
-            }
-        }
-    };
-
-    collect_bindings("gcc", "15.1.0");
-
-    // Should have traversed the entire binding tree
-    EXPECT_EQ(to_switch.size(), 4u);
-    EXPECT_EQ(to_switch.at("gcc"), "15.1.0");
-    EXPECT_EQ(to_switch.at("xim-gnu-gcc"), "15.1.0");
-    EXPECT_EQ(to_switch.at("g++"), "15.1.0");
-    EXPECT_EQ(to_switch.at("gcc-ar"), "gcc-15.1.0");
+    ASSERT_TRUE(selection.has_value()) << selection.error().message;
+    EXPECT_EQ(selection->source, xlings::xvm::BindingSource::LegacyGraph);
+    EXPECT_EQ(selection->members,
+              (std::map<std::string, std::string>{
+                  {"g++", "15.1.0"},
+                  {"gcc", "15.1.0"},
+                  {"gcc-ar", "gcc-15.1.0"},
+                  {"xim-gnu-gcc", "15.1.0"},
+              }));
 }
 
 TEST(XvmDbTest, BindingJsonRoundTrip) {

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -22,6 +22,7 @@ import xlings.core.xvm.types;
 import xlings.core.xvm.db;
 import xlings.core.xvm.bindings;
 import xlings.core.xvm.removal;
+import xlings.core.xvm.registration;
 import xlings.core.xvm.shim;
 import xlings.core.xvm.commands;
 import xlings.core.compact;
@@ -3608,6 +3609,1184 @@ void expect_binding_metadata_error(
 }
 
 }  // namespace
+
+TEST(XvmRegistrationTest,
+     RegistersChildBeforeRootWithNamespacedTransformedVersions) {
+    xlings::xvm::VersionDB db;
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+    const xlings::xvm::RegistrationBatch batch{
+        .provider = "xim:gcc",
+        .providerVersion = "15.1.0",
+        .nodes = {
+            {
+                .target = "gcc-ar",
+                .version = "xim:gcc-15.1.0",
+                .path = "/pkg/gcc/15.1.0/bin",
+                .kind = "program",
+                .sourceName = "gcc-ar-15",
+                .destinationName = "gcc-ar",
+                .binding = xlings::xvm::RegistrationBinding{
+                    .rootTarget = "xim-gnu-gcc",
+                    .rootVersion = "xim:15.1.0",
+                },
+            },
+            {
+                .target = "xim-gnu-gcc",
+                .version = "xim:15.1.0",
+                .path = "/pkg/gcc/15.1.0",
+                .kind = "group",
+            },
+        },
+    };
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, batch);
+
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    ASSERT_EQ(result->size(), 2u);
+    const auto& root =
+        db.at("xim-gnu-gcc").versions.at("xim:15.1.0");
+    const auto& child =
+        db.at("gcc-ar").versions.at("xim:gcc-15.1.0");
+    ASSERT_TRUE(root.bindingGroup.has_value());
+    ASSERT_TRUE(child.bindingGroup.has_value());
+    EXPECT_EQ(root.bindingGroup->group, "xim-gnu-gcc");
+    EXPECT_EQ(root.bindingGroup->rootTarget, "xim-gnu-gcc");
+    EXPECT_EQ(root.bindingGroup->rootVersion, "xim:15.1.0");
+    EXPECT_EQ(child.bindingGroup->provider, root.bindingGroup->provider);
+    EXPECT_EQ(
+        child.bindingGroup->providerVersion,
+        root.bindingGroup->providerVersion);
+    EXPECT_EQ(child.bindingGroup->group, root.bindingGroup->group);
+    EXPECT_EQ(
+        child.bindingGroup->rootTarget,
+        root.bindingGroup->rootTarget);
+    EXPECT_EQ(
+        child.bindingGroup->rootVersion,
+        root.bindingGroup->rootVersion);
+    EXPECT_EQ(
+        root.bindingMembers,
+        (std::map<std::string, std::string>{
+            {"gcc-ar", "xim:gcc-15.1.0"},
+            {"xim-gnu-gcc", "xim:15.1.0"},
+        }));
+    EXPECT_EQ(
+        db.at("xim-gnu-gcc")
+            .bindings.at("gcc-ar").at("xim:15.1.0"),
+        "xim:gcc-15.1.0");
+    EXPECT_EQ(
+        db.at("gcc-ar")
+            .bindings.at("xim-gnu-gcc").at("xim:gcc-15.1.0"),
+        "xim:15.1.0");
+    EXPECT_EQ(workspace.at("gcc-ar"), "xim:gcc-15.1.0");
+    EXPECT_EQ(workspace.at("xim-gnu-gcc"), "xim:15.1.0");
+    EXPECT_EQ(
+        installed.at("gcc-ar"),
+        (std::vector<std::string>{"xim:gcc-15.1.0"}));
+    EXPECT_EQ(
+        installed.at("xim-gnu-gcc"),
+        (std::vector<std::string>{"xim:15.1.0"}));
+}
+
+namespace {
+
+xlings::xvm::RegistrationNode make_registration_node(
+    std::string target,
+    std::string version,
+    std::string kind = "program") {
+    return {
+        .target = std::move(target),
+        .version = std::move(version),
+        .path = "/pkg/provider/1.0.0",
+        .kind = std::move(kind),
+        .sourceName = "payload",
+        .destinationName = "tool",
+    };
+}
+
+xlings::xvm::RegistrationBinding make_registration_binding(
+    std::string rootTarget,
+    std::string rootVersion,
+    std::string group = {}) {
+    return {
+        .rootTarget = std::move(rootTarget),
+        .rootVersion = std::move(rootVersion),
+        .group = std::move(group),
+    };
+}
+
+xlings::xvm::RegistrationBatch make_registration_batch(
+    std::vector<xlings::xvm::RegistrationNode> nodes) {
+    return {
+        .provider = "repo:provider",
+        .providerVersion = "1.0.0",
+        .nodes = std::move(nodes),
+    };
+}
+
+void expect_registration_error(
+    const std::expected<
+        std::vector<xlings::xvm::RegisteredMember>,
+        xlings::xvm::RegistrationError>& result,
+    xlings::xvm::RegistrationErrorKind kind,
+    std::string_view path,
+    std::string_view target = {},
+    std::string_view version = {}) {
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().kind, kind);
+    EXPECT_EQ(result.error().path, path);
+    EXPECT_EQ(result.error().target, target);
+    EXPECT_EQ(result.error().version, version);
+    EXPECT_FALSE(result.error().message.empty());
+}
+
+void expect_registration_state_unchanged(
+    const xlings::xvm::VersionDB& db,
+    const xlings::xvm::Workspace& workspace,
+    const xlings::xvm::WorkspaceInstalled& installed,
+    const nlohmann::json& dbBefore,
+    const xlings::xvm::Workspace& workspaceBefore,
+    const xlings::xvm::WorkspaceInstalled& installedBefore) {
+    EXPECT_EQ(xlings::xvm::versions_to_json(db), dbBefore);
+    EXPECT_EQ(workspace, workspaceBefore);
+    EXPECT_EQ(installed, installedBefore);
+}
+
+}  // namespace
+
+TEST(XvmRegistrationTest, RootFirstAndRootLastSerializeIdentically) {
+    auto root = make_registration_node("root", "repo:1.0.0", "group");
+    root.sourceName.clear();
+    root.destinationName.clear();
+    auto child = make_registration_node("tool", "repo:tool-1.0.0");
+    child.binding = make_registration_binding(
+        "root", "repo:1.0.0", "toolchain");
+
+    xlings::xvm::VersionDB rootFirstDb;
+    xlings::xvm::Workspace rootFirstWorkspace;
+    xlings::xvm::WorkspaceInstalled rootFirstInstalled;
+    auto rootFirst = xlings::xvm::apply_registration_batch(
+        rootFirstDb, rootFirstWorkspace, rootFirstInstalled,
+        make_registration_batch({root, child}));
+    ASSERT_TRUE(rootFirst.has_value()) << rootFirst.error().message;
+
+    xlings::xvm::VersionDB rootLastDb;
+    xlings::xvm::Workspace rootLastWorkspace;
+    xlings::xvm::WorkspaceInstalled rootLastInstalled;
+    auto rootLast = xlings::xvm::apply_registration_batch(
+        rootLastDb, rootLastWorkspace, rootLastInstalled,
+        make_registration_batch({child, root}));
+    ASSERT_TRUE(rootLast.has_value()) << rootLast.error().message;
+
+    EXPECT_EQ(
+        xlings::xvm::versions_to_json(rootFirstDb),
+        xlings::xvm::versions_to_json(rootLastDb));
+    EXPECT_EQ(rootFirstWorkspace, rootLastWorkspace);
+    EXPECT_EQ(rootFirstInstalled, rootLastInstalled);
+}
+
+TEST(XvmRegistrationErrorTest, RejectsPhantomRootWithoutMutation) {
+    xlings::xvm::VersionDB db;
+    db["sentinel"].versions["0"].path = "/sentinel";
+    xlings::xvm::Workspace workspace{{"sentinel", "0"}};
+    xlings::xvm::WorkspaceInstalled installed{{"sentinel", {"0"}}};
+    const auto dbBefore = xlings::xvm::versions_to_json(db);
+    const auto workspaceBefore = workspace;
+    const auto installedBefore = installed;
+    auto child = make_registration_node("tool", "repo:1.0.0");
+    child.binding =
+        make_registration_binding("missing-root", "repo:1.0.0");
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, make_registration_batch({child}));
+
+    expect_registration_error(
+        result, xlings::xvm::RegistrationErrorKind::RootNotInBatch,
+        "/nodes/0/binding", "missing-root", "repo:1.0.0");
+    expect_registration_state_unchanged(
+        db, workspace, installed,
+        dbBefore, workspaceBefore, installedBefore);
+}
+
+TEST(XvmRegistrationErrorTest, RejectsSelfBindingWithoutMutation) {
+    xlings::xvm::VersionDB db;
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+    auto node = make_registration_node("root", "repo:1.0.0", "group");
+    node.sourceName.clear();
+    node.destinationName.clear();
+    node.binding = make_registration_binding(
+        "root", "repo:1.0.0", "toolchain");
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, make_registration_batch({node}));
+
+    expect_registration_error(
+        result, xlings::xvm::RegistrationErrorKind::SelfBinding,
+        "/nodes/0/binding", "root", "repo:1.0.0");
+    EXPECT_TRUE(db.empty());
+    EXPECT_TRUE(workspace.empty());
+    EXPECT_TRUE(installed.empty());
+}
+
+TEST(XvmRegistrationErrorTest, RejectsDuplicateExactNodeWithoutMutation) {
+    xlings::xvm::VersionDB db;
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+    auto node = make_registration_node("tool", "repo:1.0.0");
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed,
+        make_registration_batch({node, node}));
+
+    expect_registration_error(
+        result, xlings::xvm::RegistrationErrorKind::DuplicateNode,
+        "/nodes/1", "tool", "repo:1.0.0");
+    EXPECT_TRUE(db.empty());
+    EXPECT_TRUE(workspace.empty());
+    EXPECT_TRUE(installed.empty());
+}
+
+TEST(XvmRegistrationErrorTest,
+     RejectsTwoVersionsOfOneTargetInOneGroupWithoutMutation) {
+    xlings::xvm::VersionDB db;
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+    auto root = make_registration_node("root", "repo:1.0.0", "group");
+    root.sourceName.clear();
+    root.destinationName.clear();
+    auto first = make_registration_node("tool", "repo:tool-1.0.0");
+    first.binding = make_registration_binding(
+        "root", "repo:1.0.0", "toolchain");
+    auto second = make_registration_node("tool", "repo:tool-alt-1.0.0");
+    second.binding = first.binding;
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed,
+        make_registration_batch({root, first, second}));
+
+    expect_registration_error(
+        result, xlings::xvm::RegistrationErrorKind::TargetVersionConflict,
+        "/nodes/2", "tool", "repo:tool-alt-1.0.0");
+    EXPECT_TRUE(db.empty());
+    EXPECT_TRUE(workspace.empty());
+    EXPECT_TRUE(installed.empty());
+}
+
+TEST(XvmRegistrationErrorTest, RejectsOneGroupLabelWithTwoRoots) {
+    xlings::xvm::VersionDB db;
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+    auto rootA = make_registration_node("root-a", "repo:a", "group");
+    rootA.sourceName.clear();
+    rootA.destinationName.clear();
+    auto rootB = make_registration_node("root-b", "repo:b", "group");
+    rootB.sourceName.clear();
+    rootB.destinationName.clear();
+    auto childA = make_registration_node("tool-a", "repo:a");
+    childA.binding =
+        make_registration_binding("root-a", "repo:a", "shared");
+    auto childB = make_registration_node("tool-b", "repo:b");
+    childB.binding =
+        make_registration_binding("root-b", "repo:b", "shared");
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed,
+        make_registration_batch({rootA, childA, rootB, childB}));
+
+    expect_registration_error(
+        result, xlings::xvm::RegistrationErrorKind::GroupConflict,
+        "/nodes/3/binding/group", "tool-b", "repo:b");
+    EXPECT_TRUE(db.empty());
+    EXPECT_TRUE(workspace.empty());
+    EXPECT_TRUE(installed.empty());
+}
+
+TEST(XvmRegistrationErrorTest, RejectsOneRootAssignedToTwoGroups) {
+    xlings::xvm::VersionDB db;
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+    auto root = make_registration_node("root", "repo:1.0.0", "group");
+    root.sourceName.clear();
+    root.destinationName.clear();
+    auto childA = make_registration_node("tool-a", "repo:a");
+    childA.binding =
+        make_registration_binding("root", "repo:1.0.0", "group-a");
+    auto childB = make_registration_node("tool-b", "repo:b");
+    childB.binding =
+        make_registration_binding("root", "repo:1.0.0", "group-b");
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed,
+        make_registration_batch({root, childA, childB}));
+
+    expect_registration_error(
+        result, xlings::xvm::RegistrationErrorKind::GroupConflict,
+        "/nodes/2/binding/group", "tool-b", "repo:b");
+    EXPECT_TRUE(db.empty());
+    EXPECT_TRUE(workspace.empty());
+    EXPECT_TRUE(installed.empty());
+}
+
+TEST(XvmRegistrationErrorTest, RejectsInvalidBatchNodeAndBindingIdentity) {
+    struct Case {
+        xlings::xvm::RegistrationBatch batch;
+        xlings::xvm::RegistrationErrorKind kind;
+        std::string path;
+        std::string target;
+        std::string version;
+    };
+
+    auto validNode = make_registration_node("tool", "repo:1.0.0");
+    auto emptyProvider = make_registration_batch({validNode});
+    emptyProvider.provider.clear();
+    auto emptyRelease = make_registration_batch({validNode});
+    emptyRelease.providerVersion.clear();
+    auto emptyTargetNode = validNode;
+    emptyTargetNode.target.clear();
+    auto emptyVersionNode = validNode;
+    emptyVersionNode.version.clear();
+    auto emptyRootNode = validNode;
+    emptyRootNode.binding =
+        make_registration_binding("", "repo:1.0.0");
+    auto emptyRootVersionNode = validNode;
+    emptyRootVersionNode.binding =
+        make_registration_binding("root", "");
+
+    const std::vector<Case> cases{
+        {
+            std::move(emptyProvider),
+            xlings::xvm::RegistrationErrorKind::InvalidBatchIdentity,
+            "/provider", "", "",
+        },
+        {
+            std::move(emptyRelease),
+            xlings::xvm::RegistrationErrorKind::InvalidBatchIdentity,
+            "/providerVersion", "", "",
+        },
+        {
+            make_registration_batch({emptyTargetNode}),
+            xlings::xvm::RegistrationErrorKind::InvalidNodeIdentity,
+            "/nodes/0/target", "", "repo:1.0.0",
+        },
+        {
+            make_registration_batch({emptyVersionNode}),
+            xlings::xvm::RegistrationErrorKind::InvalidNodeIdentity,
+            "/nodes/0/version", "tool", "",
+        },
+        {
+            make_registration_batch({emptyRootNode}),
+            xlings::xvm::RegistrationErrorKind::InvalidBindingIdentity,
+            "/nodes/0/binding/rootTarget", "tool", "repo:1.0.0",
+        },
+        {
+            make_registration_batch({emptyRootVersionNode}),
+            xlings::xvm::RegistrationErrorKind::InvalidBindingIdentity,
+            "/nodes/0/binding/rootVersion", "tool", "repo:1.0.0",
+        },
+    };
+
+    for (const auto& testCase : cases) {
+        SCOPED_TRACE(testCase.path);
+        xlings::xvm::VersionDB db;
+        xlings::xvm::Workspace workspace;
+        xlings::xvm::WorkspaceInstalled installed;
+
+        auto result = xlings::xvm::apply_registration_batch(
+            db, workspace, installed, testCase.batch);
+
+        expect_registration_error(
+            result, testCase.kind, testCase.path,
+            testCase.target, testCase.version);
+        EXPECT_TRUE(db.empty());
+        EXPECT_TRUE(workspace.empty());
+        EXPECT_TRUE(installed.empty());
+    }
+}
+
+TEST(XvmRegistrationOwnershipTest,
+     RejectsOtherProviderExactCollisionWithoutMutation) {
+    xlings::xvm::VersionDB db;
+    auto& existing = db["tool"].versions["repo:1.0.0"];
+    existing.path = "/other/tool";
+    existing.kind = "program";
+    existing.sourceName = "other-tool";
+    existing.destinationName = "tool";
+    existing.bindingGroup = xlings::xvm::BindingGroupRef{
+        .provider = "other:provider",
+        .providerVersion = "1.0.0",
+        .group = "tool",
+        .rootTarget = "tool",
+        .rootVersion = "repo:1.0.0",
+    };
+    existing.bindingMembers = {{"tool", "repo:1.0.0"}};
+    existing.bindingMembersDeclared = true;
+    xlings::xvm::Workspace workspace{{"tool", "repo:1.0.0"}};
+    xlings::xvm::WorkspaceInstalled installed{
+        {"tool", {"repo:1.0.0"}},
+    };
+    const auto dbBefore = xlings::xvm::versions_to_json(db);
+    const auto workspaceBefore = workspace;
+    const auto installedBefore = installed;
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed,
+        make_registration_batch({
+            make_registration_node("tool", "repo:1.0.0"),
+        }));
+
+    expect_registration_error(
+        result, xlings::xvm::RegistrationErrorKind::OwnershipConflict,
+        "/nodes/0", "tool", "repo:1.0.0");
+    expect_registration_state_unchanged(
+        db, workspace, installed,
+        dbBefore, workspaceBefore, installedBefore);
+}
+
+TEST(XvmRegistrationOwnershipTest,
+     RejectsSameProviderDifferentReleaseCollisionWithoutMutation) {
+    xlings::xvm::VersionDB db;
+    auto& existing = db["tool"].versions["repo:1.0.0"];
+    existing.path = "/provider/old";
+    existing.kind = "program";
+    existing.sourceName = "old-tool";
+    existing.destinationName = "tool";
+    existing.bindingGroup = xlings::xvm::BindingGroupRef{
+        .provider = "repo:provider",
+        .providerVersion = "0.9.0",
+        .group = "tool",
+        .rootTarget = "tool",
+        .rootVersion = "repo:1.0.0",
+    };
+    existing.bindingMembers = {{"tool", "repo:1.0.0"}};
+    existing.bindingMembersDeclared = true;
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+    const auto dbBefore = xlings::xvm::versions_to_json(db);
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed,
+        make_registration_batch({
+            make_registration_node("tool", "repo:1.0.0"),
+        }));
+
+    expect_registration_error(
+        result, xlings::xvm::RegistrationErrorKind::OwnershipConflict,
+        "/nodes/0", "tool", "repo:1.0.0");
+    EXPECT_EQ(xlings::xvm::versions_to_json(db), dbBefore);
+    EXPECT_TRUE(workspace.empty());
+    EXPECT_TRUE(installed.empty());
+}
+
+TEST(XvmRegistrationOwnershipTest, SameOwnerReregistrationIsIdempotent) {
+    xlings::xvm::VersionDB db;
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+    auto root = make_registration_node("root", "repo:1.0.0", "group");
+    root.sourceName.clear();
+    root.destinationName.clear();
+    auto child = make_registration_node("tool", "repo:tool-1.0.0");
+    child.sourceName = "tool-real";
+    child.destinationName = "tool";
+    child.alias = {"--driver-mode=gcc"};
+    child.envs = {{"TOOLCHAIN_ROOT", "/pkg/provider/1.0.0"}};
+    child.binding = make_registration_binding(
+        "root", "repo:1.0.0", "toolchain");
+    const auto batch = make_registration_batch({child, root});
+
+    auto first = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, batch);
+    ASSERT_TRUE(first.has_value()) << first.error().message;
+    const auto dbAfterFirst = xlings::xvm::versions_to_json(db);
+    const auto workspaceAfterFirst = workspace;
+    const auto installedAfterFirst = installed;
+
+    auto second = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, batch);
+
+    ASSERT_TRUE(second.has_value()) << second.error().message;
+    EXPECT_EQ(xlings::xvm::versions_to_json(db), dbAfterFirst);
+    EXPECT_EQ(workspace, workspaceAfterFirst);
+    EXPECT_EQ(installed, installedAfterFirst);
+    EXPECT_EQ(
+        db.at("root").bindings.at("tool").size(),
+        1u);
+    EXPECT_EQ(
+        db.at("tool").bindings.at("root").size(),
+        1u);
+}
+
+namespace {
+
+void seed_complete_legacy_registration_group(
+    xlings::xvm::VersionDB& db) {
+    auto& rootInfo = db["legacy-root"];
+    rootInfo.type = "program";
+    rootInfo.filename = "legacy-root-real";
+    auto& root = rootInfo.versions["repo:1.0.0"];
+    root.path = "/pkg/provider/1.0.0";
+    root.alias = {"root-alias"};
+    root.envs = {{"ROOT_ENV", "root"}};
+
+    auto& childInfo = db["tool"];
+    childInfo.type = "program";
+    childInfo.filename = "tool-real";
+    auto& child = childInfo.versions["repo:tool-1.0.0"];
+    child.path = "/pkg/provider/1.0.0";
+    child.alias = {"tool-alias"};
+    child.envs = {{"TOOL_ENV", "tool"}};
+
+    rootInfo.bindings["tool"]["repo:1.0.0"] =
+        "repo:tool-1.0.0";
+    childInfo.bindings["legacy-root"]["repo:tool-1.0.0"] =
+        "repo:1.0.0";
+}
+
+xlings::xvm::RegistrationBatch complete_legacy_adoption_batch() {
+    auto root =
+        make_registration_node("legacy-root", "repo:1.0.0");
+    root.sourceName = "legacy-root-real";
+    root.destinationName = "legacy-root";
+    root.alias = {"root-alias"};
+    root.envs = {{"ROOT_ENV", "root"}};
+    auto child =
+        make_registration_node("tool", "repo:tool-1.0.0");
+    child.sourceName = "tool-real";
+    child.destinationName = "tool";
+    child.alias = {"tool-alias"};
+    child.envs = {{"TOOL_ENV", "tool"}};
+    child.binding = make_registration_binding(
+        "legacy-root", "repo:1.0.0");
+    return make_registration_batch({child, root});
+}
+
+}  // namespace
+
+TEST(XvmRegistrationOwnershipTest, AdoptsCompatibleCompleteLegacyGroup) {
+    xlings::xvm::VersionDB db;
+    seed_complete_legacy_registration_group(db);
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, complete_legacy_adoption_batch());
+
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    auto selection = xlings::xvm::resolve_binding_selection(
+        db, "tool", "repo:tool-1.0.0");
+    ASSERT_TRUE(selection.has_value()) << selection.error().message;
+    EXPECT_EQ(
+        selection->members,
+        (std::map<std::string, std::string>{
+            {"legacy-root", "repo:1.0.0"},
+            {"tool", "repo:tool-1.0.0"},
+        }));
+    EXPECT_EQ(
+        db.at("tool")
+            .versions.at("repo:tool-1.0.0")
+            .bindingGroup->provider,
+        "repo:provider");
+}
+
+TEST(XvmRegistrationOwnershipTest,
+     RejectsIncompatibleLegacyPayloadWithoutMutation) {
+    xlings::xvm::VersionDB db;
+    seed_complete_legacy_registration_group(db);
+    xlings::xvm::Workspace workspace{{"tool", "repo:tool-1.0.0"}};
+    xlings::xvm::WorkspaceInstalled installed{
+        {"tool", {"repo:tool-1.0.0"}},
+    };
+    auto batch = complete_legacy_adoption_batch();
+    batch.nodes[0].path = "/different/payload";
+    const auto dbBefore = xlings::xvm::versions_to_json(db);
+    const auto workspaceBefore = workspace;
+    const auto installedBefore = installed;
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, batch);
+
+    expect_registration_error(
+        result, xlings::xvm::RegistrationErrorKind::LegacyPayloadMismatch,
+        "/nodes/0/path", "tool", "repo:tool-1.0.0");
+    expect_registration_state_unchanged(
+        db, workspace, installed,
+        dbBefore, workspaceBefore, installedBefore);
+}
+
+TEST(XvmRegistrationOwnershipTest,
+     RejectsIncompleteLegacyComponentWithoutMutation) {
+    xlings::xvm::VersionDB db;
+    seed_complete_legacy_registration_group(db);
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+    auto batch = complete_legacy_adoption_batch();
+    batch.nodes.erase(batch.nodes.begin());
+    const auto dbBefore = xlings::xvm::versions_to_json(db);
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, batch);
+
+    expect_registration_error(
+        result,
+        xlings::xvm::RegistrationErrorKind::IncompleteLegacyComponent,
+        "/nodes/0", "tool", "repo:tool-1.0.0");
+    EXPECT_EQ(xlings::xvm::versions_to_json(db), dbBefore);
+    EXPECT_TRUE(workspace.empty());
+    EXPECT_TRUE(installed.empty());
+}
+
+TEST(XvmRegistrationOwnershipTest,
+     RejectsIncompleteSameOwnerGroupReconfiguration) {
+    xlings::xvm::VersionDB db;
+    const xlings::xvm::BindingGroupRef group{
+        .provider = "repo:provider",
+        .providerVersion = "1.0.0",
+        .group = "toolchain",
+        .rootTarget = "root",
+        .rootVersion = "repo:1.0.0",
+    };
+    auto& root = db["root"].versions["repo:1.0.0"];
+    root.path = "/pkg/provider/1.0.0";
+    root.kind = "group";
+    root.bindingGroup = group;
+    root.bindingMembers = {
+        {"root", "repo:1.0.0"},
+        {"tool", "repo:tool-1.0.0"},
+    };
+    root.bindingMembersDeclared = true;
+    auto& child = db["tool"].versions["repo:tool-1.0.0"];
+    child.path = "/pkg/provider/1.0.0";
+    child.kind = "program";
+    child.sourceName = "tool-real";
+    child.destinationName = "tool";
+    child.bindingGroup = group;
+    db["root"].bindings["tool"]["repo:1.0.0"] =
+        "repo:tool-1.0.0";
+    db["tool"].bindings["root"]["repo:tool-1.0.0"] =
+        "repo:1.0.0";
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+    const auto dbBefore = xlings::xvm::versions_to_json(db);
+    auto replacement =
+        make_registration_node("root", "repo:1.0.0", "group");
+    replacement.sourceName.clear();
+    replacement.destinationName.clear();
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed,
+        make_registration_batch({replacement}));
+
+    expect_registration_error(
+        result,
+        xlings::xvm::RegistrationErrorKind::IncompleteOwnedGroup,
+        "/nodes/0", "tool", "repo:tool-1.0.0");
+    EXPECT_EQ(xlings::xvm::versions_to_json(db), dbBefore);
+    EXPECT_TRUE(workspace.empty());
+    EXPECT_TRUE(installed.empty());
+}
+
+TEST(XvmRegistrationReconfigureTest,
+     ReplacesCurrentExactEdgesAndPreservesAnotherVersion) {
+    xlings::xvm::VersionDB db;
+    const xlings::xvm::BindingGroupRef currentGroup{
+        .provider = "repo:provider",
+        .providerVersion = "1.0.0",
+        .group = "toolchain",
+        .rootTarget = "root",
+        .rootVersion = "repo:1.0.0",
+    };
+    auto& currentRoot = db["root"].versions["repo:1.0.0"];
+    currentRoot.path = "/pkg/provider/1.0.0";
+    currentRoot.kind = "group";
+    currentRoot.bindingGroup = currentGroup;
+    currentRoot.bindingMembers = {
+        {"root", "repo:1.0.0"},
+        {"tool", "repo:tool-1.0.0"},
+    };
+    currentRoot.bindingMembersDeclared = true;
+    auto& currentTool = db["tool"].versions["repo:tool-1.0.0"];
+    currentTool.path = "/pkg/provider/1.0.0";
+    currentTool.kind = "program";
+    currentTool.sourceName = "tool-real";
+    currentTool.destinationName = "tool";
+    currentTool.bindingGroup = currentGroup;
+    db["root"].bindings["tool"]["repo:1.0.0"] =
+        "repo:tool-1.0.0";
+    db["tool"].bindings["root"]["repo:tool-1.0.0"] =
+        "repo:1.0.0";
+
+    auto& stale = db["stale"].versions["repo:stale-1.0.0"];
+    stale.path = "/pkg/stale";
+    stale.kind = "program";
+    stale.sourceName = "stale";
+    stale.destinationName = "stale";
+    db["root"].bindings["stale"]["repo:1.0.0"] =
+        "repo:stale-1.0.0";
+    db["stale"].bindings["root"]["repo:stale-1.0.0"] =
+        "repo:1.0.0";
+
+    const xlings::xvm::BindingGroupRef oldGroup{
+        .provider = "repo:provider",
+        .providerVersion = "0.9.0",
+        .group = "toolchain",
+        .rootTarget = "root",
+        .rootVersion = "repo:0.9.0",
+    };
+    auto& oldRoot = db["root"].versions["repo:0.9.0"];
+    oldRoot.path = "/pkg/provider/0.9.0";
+    oldRoot.kind = "group";
+    oldRoot.bindingGroup = oldGroup;
+    oldRoot.bindingMembers = {
+        {"root", "repo:0.9.0"},
+        {"tool", "repo:tool-0.9.0"},
+    };
+    oldRoot.bindingMembersDeclared = true;
+    auto& oldTool = db["tool"].versions["repo:tool-0.9.0"];
+    oldTool.path = "/pkg/provider/0.9.0";
+    oldTool.kind = "program";
+    oldTool.sourceName = "tool-old";
+    oldTool.destinationName = "tool";
+    oldTool.alias = {"--old"};
+    oldTool.envs = {{"OLD", "1"}};
+    oldTool.bindingGroup = oldGroup;
+    db["root"].bindings["tool"]["repo:0.9.0"] =
+        "repo:tool-0.9.0";
+    db["tool"].bindings["root"]["repo:tool-0.9.0"] =
+        "repo:0.9.0";
+    const auto oldRootBefore = xlings::xvm::vdata_to_json(oldRoot);
+    const auto oldToolBefore = xlings::xvm::vdata_to_json(oldTool);
+    const auto staleBefore = xlings::xvm::vdata_to_json(stale);
+
+    auto root = make_registration_node("root", "repo:1.0.0", "group");
+    root.sourceName.clear();
+    root.destinationName.clear();
+    auto tool =
+        make_registration_node("tool", "repo:tool-1.0.0");
+    tool.sourceName = "tool-real";
+    tool.destinationName = "tool";
+    tool.binding = make_registration_binding(
+        "root", "repo:1.0.0", "toolchain");
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed,
+        make_registration_batch({tool, root}));
+
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    EXPECT_FALSE(db.at("root").bindings.contains("stale"));
+    EXPECT_FALSE(db.at("stale").bindings.contains("root"));
+    EXPECT_EQ(
+        xlings::xvm::vdata_to_json(
+            db.at("root").versions.at("repo:0.9.0")),
+        oldRootBefore);
+    EXPECT_EQ(
+        xlings::xvm::vdata_to_json(
+            db.at("tool").versions.at("repo:tool-0.9.0")),
+        oldToolBefore);
+    EXPECT_EQ(
+        xlings::xvm::vdata_to_json(
+            db.at("stale").versions.at("repo:stale-1.0.0")),
+        staleBefore);
+    EXPECT_EQ(
+        db.at("root")
+            .bindings.at("tool").at("repo:0.9.0"),
+        "repo:tool-0.9.0");
+    EXPECT_EQ(
+        db.at("tool")
+            .bindings.at("root").at("repo:tool-0.9.0"),
+        "repo:0.9.0");
+}
+
+TEST(XvmRegistrationTest, KeepsProviderReleaseGroupsIndependent) {
+    auto rootA = make_registration_node("root-a", "repo:a", "group");
+    rootA.sourceName.clear();
+    rootA.destinationName.clear();
+    auto toolA = make_registration_node("tool", "repo:tool-a");
+    toolA.sourceName = "tool-a";
+    toolA.binding =
+        make_registration_binding("root-a", "repo:a", "group-a");
+    auto rootB = make_registration_node("root-b", "repo:b", "group");
+    rootB.sourceName.clear();
+    rootB.destinationName.clear();
+    auto toolB = make_registration_node("tool", "repo:tool-b");
+    toolB.sourceName = "tool-b";
+    toolB.binding =
+        make_registration_binding("root-b", "repo:b", "group-b");
+    xlings::xvm::VersionDB db;
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed,
+        make_registration_batch({toolB, rootA, toolA, rootB}));
+
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    auto selectedA =
+        xlings::xvm::resolve_binding_selection(db, "root-a", "repo:a");
+    auto selectedB =
+        xlings::xvm::resolve_binding_selection(db, "root-b", "repo:b");
+    ASSERT_TRUE(selectedA.has_value()) << selectedA.error().message;
+    ASSERT_TRUE(selectedB.has_value()) << selectedB.error().message;
+    EXPECT_EQ(
+        selectedA->members,
+        (std::map<std::string, std::string>{
+            {"root-a", "repo:a"},
+            {"tool", "repo:tool-a"},
+        }));
+    EXPECT_EQ(
+        selectedB->members,
+        (std::map<std::string, std::string>{
+            {"root-b", "repo:b"},
+            {"tool", "repo:tool-b"},
+        }));
+}
+
+TEST(XvmRegistrationTest,
+     SameTargetIndependentGroupsIgnoreBatchNodeOrder) {
+    auto rootA = make_registration_node("root-a", "repo:a", "group");
+    rootA.sourceName.clear();
+    rootA.destinationName.clear();
+    auto toolA =
+        make_registration_node("tool", "repo:tool-a", "program");
+    toolA.sourceName = "tool-a";
+    toolA.destinationName = "tool";
+    toolA.binding =
+        make_registration_binding("root-a", "repo:a", "group-a");
+    auto rootB = make_registration_node("root-b", "repo:b", "group");
+    rootB.sourceName.clear();
+    rootB.destinationName.clear();
+    auto toolB = make_registration_node("tool", "repo:tool-b", "lib");
+    toolB.sourceName = "libtool-b.so.1";
+    toolB.destinationName = "libtool.so.1";
+    toolB.binding =
+        make_registration_binding("root-b", "repo:b", "group-b");
+
+    xlings::xvm::VersionDB forwardDb;
+    xlings::xvm::Workspace forwardWorkspace;
+    xlings::xvm::WorkspaceInstalled forwardInstalled;
+    auto forward = xlings::xvm::apply_registration_batch(
+        forwardDb, forwardWorkspace, forwardInstalled,
+        make_registration_batch({rootA, toolA, rootB, toolB}));
+    ASSERT_TRUE(forward.has_value()) << forward.error().message;
+
+    xlings::xvm::VersionDB reverseDb;
+    xlings::xvm::Workspace reverseWorkspace;
+    xlings::xvm::WorkspaceInstalled reverseInstalled;
+    auto reverse = xlings::xvm::apply_registration_batch(
+        reverseDb, reverseWorkspace, reverseInstalled,
+        make_registration_batch({toolB, rootB, toolA, rootA}));
+    ASSERT_TRUE(reverse.has_value()) << reverse.error().message;
+
+    EXPECT_EQ(
+        xlings::xvm::versions_to_json(forwardDb),
+        xlings::xvm::versions_to_json(reverseDb));
+    EXPECT_EQ(forwardWorkspace, reverseWorkspace);
+    EXPECT_EQ(forwardInstalled, reverseInstalled);
+}
+
+TEST(XvmRegistrationHeaderTest, RoutesExplicitHeaderToNamedGroupRoot) {
+    auto rootA = make_registration_node("root-a", "repo:a", "group");
+    rootA.sourceName.clear();
+    rootA.destinationName.clear();
+    auto toolA = make_registration_node("tool-a", "repo:a");
+    toolA.binding =
+        make_registration_binding("root-a", "repo:a", "group-a");
+    auto rootB = make_registration_node("root-b", "repo:b", "group");
+    rootB.sourceName.clear();
+    rootB.destinationName.clear();
+    auto toolB = make_registration_node("tool-b", "repo:b");
+    toolB.binding =
+        make_registration_binding("root-b", "repo:b", "group-b");
+    auto batch =
+        make_registration_batch({rootA, toolA, rootB, toolB});
+    batch.headers = {
+        {
+            .sourceDir = "include/compiler",
+            .destinationPrefix = "compiler",
+            .group = "group-b",
+        },
+    };
+    xlings::xvm::VersionDB db;
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, batch);
+
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    EXPECT_TRUE(
+        db.at("root-a").versions.at("repo:a").bindingHeaders.empty());
+    const auto& routed =
+        db.at("root-b").versions.at("repo:b").bindingHeaders;
+    ASSERT_EQ(routed.size(), 1u);
+    EXPECT_EQ(routed[0].sourceDir, "include/compiler");
+    EXPECT_EQ(routed[0].destinationPrefix, "compiler");
+}
+
+TEST(XvmRegistrationHeaderTest, AcceptsUngroupedHeaderForSingleGroup) {
+    auto root = make_registration_node("root", "repo:1.0.0", "group");
+    root.sourceName.clear();
+    root.destinationName.clear();
+    auto batch = make_registration_batch({root});
+    batch.headers = {
+        {
+            .sourceDir = "include",
+            .destinationPrefix = "",
+        },
+    };
+    xlings::xvm::VersionDB db;
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, batch);
+
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    const auto& data =
+        db.at("root").versions.at("repo:1.0.0");
+    ASSERT_EQ(data.bindingHeaders.size(), 1u);
+    EXPECT_EQ(data.bindingHeaders[0].sourceDir, "include");
+    EXPECT_TRUE(data.bindingHeaders[0].destinationPrefix.empty());
+    EXPECT_TRUE(data.bindingHeadersDeclared);
+}
+
+TEST(XvmRegistrationHeaderErrorTest,
+     RejectsAmbiguousUngroupedHeaderWithoutMutation) {
+    auto first = make_registration_node("first", "repo:first");
+    auto second = make_registration_node("second", "repo:second");
+    auto batch = make_registration_batch({first, second});
+    batch.headers = {
+        {
+            .sourceDir = "include",
+        },
+    };
+    xlings::xvm::VersionDB db;
+    db["sentinel"].versions["0"].path = "/sentinel";
+    xlings::xvm::Workspace workspace{{"sentinel", "0"}};
+    xlings::xvm::WorkspaceInstalled installed{{"sentinel", {"0"}}};
+    const auto dbBefore = xlings::xvm::versions_to_json(db);
+    const auto workspaceBefore = workspace;
+    const auto installedBefore = installed;
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, batch);
+
+    expect_registration_error(
+        result, xlings::xvm::RegistrationErrorKind::HeaderAmbiguous,
+        "/headers/0/group");
+    expect_registration_state_unchanged(
+        db, workspace, installed,
+        dbBefore, workspaceBefore, installedBefore);
+}
+
+TEST(XvmRegistrationHeaderErrorTest,
+     RejectsMissingExplicitHeaderGroupWithoutMutation) {
+    auto root = make_registration_node("root", "repo:1.0.0", "group");
+    root.sourceName.clear();
+    root.destinationName.clear();
+    auto batch = make_registration_batch({root});
+    batch.headers = {
+        {
+            .sourceDir = "include",
+            .group = "missing-group",
+        },
+    };
+    xlings::xvm::VersionDB db;
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, batch);
+
+    expect_registration_error(
+        result, xlings::xvm::RegistrationErrorKind::HeaderGroupNotFound,
+        "/headers/0/group", "missing-group");
+    EXPECT_TRUE(db.empty());
+    EXPECT_TRUE(workspace.empty());
+    EXPECT_TRUE(installed.empty());
+}
+
+TEST(XvmRegistrationHeaderErrorTest,
+     RejectsEmptyHeaderSourceWithoutMutation) {
+    auto root = make_registration_node("root", "repo:1.0.0", "group");
+    root.sourceName.clear();
+    root.destinationName.clear();
+    auto batch = make_registration_batch({root});
+    batch.headers = {
+        {
+            .sourceDir = "",
+        },
+    };
+    xlings::xvm::VersionDB db;
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, batch);
+
+    expect_registration_error(
+        result, xlings::xvm::RegistrationErrorKind::InvalidHeader,
+        "/headers/0/sourceDir");
+    EXPECT_TRUE(db.empty());
+    EXPECT_TRUE(workspace.empty());
+    EXPECT_TRUE(installed.empty());
+}
+
+TEST(XvmRegistrationHeaderTest, HeaderNeverCreatesTargetOrVersion) {
+    auto root = make_registration_node("root", "repo:1.0.0", "group");
+    root.sourceName.clear();
+    root.destinationName.clear();
+    auto batch = make_registration_batch({root});
+    batch.headers = {
+        {
+            .sourceDir = "phantom-header-target",
+            .destinationPrefix = "sdk",
+        },
+    };
+    xlings::xvm::VersionDB db;
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, batch);
+
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    EXPECT_EQ(db.size(), 1u);
+    EXPECT_FALSE(db.contains("phantom-header-target"));
+    EXPECT_EQ(
+        db.at("root")
+            .versions.at("repo:1.0.0")
+            .bindingHeaders.size(),
+        1u);
+}
+
+TEST(XvmRegistrationStateTest,
+     RegistersEveryMemberOnceAndHonorsActivationPolicy) {
+    xlings::xvm::VersionDB db;
+    xlings::xvm::Workspace workspace{
+        {"root", "repo:0.9.0"},
+        {"tool", "repo:tool-0.9.0"},
+        {"runtime", "repo:runtime-0.9.0"},
+    };
+    xlings::xvm::WorkspaceInstalled installed{
+        {"root", {"repo:0.9.0"}},
+        {
+            "tool",
+            {
+                "repo:tool-0.9.0",
+                "repo:tool-1.0.0",
+                "repo:tool-1.0.0",
+            },
+        },
+        {"runtime", {"repo:runtime-0.9.0"}},
+    };
+    auto root = make_registration_node("root", "repo:1.0.0", "group");
+    root.sourceName = "must-not-be-a-shim";
+    root.destinationName = "must-not-be-a-shim";
+    auto tool =
+        make_registration_node("tool", "repo:tool-1.0.0");
+    tool.sourceName = "tool-real";
+    tool.destinationName = "tool";
+    tool.binding = make_registration_binding(
+        "root", "repo:1.0.0", "toolchain");
+    auto runtime = make_registration_node(
+        "runtime", "repo:runtime-1.0.0", "lib");
+    runtime.sourceName = "libruntime.so.1.0";
+    runtime.destinationName = "libruntime.so.1";
+    runtime.binding = tool.binding;
+    auto batch = make_registration_batch({runtime, root, tool});
+
+    auto first = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, batch);
+
+    ASSERT_TRUE(first.has_value()) << first.error().message;
+    EXPECT_EQ(first->size(), 3u);
+    EXPECT_EQ(workspace.at("root"), "repo:0.9.0");
+    EXPECT_EQ(workspace.at("tool"), "repo:tool-0.9.0");
+    EXPECT_EQ(
+        workspace.at("runtime"), "repo:runtime-0.9.0");
+    EXPECT_EQ(
+        std::ranges::count(
+            installed.at("root"), "repo:1.0.0"),
+        1);
+    EXPECT_EQ(
+        std::ranges::count(
+            installed.at("tool"), "repo:tool-1.0.0"),
+        1);
+    EXPECT_EQ(
+        std::ranges::count(
+            installed.at("runtime"), "repo:runtime-1.0.0"),
+        1);
+
+    batch.useAfterInstall = true;
+    auto second = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, batch);
+
+    ASSERT_TRUE(second.has_value()) << second.error().message;
+    EXPECT_EQ(workspace.at("root"), "repo:1.0.0");
+    EXPECT_EQ(workspace.at("tool"), "repo:tool-1.0.0");
+    EXPECT_EQ(
+        workspace.at("runtime"), "repo:runtime-1.0.0");
+    EXPECT_EQ(
+        std::ranges::count(
+            installed.at("tool"), "repo:tool-1.0.0"),
+        1);
+}
+
+TEST(XvmRegistrationStateTest,
+     VirtualGroupRetainsEmptyPayloadAndNoSelfEdge) {
+    xlings::xvm::VersionDB db;
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+    auto root = make_registration_node("root", "repo:1.0.0", "group");
+    root.sourceName = "bogus-executable";
+    root.destinationName = "bogus-shim";
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed,
+        make_registration_batch({root}));
+
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    const auto& data =
+        db.at("root").versions.at("repo:1.0.0");
+    EXPECT_EQ(data.kind, "group");
+    EXPECT_TRUE(data.sourceName.empty());
+    EXPECT_TRUE(data.destinationName.empty());
+    EXPECT_FALSE(db.at("root").bindings.contains("root"));
+    EXPECT_EQ(workspace.at("root"), "repo:1.0.0");
+    EXPECT_EQ(
+        installed.at("root"),
+        (std::vector<std::string>{"repo:1.0.0"}));
+}
+
+TEST(XvmRegistrationStateTest,
+     FinalComponentValidationFailurePreservesEveryStateObject) {
+    xlings::xvm::VersionDB db;
+    db["sentinel"].versions["0"].path = "/sentinel";
+    xlings::xvm::Workspace workspace{{"sentinel", "0"}};
+    xlings::xvm::WorkspaceInstalled installed{{"sentinel", {"0"}}};
+    const auto dbBefore = xlings::xvm::versions_to_json(db);
+    const auto workspaceBefore = workspace;
+    const auto installedBefore = installed;
+    auto valid =
+        make_registration_node("a-valid", "repo:valid");
+    auto invalid =
+        make_registration_node("z-invalid", "repo:invalid", "archive");
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed,
+        make_registration_batch({valid, invalid}));
+
+    expect_registration_error(
+        result,
+        xlings::xvm::RegistrationErrorKind::BindingValidationFailed,
+        "", "z-invalid", "repo:invalid");
+    expect_registration_state_unchanged(
+        db, workspace, installed,
+        dbBefore, workspaceBefore, installedBefore);
+}
 
 TEST(XvmBindingSelectionTest, ProviderGroupResolvesRootAndLeafExactly) {
     xlings::xvm::VersionDB db;

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -21,6 +21,7 @@ import xlings.core.xim.extract;
 import xlings.core.xvm.types;
 import xlings.core.xvm.db;
 import xlings.core.xvm.bindings;
+import xlings.core.xvm.removal;
 import xlings.core.xvm.shim;
 import xlings.core.xvm.commands;
 import xlings.core.compact;
@@ -36,6 +37,7 @@ import xlings.capabilities;
 import xlings.libs.tinyhttps;
 import xlings.libs.sha256;
 import mcpplibs.xpkg;
+import mcpplibs.xpkg.executor;
 import mcpplibs.cmdline;
 
 namespace {
@@ -1663,12 +1665,14 @@ TEST(XvmDbTest, AddAndRemoveVersion) {
     auto all = xlings::xvm::get_all_versions(db, "gcc");
     EXPECT_EQ(all.size(), 2u);
 
-    xlings::xvm::remove_version(db, "gcc", "14.2.0");
+    ASSERT_TRUE(
+        xlings::xvm::remove_version(db, "gcc", "14.2.0").has_value());
     EXPECT_FALSE(xlings::xvm::has_version(db, "gcc", "14.2.0"));
     EXPECT_TRUE(xlings::xvm::has_version(db, "gcc", "15.1.0"));
 
     // Remove last version removes the target entirely
-    xlings::xvm::remove_version(db, "gcc", "15.1.0");
+    ASSERT_TRUE(
+        xlings::xvm::remove_version(db, "gcc", "15.1.0").has_value());
     EXPECT_FALSE(xlings::xvm::has_target(db, "gcc"));
 }
 
@@ -4498,6 +4502,734 @@ TEST(XvmDbTest, AddVersionWithBindingMultipleVersions) {
     ASSERT_NE(gcc_info, nullptr);
     EXPECT_EQ(gcc_info->bindings.at("xim-gnu-gcc").at("15.1.0"), "15.1.0");
     EXPECT_EQ(gcc_info->bindings.at("xim-gnu-gcc").at("14.2.0"), "14.2.0");
+}
+
+TEST(XvmExactRemovalTest, RemovesOnlyExactVersionReciprocalEdges) {
+    xlings::xvm::VersionDB db;
+
+    xlings::xvm::add_version(
+        db, "toolchain", "15.1.0", "/pkg/toolchain-15");
+    xlings::xvm::add_version(
+        db, "cc", "15.1.0", "/pkg/toolchain-15",
+        "program", "cc-15", "cc", "", "toolchain@15.1.0");
+    xlings::xvm::add_version(
+        db, "toolchain", "14.2.0", "/pkg/toolchain-14");
+    xlings::xvm::add_version(
+        db, "cc", "14.2.0", "/pkg/toolchain-14",
+        "program", "cc-14", "cc", "", "toolchain@14.2.0");
+
+    ASSERT_TRUE(
+        xlings::xvm::remove_version(db, "cc", "15.1.0").has_value());
+
+    ASSERT_TRUE(db.contains("cc"));
+    EXPECT_FALSE(db.at("cc").versions.contains("15.1.0"));
+    EXPECT_TRUE(db.at("cc").versions.contains("14.2.0"));
+    ASSERT_TRUE(db.at("cc").bindings.contains("toolchain"));
+    EXPECT_EQ(db.at("cc").bindings.at("toolchain").size(), 1u);
+    EXPECT_EQ(
+        db.at("cc").bindings.at("toolchain").at("14.2.0"),
+        "14.2.0");
+
+    ASSERT_TRUE(db.at("toolchain").bindings.contains("cc"));
+    EXPECT_EQ(db.at("toolchain").bindings.at("cc").size(), 1u);
+    EXPECT_EQ(
+        db.at("toolchain").bindings.at("cc").at("14.2.0"),
+        "14.2.0");
+}
+
+TEST(XvmExactRemovalTest, AmbiguousBareVersionFailsWithoutMutation) {
+    xlings::xvm::VersionDB db;
+    xlings::xvm::add_version(
+        db, "cc", "1.0.0", "/pkg/repo-a", "program",
+        "cc-a", "cc", "repo-a");
+    xlings::xvm::add_version(
+        db, "cc", "1.0.0", "/pkg/repo-b", "program",
+        "cc-b", "cc", "repo-b");
+    const auto before = xlings::xvm::versions_to_json(db);
+
+    auto result = xlings::xvm::remove_version(db, "cc", "1.0.0");
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(
+        result.error().kind,
+        xlings::xvm::RemovalErrorKind::AmbiguousVersion);
+    EXPECT_EQ(result.error().target, "cc");
+    EXPECT_EQ(result.error().version, "1.0.0");
+    EXPECT_TRUE(result.error().peerTarget.empty());
+    EXPECT_TRUE(result.error().peerVersion.empty());
+    EXPECT_EQ(xlings::xvm::versions_to_json(db), before);
+}
+
+TEST(XvmRemovalBatchTest, LateAsymmetricEdgeFailsWithoutPartialMutation) {
+    xlings::xvm::VersionDB db;
+    db["safe"].versions["repo:safe-1"].path = "/pkg/safe";
+    db["a"].versions["repo:a-1"].path = "/pkg/a";
+    db["b"].versions["repo:b-1"].path = "/pkg/b";
+    db["a"].bindings["b"]["repo:a-1"] = "repo:b-1";
+    db["b"].bindings["a"]["repo:b-1"] = "repo:wrong-a";
+    xlings::xvm::Workspace workspace{
+        {"safe", "repo:safe-1"},
+        {"a", "repo:a-1"},
+    };
+    xlings::xvm::WorkspaceInstalled installed{
+        {"safe", {"repo:safe-1"}},
+        {"a", {"repo:a-1"}},
+    };
+    const auto dbBefore = xlings::xvm::versions_to_json(db);
+    const auto workspaceBefore = workspace;
+    const auto installedBefore = installed;
+    const std::vector<xlings::xvm::RemovalOperation> operations{
+        {
+            .op = "remove",
+            .name = "safe",
+            .version = "repo:safe-1",
+        },
+        {
+            .op = "remove",
+            .name = "a",
+            .version = "repo:a-1",
+        },
+    };
+
+    auto result = xlings::xvm::apply_removal_batch(
+        db, workspace, installed, operations, {});
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(
+        result.error().kind,
+        xlings::xvm::RemovalErrorKind::AsymmetricEdge);
+    EXPECT_EQ(result.error().target, "a");
+    EXPECT_EQ(result.error().version, "repo:a-1");
+    EXPECT_EQ(result.error().peerTarget, "b");
+    EXPECT_EQ(result.error().peerVersion, "repo:b-1");
+    EXPECT_EQ(xlings::xvm::versions_to_json(db), dbBefore);
+    EXPECT_EQ(workspace, workspaceBefore);
+    EXPECT_EQ(installed, installedBefore);
+}
+
+TEST(XvmExactRemovalTest, UnpairedIncomingEdgeFailsWithoutMutation) {
+    xlings::xvm::VersionDB db;
+    db["a"].versions["repo:a-1"].path = "/pkg/a";
+    db["b"].versions["repo:b-1"].path = "/pkg/b";
+    db["b"].bindings["a"]["repo:b-1"] = "repo:a-1";
+    const auto before = xlings::xvm::versions_to_json(db);
+
+    auto result =
+        xlings::xvm::remove_version(db, "a", "repo:a-1");
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(
+        result.error().kind,
+        xlings::xvm::RemovalErrorKind::AsymmetricEdge);
+    EXPECT_EQ(result.error().target, "a");
+    EXPECT_EQ(result.error().version, "repo:a-1");
+    EXPECT_EQ(result.error().peerTarget, "b");
+    EXPECT_EQ(result.error().peerVersion, "repo:b-1");
+    EXPECT_EQ(xlings::xvm::versions_to_json(db), before);
+}
+
+TEST(XvmRemovalBatchTest, RawEmptyOperationNeverMeansAllVersions) {
+    xlings::xvm::VersionDB db;
+    db["sibling"].versions["repo-a:1.0.0"].path = "/pkg/a";
+    db["sibling"].versions["repo-b:1.0.0"].path = "/pkg/b";
+    xlings::xvm::Workspace workspace{
+        {"sibling", "repo-a:1.0.0"},
+    };
+    xlings::xvm::WorkspaceInstalled installed{
+        {"sibling", {"repo-a:1.0.0", "repo-b:1.0.0"}},
+    };
+    const auto dbBefore = xlings::xvm::versions_to_json(db);
+    const auto workspaceBefore = workspace;
+    const auto installedBefore = installed;
+    const std::vector<xlings::xvm::RemovalOperation> operations{
+        {
+            .op = "remove",
+            .name = "sibling",
+            .version = "",
+        },
+    };
+
+    auto result = xlings::xvm::apply_removal_batch(
+        db, workspace, installed, operations, {});
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(
+        result.error().kind,
+        xlings::xvm::RemovalErrorKind::AmbiguousVersion);
+    EXPECT_EQ(result.error().target, "sibling");
+    EXPECT_TRUE(result.error().version.empty());
+    EXPECT_EQ(xlings::xvm::versions_to_json(db), dbBefore);
+    EXPECT_EQ(workspace, workspaceBefore);
+    EXPECT_EQ(installed, installedBefore);
+
+    db["sibling"].versions.erase("repo-b:1.0.0");
+    workspace = {{"sibling", "repo-a:1.0.0"}};
+    installed = {{"sibling", {"repo-a:1.0.0"}}};
+    const auto oneVersionBefore = xlings::xvm::versions_to_json(db);
+
+    result = xlings::xvm::apply_removal_batch(
+        db, workspace, installed, operations, {});
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(
+        result.error().kind,
+        xlings::xvm::RemovalErrorKind::VersionNotFound);
+    EXPECT_EQ(xlings::xvm::versions_to_json(db), oneVersionBefore);
+    EXPECT_EQ(workspace.at("sibling"), "repo-a:1.0.0");
+    EXPECT_EQ(
+        installed.at("sibling"),
+        (std::vector<std::string>{"repo-a:1.0.0"}));
+}
+
+TEST(XvmRemovalBatchTest,
+     LegacySnapshotRemovesTransformedNamespacedMembersExactly) {
+    xlings::xvm::VersionDB db;
+    xlings::xvm::add_version(
+        db, "toolchain", "15.1.0", "/pkg/toolchain-15",
+        "program", "", "", "repo-a");
+    xlings::xvm::add_version(
+        db, "cc", "gcc-15.1.0", "/pkg/toolchain-15",
+        "program", "cc-15", "cc", "repo-a",
+        "toolchain@15.1.0");
+    xlings::xvm::add_version(
+        db, "toolchain", "14.2.0", "/pkg/toolchain-14",
+        "program", "", "", "repo-a");
+    xlings::xvm::add_version(
+        db, "cc", "gcc-14.2.0", "/pkg/toolchain-14",
+        "program", "cc-14", "cc", "repo-a",
+        "toolchain@14.2.0");
+    xlings::xvm::Workspace workspace{
+        {"toolchain", "repo-a:15.1.0"},
+        {"cc", "repo-a:gcc-15.1.0"},
+    };
+    xlings::xvm::WorkspaceInstalled installed{
+        {
+            "toolchain",
+            {"repo-a:14.2.0", "repo-a:15.1.0"},
+        },
+        {
+            "cc",
+            {"repo-a:gcc-14.2.0", "repo-a:gcc-15.1.0"},
+        },
+    };
+    const std::vector<xlings::xvm::RemovalOperation> operations{
+        {
+            .op = "remove",
+            .name = "toolchain",
+            .version = "",
+        },
+    };
+
+    auto context = xlings::xvm::snapshot_removal_context(
+        db, "toolchain", "repo-a:15.1.0");
+    ASSERT_TRUE(context.has_value()) << context.error().message;
+    ASSERT_TRUE(context->hasSelection);
+    EXPECT_TRUE(context->provider.empty());
+
+    auto result = xlings::xvm::apply_removal_batch(
+        db, workspace, installed, operations, *context);
+
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    ASSERT_EQ(result->removed.size(), 2u);
+    EXPECT_EQ(result->removed[0].target, "toolchain");
+    EXPECT_EQ(result->removed[0].version, "repo-a:15.1.0");
+    EXPECT_EQ(result->removed[1].target, "cc");
+    EXPECT_EQ(result->removed[1].version, "repo-a:gcc-15.1.0");
+
+    ASSERT_TRUE(db.contains("toolchain"));
+    EXPECT_EQ(db.at("toolchain").versions.size(), 1u);
+    EXPECT_TRUE(db.at("toolchain").versions.contains("repo-a:14.2.0"));
+    ASSERT_TRUE(db.at("toolchain").bindings.contains("cc"));
+    EXPECT_EQ(db.at("toolchain").bindings.at("cc").size(), 1u);
+    EXPECT_EQ(
+        db.at("toolchain").bindings.at("cc").at("repo-a:14.2.0"),
+        "repo-a:gcc-14.2.0");
+
+    ASSERT_TRUE(db.contains("cc"));
+    EXPECT_EQ(db.at("cc").versions.size(), 1u);
+    EXPECT_TRUE(db.at("cc").versions.contains("repo-a:gcc-14.2.0"));
+    ASSERT_TRUE(db.at("cc").bindings.contains("toolchain"));
+    EXPECT_EQ(db.at("cc").bindings.at("toolchain").size(), 1u);
+    EXPECT_EQ(
+        db.at("cc").bindings.at("toolchain").at(
+            "repo-a:gcc-14.2.0"),
+        "repo-a:14.2.0");
+
+    EXPECT_EQ(workspace.at("toolchain"), "repo-a:14.2.0");
+    EXPECT_EQ(workspace.at("cc"), "repo-a:gcc-14.2.0");
+    EXPECT_EQ(
+        installed.at("toolchain"),
+        (std::vector<std::string>{"repo-a:14.2.0"}));
+    EXPECT_EQ(
+        installed.at("cc"),
+        (std::vector<std::string>{"repo-a:gcc-14.2.0"}));
+}
+
+TEST(XvmRemovalBatchTest,
+     ProviderRootOperationRemovesWholeOwnedReleaseOnly) {
+    xlings::xvm::VersionDB db;
+    auto addRelease = [&](const std::string& release,
+                          const std::string& rootVersion,
+                          const std::string& memberVersion) {
+        const auto group = make_binding_group_ref(
+            "repo-a:toolchain", release, "compiler",
+            "toolchain", rootVersion);
+        auto& root = add_provider_group_member(
+            db, "toolchain", rootVersion, group, "group");
+        root.bindingMembers = {
+            {"cc", memberVersion},
+            {"toolchain", rootVersion},
+        };
+        add_provider_group_member(
+            db, "cc", memberVersion, group,
+            "program", "cc-a", "cc");
+    };
+    addRelease("1.0.0", "repo-a:1.0.0", "repo-a:gcc-1.0.0");
+    addRelease("2.0.0", "repo-a:2.0.0", "repo-a:gcc-2.0.0");
+    xlings::xvm::Workspace workspace{
+        {"toolchain", "repo-a:1.0.0"},
+        {"cc", "repo-a:gcc-1.0.0"},
+    };
+    xlings::xvm::WorkspaceInstalled installed{
+        {"toolchain", {"repo-a:1.0.0", "repo-a:2.0.0"}},
+        {"cc", {"repo-a:gcc-1.0.0", "repo-a:gcc-2.0.0"}},
+    };
+    const std::vector<xlings::xvm::RemovalOperation> operations{
+        {
+            .op = "remove",
+            .name = "toolchain",
+        },
+    };
+    auto context = xlings::xvm::snapshot_removal_context(
+        db, "toolchain", "repo-a:1.0.0");
+    ASSERT_TRUE(context.has_value()) << context.error().message;
+
+    auto result = xlings::xvm::apply_removal_batch(
+        db, workspace, installed, operations, *context);
+
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    EXPECT_EQ(result->removed.size(), 2u);
+    EXPECT_FALSE(
+        db.at("toolchain").versions.contains("repo-a:1.0.0"));
+    EXPECT_TRUE(
+        db.at("toolchain").versions.contains("repo-a:2.0.0"));
+    EXPECT_FALSE(
+        db.at("cc").versions.contains("repo-a:gcc-1.0.0"));
+    EXPECT_TRUE(
+        db.at("cc").versions.contains("repo-a:gcc-2.0.0"));
+    EXPECT_EQ(workspace.at("toolchain"), "repo-a:2.0.0");
+    EXPECT_EQ(workspace.at("cc"), "repo-a:gcc-2.0.0");
+}
+
+TEST(XvmRemovalBatchTest,
+     RemoveAllDeletesOnlyExecutingProviderAcrossReleases) {
+    xlings::xvm::VersionDB db;
+    auto& providerA1 = db["cc"].versions["repo-a:1.0.0"];
+    providerA1.path = "/pkg/a/1";
+    providerA1.kind = "program";
+    providerA1.bindingGroup = make_binding_group_ref(
+        "repo-a:provider", "1.0.0", "cc-a-1",
+        "root-a-1", "repo-a:1.0.0");
+    auto& providerA2 = db["cc"].versions["repo-a:2.0.0"];
+    providerA2.path = "/pkg/a/2";
+    providerA2.kind = "program";
+    providerA2.bindingGroup = make_binding_group_ref(
+        "repo-a:provider", "2.0.0", "cc-a-2",
+        "root-a-2", "repo-a:2.0.0");
+    auto& providerB = db["cc"].versions["repo-b:9.0.0"];
+    providerB.path = "/pkg/b/9";
+    providerB.kind = "program";
+    providerB.bindingGroup = make_binding_group_ref(
+        "repo-b:provider", "9.0.0", "cc-b-9",
+        "root-b-9", "repo-b:9.0.0");
+    db["cc"].versions["legacy:0.9.0"].path = "/pkg/legacy";
+
+    xlings::xvm::Workspace workspace{
+        {"cc", "repo-a:2.0.0"},
+    };
+    xlings::xvm::WorkspaceInstalled installed{
+        {
+            "cc",
+            {
+                "legacy:0.9.0",
+                "repo-b:9.0.0",
+                "repo-a:1.0.0",
+                "repo-a:2.0.0",
+            },
+        },
+    };
+    const std::vector<xlings::xvm::RemovalOperation> operations{
+        {
+            .op = "remove_all",
+            .name = "cc",
+            .version = "",
+        },
+    };
+    const xlings::xvm::RemovalContext context{
+        .provider = "repo-a:provider",
+    };
+
+    auto result = xlings::xvm::apply_removal_batch(
+        db, workspace, installed, operations, context);
+
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    ASSERT_EQ(result->removed.size(), 2u);
+    EXPECT_EQ(result->removed[0].target, "cc");
+    EXPECT_EQ(result->removed[0].version, "repo-a:1.0.0");
+    EXPECT_EQ(result->removed[1].target, "cc");
+    EXPECT_EQ(result->removed[1].version, "repo-a:2.0.0");
+
+    ASSERT_TRUE(db.contains("cc"));
+    EXPECT_EQ(db.at("cc").versions.size(), 2u);
+    EXPECT_TRUE(db.at("cc").versions.contains("repo-b:9.0.0"));
+    EXPECT_TRUE(db.at("cc").versions.contains("legacy:0.9.0"));
+    EXPECT_EQ(workspace.at("cc"), "repo-b:9.0.0");
+    EXPECT_EQ(
+        installed.at("cc"),
+        (std::vector<std::string>{
+            "legacy:0.9.0",
+            "repo-b:9.0.0",
+        }));
+}
+
+TEST(XvmRemovalBatchTest, RemoveAllRejectsMissingProviderContext) {
+    xlings::xvm::VersionDB db;
+    auto& data = db["cc"].versions["repo-a:1.0.0"];
+    data.path = "/pkg/a/1";
+    data.kind = "program";
+    data.bindingGroup = make_binding_group_ref(
+        "repo-a:provider", "1.0.0", "cc-a",
+        "root-a", "repo-a:1.0.0");
+    xlings::xvm::Workspace workspace{
+        {"cc", "repo-a:1.0.0"},
+    };
+    xlings::xvm::WorkspaceInstalled installed{
+        {"cc", {"repo-a:1.0.0"}},
+    };
+    const auto dbBefore = xlings::xvm::versions_to_json(db);
+    const auto workspaceBefore = workspace;
+    const auto installedBefore = installed;
+    const std::vector<xlings::xvm::RemovalOperation> operations{
+        {
+            .op = "remove_all",
+            .name = "cc",
+            .version = "",
+        },
+    };
+
+    auto result = xlings::xvm::apply_removal_batch(
+        db, workspace, installed, operations, {});
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(
+        result.error().kind,
+        xlings::xvm::RemovalErrorKind::ProviderRequired);
+    EXPECT_EQ(result.error().target, "cc");
+    EXPECT_TRUE(result.error().version.empty());
+    EXPECT_EQ(xlings::xvm::versions_to_json(db), dbBefore);
+    EXPECT_EQ(workspace, workspaceBefore);
+    EXPECT_EQ(installed, installedBefore);
+}
+
+TEST(XvmRemovalBatchTest, RemoveAllRejectsNoOwnedMatchingVersion) {
+    xlings::xvm::VersionDB db;
+    auto& providerB = db["cc"].versions["repo-b:9.0.0"];
+    providerB.path = "/pkg/b/9";
+    providerB.kind = "program";
+    providerB.bindingGroup = make_binding_group_ref(
+        "repo-b:provider", "9.0.0", "cc-b",
+        "root-b", "repo-b:9.0.0");
+    db["cc"].versions["legacy:0.9.0"].path = "/pkg/legacy";
+    xlings::xvm::Workspace workspace{
+        {"cc", "repo-b:9.0.0"},
+    };
+    xlings::xvm::WorkspaceInstalled installed{
+        {"cc", {"legacy:0.9.0", "repo-b:9.0.0"}},
+    };
+    const auto dbBefore = xlings::xvm::versions_to_json(db);
+    const auto workspaceBefore = workspace;
+    const auto installedBefore = installed;
+    const std::vector<xlings::xvm::RemovalOperation> operations{
+        {
+            .op = "remove_all",
+            .name = "cc",
+            .version = "",
+        },
+    };
+    const xlings::xvm::RemovalContext context{
+        .provider = "repo-a:provider",
+    };
+
+    auto result = xlings::xvm::apply_removal_batch(
+        db, workspace, installed, operations, context);
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(
+        result.error().kind,
+        xlings::xvm::RemovalErrorKind::ProviderVersionNotFound);
+    EXPECT_EQ(result.error().target, "cc");
+    EXPECT_TRUE(result.error().version.empty());
+    EXPECT_EQ(xlings::xvm::versions_to_json(db), dbBefore);
+    EXPECT_EQ(workspace, workspaceBefore);
+    EXPECT_EQ(installed, installedBefore);
+}
+
+TEST(XvmRemovalBatchTest,
+     ProviderSnapshotRejectsRecipeVersionOutsideOwnedSelection) {
+    xlings::xvm::VersionDB db;
+    const auto groupA = make_binding_group_ref(
+        "repo-a:provider", "1.0.0", "group-a",
+        "root-a", "repo-a:1.0.0");
+    auto& rootA = add_provider_group_member(
+        db, "root-a", "repo-a:1.0.0", groupA, "group");
+    rootA.bindingMembers = {
+        {"cc", "repo-a:1.0.0"},
+        {"root-a", "repo-a:1.0.0"},
+    };
+    add_provider_group_member(
+        db, "cc", "repo-a:1.0.0", groupA,
+        "program", "cc-a", "cc");
+
+    const auto groupB = make_binding_group_ref(
+        "repo-b:provider", "2.0.0", "group-b",
+        "root-b", "repo-b:2.0.0");
+    auto& rootB = add_provider_group_member(
+        db, "root-b", "repo-b:2.0.0", groupB, "group");
+    rootB.bindingMembers = {
+        {"cc", "repo-b:2.0.0"},
+        {"root-b", "repo-b:2.0.0"},
+    };
+    add_provider_group_member(
+        db, "cc", "repo-b:2.0.0", groupB,
+        "program", "cc-b", "cc");
+
+    xlings::xvm::Workspace workspace{
+        {"cc", "repo-a:1.0.0"},
+    };
+    xlings::xvm::WorkspaceInstalled installed{
+        {"cc", {"repo-a:1.0.0", "repo-b:2.0.0"}},
+    };
+    const auto dbBefore = xlings::xvm::versions_to_json(db);
+    const auto workspaceBefore = workspace;
+    const auto installedBefore = installed;
+    const std::vector<xlings::xvm::RemovalOperation> operations{
+        {
+            .op = "remove",
+            .name = "cc",
+            .version = "repo-b:2.0.0",
+        },
+    };
+    auto context = xlings::xvm::snapshot_removal_context(
+        db, "root-a", "repo-a:1.0.0");
+    ASSERT_TRUE(context.has_value()) << context.error().message;
+    EXPECT_EQ(context->provider, "repo-a:provider");
+
+    auto result = xlings::xvm::apply_removal_batch(
+        db, workspace, installed, operations, *context);
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(
+        result.error().kind,
+        xlings::xvm::RemovalErrorKind::VersionMismatch);
+    EXPECT_EQ(result.error().target, "cc");
+    EXPECT_EQ(result.error().version, "repo-b:2.0.0");
+    EXPECT_EQ(xlings::xvm::versions_to_json(db), dbBefore);
+    EXPECT_EQ(workspace, workspaceBefore);
+    EXPECT_EQ(installed, installedBefore);
+}
+
+TEST(XvmRemovalBatchTest,
+     ProviderSnapshotIncludesEveryGroupOwnedByTheRelease) {
+    xlings::xvm::VersionDB db;
+    const auto compilerGroup = make_binding_group_ref(
+        "repo-a:toolchain", "1.0.0", "compiler",
+        "compiler-root", "repo-a:1.0.0");
+    auto& compilerRoot = add_provider_group_member(
+        db, "compiler-root", "repo-a:1.0.0",
+        compilerGroup, "group");
+    compilerRoot.bindingMembers = {
+        {"cc", "repo-a:1.0.0"},
+        {"compiler-root", "repo-a:1.0.0"},
+    };
+    add_provider_group_member(
+        db, "cc", "repo-a:1.0.0",
+        compilerGroup, "program", "cc-a", "cc");
+
+    const auto toolsGroup = make_binding_group_ref(
+        "repo-a:toolchain", "1.0.0", "tools",
+        "tools-root", "repo-a:tools-1.0.0");
+    auto& toolsRoot = add_provider_group_member(
+        db, "tools-root", "repo-a:tools-1.0.0",
+        toolsGroup, "group");
+    toolsRoot.bindingMembers = {
+        {"ar", "repo-a:tools-1.0.0"},
+        {"tools-root", "repo-a:tools-1.0.0"},
+    };
+    add_provider_group_member(
+        db, "ar", "repo-a:tools-1.0.0",
+        toolsGroup, "program", "ar-a", "ar");
+
+    auto context = xlings::xvm::snapshot_removal_context(
+        db, "cc", "repo-a:1.0.0");
+
+    ASSERT_TRUE(context.has_value()) << context.error().message;
+    EXPECT_EQ(context->provider, "repo-a:toolchain");
+    EXPECT_EQ(
+        context->members,
+        (std::map<std::string, std::string>{
+            {"ar", "repo-a:tools-1.0.0"},
+            {"cc", "repo-a:1.0.0"},
+            {"compiler-root", "repo-a:1.0.0"},
+            {"tools-root", "repo-a:tools-1.0.0"},
+        }));
+}
+
+TEST(XimXvmRemovalAdapterTest,
+     PreSnapshotsUninstallSelectionForLaterVersionlessHookOps) {
+    xlings::xvm::VersionDB db;
+    xlings::xvm::add_version(
+        db, "toolchain", "15.1.0", "/pkg/toolchain",
+        "program", "", "", "repo-a");
+    xlings::xvm::add_version(
+        db, "cc", "gcc-15.1.0", "/pkg/toolchain",
+        "program", "cc-15", "cc", "repo-a",
+        "toolchain@15.1.0");
+    xlings::xvm::Workspace workspace{
+        {"toolchain", "repo-a:15.1.0"},
+        {"cc", "repo-a:gcc-15.1.0"},
+    };
+    xlings::xvm::WorkspaceInstalled installed{
+        {"toolchain", {"repo-a:15.1.0"}},
+        {"cc", {"repo-a:gcc-15.1.0"}},
+    };
+
+    auto context = xlings::xim::snapshot_xpkg_removal_context(
+        db, workspace, {}, "repo-a:toolchain", "15.1.0",
+        "toolchain", "repo-a:15.1.0");
+    ASSERT_TRUE(context.has_value()) << context.error().message;
+    const std::vector<mcpplibs::xpkg::XvmOp> hookOperations{
+        {
+            .op = "remove",
+            .name = "cc",
+        },
+    };
+
+    auto result = xlings::xim::apply_xpkg_removal_operations(
+        db, workspace, installed, hookOperations, *context);
+
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    ASSERT_EQ(result->removed.size(), 2u);
+    EXPECT_EQ(result->removed[0].target, "cc");
+    EXPECT_EQ(result->removed[0].version, "repo-a:gcc-15.1.0");
+    EXPECT_EQ(result->removed[1].target, "toolchain");
+    EXPECT_EQ(result->removed[1].version, "repo-a:15.1.0");
+    EXPECT_FALSE(db.contains("toolchain"));
+    EXPECT_FALSE(db.contains("cc"));
+}
+
+TEST(XimXvmRemovalAdapterTest,
+     PreSnapshotsConfigSelectionFromActiveRemovalTarget) {
+    xlings::xvm::VersionDB db;
+    xlings::xvm::add_version(
+        db, "toolchain", "15.1.0", "/pkg/toolchain",
+        "program", "", "", "repo-a");
+    xlings::xvm::add_version(
+        db, "cc", "gcc-15.1.0", "/pkg/toolchain",
+        "program", "cc-15", "cc", "repo-a",
+        "toolchain@15.1.0");
+    xlings::xvm::Workspace workspace{
+        {"cc", "repo-a:gcc-15.1.0"},
+    };
+    xlings::xvm::WorkspaceInstalled installed{
+        {"cc", {"repo-a:gcc-15.1.0"}},
+    };
+    const std::vector<mcpplibs::xpkg::XvmOp> operations{
+        {
+            .op = "remove",
+            .name = "cc",
+        },
+    };
+
+    auto context = xlings::xim::snapshot_xpkg_removal_context(
+        db, workspace, operations, "repo-a:toolchain", "15.1.0");
+    ASSERT_TRUE(context.has_value()) << context.error().message;
+    auto result = xlings::xim::apply_xpkg_removal_operations(
+        db, workspace, installed, operations, *context);
+
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    ASSERT_EQ(result->removed.size(), 2u);
+    EXPECT_EQ(result->removed[0].target, "cc");
+    EXPECT_EQ(result->removed[0].version, "repo-a:gcc-15.1.0");
+    EXPECT_EQ(result->removed[1].target, "toolchain");
+    EXPECT_EQ(result->removed[1].version, "repo-a:15.1.0");
+    EXPECT_FALSE(db.contains("toolchain"));
+    EXPECT_FALSE(db.contains("cc"));
+    EXPECT_TRUE(workspace.empty());
+    EXPECT_TRUE(installed.empty());
+
+    xlings::xvm::VersionDB singletonDb;
+    singletonDb["base"].versions["repo-a:1.0.0"].kind = "subos-base";
+    xlings::xvm::Workspace singletonWorkspace{
+        {"base", "repo-a:1.0.0"},
+    };
+    const std::vector<mcpplibs::xpkg::XvmOp> singletonOperations{
+        {
+            .op = "remove",
+            .name = "base",
+        },
+    };
+    auto singletonContext = xlings::xim::snapshot_xpkg_removal_context(
+        singletonDb, singletonWorkspace, singletonOperations,
+        "repo-a:base", "1.0.0");
+
+    ASSERT_TRUE(singletonContext.has_value())
+        << singletonContext.error().message;
+    EXPECT_EQ(
+        singletonContext->members.at("base"),
+        "repo-a:1.0.0");
+}
+
+TEST(XimXvmRemovalAdapterTest, TransportsRemoveAllAsDistinctOperation) {
+    xlings::xvm::VersionDB db;
+    auto& providerA = db["cc"].versions["repo-a:1.0.0"];
+    providerA.path = "/pkg/a";
+    providerA.kind = "program";
+    providerA.bindingGroup = make_binding_group_ref(
+        "repo-a:provider", "1.0.0", "group-a",
+        "root-a", "repo-a:1.0.0");
+    auto& providerB = db["cc"].versions["repo-b:2.0.0"];
+    providerB.path = "/pkg/b";
+    providerB.kind = "program";
+    providerB.bindingGroup = make_binding_group_ref(
+        "repo-b:provider", "2.0.0", "group-b",
+        "root-b", "repo-b:2.0.0");
+    xlings::xvm::Workspace workspace{
+        {"cc", "repo-a:1.0.0"},
+    };
+    xlings::xvm::WorkspaceInstalled installed{
+        {"cc", {"repo-b:2.0.0", "repo-a:1.0.0"}},
+    };
+    const std::vector<mcpplibs::xpkg::XvmOp> operations{
+        {
+            .op = "remove_all",
+            .name = "cc",
+        },
+    };
+    const xlings::xvm::RemovalContext context{
+        .provider = "repo-a:provider",
+    };
+
+    auto result = xlings::xim::apply_xpkg_removal_operations(
+        db, workspace, installed, operations, context);
+
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    ASSERT_EQ(result->removed.size(), 1u);
+    EXPECT_EQ(result->removed[0].target, "cc");
+    EXPECT_EQ(result->removed[0].version, "repo-a:1.0.0");
+    ASSERT_TRUE(db.contains("cc"));
+    EXPECT_EQ(db.at("cc").versions.size(), 1u);
+    EXPECT_TRUE(db.at("cc").versions.contains("repo-b:2.0.0"));
+    EXPECT_EQ(workspace.at("cc"), "repo-b:2.0.0");
 }
 
 TEST(XvmDbTest, AddVersionWithBindingNamespaced) {

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -4005,6 +4005,215 @@ TEST(XvmRegistrationErrorTest, RejectsInvalidBatchNodeAndBindingIdentity) {
     }
 }
 
+TEST(XvmRegistrationErrorTest,
+     RejectsInvalidNodePayloadAtIndexedPathWithoutMutation) {
+    struct Case {
+        xlings::xvm::RegistrationNode node;
+        std::string path;
+    };
+
+    auto unsupported =
+        make_registration_node("archive", "repo:archive", "archive");
+    auto emptyProgramSource =
+        make_registration_node("program", "repo:program", "program");
+    emptyProgramSource.sourceName.clear();
+    auto emptyProgramDestination =
+        make_registration_node("program", "repo:program", "program");
+    emptyProgramDestination.destinationName.clear();
+    auto emptyLibrarySource =
+        make_registration_node("library", "repo:library", "lib");
+    emptyLibrarySource.sourceName.clear();
+    auto emptyLibraryDestination =
+        make_registration_node("library", "repo:library", "lib");
+    emptyLibraryDestination.destinationName.clear();
+
+    const std::vector<Case> cases{
+        {
+            std::move(unsupported),
+            "/nodes/0/kind",
+        },
+        {
+            std::move(emptyProgramSource),
+            "/nodes/0/sourceName",
+        },
+        {
+            std::move(emptyProgramDestination),
+            "/nodes/0/destinationName",
+        },
+        {
+            std::move(emptyLibrarySource),
+            "/nodes/0/sourceName",
+        },
+        {
+            std::move(emptyLibraryDestination),
+            "/nodes/0/destinationName",
+        },
+    };
+
+    for (const auto& testCase : cases) {
+        SCOPED_TRACE(testCase.path);
+        xlings::xvm::VersionDB db;
+        db["sentinel"].versions["0"].path = "/sentinel";
+        xlings::xvm::Workspace workspace{{"sentinel", "0"}};
+        xlings::xvm::WorkspaceInstalled installed{{"sentinel", {"0"}}};
+        const auto dbBefore = xlings::xvm::versions_to_json(db);
+        const auto workspaceBefore = workspace;
+        const auto installedBefore = installed;
+
+        auto result = xlings::xvm::apply_registration_batch(
+            db, workspace, installed,
+            make_registration_batch({testCase.node}));
+
+        expect_registration_error(
+            result,
+            xlings::xvm::RegistrationErrorKind::InvalidNodePayload,
+            testCase.path, testCase.node.target, testCase.node.version);
+        expect_registration_state_unchanged(
+            db, workspace, installed,
+            dbBefore, workspaceBefore, installedBefore);
+    }
+}
+
+TEST(XvmRegistrationOwnershipTest,
+     RejectsPersistedGroupLabelWithDifferentRootWithoutMutation) {
+    xlings::xvm::VersionDB db;
+    const xlings::xvm::BindingGroupRef existingGroup{
+        .provider = "repo:provider",
+        .providerVersion = "1.0.0",
+        .group = "shared",
+        .rootTarget = "old-root",
+        .rootVersion = "repo:old-root",
+    };
+    auto& oldRoot = db["old-root"].versions["repo:old-root"];
+    oldRoot.path = "/pkg/provider/old";
+    oldRoot.kind = "group";
+    oldRoot.bindingGroup = existingGroup;
+    oldRoot.bindingMembers = {
+        {"old-root", "repo:old-root"},
+    };
+    oldRoot.bindingMembersDeclared = true;
+
+    auto newRoot =
+        make_registration_node("new-root", "repo:new-root", "group");
+    auto newTool =
+        make_registration_node("new-tool", "repo:new-tool");
+    newTool.binding = make_registration_binding(
+        "new-root", "repo:new-root", "shared");
+    xlings::xvm::Workspace workspace{{"sentinel", "0"}};
+    xlings::xvm::WorkspaceInstalled installed{{"sentinel", {"0"}}};
+    const auto dbBefore = xlings::xvm::versions_to_json(db);
+    const auto workspaceBefore = workspace;
+    const auto installedBefore = installed;
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed,
+        make_registration_batch({newRoot, newTool}));
+
+    expect_registration_error(
+        result, xlings::xvm::RegistrationErrorKind::GroupConflict,
+        "/nodes/1/binding/group", "new-tool", "repo:new-tool");
+    expect_registration_state_unchanged(
+        db, workspace, installed,
+        dbBefore, workspaceBefore, installedBefore);
+}
+
+TEST(XvmRegistrationOwnershipTest,
+     RejectsPersistedGroupLabelWithDuplicateRootsWithoutMutation) {
+    xlings::xvm::VersionDB db;
+    const xlings::xvm::BindingGroupRef oldGroup{
+        .provider = "repo:provider",
+        .providerVersion = "1.0.0",
+        .group = "shared",
+        .rootTarget = "old-root",
+        .rootVersion = "repo:old-root",
+    };
+    auto& oldRoot = db["old-root"].versions["repo:old-root"];
+    oldRoot.path = "/pkg/provider/old";
+    oldRoot.kind = "group";
+    oldRoot.bindingGroup = oldGroup;
+    oldRoot.bindingMembers = {
+        {"old-root", "repo:old-root"},
+    };
+    oldRoot.bindingMembersDeclared = true;
+
+    const xlings::xvm::BindingGroupRef otherGroup{
+        .provider = "repo:provider",
+        .providerVersion = "1.0.0",
+        .group = "shared",
+        .rootTarget = "other-root",
+        .rootVersion = "repo:other-root",
+    };
+    auto& otherRoot = db["other-root"].versions["repo:other-root"];
+    otherRoot.path = "/pkg/provider/other";
+    otherRoot.kind = "group";
+    otherRoot.bindingGroup = otherGroup;
+    otherRoot.bindingMembers = {
+        {"other-root", "repo:other-root"},
+    };
+    otherRoot.bindingMembersDeclared = true;
+
+    xlings::xvm::Workspace workspace{{"sentinel", "0"}};
+    xlings::xvm::WorkspaceInstalled installed{{"sentinel", {"0"}}};
+    const auto dbBefore = xlings::xvm::versions_to_json(db);
+    const auto workspaceBefore = workspace;
+    const auto installedBefore = installed;
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed,
+        make_registration_batch({
+            make_registration_node("fresh", "repo:fresh"),
+        }));
+
+    expect_registration_error(
+        result, xlings::xvm::RegistrationErrorKind::GroupConflict,
+        "/bindingGroups/shared", "other-root", "repo:other-root");
+    expect_registration_state_unchanged(
+        db, workspace, installed,
+        dbBefore, workspaceBefore, installedBefore);
+}
+
+TEST(XvmRegistrationOwnershipTest,
+     MissingPersistedRootStillRequiresEveryOwnedMemberWithoutMutation) {
+    xlings::xvm::VersionDB db;
+    const xlings::xvm::BindingGroupRef existingGroup{
+        .provider = "repo:provider",
+        .providerVersion = "1.0.0",
+        .group = "shared",
+        .rootTarget = "root",
+        .rootVersion = "repo:root",
+    };
+    auto& oldMember = db["old-member"].versions["repo:old-member"];
+    oldMember.path = "/pkg/provider/old";
+    oldMember.kind = "program";
+    oldMember.sourceName = "old-member";
+    oldMember.destinationName = "old-member";
+    oldMember.bindingGroup = existingGroup;
+
+    auto root = make_registration_node("root", "repo:root", "group");
+    auto newMember =
+        make_registration_node("new-member", "repo:new-member");
+    newMember.binding =
+        make_registration_binding("root", "repo:root", "shared");
+    xlings::xvm::Workspace workspace{{"sentinel", "0"}};
+    xlings::xvm::WorkspaceInstalled installed{{"sentinel", {"0"}}};
+    const auto dbBefore = xlings::xvm::versions_to_json(db);
+    const auto workspaceBefore = workspace;
+    const auto installedBefore = installed;
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed,
+        make_registration_batch({root, newMember}));
+
+    expect_registration_error(
+        result,
+        xlings::xvm::RegistrationErrorKind::IncompleteOwnedGroup,
+        "/nodes/1/binding/group",
+        "old-member", "repo:old-member");
+    expect_registration_state_unchanged(
+        db, workspace, installed,
+        dbBefore, workspaceBefore, installedBefore);
+}
+
 TEST(XvmRegistrationOwnershipTest,
      RejectsOtherProviderExactCollisionWithoutMutation) {
     xlings::xvm::VersionDB db;
@@ -4190,6 +4399,33 @@ TEST(XvmRegistrationOwnershipTest, AdoptsCompatibleCompleteLegacyGroup) {
 }
 
 TEST(XvmRegistrationOwnershipTest,
+     AdoptsOwnerlessLegacyGroupWithNormalizedVirtualPayload) {
+    xlings::xvm::VersionDB db;
+    auto& info = db["virtual"];
+    info.type = "group";
+    auto& legacy = info.versions["repo:virtual"];
+    legacy.path = "/pkg/provider/1.0.0";
+    legacy.kind = "group";
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+    auto group =
+        make_registration_node("virtual", "repo:virtual", "group");
+    group.sourceName = "ignored-payload";
+    group.destinationName = "ignored-shim";
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed,
+        make_registration_batch({group}));
+
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    const auto& adopted = db.at("virtual").versions.at("repo:virtual");
+    EXPECT_TRUE(adopted.sourceName.empty());
+    EXPECT_TRUE(adopted.destinationName.empty());
+    ASSERT_TRUE(adopted.bindingGroup.has_value());
+    EXPECT_EQ(adopted.bindingGroup->group, "virtual");
+}
+
+TEST(XvmRegistrationOwnershipTest,
      RejectsIncompatibleLegacyPayloadWithoutMutation) {
     xlings::xvm::VersionDB db;
     seed_complete_legacy_registration_group(db);
@@ -4234,6 +4470,42 @@ TEST(XvmRegistrationOwnershipTest,
     EXPECT_EQ(xlings::xvm::versions_to_json(db), dbBefore);
     EXPECT_TRUE(workspace.empty());
     EXPECT_TRUE(installed.empty());
+}
+
+TEST(XvmRegistrationOwnershipTest,
+     RejectsIncomingOnlyLegacyEdgeWithoutMutation) {
+    xlings::xvm::VersionDB db;
+    auto& toolInfo = db["tool"];
+    toolInfo.type = "program";
+    toolInfo.filename = "payload";
+    auto& tool = toolInfo.versions["repo:tool"];
+    tool.path = "/pkg/provider/1.0.0";
+
+    auto& peerInfo = db["peer"];
+    peerInfo.type = "program";
+    peerInfo.filename = "peer";
+    peerInfo.versions["repo:peer"].path = "/pkg/peer";
+    peerInfo.bindings["tool"]["repo:peer"] = "repo:tool";
+
+    xlings::xvm::Workspace workspace{{"sentinel", "0"}};
+    xlings::xvm::WorkspaceInstalled installed{{"sentinel", {"0"}}};
+    const auto dbBefore = xlings::xvm::versions_to_json(db);
+    const auto workspaceBefore = workspace;
+    const auto installedBefore = installed;
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed,
+        make_registration_batch({
+            make_registration_node("tool", "repo:tool"),
+        }));
+
+    expect_registration_error(
+        result,
+        xlings::xvm::RegistrationErrorKind::BindingValidationFailed,
+        "/nodes/0", "peer", "repo:peer");
+    expect_registration_state_unchanged(
+        db, workspace, installed,
+        dbBefore, workspaceBefore, installedBefore);
 }
 
 TEST(XvmRegistrationOwnershipTest,
@@ -4762,7 +5034,7 @@ TEST(XvmRegistrationStateTest,
 }
 
 TEST(XvmRegistrationStateTest,
-     FinalComponentValidationFailurePreservesEveryStateObject) {
+     InvalidPayloadInFinalNodePreservesEveryStateObject) {
     xlings::xvm::VersionDB db;
     db["sentinel"].versions["0"].path = "/sentinel";
     xlings::xvm::Workspace workspace{{"sentinel", "0"}};
@@ -4781,8 +5053,8 @@ TEST(XvmRegistrationStateTest,
 
     expect_registration_error(
         result,
-        xlings::xvm::RegistrationErrorKind::BindingValidationFailed,
-        "", "z-invalid", "repo:invalid");
+        xlings::xvm::RegistrationErrorKind::InvalidNodePayload,
+        "/nodes/1/kind", "z-invalid", "repo:invalid");
     expect_registration_state_unchanged(
         db, workspace, installed,
         dbBefore, workspaceBefore, installedBefore);
@@ -5558,6 +5830,56 @@ TEST(XvmBindingSelectionErrorTest, LegacyRejectsAsymmetricEdge) {
 
     expect_binding_error(
         result, xlings::xvm::BindingErrorKind::AsymmetricEdge, "b", "1");
+}
+
+TEST(XvmBindingSelectionErrorTest,
+     LegacyRejectsIncomingOnlyEdgeFromStartingNode) {
+    xlings::xvm::VersionDB db;
+    db["tool"].type = "program";
+    db["tool"].versions["1"].path = "/tool";
+    db["peer"].type = "program";
+    db["peer"].versions["1"].path = "/peer";
+    db["peer"].bindings["tool"]["1"] = "1";
+
+    auto result =
+        xlings::xvm::resolve_binding_selection(db, "tool", "1");
+
+    expect_binding_error(
+        result, xlings::xvm::BindingErrorKind::AsymmetricEdge, "peer", "1");
+}
+
+TEST(XvmBindingSelectionErrorTest,
+     LegacyIncomingEdgeRejectsMissingSourceVersion) {
+    xlings::xvm::VersionDB db;
+    db["tool"].type = "program";
+    db["tool"].versions["1"].path = "/tool";
+    db["peer"].type = "program";
+    db["peer"].versions["1"].path = "/peer";
+    db["peer"].bindings["tool"]["2"] = "1";
+
+    auto result =
+        xlings::xvm::resolve_binding_selection(db, "tool", "1");
+
+    expect_binding_error(
+        result, xlings::xvm::BindingErrorKind::VersionNotFound, "peer", "2");
+}
+
+TEST(XvmBindingSelectionErrorTest,
+     LegacyIncomingEdgeReportsMismatchedReciprocalSourceExactly) {
+    xlings::xvm::VersionDB db;
+    db["tool"].type = "program";
+    db["tool"].versions["1"].path = "/tool";
+    db["peer"].type = "program";
+    db["peer"].versions["1"].path = "/peer/1";
+    db["peer"].versions["2"].path = "/peer/2";
+    db["peer"].bindings["tool"]["1"] = "1";
+    db["tool"].bindings["peer"]["1"] = "2";
+
+    auto result =
+        xlings::xvm::resolve_binding_selection(db, "tool", "1");
+
+    expect_binding_error(
+        result, xlings::xvm::BindingErrorKind::AsymmetricEdge, "peer", "1");
 }
 
 TEST(XvmBindingSelectionErrorTest, LegacyRejectsSelfEdge) {


### PR DESCRIPTION
## Summary

This draft introduces the provider-scoped binding-group foundation required
for coherent multi-program toolchains such as GCC (`gcc`, `g++`, headers, and
libraries).

- model a binding group as one provider release with exact member versions
- resolve the same canonical group from its root or any bound member
- reject malformed, partial, mixed-provider, and cross-version group metadata
- translate xpkg effects into an immutable `RegistrationBatch`, validate the
  complete batch first, then apply it atomically
- support controlled binding-root migration without silently adopting
  unrelated existing state
- remove/uninstall members only through exact provider-owned version authority
- preserve complete registration state when validation fails instead of
  leaving partial mutations
- add detailed architecture and implementation-plan documents under
  `.agents/docs`

## Why

XVM previously treated each target independently. Package hooks could therefore
register or remove members one at a time, and active/version metadata did not
carry a canonical provider-group identity. For coupled toolchains this allows
mixed releases and incomplete state—for example, selecting one GCC member
without proving that `gcc`, `g++`, runtime libraries, and headers belong to the
same provider release.

This change establishes a fail-closed group identity:

```text
(provider, providerVersion, bindingGroup)
  -> exact root
  -> exact member target/version set
```

All member entry points resolve through that identity. Provider metadata is
validated before mutation, and legacy entries cannot borrow provider-owned
target metadata.

## Architecture

### Canonical selection

`src/core/xvm/bindings.cppm` centralizes group parsing, integrity checks,
canonical member/root resolution, and deterministic diagnostics. Complete
selections are provider-scoped and carry exact member versions.

### Strict state validation

XVM DB/config loading validates binding metadata both at JSON boundaries and
when constructing in-memory state. Invalid group shapes,
duplicate/conflicting members, partial provider metadata, and illegal root
migration fail closed.

### Two-phase registration

`src/core/xvm/registration.cppm` builds and validates an immutable registration
batch before applying any DB changes. The apply phase registers a complete
group in one operation and no longer exposes partially registered members when
a later effect fails.

### Exact removal authority

`src/core/xvm/removal.cppm` derives removal plans from exact provider-owned
selections. Uninstall paths cannot fall back to target-only or bare-version
deletion and cannot remove versions belonging to another provider.

## Validation

All valid build/test commands used isolated `HOME`, `XLINGS_HOME`, XDG
directories, temp directories, and a private `MCPP_HOME`; they did not
intentionally use the host xlings environment.

- focused binding/registration suite: **61/61 passed**
- broad XVM suite: **173/173 passed**
- latest-resolution regression suite: **3/3 passed**
- deterministic direct test binaries: **503 passed**, **17 optional fixture
  skips** across 11 binaries
- GCC 16.1 isolated no-cache build: passed (49.32 s)
- `git diff --check origin/main...HEAD`: passed

One known network-dependent package fixture was excluded from the deterministic
direct-binary loop; no passing claim is made for that external-network case.

## Draft boundary / follow-up

This PR currently contains the reviewed selection, validation, registration,
and exact-removal foundation. It does **not yet claim the final end-to-end
`xlings use gcc 15/16` switch behavior**. The locked filesystem
materialization transaction, version-scoped shim dispatch, self-switch safety,
diagnostics/E2E coverage, and version bump remain follow-up work before this
draft is ready to merge.

The branch deliberately excludes the current uncommitted switch-planner work
until it passes its own contract review and isolated verification.
