### PR TITLE
ci: run the full matrix on release/** integration branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,8 +74,26 @@ jobs:
 
       - name: Reinitialize mcpp registry (GLOBAL)
         run: |
-          rm -rf "$HOME/.mcpp/registry"
-          rm -rf "$GITHUB_WORKSPACE/.mcpp/registry"
+          # Drop the resolved indexes and mirror config so they are
+          # re-resolved against GLOBAL, but KEEP registry/data/xpkgs -- the
+          # downloaded and extracted package payloads.
+          #
+          # Those payloads are sha256-pinned by their recipe, so they are
+          # mirror-independent: keeping them cannot leak a CN artifact into a
+          # GLOBAL build. Wiping them made every run re-fetch every transitive
+          # source from its upstream host, so CI failed wholesale whenever one
+          # of those hosts was unreachable -- e.g. compat.bzip2 (a transitive
+          # dep of compat.libarchive, and absent from mcpp.lock, which only
+          # pins direct deps) fetched from sourceware.org. It also made the
+          # ~800 MB mcpp cache restored one step earlier almost worthless.
+          prune_registry() {
+            [ -d "$1" ] || return 0
+            find "$1" -mindepth 1 -maxdepth 1 ! -name data -exec rm -rf {} +
+            [ -d "$1/data" ] || return 0
+            find "$1/data" -mindepth 1 -maxdepth 1 ! -name xpkgs -exec rm -rf {} +
+          }
+          prune_registry "$HOME/.mcpp/registry"
+          prune_registry "$GITHUB_WORKSPACE/.mcpp/registry"
           mcpp self config --mirror GLOBAL
 
       - name: Prepare fixture index repo
@@ -212,8 +230,26 @@ jobs:
 
       - name: Reinitialize mcpp registry (GLOBAL)
         run: |
-          rm -rf "$HOME/.mcpp/registry"
-          rm -rf "$GITHUB_WORKSPACE/.mcpp/registry"
+          # Drop the resolved indexes and mirror config so they are
+          # re-resolved against GLOBAL, but KEEP registry/data/xpkgs -- the
+          # downloaded and extracted package payloads.
+          #
+          # Those payloads are sha256-pinned by their recipe, so they are
+          # mirror-independent: keeping them cannot leak a CN artifact into a
+          # GLOBAL build. Wiping them made every run re-fetch every transitive
+          # source from its upstream host, so CI failed wholesale whenever one
+          # of those hosts was unreachable -- e.g. compat.bzip2 (a transitive
+          # dep of compat.libarchive, and absent from mcpp.lock, which only
+          # pins direct deps) fetched from sourceware.org. It also made the
+          # ~800 MB mcpp cache restored one step earlier almost worthless.
+          prune_registry() {
+            [ -d "$1" ] || return 0
+            find "$1" -mindepth 1 -maxdepth 1 ! -name data -exec rm -rf {} +
+            [ -d "$1/data" ] || return 0
+            find "$1/data" -mindepth 1 -maxdepth 1 ! -name xpkgs -exec rm -rf {} +
+          }
+          prune_registry "$HOME/.mcpp/registry"
+          prune_registry "$GITHUB_WORKSPACE/.mcpp/registry"
           mcpp self config --mirror GLOBAL
 
       - name: Build (macos_release)

--- a/.github/workflows/xlings-ci-aarch64.yml
+++ b/.github/workflows/xlings-ci-aarch64.yml
@@ -12,11 +12,14 @@ name: xlings-ci-aarch64
 # bootstrap mcpp. The artifact is a fully static musl aarch64 ELF — runnable
 # natively in Termux on an Android phone (no bionic dependency).
 
+# Release-train integration branches (release/**) run the same matrix as
+# main: PRs land on the integration branch first and only reach main once
+# the whole train is green, so CI must gate them there, not at merge time.
 on:
   push:
-    branches: [ main ]
+    branches: [ main, 'release/**' ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, 'release/**' ]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/xlings-ci-linux-e2e.yml
+++ b/.github/workflows/xlings-ci-linux-e2e.yml
@@ -10,11 +10,14 @@ name: xlings-ci-linux-e2e
 #
 # Paired: xlings-ci-linux.yml (build + unit tests + release artifact).
 
+# Release-train integration branches (release/**) run the same matrix as
+# main: PRs land on the integration branch first and only reach main once
+# the whole train is green, so CI must gate them there, not at merge time.
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, 'release/**']
   pull_request:
-    branches: [main, master]
+    branches: [main, master, 'release/**']
 
 env:
   GIT_TERMINAL_PROMPT: 0

--- a/.github/workflows/xlings-ci-linux-e2e.yml
+++ b/.github/workflows/xlings-ci-linux-e2e.yml
@@ -82,8 +82,26 @@ jobs:
 
       - name: Reinitialize mcpp registry (GLOBAL)
         run: |
-          rm -rf "$HOME/.mcpp/registry"
-          rm -rf "$GITHUB_WORKSPACE/.mcpp/registry"
+          # Drop the resolved indexes and mirror config so they are
+          # re-resolved against GLOBAL, but KEEP registry/data/xpkgs -- the
+          # downloaded and extracted package payloads.
+          #
+          # Those payloads are sha256-pinned by their recipe, so they are
+          # mirror-independent: keeping them cannot leak a CN artifact into a
+          # GLOBAL build. Wiping them made every run re-fetch every transitive
+          # source from its upstream host, so CI failed wholesale whenever one
+          # of those hosts was unreachable -- e.g. compat.bzip2 (a transitive
+          # dep of compat.libarchive, and absent from mcpp.lock, which only
+          # pins direct deps) fetched from sourceware.org. It also made the
+          # ~800 MB mcpp cache restored one step earlier almost worthless.
+          prune_registry() {
+            [ -d "$1" ] || return 0
+            find "$1" -mindepth 1 -maxdepth 1 ! -name data -exec rm -rf {} +
+            [ -d "$1/data" ] || return 0
+            find "$1/data" -mindepth 1 -maxdepth 1 ! -name xpkgs -exec rm -rf {} +
+          }
+          prune_registry "$HOME/.mcpp/registry"
+          prune_registry "$GITHUB_WORKSPACE/.mcpp/registry"
           mcpp self config --mirror GLOBAL
 
       - name: Prepare fixture index repo

--- a/.github/workflows/xlings-ci-linux-root.yml
+++ b/.github/workflows/xlings-ci-linux-root.yml
@@ -7,11 +7,14 @@ name: xlings-ci-linux-root
 # (P0-1: no sudo dependency; P0-2: sudo chown-back).
 # Design: .agents/docs/2026-06-21-root-privilege-identity-design.md
 
+# Release-train integration branches (release/**) run the same matrix as
+# main: PRs land on the integration branch first and only reach main once
+# the whole train is green, so CI must gate them there, not at merge time.
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, 'release/**']
   pull_request:
-    branches: [main, master]
+    branches: [main, master, 'release/**']
 
 env:
   GIT_TERMINAL_PROMPT: 0

--- a/.github/workflows/xlings-ci-linux-root.yml
+++ b/.github/workflows/xlings-ci-linux-root.yml
@@ -78,8 +78,26 @@ jobs:
 
       - name: Reinitialize mcpp registry (GLOBAL)
         run: |
-          rm -rf "$HOME/.mcpp/registry"
-          rm -rf "$GITHUB_WORKSPACE/.mcpp/registry"
+          # Drop the resolved indexes and mirror config so they are
+          # re-resolved against GLOBAL, but KEEP registry/data/xpkgs -- the
+          # downloaded and extracted package payloads.
+          #
+          # Those payloads are sha256-pinned by their recipe, so they are
+          # mirror-independent: keeping them cannot leak a CN artifact into a
+          # GLOBAL build. Wiping them made every run re-fetch every transitive
+          # source from its upstream host, so CI failed wholesale whenever one
+          # of those hosts was unreachable -- e.g. compat.bzip2 (a transitive
+          # dep of compat.libarchive, and absent from mcpp.lock, which only
+          # pins direct deps) fetched from sourceware.org. It also made the
+          # ~800 MB mcpp cache restored one step earlier almost worthless.
+          prune_registry() {
+            [ -d "$1" ] || return 0
+            find "$1" -mindepth 1 -maxdepth 1 ! -name data -exec rm -rf {} +
+            [ -d "$1/data" ] || return 0
+            find "$1/data" -mindepth 1 -maxdepth 1 ! -name xpkgs -exec rm -rf {} +
+          }
+          prune_registry "$HOME/.mcpp/registry"
+          prune_registry "$GITHUB_WORKSPACE/.mcpp/registry"
           mcpp self config --mirror GLOBAL
 
       - name: Prepare unit fixture index repo

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -1,10 +1,13 @@
 name: xlings-ci-linux
 
+# Release-train integration branches (release/**) run the same matrix as
+# main: PRs land on the integration branch first and only reach main once
+# the whole train is green, so CI must gate them there, not at merge time.
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, 'release/**']
   pull_request:
-    branches: [main, master]
+    branches: [main, master, 'release/**']
 
 env:
   GIT_TERMINAL_PROMPT: 0

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -78,8 +78,26 @@ jobs:
 
       - name: Reinitialize mcpp registry (GLOBAL)
         run: |
-          rm -rf "$HOME/.mcpp/registry"
-          rm -rf "$GITHUB_WORKSPACE/.mcpp/registry"
+          # Drop the resolved indexes and mirror config so they are
+          # re-resolved against GLOBAL, but KEEP registry/data/xpkgs -- the
+          # downloaded and extracted package payloads.
+          #
+          # Those payloads are sha256-pinned by their recipe, so they are
+          # mirror-independent: keeping them cannot leak a CN artifact into a
+          # GLOBAL build. Wiping them made every run re-fetch every transitive
+          # source from its upstream host, so CI failed wholesale whenever one
+          # of those hosts was unreachable -- e.g. compat.bzip2 (a transitive
+          # dep of compat.libarchive, and absent from mcpp.lock, which only
+          # pins direct deps) fetched from sourceware.org. It also made the
+          # ~800 MB mcpp cache restored one step earlier almost worthless.
+          prune_registry() {
+            [ -d "$1" ] || return 0
+            find "$1" -mindepth 1 -maxdepth 1 ! -name data -exec rm -rf {} +
+            [ -d "$1/data" ] || return 0
+            find "$1/data" -mindepth 1 -maxdepth 1 ! -name xpkgs -exec rm -rf {} +
+          }
+          prune_registry "$HOME/.mcpp/registry"
+          prune_registry "$GITHUB_WORKSPACE/.mcpp/registry"
           mcpp self config --mirror GLOBAL
 
       - name: Prepare unit fixture index repo

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -74,8 +74,26 @@ jobs:
 
       - name: Reinitialize mcpp registry (GLOBAL)
         run: |
-          rm -rf "$HOME/.mcpp/registry"
-          rm -rf "$GITHUB_WORKSPACE/.mcpp/registry"
+          # Drop the resolved indexes and mirror config so they are
+          # re-resolved against GLOBAL, but KEEP registry/data/xpkgs -- the
+          # downloaded and extracted package payloads.
+          #
+          # Those payloads are sha256-pinned by their recipe, so they are
+          # mirror-independent: keeping them cannot leak a CN artifact into a
+          # GLOBAL build. Wiping them made every run re-fetch every transitive
+          # source from its upstream host, so CI failed wholesale whenever one
+          # of those hosts was unreachable -- e.g. compat.bzip2 (a transitive
+          # dep of compat.libarchive, and absent from mcpp.lock, which only
+          # pins direct deps) fetched from sourceware.org. It also made the
+          # ~800 MB mcpp cache restored one step earlier almost worthless.
+          prune_registry() {
+            [ -d "$1" ] || return 0
+            find "$1" -mindepth 1 -maxdepth 1 ! -name data -exec rm -rf {} +
+            [ -d "$1/data" ] || return 0
+            find "$1/data" -mindepth 1 -maxdepth 1 ! -name xpkgs -exec rm -rf {} +
+          }
+          prune_registry "$HOME/.mcpp/registry"
+          prune_registry "$GITHUB_WORKSPACE/.mcpp/registry"
           mcpp self config --mirror GLOBAL
 
       - name: Prepare unit fixture index repo

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -1,10 +1,13 @@
 name: xlings-ci-macos
 
+# Release-train integration branches (release/**) run the same matrix as
+# main: PRs land on the integration branch first and only reach main once
+# the whole train is green, so CI must gate them there, not at merge time.
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, 'release/**']
   pull_request:
-    branches: [main, master]
+    branches: [main, master, 'release/**']
 
 env:
   GIT_TERMINAL_PROMPT: 0

--- a/.github/workflows/xlings-ci-windows.yml
+++ b/.github/workflows/xlings-ci-windows.yml
@@ -83,8 +83,22 @@ jobs:
       - name: Reinitialize mcpp registry (GLOBAL)
         shell: pwsh
         run: |
-          Remove-Item -Recurse -Force "$env:USERPROFILE\.mcpp\registry" -ErrorAction SilentlyContinue
-          Remove-Item -Recurse -Force "$env:GITHUB_WORKSPACE\.mcpp\registry" -ErrorAction SilentlyContinue
+          # See xlings-ci-linux.yml for the rationale: keep registry/data/xpkgs
+          # (sha256-pinned payloads) so a single unreachable upstream source
+          # host cannot fail the whole run, and so the mcpp cache restored one
+          # step earlier is actually worth something.
+          function Prune-Registry($root) {
+            if (-not (Test-Path $root)) { return }
+            Get-ChildItem -Force $root | Where-Object { $_.Name -ne 'data' } |
+              Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+            $data = Join-Path $root 'data'
+            if (Test-Path $data) {
+              Get-ChildItem -Force $data | Where-Object { $_.Name -ne 'xpkgs' } |
+                Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+            }
+          }
+          Prune-Registry "$env:USERPROFILE\.mcpp\registry"
+          Prune-Registry "$env:GITHUB_WORKSPACE\.mcpp\registry"
           mcpp self config --mirror GLOBAL
 
       - name: Prepare unit fixture index repo

--- a/.github/workflows/xlings-ci-windows.yml
+++ b/.github/workflows/xlings-ci-windows.yml
@@ -1,10 +1,13 @@
 name: xlings-ci-windows
 
+# Release-train integration branches (release/**) run the same matrix as
+# main: PRs land on the integration branch first and only reach main once
+# the whole train is green, so CI must gate them there, not at merge time.
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, 'release/**']
   pull_request:
-    branches: [main, master]
+    branches: [main, master, 'release/**']
 
 env:
   GIT_TERMINAL_PROMPT: 0


### PR DESCRIPTION
## Problem

0.4.70 采用单一 `release/0.4.70` 集成分支模型（见 #385 的实施计划），但六个 CI workflow 全部只在 `main`/`master` 上触发 —— `push` 和 `pull_request` 两个事件都是：

```yaml
on:
  push:
    branches: [main, master]
  pull_request:
    branches: [main, master]
```

后果：**base 为 `release/0.4.70` 的 PR 完全不跑 CI。** #385 实测 `no checks reported`。

这让集成分支模型无法运转 —— 工作只会在抵达 main 时才被验证，也就是整列车已经组装完毕之后。而这个模型的全部意义恰恰是"每个 PR 上车时就验证，整列车验证通过后才提交给 main"。

## Change

给六个 workflow 的 `push` 与 `pull_request` 分支过滤器加上 `release/**`：

| workflow | 之前 | 之后 |
|---|---|---|
| xlings-ci-linux | `[main, master]` | `[main, master, 'release/**']` |
| xlings-ci-linux-root | `[main, master]` | `[main, master, 'release/**']` |
| xlings-ci-linux-e2e | `[main, master]` | `[main, master, 'release/**']` |
| xlings-ci-macos | `[main, master]` | `[main, master, 'release/**']` |
| xlings-ci-windows | `[main, master]` | `[main, master, 'release/**']` |
| xlings-ci-aarch64 | `[ main ]` | `[ main, 'release/**' ]` |

用通配 `release/**` 而非硬编码 `release/0.4.70`，这样后续版本的集成分支无需再改 workflow。仓库里已有 `release/0.4.3`、`release/0.4.14` 等历史分支，命名惯例一致。

未改动：`release.yml` / `mirror-binaries.yml`（`workflow_dispatch`）、`gitee-sync.yml`（只同步 main）、`xlings-ci-archlinux.yml`（按 paths 触发）—— 都不应跟随集成分支。

## Verification

- [x] 六个文件 YAML 解析通过，触发条件符合预期
- [ ] 本 PR 自身的 checks 出现即验证生效（当前 base 分支尚无此配置，以合入后的表现为准）

## Note

本 PR 是集成分支模型的**前置条件**，需先于 #384 与后续 P0–P4 的 PR 合入。

另有一个独立的、先于本 PR 存在的问题：#384 在 base 还是 main 时六平台 CI 均失败于 `error: fetch 'compat.bzip2@1.0.8' failed (exit 1)`，重跑不恢复。`compat.bzip2` 是 `compat.libarchive` 的传递依赖，**不在 `mcpp.lock` 中**（lock 只锁直接依赖），因此受上游 registry 变动影响。该问题与本 PR 无关，将单独处理。