### PR TITLE
fix(xself): hook every PowerShell host, not just Windows PowerShell 5.1

### DIFF
--- a/.agents/docs/2026-07-28-shell-profile-hosts-design.md
+++ b/.agents/docs/2026-07-28-shell-profile-hosts-design.md
@@ -1,0 +1,141 @@
+# Shell profile hooks: one host was hardcoded, Windows has two
+
+Date: 2026-07-28
+Issue: [#387](https://github.com/openxlings/xlings/issues/387) ·
+Origin PR: [#388](https://github.com/openxlings/xlings/pull/388) (diagnosis by @ZheFeng7110)
+Code: `src/core/xself/shell_profile.cppm`, `src/core/xself/install.cppm`,
+`src/core/xself/uninstall.cppm`, `tests/unit/test_shell_profile.cpp`,
+`tests/e2e/release_self_install_test.ps1`
+
+## The report
+
+On Windows with PowerShell 7 installed, `xlings subos use <name>` came up in a
+shell where xlings was not configured: no prompt marker, no `XLINGS_BIN`, the
+subos's `bin/` not on `PATH`.
+
+## Why
+
+Windows has two PowerShell hosts and they read **different** startup files:
+
+| host         | product                | `$PROFILE`                                             |
+| ------------ | ---------------------- | ------------------------------------------------------ |
+| `powershell` | Windows PowerShell 5.1 | `Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1` |
+| `pwsh`       | PowerShell 7+          | `Documents\PowerShell\Microsoft.PowerShell_profile.ps1`        |
+
+`setup_shell_profiles()` hooked `powershell` only. `use_spawn_shell()`
+(`src/core/subos.cppm`) tries `pwsh.exe` **first**. So the one host xlings
+never hooked was the one xlings itself launches — on any box with pwsh 7, the
+feature hooked the wrong shell 100% of the time.
+
+Neither path is guessable, either: OneDrive Known Folder Redirection moves
+`Documents` out from under `%USERPROFILE%`, so a hardcoded
+`Documents\PowerShell\` is wrong on a large share of real machines.
+
+## What was actually wrong with the old code
+
+The missing host was the symptom. The shape was the cause:
+
+```cpp
+std::string psCmd = "powershell -NoProfile -Command \""
+    "$prof=$PROFILE;"
+    ...
+    "Add-Content $prof \\\"`n# xlings`nif(Test-Path '" + profilePs1.string() + "'){...}\\\""
+    ...;
+platform::exec(psCmd);
+```
+
+- **One host, spelled inline.** Adding a second meant copy-pasting the block.
+- **A file edit written as a shell script inside a C++ string literal inside a
+  `-Command` string inside `std::system()`.** Three escaping layers. A `'` in
+  the home path closed the PowerShell literal early and left every future
+  shell starting with a parse error.
+- **The exit code was discarded.** A profile that was never written and one
+  that was produced identical output — the recurring failure shape in this
+  codebase.
+- **Untestable.** No unit test could reach it and no e2e asserted it, which is
+  why a whole missing host survived.
+
+## The design
+
+A new module, `xlings.core.xself.shell_profile`, owns *which shells xlings
+hooks and how*. Three separable pieces:
+
+1. **Hosts are data.** `kPowerShellHosts = { "powershell", "pwsh" }`. Adding a
+   host is one array entry, not a second copy of a code block.
+2. **Location is asked, not computed.** `probe_command(host)` builds
+   `<host> -NoProfile -NonInteractive -Command "Write-Output ('XLINGS_PROFILE=' + $PROFILE)"`.
+   Each host reports its own startup file, which is correct under OneDrive
+   redirection by construction, and the same call doubles as the
+   is-it-installed probe — a host that is not installed cannot answer.
+   The answer is **tagged** because `run_command_capture()` merges stderr into
+   stdout: untagged, a warning banner would be adopted as a path and written to.
+3. **The edit is ordinary C++.** `hook()` does the same read → marker → append
+   the POSIX branch has always done, and returns
+   `Added` / `AlreadyHooked` / `Failed` so the caller can report the truth.
+   Nothing passes through a shell, so `powershell_snippet()` can escape `'` by
+   doubling it and be *tested* for that.
+
+`install.cppm` keeps only what genuinely belongs to it: spawning the probe
+process and printing the result — including a manual fallback hint when no
+host answered at all.
+
+### Deliberate non-decisions
+
+- **No dedup by path.** `hook()` is idempotent on the `xlings-profile` marker,
+  so two hosts reporting the same file converge on their own. A dedup pass
+  would be a second mechanism for a problem the first one already solves.
+- **Idempotency by marker, not by exact line.** A user who reformatted the
+  line, or an older xlings that wrote a different one, must not get a
+  second copy.
+- **The `Test-Path` guard stays.** `self uninstall` does not edit the user's
+  profile back; without the guard, every shell after an uninstall would start
+  with a "file not found".
+- **pwsh on Linux/macOS is not hooked.** It is reachable with the same module
+  (the module is platform-neutral), but `subos use` on POSIX follows `$SHELL`,
+  so there is no reported failure to fix. Left for when there is one.
+- **`tools/other/quick_install.ps1` is unchanged.** PR #388 also added a
+  ~40-line PowerShell reimplementation of the same policy there as a safety
+  net. `quick_install.ps1` runs `xlings self install` from the release it just
+  downloaded, so with the fix in xlings the net is dead weight — a second copy
+  of the policy, in a second language, free to drift from the first.
+
+## Fallout fixed on the way
+
+`emit_shell_advisory_()` in `uninstall.cppm` listed the POSIX rc files by
+relative name. On Windows that set is empty, so uninstall reported *nothing*
+while leaving a source line behind in one or two PowerShell profiles. It now
+builds its candidate list from the same host registry, and matches the home
+path in both its generic and native spellings (PowerShell profiles carry
+backslashes; `generic_string()` alone never matched them).
+
+## Tests
+
+`tests/unit/test_shell_profile.cpp` — 20 cases, platform-neutral, run on every
+CI runner including Linux. The probe is injected, so the Windows-only policy is
+testable off Windows; every case asserts the observable effect rather than the
+verdict alone. `TheShippedHostListCoversBothWindowsPowerShellHosts` asserts
+against the shipped `kPowerShellHosts` array — dropping `pwsh` from it, i.e.
+reintroducing #387, fails that test.
+
+`tests/e2e/release_self_install_test.ps1` — after `self install`, every
+PowerShell host reachable on the runner must have a profile that sources the
+installed home's `xlings-profile.ps1`. Three details make it real rather than
+decorative:
+
+- The install runs with the host directories explicitly on `PATH`
+  (`Get-MinimalSystemPath` omits `C:\Program Files\PowerShell\7`) — a pwsh
+  xlings cannot start is one it is *right* to skip, which would make the
+  assertion vacuous.
+- The runner's profiles are **deleted** before the install: the CI job
+  installs a bootstrap xlings into the runner's own home first, and hooking is
+  correctly idempotent, so an already-hooked profile would be left alone and
+  the assertion would measure nothing.
+- They are snapshotted and restored in a `finally`. `$PROFILE` resolves from
+  the real Documents folder — no environment variable redirects it — so
+  without the restore every later CI step would start by sourcing a throwaway
+  home.
+
+Idempotency is *not* re-asserted in the e2e: a second `self install` of the
+same version stops at an interactive confirmation that CI answers "no", so the
+assertion would pass without running the code it claims to cover. It lives in
+the unit test instead.

--- a/.agents/docs/2026-07-28-shell-profile-hosts-design.md
+++ b/.agents/docs/2026-07-28-shell-profile-hosts-design.md
@@ -63,24 +63,34 @@ hooks and how*. Four separable pieces:
 1. **Hosts are data.** `kPowerShellHosts = { "powershell", "pwsh" }`. Adding a
    host is one array entry, not a second copy of a code block.
 2. **Location is asked, not computed.** `probe_command(host)` builds
-   `<host> -NoProfile -NonInteractive -Command Write-Output XLINGS_PROFILE=$PROFILE`.
+   `<host> -NoProfile -NonInteractive -Command 'XLINGS_PROFILE='+$PROFILE`.
    Each host reports its own startup file, which is correct under OneDrive
    redirection by construction, and the same call doubles as the
    is-it-installed probe — a host that is not installed cannot answer.
    The answer is **tagged** because `run_command_capture()` merges stderr into
    stdout: untagged, a warning banner would be adopted as a path and written to.
 
-   The script carries **no quote of either kind**, which is not cosmetic. It
-   travels `_popen` → `cmd.exe` → `powershell.exe`, and each layer re-parses
-   quotes by its own rules — powershell.exe 5.1 does not even use argv for
-   `-Command`, it takes the rest of the line and strips quotes itself. The
-   first version of this fix used
-   `-Command "Write-Output ('XLINGS_PROFILE=' + $PROFILE)"`; on the CI runner
-   `pwsh` answered it and `powershell` did not, which is the failure mode the
-   whole redesign exists to stop guessing about. Writing the script so that no
-   layer has anything to re-parse — PowerShell's argument mode expands the
-   bare word `XLINGS_PROFILE=$PROFILE` — removes the class rather than one
-   member of it.
+   The exact shape of that script cost two CI rounds and is worth recording,
+   because the two hosts disagree about more than their profile paths:
+
+   | script passed to `-Command` | pwsh 7 | Windows PowerShell 5.1 |
+   | --- | --- | --- |
+   | `"Write-Output ('XLINGS_PROFILE=' + $PROFILE)"` | answers | **no answer** |
+   | `Write-Output XLINGS_PROFILE=$PROFILE` (bare word) | answers | **`XLINGS_PROFILE=`**, path missing |
+   | `'XLINGS_PROFILE='+$PROFILE` | answers | answers |
+
+   Two independent rules fall out, and the unit test
+   `ProbeCommandIsASingleUnquotedExpression` holds both:
+
+   - **No double quote.** The command travels `_popen` → `cmd.exe` →
+     `powershell.exe`, and 5.1 does not use argv for `-Command` — it takes the
+     rest of the line and strips double quotes itself. Single quotes pass all
+     three layers untouched, so the script can still quote its own literal.
+   - **An expression, not a command with arguments.** The bare-word form
+     relies on argument-mode expansion, which pwsh 7 does and 5.1 does not.
+     5.1's reply was the tag with an empty value — indistinguishable from a
+     host that has no profile, which is exactly why round two still missed it
+     and why `Unusable` (below) exists.
 3. **Every host gets a verdict.** `probe_hosts()` returns one `Probe` per host
    with `Answered` / `NotInstalled` / `Unusable`, and the raw reply. A host
    that quietly drops out of the result cannot be reported on, and an
@@ -149,21 +159,32 @@ reintroducing #387, fails that test.
 
 `tests/e2e/release_self_install_test.ps1` — after `self install`, every
 PowerShell host reachable on the runner must have a profile that sources the
-installed home's `xlings-profile.ps1`. Three details make it real rather than
+installed home's `xlings-profile.ps1`. Four details make it real rather than
 decorative:
 
 - The install runs with the host directories explicitly on `PATH`
-  (`Get-MinimalSystemPath` omits `C:\Program Files\PowerShell\7`) — a pwsh
-  xlings cannot start is one it is *right* to skip, which would make the
-  assertion vacuous.
-- The runner's profiles are **deleted** before the install: the CI job
-  installs a bootstrap xlings into the runner's own home first, and hooking is
-  correctly idempotent, so an already-hooked profile would be left alone and
-  the assertion would measure nothing.
-- They are snapshotted and restored in a `finally`. `$PROFILE` resolves from
-  the real Documents folder — no environment variable redirects it — so
-  without the restore every later CI step would start by sourcing a throwaway
-  home.
+  (`Get-MinimalSystemPath` omits both `System32\WindowsPowerShell\v1.0` and
+  `C:\Program Files\PowerShell\7`) — a host xlings cannot start is one it is
+  *right* to skip, which would make the assertion vacuous.
+- Each host's `$PROFILE` is resolved **inside** the redirected environment,
+  because it is not environment-independent: pwsh 7 derives it from
+  `USERPROFILE` and lands inside the sandbox, while 5.1 may answer with the
+  runner's real Documents folder. Resolving before the redirect measured the
+  install's work against the wrong path for whichever host follows
+  `USERPROFILE`.
+- The profiles are **deleted** before the install: the CI job installs a
+  bootstrap xlings into the runner's own home first, and hooking is correctly
+  idempotent, so an already-hooked profile would be left alone and the
+  assertion would measure nothing.
+- Anything found is snapshotted and restored in a `finally`, so a profile that
+  did land outside the sandbox does not leave later CI steps sourcing a
+  throwaway home.
+
+The test resolves `$PROFILE` with `-Command '$PROFILE'` rather than reusing
+`probe_command()`'s spelling. That is deliberate: a test that asks the question
+the same way the production code does agrees with it when it is wrong — with
+the bare-word form, both would have read an empty answer and the test would
+have passed against an install that hooked nothing.
 
 Idempotency is *not* re-asserted in the e2e: a second `self install` of the
 same version stops at an interactive confirmation that CI answers "no", so the

--- a/.agents/docs/2026-07-28-shell-profile-hosts-design.md
+++ b/.agents/docs/2026-07-28-shell-profile-hosts-design.md
@@ -159,7 +159,7 @@ reintroducing #387, fails that test.
 
 `tests/e2e/release_self_install_test.ps1` — after `self install`, every
 PowerShell host reachable on the runner must have a profile that sources the
-installed home's `xlings-profile.ps1`. Four details make it real rather than
+installed home's `xlings-profile.ps1`. Five details make it real rather than
 decorative:
 
 - The install runs with the host directories explicitly on `PATH`
@@ -172,6 +172,13 @@ decorative:
   runner's real Documents folder. Resolving before the redirect measured the
   install's work against the wrong path for whichever host follows
   `USERPROFILE`.
+- The sandbox home is given a `Documents` folder before anything is probed.
+  Windows PowerShell 5.1 answers an **empty** `$PROFILE` when that folder is
+  missing — .NET Framework's `GetFolderPath` returns `""` for a folder that
+  does not exist, while .NET Core (pwsh 7) returns the path regardless. A real
+  user profile always has one, so without this the sandbox stops being a
+  stand-in for a user's home and 5.1 drops out of the test for a reason that
+  cannot happen on a real machine.
 - The profiles are **deleted** before the install: the CI job installs a
   bootstrap xlings into the runner's own home first, and hooking is correctly
   idempotent, so an already-hooked profile would be left alone and the

--- a/.agents/docs/2026-07-28-shell-profile-hosts-design.md
+++ b/.agents/docs/2026-07-28-shell-profile-hosts-design.md
@@ -58,18 +58,39 @@ platform::exec(psCmd);
 ## The design
 
 A new module, `xlings.core.xself.shell_profile`, owns *which shells xlings
-hooks and how*. Three separable pieces:
+hooks and how*. Four separable pieces:
 
 1. **Hosts are data.** `kPowerShellHosts = { "powershell", "pwsh" }`. Adding a
    host is one array entry, not a second copy of a code block.
 2. **Location is asked, not computed.** `probe_command(host)` builds
-   `<host> -NoProfile -NonInteractive -Command "Write-Output ('XLINGS_PROFILE=' + $PROFILE)"`.
+   `<host> -NoProfile -NonInteractive -Command Write-Output XLINGS_PROFILE=$PROFILE`.
    Each host reports its own startup file, which is correct under OneDrive
    redirection by construction, and the same call doubles as the
    is-it-installed probe — a host that is not installed cannot answer.
    The answer is **tagged** because `run_command_capture()` merges stderr into
    stdout: untagged, a warning banner would be adopted as a path and written to.
-3. **The edit is ordinary C++.** `hook()` does the same read → marker → append
+
+   The script carries **no quote of either kind**, which is not cosmetic. It
+   travels `_popen` → `cmd.exe` → `powershell.exe`, and each layer re-parses
+   quotes by its own rules — powershell.exe 5.1 does not even use argv for
+   `-Command`, it takes the rest of the line and strips quotes itself. The
+   first version of this fix used
+   `-Command "Write-Output ('XLINGS_PROFILE=' + $PROFILE)"`; on the CI runner
+   `pwsh` answered it and `powershell` did not, which is the failure mode the
+   whole redesign exists to stop guessing about. Writing the script so that no
+   layer has anything to re-parse — PowerShell's argument mode expands the
+   bare word `XLINGS_PROFILE=$PROFILE` — removes the class rather than one
+   member of it.
+3. **Every host gets a verdict.** `probe_hosts()` returns one `Probe` per host
+   with `Answered` / `NotInstalled` / `Unusable`, and the raw reply. A host
+   that quietly drops out of the result cannot be reported on, and an
+   unreported host is exactly how #387 looked from outside: `self install`
+   printed success and hooked nothing. `NotInstalled` is the ordinary shape of
+   a 5.1-only machine and stays at debug; `Unusable` — it started and said
+   something we cannot hook — is a defect and is warned about, with what it
+   said. `self install` prints the manual `$PROFILE` hint when *nothing* got
+   hooked, counted from the hooks rather than from the probe list.
+4. **The edit is ordinary C++.** `hook()` does the same read → marker → append
    the POSIX branch has always done, and returns
    `Added` / `AlreadyHooked` / `Failed` so the caller can report the truth.
    Nothing passes through a shell, so `powershell_snippet()` can escape `'` by
@@ -93,6 +114,15 @@ host answered at all.
 - **pwsh on Linux/macOS is not hooked.** It is reachable with the same module
   (the module is platform-neutral), but `subos use` on POSIX follows `$SHELL`,
   so there is no reported failure to fix. Left for when there is one.
+- **The two `powershell` calls above the profile block stay single-host.**
+  `setup_shell_profiles()` also sets `XLINGS_HOME` and prepends to `PATH` via
+  `[System.Environment]::SetEnvironmentVariable(..., 'User')`. Those write
+  **per-user registry** values, which every host reads — unlike `$PROFILE`,
+  one host genuinely suffices there, so routing them through the registry
+  would add a second process for no behavioural gain. They do still discard
+  their exit code (a `powershell` that is not on `PATH` makes them no-ops that
+  report success), which is a real but separate gap: it is not what #387
+  reports, and no supported Windows ships without Windows PowerShell 5.1.
 - **`tools/other/quick_install.ps1` is unchanged.** PR #388 also added a
   ~40-line PowerShell reimplementation of the same policy there as a safety
   net. `quick_install.ps1` runs `xlings self install` from the release it just
@@ -110,7 +140,7 @@ backslashes; `generic_string()` alone never matched them).
 
 ## Tests
 
-`tests/unit/test_shell_profile.cpp` — 20 cases, platform-neutral, run on every
+`tests/unit/test_shell_profile.cpp` — 22 cases, platform-neutral, run on every
 CI runner including Linux. The probe is injected, so the Windows-only policy is
 testable off Windows; every case asserts the observable effect rather than the
 verdict alone. `TheShippedHostListCoversBothWindowsPowerShellHosts` asserts

--- a/src/core/xself/install.cppm
+++ b/src/core/xself/install.cppm
@@ -374,6 +374,10 @@ static void setup_shell_profiles(const fs::path& homeDir) {
     platform::exec(checkCmd);
 
     auto profilePs1 = homeDir / "config" / "shell" / "xlings-profile.ps1";
+
+    std::string profileSnippet = "`n# xlings`nif(Test-Path '" + profilePs1.string() +
+                                 "'){. '" + profilePs1.string() + "'}";
+
     std::string psCmd = "powershell -NoProfile -Command \""
         "$prof=$PROFILE;"
         "$dir=Split-Path $prof;"
@@ -381,11 +385,25 @@ static void setup_shell_profiles(const fs::path& homeDir) {
         "if(!(Test-Path $prof)){New-Item -ItemType File -Force $prof|Out-Null};"
         "$c=Get-Content $prof -Raw -ErrorAction SilentlyContinue;"
         "if(!$c -or $c -notlike '*xlings-profile*'){"
-        "Add-Content $prof \\\"`n# xlings`nif(Test-Path '" + profilePs1.string() +
-        "'){. '" + profilePs1.string() + "'}\\\""
+        "Add-Content $prof \\\"" + profileSnippet + "\\\""
         ";Write-Host 'PS profile added'"
         "}else{Write-Host 'PS profile already set'}\"";
     platform::exec(psCmd);
+
+    std::string checkPwsh = "where pwsh >nul 2>&1";
+    if (platform::exec(checkPwsh) == 0) {
+        std::string pwshProfileCmd = "pwsh -NoProfile -Command \""
+            "$prof=$PROFILE;"
+            "$dir=Split-Path $prof;"
+            "if(!(Test-Path $dir)){New-Item -ItemType Directory -Force $dir|Out-Null};"
+            "if(!(Test-Path $prof)){New-Item -ItemType File -Force $prof|Out-Null};"
+            "$c=Get-Content $prof -Raw -ErrorAction SilentlyContinue;"
+            "if(!$c -or $c -notlike '*xlings-profile*'){"
+            "Add-Content $prof \\\"" + profileSnippet + "\\\""
+            ";Write-Host 'PS profile (pwsh) added'"
+            "}else{Write-Host 'PS profile (pwsh) already set'}\"";
+        platform::exec(pwshProfileCmd);
+    }
 #endif
 }
 

--- a/src/core/xself/install.cppm
+++ b/src/core/xself/install.cppm
@@ -2,6 +2,7 @@ export module xlings.core.xself.install;
 
 import std;
 import xlings.core.xself.init;
+import xlings.core.xself.shell_profile;
 
 import xlings.core.config;
 import xlings.core.xvm.lock;
@@ -373,36 +374,48 @@ static void setup_shell_profiles(const fs::path& homeDir) {
         "}else{Write-Host 'PATH already set'}\"";
     platform::exec(checkCmd);
 
+    // Hook every PowerShell host on the box, not just the one xlings happens
+    // to shell out to. Windows PowerShell 5.1 and PowerShell 7+ read different
+    // startup files, and `xlings subos use` spawns pwsh.exe first -- so the
+    // 5.1-only hook this used to be left the shell xlings itself launches
+    // without XLINGS_BIN on PATH (#387). Policy and mechanics live in
+    // xlings.core.xself.shell_profile, which is unit-tested; what stays here
+    // is the process spawning and the reporting.
     auto profilePs1 = homeDir / "config" / "shell" / "xlings-profile.ps1";
+    auto snippet = shell_profile::powershell_snippet(profilePs1);
 
-    std::string profileSnippet = "`n# xlings`nif(Test-Path '" + profilePs1.string() +
-                                 "'){. '" + profilePs1.string() + "'}";
+    auto targets = shell_profile::resolve_targets(
+        shell_profile::kPowerShellHosts,
+        [](const std::string& cmd) -> std::optional<std::string> {
+            // A host that is not installed cannot answer: cmd fails to resolve
+            // the executable and exits non-zero, which is the probe.
+            auto [rc, out] = platform::run_command_capture(cmd);
+            if (rc != 0) return std::nullopt;
+            return out;
+        });
 
-    std::string psCmd = "powershell -NoProfile -Command \""
-        "$prof=$PROFILE;"
-        "$dir=Split-Path $prof;"
-        "if(!(Test-Path $dir)){New-Item -ItemType Directory -Force $dir|Out-Null};"
-        "if(!(Test-Path $prof)){New-Item -ItemType File -Force $prof|Out-Null};"
-        "$c=Get-Content $prof -Raw -ErrorAction SilentlyContinue;"
-        "if(!$c -or $c -notlike '*xlings-profile*'){"
-        "Add-Content $prof \\\"" + profileSnippet + "\\\""
-        ";Write-Host 'PS profile added'"
-        "}else{Write-Host 'PS profile already set'}\"";
-    platform::exec(psCmd);
+    for (const auto& t : targets) {
+        switch (shell_profile::hook(t.path, snippet)) {
+        case shell_profile::HookResult::Added:
+            log::println("[xlings:self] added profile ({})", t.host);
+            log::debug("[xlings:self]   {}", t.path.string());
+            break;
+        case shell_profile::HookResult::AlreadyHooked:
+            log::debug("[xlings:self] profile ok ({})", t.host);
+            break;
+        case shell_profile::HookResult::Failed:
+            // Reported rather than swallowed: the old one-liner discarded its
+            // exit code, so a profile that was never written looked exactly
+            // like one that was.
+            log::warn("[xlings:self] could not write {} profile: {}",
+                      t.host, t.path.string());
+            break;
+        }
+    }
 
-    std::string checkPwsh = "where pwsh >nul 2>&1";
-    if (platform::exec(checkPwsh) == 0) {
-        std::string pwshProfileCmd = "pwsh -NoProfile -Command \""
-            "$prof=$PROFILE;"
-            "$dir=Split-Path $prof;"
-            "if(!(Test-Path $dir)){New-Item -ItemType Directory -Force $dir|Out-Null};"
-            "if(!(Test-Path $prof)){New-Item -ItemType File -Force $prof|Out-Null};"
-            "$c=Get-Content $prof -Raw -ErrorAction SilentlyContinue;"
-            "if(!$c -or $c -notlike '*xlings-profile*'){"
-            "Add-Content $prof \\\"" + profileSnippet + "\\\""
-            ";Write-Host 'PS profile (pwsh) added'"
-            "}else{Write-Host 'PS profile (pwsh) already set'}\"";
-        platform::exec(pwshProfileCmd);
+    if (targets.empty()) {
+        std::println("[xlings:self] no PowerShell host answered, add manually to $PROFILE:");
+        std::println("  {}", snippet);
     }
 #endif
 }

--- a/src/core/xself/install.cppm
+++ b/src/core/xself/install.cppm
@@ -384,37 +384,51 @@ static void setup_shell_profiles(const fs::path& homeDir) {
     auto profilePs1 = homeDir / "config" / "shell" / "xlings-profile.ps1";
     auto snippet = shell_profile::powershell_snippet(profilePs1);
 
-    auto targets = shell_profile::resolve_targets(
+    auto probes = shell_profile::probe_hosts(
         shell_profile::kPowerShellHosts,
-        [](const std::string& cmd) -> std::optional<std::string> {
-            // A host that is not installed cannot answer: cmd fails to resolve
-            // the executable and exits non-zero, which is the probe.
-            auto [rc, out] = platform::run_command_capture(cmd);
-            if (rc != 0) return std::nullopt;
-            return out;
+        [](const std::string& cmd) {
+            auto result = platform::run_command_capture(cmd);
+            log::debug("[xlings:self] probe: {} -> rc={} out={}",
+                       cmd, result.first, result.second);
+            return result;
         });
 
-    for (const auto& t : targets) {
-        switch (shell_profile::hook(t.path, snippet)) {
+    int hooked = 0;
+    for (const auto& p : probes) {
+        if (p.status == shell_profile::ProbeStatus::NotInstalled) {
+            // The ordinary shape of a machine without PowerShell 7. Not news.
+            log::debug("[xlings:self] {} not installed", p.host);
+            continue;
+        }
+        if (p.status == shell_profile::ProbeStatus::Unusable) {
+            // It started and said something we cannot hook. That is a defect,
+            // not a machine shape, so it is shown with what it actually said.
+            log::warn("[xlings:self] {} did not report $PROFILE: {}",
+                      p.host, p.output);
+            continue;
+        }
+        switch (shell_profile::hook(p.path, snippet)) {
         case shell_profile::HookResult::Added:
-            log::println("[xlings:self] added profile ({})", t.host);
-            log::debug("[xlings:self]   {}", t.path.string());
+            ++hooked;
+            log::println("[xlings:self] added profile ({})", p.host);
+            log::debug("[xlings:self]   {}", p.path.string());
             break;
         case shell_profile::HookResult::AlreadyHooked:
-            log::debug("[xlings:self] profile ok ({})", t.host);
+            ++hooked;
+            log::debug("[xlings:self] profile ok ({})", p.host);
             break;
         case shell_profile::HookResult::Failed:
             // Reported rather than swallowed: the old one-liner discarded its
             // exit code, so a profile that was never written looked exactly
             // like one that was.
             log::warn("[xlings:self] could not write {} profile: {}",
-                      t.host, t.path.string());
+                      p.host, p.path.string());
             break;
         }
     }
 
-    if (targets.empty()) {
-        std::println("[xlings:self] no PowerShell host answered, add manually to $PROFILE:");
+    if (hooked == 0) {
+        std::println("[xlings:self] no PowerShell host was configured, add manually to $PROFILE:");
         std::println("  {}", snippet);
     }
 #endif

--- a/src/core/xself/shell_profile.cppm
+++ b/src/core/xself/shell_profile.cppm
@@ -49,10 +49,21 @@ inline constexpr std::string_view kProbePrefix = "XLINGS_PROFILE=";
 // only correct answer is "whichever starts, xlings is there".
 inline constexpr std::string_view kPowerShellHosts[] = { "powershell", "pwsh" };
 
-// A shell startup file to hook, and the host that reads it.
-struct Target {
+enum class ProbeStatus {
+    Answered,      // reported a usable $PROFILE
+    NotInstalled,  // the host could not be started at all
+    Unusable,      // it started, but said nothing we can hook
+};
+
+// What one host answered. There is one of these per host, always — a host
+// that quietly disappears from the result cannot be reported on, and an
+// unreported host is precisely how #387 looked from the outside: `self
+// install` printed success and hooked nothing.
+struct Probe {
     std::string host;
-    fs::path    path;
+    ProbeStatus status { ProbeStatus::NotInstalled };
+    fs::path    path;    // set only when Answered
+    std::string output;  // raw reply, kept so Unusable can be reported usefully
 };
 
 enum class HookResult {
@@ -61,11 +72,10 @@ enum class HookResult {
     Failed,         // the profile could not be read or written
 };
 
-// Runs a probe command and returns its combined output, or nullopt when the
-// command could not be run at all (host not installed). Injected: this module
-// owns the policy and does no process spawning of its own, which is what lets
-// the Windows-only rules be tested on any platform.
-using CommandRunner = std::function<std::optional<std::string>(const std::string&)>;
+// Runs a probe command and returns {exit code, combined output}. Injected:
+// this module owns the policy and does no process spawning of its own, which
+// is what lets the Windows-only rules be tested on any platform.
+using CommandRunner = std::function<std::pair<int, std::string>(const std::string&)>;
 
 // Ask a host where ITS OWN startup file is, rather than composing the path
 // from a known-folder guess. The path differs per host, and both are subject
@@ -75,10 +85,17 @@ using CommandRunner = std::function<std::optional<std::string>(const std::string
 // -NoProfile: the probe must not source the profile it is about to edit.
 // -NonInteractive: a misconfigured profile must not park `self install` on a
 // prompt.
+//
+// The script carries NO quote of either kind. It travels through _popen ->
+// cmd.exe -> powershell.exe, and every layer re-parses quotes by its own
+// rules -- powershell.exe 5.1 does not even use argv for -Command, it takes
+// the rest of the line and strips quotes itself. Rather than find the one
+// spelling all three agree on, the script is written so none of them has
+// anything to re-parse: PowerShell's argument mode expands the bare word
+// `XLINGS_PROFILE=$PROFILE` into the tagged answer.
 inline std::string probe_command(std::string_view host) {
-    return std::string(host) +
-           " -NoProfile -NonInteractive -Command \"Write-Output ('" +
-           std::string(kProbePrefix) + "' + $PROFILE)\"";
+    return std::string(host) + " -NoProfile -NonInteractive -Command Write-Output " +
+           std::string(kProbePrefix) + "$PROFILE";
 }
 
 // Pull the tagged path out of a probe's output. Untagged lines are noise by
@@ -106,20 +123,29 @@ inline std::optional<fs::path> parse_probe_output(std::string_view raw) {
     return std::nullopt;
 }
 
-// One probe per host; hosts that do not answer usably are simply absent from
-// the result. An empty result is itself meaningful to the caller -- it means
-// no shell was hooked, and the user needs the manual hint.
-inline std::vector<Target> resolve_targets(std::span<const std::string_view> hosts,
-                                           const CommandRunner& run) {
-    std::vector<Target> targets;
+// One probe per host, one result per host. Nothing is filtered here: the
+// caller decides what to say about each outcome, and can only do that if it
+// is told about every host.
+inline std::vector<Probe> probe_hosts(std::span<const std::string_view> hosts,
+                                      const CommandRunner& run) {
+    std::vector<Probe> probes;
     for (auto host : hosts) {
-        auto out = run(probe_command(host));
-        if (!out) continue;
-        auto path = parse_probe_output(*out);
-        if (!path) continue;
-        targets.push_back(Target{std::string(host), *path});
+        auto [rc, out] = run(probe_command(host));
+        Probe p{std::string(host), ProbeStatus::NotInstalled, {}, std::move(out)};
+        if (rc == 0) {
+            if (auto path = parse_probe_output(p.output)) {
+                p.status = ProbeStatus::Answered;
+                p.path   = *path;
+            } else {
+                // It ran and said something we cannot use. Distinct from "not
+                // installed" because it is a defect rather than a normal
+                // machine shape, and the caller should surface it.
+                p.status = ProbeStatus::Unusable;
+            }
+        }
+        probes.push_back(std::move(p));
     }
-    return targets;
+    return probes;
 }
 
 // The line appended to a PowerShell startup file.

--- a/src/core/xself/shell_profile.cppm
+++ b/src/core/xself/shell_profile.cppm
@@ -86,16 +86,22 @@ using CommandRunner = std::function<std::pair<int, std::string>(const std::strin
 // -NonInteractive: a misconfigured profile must not park `self install` on a
 // prompt.
 //
-// The script carries NO quote of either kind. It travels through _popen ->
-// cmd.exe -> powershell.exe, and every layer re-parses quotes by its own
-// rules -- powershell.exe 5.1 does not even use argv for -Command, it takes
-// the rest of the line and strips quotes itself. Rather than find the one
-// spelling all three agree on, the script is written so none of them has
-// anything to re-parse: PowerShell's argument mode expands the bare word
-// `XLINGS_PROFILE=$PROFILE` into the tagged answer.
+// The script is one whitespace-free token with no DOUBLE quote in it. Both
+// properties were established on a real Windows runner, and both matter:
+//
+//   * The command travels _popen -> cmd.exe -> powershell.exe. Windows
+//     PowerShell 5.1 does not use argv for -Command; it takes the rest of the
+//     line and strips double quotes itself. Single quotes pass all three
+//     layers untouched, so the script quotes its own literal with those and
+//     no layer has a quote left to re-parse.
+//   * It is an EXPRESSION (`'TAG='+$PROFILE`), not a command with arguments.
+//     `Write-Output TAG=$PROFILE` relies on argument mode expanding a bare
+//     word: pwsh 7 does, 5.1 does not. 5.1 answered a bare `XLINGS_PROFILE=`
+//     with the path missing -- which looks exactly like a host that has no
+//     profile, and is how the second round of this fix still missed 5.1.
 inline std::string probe_command(std::string_view host) {
-    return std::string(host) + " -NoProfile -NonInteractive -Command Write-Output " +
-           std::string(kProbePrefix) + "$PROFILE";
+    return std::string(host) + " -NoProfile -NonInteractive -Command '" +
+           std::string(kProbePrefix) + "'+$PROFILE";
 }
 
 // Pull the tagged path out of a probe's output. Untagged lines are noise by

--- a/src/core/xself/shell_profile.cppm
+++ b/src/core/xself/shell_profile.cppm
@@ -1,0 +1,172 @@
+export module xlings.core.xself.shell_profile;
+
+import std;
+import xlings.platform;
+
+// Which shell startup files `self install` hooks, and how.
+//
+// Split out of install.cppm because the Windows half of setup_shell_profiles()
+// had grown into a nested-quoted PowerShell one-liner that built a file edit
+// out of a C++ string, inside a `-Command "..."` string, inside a std::system()
+// string. Three escaping layers, one hardcoded host, no return-code check and
+// no tests -- and the bug it hid was structural rather than a typo: Windows has
+// two PowerShell hosts with two different startup files.
+//
+//   powershell (Windows PowerShell 5.1) -> Documents\WindowsPowerShell\...
+//   pwsh       (PowerShell 7+)          -> Documents\PowerShell\...
+//
+// `xlings subos use` spawns pwsh in preference to powershell (subos.cppm), so
+// the only host xlings hooked was the one it does not launch: the subos shell
+// came up without XLINGS_BIN on PATH and without the prompt marker (#387).
+//
+// The shape here answers that generally rather than by adding a second copy of
+// the one-liner: hosts are a list, "where is your startup file" is one probe
+// per host, and the edit itself is ordinary C++ -- the same read/marker/append
+// the POSIX branch has always used. Adding a host is one array entry, and
+// every part is testable off-Windows because the probe is injected.
+//
+// Deliberately NOT deduplicated by path: hook() is idempotent on the marker,
+// so two hosts reporting the same startup file converge on their own.
+export namespace xlings::xself::shell_profile {
+
+namespace fs = std::filesystem;
+
+// Present in every line xlings appends, and the thing hook() looks for to
+// decide it has already run. It is a substring of `xlings-profile.ps1`, so
+// the snippet carries it without a separate comment tag -- and so profiles
+// written by older xlings versions are still recognized as hooked.
+inline constexpr std::string_view kMarker = "xlings-profile";
+
+// Tags the probe's answer. run_command_capture() merges stderr into stdout,
+// so an untagged reply would let a warning banner ("WARNING: module shadowed")
+// pass for a profile path -- and xlings would then create and edit a file
+// named after it.
+inline constexpr std::string_view kProbePrefix = "XLINGS_PROFILE=";
+
+// The PowerShell hosts to hook, in probe order. Both are hooked when both are
+// installed: which one starts is not xlings's decision (the user's terminal,
+// the Start menu shortcut and `subos use` can each pick differently), so the
+// only correct answer is "whichever starts, xlings is there".
+inline constexpr std::string_view kPowerShellHosts[] = { "powershell", "pwsh" };
+
+// A shell startup file to hook, and the host that reads it.
+struct Target {
+    std::string host;
+    fs::path    path;
+};
+
+enum class HookResult {
+    Added,          // the source line was appended
+    AlreadyHooked,  // the marker was already there; the file was not touched
+    Failed,         // the profile could not be read or written
+};
+
+// Runs a probe command and returns its combined output, or nullopt when the
+// command could not be run at all (host not installed). Injected: this module
+// owns the policy and does no process spawning of its own, which is what lets
+// the Windows-only rules be tested on any platform.
+using CommandRunner = std::function<std::optional<std::string>(const std::string&)>;
+
+// Ask a host where ITS OWN startup file is, rather than composing the path
+// from a known-folder guess. The path differs per host, and both are subject
+// to OneDrive Known Folder Redirection of Documents -- which moves the file
+// somewhere no hardcoded `Documents\PowerShell\` would find.
+//
+// -NoProfile: the probe must not source the profile it is about to edit.
+// -NonInteractive: a misconfigured profile must not park `self install` on a
+// prompt.
+inline std::string probe_command(std::string_view host) {
+    return std::string(host) +
+           " -NoProfile -NonInteractive -Command \"Write-Output ('" +
+           std::string(kProbePrefix) + "' + $PROFILE)\"";
+}
+
+// Pull the tagged path out of a probe's output. Untagged lines are noise by
+// definition, so a warning before or after the answer is harmless.
+inline std::optional<fs::path> parse_probe_output(std::string_view raw) {
+    constexpr std::string_view kSpace = " \t\r\n";
+    std::size_t pos = 0;
+    while (pos <= raw.size()) {
+        auto eol  = raw.find('\n', pos);
+        auto line = raw.substr(pos, eol == std::string_view::npos
+                                        ? std::string_view::npos : eol - pos);
+        if (auto tag = line.find(kProbePrefix); tag != std::string_view::npos) {
+            auto value = line.substr(tag + kProbePrefix.size());
+            auto first = value.find_first_not_of(kSpace);
+            if (first != std::string_view::npos) {
+                auto last = value.find_last_not_of(kSpace);
+                return fs::path(std::string(value.substr(first, last - first + 1)));
+            }
+            // A host that answers with an empty $PROFILE has nothing to hook.
+            return std::nullopt;
+        }
+        if (eol == std::string_view::npos) break;
+        pos = eol + 1;
+    }
+    return std::nullopt;
+}
+
+// One probe per host; hosts that do not answer usably are simply absent from
+// the result. An empty result is itself meaningful to the caller -- it means
+// no shell was hooked, and the user needs the manual hint.
+inline std::vector<Target> resolve_targets(std::span<const std::string_view> hosts,
+                                           const CommandRunner& run) {
+    std::vector<Target> targets;
+    for (auto host : hosts) {
+        auto out = run(probe_command(host));
+        if (!out) continue;
+        auto path = parse_probe_output(*out);
+        if (!path) continue;
+        targets.push_back(Target{std::string(host), *path});
+    }
+    return targets;
+}
+
+// The line appended to a PowerShell startup file.
+//
+// The Test-Path guard is what makes an uninstalled xlings harmless: the line
+// survives `self uninstall` (we do not edit the user's profile back), and
+// without the guard every later shell would start with a "file not found"
+// error.
+inline std::string powershell_snippet(const fs::path& profileScript) {
+    // PowerShell escapes ' inside a '...' literal by doubling it. Without
+    // this, a home under C:\Users\o'brien closes the literal early and leaves
+    // a syntactically broken profile that fails on every subsequent shell.
+    std::string quoted;
+    for (char c : profileScript.string()) {
+        quoted += c;
+        if (c == '\'') quoted += '\'';
+    }
+    return "if(Test-Path '" + quoted + "'){. '" + quoted + "'}";
+}
+
+// Append the snippet to a startup file, once.
+//
+// Idempotency is by marker rather than by exact-line match on purpose: a user
+// who reformatted the line, or an older xlings that wrote a different one,
+// must not get a second copy.
+inline HookResult hook(const fs::path& profile, std::string_view snippet) {
+    try {
+        std::error_code ec;
+        if (auto parent = profile.parent_path(); !parent.empty()) {
+            fs::create_directories(parent, ec);
+            if (!fs::is_directory(parent, ec)) return HookResult::Failed;
+        }
+
+        std::string content;
+        if (fs::exists(profile, ec) && !ec) {
+            content = platform::read_file_to_string(profile.string());
+            if (content.find(kMarker) != std::string::npos) {
+                return HookResult::AlreadyHooked;
+            }
+        }
+        platform::write_string_to_file(
+            profile.string(),
+            content + "\n# xlings\n" + std::string(snippet) + "\n");
+        return HookResult::Added;
+    } catch (const std::exception&) {
+        return HookResult::Failed;
+    }
+}
+
+} // namespace xlings::xself::shell_profile

--- a/src/core/xself/uninstall.cppm
+++ b/src/core/xself/uninstall.cppm
@@ -198,14 +198,12 @@ static std::vector<fs::path> hooked_startup_files_(const fs::path& userHome) {
     // Not a fixed path under the home: each PowerShell host reports its own
     // $PROFILE, and OneDrive folder redirection can move both. Same probe
     // install used to find them.
-    for (const auto& t : shell_profile::resolve_targets(
+    for (const auto& p : shell_profile::probe_hosts(
              shell_profile::kPowerShellHosts,
-             [](const std::string& cmd) -> std::optional<std::string> {
-                 auto [rc, out] = platform::run_command_capture(cmd);
-                 if (rc != 0) return std::nullopt;
-                 return out;
+             [](const std::string& cmd) {
+                 return platform::run_command_capture(cmd);
              })) {
-        files.push_back(t.path);
+        if (p.status == shell_profile::ProbeStatus::Answered) files.push_back(p.path);
     }
 #endif
     return files;

--- a/src/core/xself/uninstall.cppm
+++ b/src/core/xself/uninstall.cppm
@@ -3,6 +3,7 @@ export module xlings.core.xself.uninstall;
 import std;
 import xlings.core.config;
 import xlings.core.log;
+import xlings.core.xself.shell_profile;
 import xlings.platform;
 
 // `xlings self uninstall [-y] [--keep-data] [--dry-run]`
@@ -182,20 +183,48 @@ static bool prompt_yes_no_(const std::string& question) {
     return line[0] == 'y' || line[0] == 'Y';
 }
 
+// Every startup file `self install` may have hooked, so the advisory covers
+// the same set the install wrote to. The list used to be POSIX-only, which on
+// Windows meant uninstall reported nothing at all while leaving a source line
+// behind in one or two PowerShell profiles.
+static std::vector<fs::path> hooked_startup_files_(const fs::path& userHome) {
+    static const std::vector<std::string> rc_files = {
+        ".bashrc", ".zshrc", ".profile", ".config/fish/config.fish"
+    };
+    std::vector<fs::path> files;
+    for (auto& rel : rc_files) files.push_back(userHome / rel);
+
+#ifdef _WIN32
+    // Not a fixed path under the home: each PowerShell host reports its own
+    // $PROFILE, and OneDrive folder redirection can move both. Same probe
+    // install used to find them.
+    for (const auto& t : shell_profile::resolve_targets(
+             shell_profile::kPowerShellHosts,
+             [](const std::string& cmd) -> std::optional<std::string> {
+                 auto [rc, out] = platform::run_command_capture(cmd);
+                 if (rc != 0) return std::nullopt;
+                 return out;
+             })) {
+        files.push_back(t.path);
+    }
+#endif
+    return files;
+}
+
 static void emit_shell_advisory_(const fs::path& home) {
-    // Detect rc-file lines that source xlings's shell init scripts and
+    // Detect startup-file lines that source xlings's shell init scripts and
     // print them so the user can clean up manually.
     auto userHome = fs::path(platform::get_home_dir());
     if (userHome.empty()) return;
 
-    static const std::vector<std::string> rc_files = {
-        ".bashrc", ".zshrc", ".profile", ".config/fish/config.fish"
-    };
-    auto homeStr = home.generic_string();
+    // Both spellings: POSIX rc files carry the generic form, PowerShell
+    // profiles carry the native backslash form. On POSIX the two are equal
+    // and the second check costs nothing.
+    const auto homeGeneric = home.generic_string();
+    const auto homeNative  = home.string();
     bool found_any = false;
     std::error_code ec;
-    for (auto& rel : rc_files) {
-        auto rc = userHome / rel;
+    for (auto& rc : hooked_startup_files_(userHome)) {
         if (!fs::exists(rc, ec) || !fs::is_regular_file(rc, ec)) continue;
         std::ifstream in(rc);
         if (!in) continue;
@@ -204,10 +233,11 @@ static void emit_shell_advisory_(const fs::path& home) {
             // Match lines that reference our XLINGS_HOME path (source / export PATH /
             // env XLINGS_HOME=...). Substring match is enough — false positives are
             // rare and the consequence is just a manual-cleanup hint.
-            if (line.find(homeStr) != std::string::npos) {
+            if (line.find(homeGeneric) != std::string::npos ||
+                line.find(homeNative) != std::string::npos) {
                 if (!found_any) {
                     log::println("");
-                    log::println("[info] shell rc files reference XLINGS_HOME — you may want to remove these lines manually:");
+                    log::println("[info] shell startup files reference XLINGS_HOME — you may want to remove these lines manually:");
                     found_any = true;
                 }
                 log::println("  {}: {}", rc.string(), line);

--- a/tests/e2e/release_self_install_test.ps1
+++ b/tests/e2e/release_self_install_test.ps1
@@ -24,51 +24,61 @@ if (-not (Test-Path "$PKG_DIR\bin\xlings.exe")) { Fail "bootstrap binary missing
 # spawns pwsh.exe first — hooking only 5.1 left the shell xlings itself
 # launches without XLINGS_BIN on PATH (#387).
 #
-# $PROFILE resolves from the user's real Documents folder; no environment
-# variable redirects it, so this test necessarily touches the runner's own
-# profiles. Snapshot them here and put them back below, or every later CI
-# step would start by sourcing this throwaway home.
+# Locate the host executables under the FULL path first — the install below
+# runs on a deliberately minimal one, and Get-MinimalSystemPath carries
+# System32 but neither System32\WindowsPowerShell\v1.0 nor
+# C:\Program Files\PowerShell\7. A host xlings cannot start is a host it is
+# right to skip, which would make the assertions vacuous.
 $psHosts = @()
 foreach ($exe in @('powershell', 'pwsh')) {
     $found = Get-Command $exe -ErrorAction SilentlyContinue
     if (-not $found) { continue }
-    $reported = & $exe -NoProfile -NonInteractive -Command '$PROFILE' 2>$null | Select-Object -First 1
-    if (-not $reported) { Fail "$exe did not report a `$PROFILE path" }
-    $reported = $reported.Trim()
-    $backup = $null
-    if (Test-Path $reported) { $backup = Get-Content $reported -Raw }
     $psHosts += [pscustomobject]@{
         Exe    = $exe
-        Path   = $reported
         Dir    = (Split-Path $found.Source -Parent)
-        Backup = $backup
+        Path   = $null   # resolved below, under the install's own environment
+        Backup = $null
     }
 }
 if ($psHosts.Count -eq 0) { Fail "no PowerShell host found on this machine" }
 
-# Install with minimal env. The host directories are added explicitly:
-# Get-MinimalSystemPath carries System32 (Windows PowerShell) but not
-# C:\Program Files\PowerShell\7, and a pwsh xlings cannot start is a pwsh it
-# is right to skip — which would make the assertion below vacuous.
 $hostDirs = ($psHosts | ForEach-Object { $_.Dir }) -join ';'
 $INSTALLED_HOME = Join-Path $INSTALL_USER '.xlings'
 $XLINGS_PS_PROFILE = Join-Path $INSTALLED_HOME 'config\shell\xlings-profile.ps1'
 
 try {
-    # Start from an unhooked profile. The CI job installs a bootstrap xlings
-    # into the runner's own home before this test runs, and hooking is
-    # idempotent on a marker — so an already-hooked profile would correctly
-    # be left alone, and the assertions below would be measuring nothing.
-    foreach ($h in $psHosts) {
-        Remove-Item -Force $h.Path -ErrorAction SilentlyContinue
-    }
-
     $origProfile = $env:USERPROFILE
     $origPath = $env:Path
     $env:USERPROFILE = $INSTALL_USER
     $env:Path = "$hostDirs;$(Get-MinimalSystemPath)"
     Remove-Item Env:XLINGS_HOME -ErrorAction SilentlyContinue
     try {
+        # Resolve $PROFILE per host INSIDE the redirected environment, because
+        # it is not environment-independent: pwsh 7 derives it from
+        # USERPROFILE and lands inside this sandbox, while Windows PowerShell
+        # 5.1 may answer with the runner's real Documents folder. Resolving
+        # before the redirect compared the install's work against the wrong
+        # path for whichever host follows USERPROFILE.
+        #
+        # `-Command '$PROFILE'` and not the bare-word form: 5.1 does not
+        # expand a bare word in argument mode (see shell_profile.cppm), and a
+        # probe that silently answers "" would make this test agree with a
+        # broken install instead of catching it.
+        foreach ($h in $psHosts) {
+            $reported = & $h.Exe -NoProfile -NonInteractive -Command '$PROFILE' 2>$null |
+                        Select-Object -First 1
+            if (-not $reported) { Fail "$($h.Exe) did not report a `$PROFILE path" }
+            $h.Path = $reported.Trim()
+            # Snapshot anything outside the sandbox so later CI steps do not
+            # end up sourcing this throwaway home; restored in the finally.
+            if (Test-Path $h.Path) { $h.Backup = Get-Content $h.Path -Raw }
+            # Start unhooked. The CI job installs a bootstrap xlings into the
+            # runner's own home first, and hooking is idempotent on a marker —
+            # an already-hooked profile would correctly be left alone, and the
+            # assertions would be measuring nothing.
+            Remove-Item -Force $h.Path -ErrorAction SilentlyContinue
+        }
+
         # --verbose so the per-host probe (command, exit code, raw reply) is in
         # the log. When a host silently fails to be hooked, that line is the
         # difference between a diagnosis and another CI round-trip.
@@ -98,6 +108,9 @@ try {
     }
 } finally {
     foreach ($h in $psHosts) {
+        # Path is null for hosts we never got to resolve (an earlier one
+        # failed); there is nothing of theirs to put back.
+        if (-not $h.Path) { continue }
         if ($null -eq $h.Backup) {
             Remove-Item -Force $h.Path -ErrorAction SilentlyContinue
         } else {

--- a/tests/e2e/release_self_install_test.ps1
+++ b/tests/e2e/release_self_install_test.ps1
@@ -69,7 +69,10 @@ try {
     $env:Path = "$hostDirs;$(Get-MinimalSystemPath)"
     Remove-Item Env:XLINGS_HOME -ErrorAction SilentlyContinue
     try {
-        & "$PKG_DIR\bin\xlings.exe" self install
+        # --verbose so the per-host probe (command, exit code, raw reply) is in
+        # the log. When a host silently fails to be hooked, that line is the
+        # difference between a diagnosis and another CI round-trip.
+        & "$PKG_DIR\bin\xlings.exe" self install --verbose
         if ($LASTEXITCODE -ne 0) { Fail "self install exited with code $LASTEXITCODE" }
 
         # The regression: EVERY host that was reachable must now source

--- a/tests/e2e/release_self_install_test.ps1
+++ b/tests/e2e/release_self_install_test.ps1
@@ -18,21 +18,90 @@ New-Item -ItemType Directory -Force -Path $INSTALL_USER | Out-Null
 if (-not (Test-Path "$PKG_DIR\.xlings.json")) { Fail "bootstrap config missing in release package" }
 if (-not (Test-Path "$PKG_DIR\bin\xlings.exe")) { Fail "bootstrap binary missing in release package" }
 
-# Install with minimal env
-$origProfile = $env:USERPROFILE
-$origPath = $env:Path
-$env:USERPROFILE = $INSTALL_USER
-$env:Path = Get-MinimalSystemPath
-Remove-Item Env:XLINGS_HOME -ErrorAction SilentlyContinue
-try {
-    & "$PKG_DIR\bin\xlings.exe" self install
-    if ($LASTEXITCODE -ne 0) { Fail "self install exited with code $LASTEXITCODE" }
-} finally {
-    $env:USERPROFILE = $origProfile
-    $env:Path = $origPath
+# ── PowerShell hosts ────────────────────────────────────────────────
+# `self install` hooks every PowerShell host it can start. Windows PowerShell
+# 5.1 and PowerShell 7+ read DIFFERENT startup files, and `xlings subos use`
+# spawns pwsh.exe first — hooking only 5.1 left the shell xlings itself
+# launches without XLINGS_BIN on PATH (#387).
+#
+# $PROFILE resolves from the user's real Documents folder; no environment
+# variable redirects it, so this test necessarily touches the runner's own
+# profiles. Snapshot them here and put them back below, or every later CI
+# step would start by sourcing this throwaway home.
+$psHosts = @()
+foreach ($exe in @('powershell', 'pwsh')) {
+    $found = Get-Command $exe -ErrorAction SilentlyContinue
+    if (-not $found) { continue }
+    $reported = & $exe -NoProfile -NonInteractive -Command '$PROFILE' 2>$null | Select-Object -First 1
+    if (-not $reported) { Fail "$exe did not report a `$PROFILE path" }
+    $reported = $reported.Trim()
+    $backup = $null
+    if (Test-Path $reported) { $backup = Get-Content $reported -Raw }
+    $psHosts += [pscustomobject]@{
+        Exe    = $exe
+        Path   = $reported
+        Dir    = (Split-Path $found.Source -Parent)
+        Backup = $backup
+    }
 }
+if ($psHosts.Count -eq 0) { Fail "no PowerShell host found on this machine" }
 
+# Install with minimal env. The host directories are added explicitly:
+# Get-MinimalSystemPath carries System32 (Windows PowerShell) but not
+# C:\Program Files\PowerShell\7, and a pwsh xlings cannot start is a pwsh it
+# is right to skip — which would make the assertion below vacuous.
+$hostDirs = ($psHosts | ForEach-Object { $_.Dir }) -join ';'
 $INSTALLED_HOME = Join-Path $INSTALL_USER '.xlings'
+$XLINGS_PS_PROFILE = Join-Path $INSTALLED_HOME 'config\shell\xlings-profile.ps1'
+
+try {
+    # Start from an unhooked profile. The CI job installs a bootstrap xlings
+    # into the runner's own home before this test runs, and hooking is
+    # idempotent on a marker — so an already-hooked profile would correctly
+    # be left alone, and the assertions below would be measuring nothing.
+    foreach ($h in $psHosts) {
+        Remove-Item -Force $h.Path -ErrorAction SilentlyContinue
+    }
+
+    $origProfile = $env:USERPROFILE
+    $origPath = $env:Path
+    $env:USERPROFILE = $INSTALL_USER
+    $env:Path = "$hostDirs;$(Get-MinimalSystemPath)"
+    Remove-Item Env:XLINGS_HOME -ErrorAction SilentlyContinue
+    try {
+        & "$PKG_DIR\bin\xlings.exe" self install
+        if ($LASTEXITCODE -ne 0) { Fail "self install exited with code $LASTEXITCODE" }
+
+        # The regression: EVERY host that was reachable must now source
+        # xlings-profile.ps1 from the home just installed.
+        foreach ($h in $psHosts) {
+            if (-not (Test-Path $h.Path)) {
+                Fail "self install left the $($h.Exe) profile unwritten: $($h.Path)"
+            }
+            $content = Get-Content $h.Path -Raw
+            if ($content -notmatch [regex]::Escape($XLINGS_PS_PROFILE)) {
+                Fail "$($h.Exe) profile does not source xlings-profile.ps1 ($($h.Path))"
+            }
+        }
+        # Idempotency is not re-checked here on purpose: a second
+        # `self install` of the same version stops at an interactive
+        # confirmation, which in CI answers "no" and skips profile setup
+        # entirely — the assertion would pass without ever running the code
+        # it claims to cover. It is covered by
+        # tests/unit/test_shell_profile.cpp instead.
+    } finally {
+        $env:USERPROFILE = $origProfile
+        $env:Path = $origPath
+    }
+} finally {
+    foreach ($h in $psHosts) {
+        if ($null -eq $h.Backup) {
+            Remove-Item -Force $h.Path -ErrorAction SilentlyContinue
+        } else {
+            Set-Content -Path $h.Path -Value $h.Backup -NoNewline
+        }
+    }
+}
 if (-not (Test-Path "$INSTALLED_HOME\bin\xlings.exe")) { Fail "installed home missing bin\xlings.exe" }
 if (-not (Test-Path "$INSTALLED_HOME\subos\current")) { Fail "installed home missing subos\current link" }
 

--- a/tests/e2e/release_self_install_test.ps1
+++ b/tests/e2e/release_self_install_test.ps1
@@ -64,10 +64,21 @@ try {
         # expand a bare word in argument mode (see shell_profile.cppm), and a
         # probe that silently answers "" would make this test agree with a
         # broken install instead of catching it.
+        # A real user profile has a Documents folder; this throwaway one does
+        # not, and Windows PowerShell 5.1 answers an empty $PROFILE when it is
+        # missing (.NET Framework's GetFolderPath returns "" for a folder that
+        # does not exist; .NET Core, i.e. pwsh 7, returns the path regardless).
+        # Without this the sandbox is not a stand-in for a user's home, and
+        # 5.1 drops out of the test for a reason that cannot happen on a real
+        # machine.
+        New-Item -ItemType Directory -Force (Join-Path $INSTALL_USER 'Documents') | Out-Null
+
         foreach ($h in $psHosts) {
             $reported = & $h.Exe -NoProfile -NonInteractive -Command '$PROFILE' 2>$null |
                         Select-Object -First 1
-            if (-not $reported) { Fail "$($h.Exe) did not report a `$PROFILE path" }
+            if (-not $reported) {
+                Fail "$($h.Exe) reported an empty `$PROFILE under USERPROFILE=$INSTALL_USER"
+            }
             $h.Path = $reported.Trim()
             # Snapshot anything outside the sandbox so later CI steps do not
             # end up sourcing this throwaway home; restored in the finally.

--- a/tests/unit/test_shell_profile.cpp
+++ b/tests/unit/test_shell_profile.cpp
@@ -99,20 +99,26 @@ TEST(ShellProfileProbe, ProbeCommandTagsTheAnswer) {
               std::string::npos);
 }
 
-// The command reaches powershell.exe through _popen -> cmd.exe, and each
-// layer re-parses quotes by its own rules — powershell.exe 5.1 does not even
-// use argv for -Command, it takes the rest of the line and strips quotes.
-// So the command carries NO quote of either kind: PowerShell's argument mode
-// expands `XLINGS_PROFILE=$PROFILE` as a bare word, which removes the whole
-// class of quoting bugs instead of working around one of them.
-TEST(ShellProfileProbe, ProbeCommandHasNoQuotesForAShellToReparse) {
+// Two properties, both established the hard way on a real Windows runner.
+//
+// No DOUBLE quote: the command reaches powershell.exe through _popen ->
+// cmd.exe, and powershell.exe 5.1 does not use argv for -Command — it takes
+// the rest of the line and strips double quotes itself. Single quotes pass
+// all three layers untouched, so the script can still quote its own literal.
+//
+// One whitespace-free token: the script must be an EXPRESSION, not a command
+// with arguments. `Write-Output XLINGS_PROFILE=$PROFILE` relies on argument
+// mode expanding a bare word, which pwsh 7 does and Windows PowerShell 5.1
+// does not — 5.1 answered a literal `XLINGS_PROFILE=` with the path missing,
+// which is indistinguishable from a host with no profile at all.
+TEST(ShellProfileProbe, ProbeCommandIsASingleUnquotedExpression) {
     for (auto host : sp::kPowerShellHosts) {
         auto cmd = sp::probe_command(host);
         EXPECT_EQ(cmd.find('"'), std::string::npos) << cmd;
-        EXPECT_EQ(cmd.find('\''), std::string::npos) << cmd;
-        // …and the tag stays glued to $PROFILE, so it survives argument mode.
-        EXPECT_NE(cmd.find(std::string(sp::kProbePrefix) + "$PROFILE"),
-                  std::string::npos) << cmd;
+
+        auto script = cmd.substr(cmd.rfind(' ') + 1);
+        EXPECT_NE(script.find(sp::kProbePrefix), std::string::npos) << cmd;
+        EXPECT_NE(script.find("$PROFILE"), std::string::npos) << cmd;
     }
 }
 

--- a/tests/unit/test_shell_profile.cpp
+++ b/tests/unit/test_shell_profile.cpp
@@ -1,0 +1,295 @@
+// tests/unit/test_shell_profile.cpp — the shell-profile hook registry.
+//
+// `self install` has to hook every shell that will later start an xlings
+// session. On Windows there is more than one: Windows PowerShell 5.1
+// (`powershell`) and PowerShell 7+ (`pwsh`) read DIFFERENT startup files, and
+// `xlings subos use` spawns pwsh in preference to powershell — so hooking only
+// the 5.1 profile leaves the shell xlings itself launches un-hooked (#387).
+//
+// Everything here is platform-neutral on purpose: the host list is data, the
+// probe is injected, and the file mutation is ordinary C++. That is what makes
+// the Windows-only policy testable on the Linux CI runner, and it is why the
+// old inline `powershell -Command "...Add-Content..."` one-liner had no tests
+// at all.
+//
+// Every case asserts the observable effect, not just the verdict — a hook that
+// reported Added while appending nothing is exactly this codebase's recurring
+// failure shape.
+
+#include <gtest/gtest.h>
+
+import std;
+import xlings.core.xself.shell_profile;
+
+namespace fs = std::filesystem;
+namespace sp = xlings::xself::shell_profile;
+
+using sp::HookResult;
+
+namespace {
+
+// Answers each probe command from a scripted table and records what it was
+// asked. Anything not in the table is "host not installed" (nullopt), which
+// is what a real runner reports for a missing pwsh.
+struct FakeRunner {
+    std::map<std::string, std::string>  replies;
+    mutable std::vector<std::string>    ran;
+
+    std::optional<std::string> operator()(const std::string& cmd) const {
+        ran.push_back(cmd);
+        if (auto it = replies.find(cmd); it != replies.end()) return it->second;
+        return std::nullopt;
+    }
+};
+
+// A scratch directory per test, removed on teardown.
+class ShellProfileFileTest : public ::testing::Test {
+protected:
+    fs::path dir;
+
+    void SetUp() override {
+        auto base = fs::temp_directory_path() / "xlings-shell-profile-test";
+        std::error_code ec;
+        fs::remove_all(base, ec);
+        fs::create_directories(base);
+        dir = base;
+    }
+    void TearDown() override {
+        std::error_code ec;
+        fs::remove_all(dir, ec);
+    }
+
+    std::string read(const fs::path& p) const {
+        std::ifstream in(p, std::ios::binary);
+        return std::string(std::istreambuf_iterator<char>(in), {});
+    }
+    void write(const fs::path& p, std::string_view content) const {
+        std::ofstream out(p, std::ios::binary);
+        out << content;
+    }
+};
+
+const std::vector<std::string_view> kHosts { "powershell", "pwsh" };
+
+} // namespace
+
+// ─── probe_command ──────────────────────────────────────────────────
+
+// -NoProfile matters: without it the probe would source the very profile it
+// is about to edit, and on a half-configured home that profile can fail.
+// -NonInteractive keeps a misbehaving profile from parking on a prompt.
+TEST(ShellProfileProbe, ProbeCommandStartsHostWithoutItsOwnProfile) {
+    auto cmd = sp::probe_command("pwsh");
+    EXPECT_TRUE(cmd.starts_with("pwsh ")) << cmd;
+    EXPECT_NE(cmd.find("-NoProfile"), std::string::npos) << cmd;
+    EXPECT_NE(cmd.find("-NonInteractive"), std::string::npos) << cmd;
+    EXPECT_NE(cmd.find("$PROFILE"), std::string::npos) << cmd;
+}
+
+// The answer is tagged rather than read as "whatever the process printed":
+// the runner merges stderr into stdout, so an unrelated warning line would
+// otherwise be adopted as a profile path and written to.
+TEST(ShellProfileProbe, ProbeCommandTagsTheAnswer) {
+    EXPECT_NE(sp::probe_command("powershell").find(sp::kProbePrefix),
+              std::string::npos);
+}
+
+// ─── parse_probe_output ─────────────────────────────────────────────
+
+TEST(ShellProfileParse, ReadsTheTaggedPath) {
+    auto p = sp::parse_probe_output(
+        "XLINGS_PROFILE=C:\\Users\\me\\Documents\\PowerShell\\Microsoft.PowerShell_profile.ps1\n");
+    ASSERT_TRUE(p.has_value());
+    EXPECT_EQ(p->string(),
+              "C:\\Users\\me\\Documents\\PowerShell\\Microsoft.PowerShell_profile.ps1");
+}
+
+// The failure this guards: a deprecation warning printed before the answer
+// used to be indistinguishable from the answer itself.
+TEST(ShellProfileParse, IgnoresUntaggedNoise) {
+    auto p = sp::parse_probe_output(
+        "WARNING: module 'foo' shadowed\n"
+        "XLINGS_PROFILE=C:\\p\\profile.ps1\n"
+        "trailing chatter\n");
+    ASSERT_TRUE(p.has_value());
+    EXPECT_EQ(p->string(), "C:\\p\\profile.ps1");
+}
+
+// _popen hands back CRLF; an unstripped CR becomes part of the filename.
+TEST(ShellProfileParse, StripsCarriageReturnAndSurroundingSpace) {
+    auto p = sp::parse_probe_output("XLINGS_PROFILE=  C:\\p\\profile.ps1  \r\n");
+    ASSERT_TRUE(p.has_value());
+    EXPECT_EQ(p->string(), "C:\\p\\profile.ps1");
+}
+
+TEST(ShellProfileParse, RejectsOutputWithoutTheTag) {
+    EXPECT_FALSE(sp::parse_probe_output("'pwsh' is not recognized\n").has_value());
+    EXPECT_FALSE(sp::parse_probe_output("").has_value());
+}
+
+// A host that answers with an empty $PROFILE has nothing to hook; treating
+// that as a path would create a file named after the current directory.
+TEST(ShellProfileParse, RejectsBlankTaggedValue) {
+    EXPECT_FALSE(sp::parse_probe_output("XLINGS_PROFILE=\n").has_value());
+    EXPECT_FALSE(sp::parse_probe_output("XLINGS_PROFILE=   \r\n").has_value());
+}
+
+// ─── resolve_targets ────────────────────────────────────────────────
+
+TEST(ShellProfileResolve, ReturnsOneTargetPerHostThatAnswers) {
+    FakeRunner run {{
+        {sp::probe_command("powershell"), "XLINGS_PROFILE=C:\\ps5\\profile.ps1\r\n"},
+        {sp::probe_command("pwsh"),       "XLINGS_PROFILE=C:\\ps7\\profile.ps1\r\n"},
+    }};
+
+    auto targets = sp::resolve_targets(kHosts, std::ref(run));
+
+    ASSERT_EQ(targets.size(), 2u);
+    EXPECT_EQ(targets[0].host, "powershell");
+    EXPECT_EQ(targets[0].path.string(), "C:\\ps5\\profile.ps1");
+    EXPECT_EQ(targets[1].host, "pwsh");
+    EXPECT_EQ(targets[1].path.string(), "C:\\ps7\\profile.ps1");
+}
+
+// The regression under test, from the other side: a machine WITH pwsh must
+// yield a pwsh target. Before the fix there was no pwsh entry to yield.
+TEST(ShellProfileResolve, HooksPwshEvenWhenItsProfileDiffersFromPowerShell5) {
+    FakeRunner run {{
+        {sp::probe_command("powershell"),
+         "XLINGS_PROFILE=C:\\U\\Documents\\WindowsPowerShell\\Microsoft.PowerShell_profile.ps1\r\n"},
+        {sp::probe_command("pwsh"),
+         "XLINGS_PROFILE=C:\\U\\Documents\\PowerShell\\Microsoft.PowerShell_profile.ps1\r\n"},
+    }};
+
+    auto targets = sp::resolve_targets(kHosts, std::ref(run));
+
+    ASSERT_EQ(targets.size(), 2u);
+    EXPECT_NE(targets[0].path, targets[1].path);
+}
+
+TEST(ShellProfileResolve, SkipsHostThatIsNotInstalled) {
+    FakeRunner run {{
+        {sp::probe_command("powershell"), "XLINGS_PROFILE=C:\\ps5\\profile.ps1\r\n"},
+    }};
+
+    auto targets = sp::resolve_targets(kHosts, std::ref(run));
+
+    ASSERT_EQ(targets.size(), 1u);
+    EXPECT_EQ(targets[0].host, "powershell");
+}
+
+TEST(ShellProfileResolve, SkipsHostWhoseAnswerIsUnusable) {
+    FakeRunner run {{
+        {sp::probe_command("powershell"), "XLINGS_PROFILE=C:\\ps5\\profile.ps1\r\n"},
+        {sp::probe_command("pwsh"),       "pwsh: command not found\r\n"},
+    }};
+
+    auto targets = sp::resolve_targets(kHosts, std::ref(run));
+
+    ASSERT_EQ(targets.size(), 1u);
+    EXPECT_EQ(targets[0].host, "powershell");
+}
+
+// The shipped host list is the thing install.cppm actually passes, so assert
+// on it rather than only on the hand-rolled list the other cases use. pwsh
+// missing from it is the whole of #387.
+TEST(ShellProfileResolve, TheShippedHostListCoversBothWindowsPowerShellHosts) {
+    FakeRunner run {{
+        {sp::probe_command("powershell"), "XLINGS_PROFILE=C:\\ps5\\profile.ps1\r\n"},
+        {sp::probe_command("pwsh"),       "XLINGS_PROFILE=C:\\ps7\\profile.ps1\r\n"},
+    }};
+
+    auto targets = sp::resolve_targets(sp::kPowerShellHosts, std::ref(run));
+
+    ASSERT_EQ(targets.size(), 2u);
+    EXPECT_EQ(targets[0].host, "powershell");
+    EXPECT_EQ(targets[1].host, "pwsh");
+}
+
+// Each host is started once. Probing pwsh twice would double a ~1s startup
+// on every `self install` / `self update`.
+TEST(ShellProfileResolve, StartsEachHostExactlyOnce) {
+    FakeRunner run {{
+        {sp::probe_command("powershell"), "XLINGS_PROFILE=C:\\ps5\\profile.ps1\r\n"},
+        {sp::probe_command("pwsh"),       "XLINGS_PROFILE=C:\\ps7\\profile.ps1\r\n"},
+    }};
+
+    sp::resolve_targets(kHosts, std::ref(run));
+
+    ASSERT_EQ(run.ran.size(), 2u);
+    EXPECT_EQ(run.ran[0], sp::probe_command("powershell"));
+    EXPECT_EQ(run.ran[1], sp::probe_command("pwsh"));
+}
+
+// ─── powershell_snippet ─────────────────────────────────────────────
+
+TEST(ShellProfileSnippet, SourcesTheScriptBehindAnExistenceGuard) {
+    auto s = sp::powershell_snippet("C:\\home\\config\\shell\\xlings-profile.ps1");
+    EXPECT_NE(s.find("Test-Path"), std::string::npos) << s;
+    EXPECT_NE(s.find("C:\\home\\config\\shell\\xlings-profile.ps1"), std::string::npos) << s;
+}
+
+// hook() is idempotent by looking for the marker in the file, so the snippet
+// it writes must carry that marker.
+TEST(ShellProfileSnippet, CarriesTheIdempotencyMarker) {
+    auto s = sp::powershell_snippet("C:\\home\\config\\shell\\xlings-profile.ps1");
+    EXPECT_NE(s.find(sp::kMarker), std::string::npos) << s;
+}
+
+// A quote in the home path used to close the PowerShell string literal early
+// and leave a syntactically broken profile behind — every later shell then
+// started with a parse error. PowerShell escapes ' inside '...' by doubling.
+TEST(ShellProfileSnippet, EscapesSingleQuotesInThePath) {
+    auto s = sp::powershell_snippet("C:\\Users\\o'brien\\.xlings\\xlings-profile.ps1");
+    EXPECT_EQ(s.find("o'brien"), std::string::npos)
+        << "raw quote left unescaped: " << s;
+    EXPECT_NE(s.find("o''brien"), std::string::npos) << s;
+}
+
+// ─── hook ───────────────────────────────────────────────────────────
+
+TEST_F(ShellProfileFileTest, AppendsToAnExistingProfileAndKeepsItsContent) {
+    auto prof = dir / "Microsoft.PowerShell_profile.ps1";
+    write(prof, "Set-Alias ll Get-ChildItem\n");
+
+    auto r = sp::hook(prof, "if(Test-Path 'p'){. 'p'}  # xlings-profile");
+
+    EXPECT_EQ(r, HookResult::Added);
+    auto content = read(prof);
+    EXPECT_TRUE(content.starts_with("Set-Alias ll Get-ChildItem\n")) << content;
+    EXPECT_NE(content.find("xlings-profile"), std::string::npos) << content;
+}
+
+TEST_F(ShellProfileFileTest, SecondHookLeavesTheFileByteIdentical) {
+    auto prof = dir / "profile.ps1";
+    write(prof, "# user config\n");
+    std::string snippet = "if(Test-Path 'p'){. 'p'}  # xlings-profile";
+
+    ASSERT_EQ(sp::hook(prof, snippet), HookResult::Added);
+    auto after_first = read(prof);
+
+    EXPECT_EQ(sp::hook(prof, snippet), HookResult::AlreadyHooked);
+    EXPECT_EQ(read(prof), after_first);
+}
+
+// A fresh Windows account has no Documents\PowerShell directory at all.
+TEST_F(ShellProfileFileTest, CreatesTheProfileAndItsParentDirectories) {
+    auto prof = dir / "Documents" / "PowerShell" / "Microsoft.PowerShell_profile.ps1";
+
+    auto r = sp::hook(prof, "if(Test-Path 'p'){. 'p'}  # xlings-profile");
+
+    EXPECT_EQ(r, HookResult::Added);
+    ASSERT_TRUE(fs::exists(prof));
+    EXPECT_NE(read(prof).find("xlings-profile"), std::string::npos);
+}
+
+// Failure must be reported, not swallowed: `self install` prints a manual
+// fallback hint when it could not hook a shell, and cannot do that if a
+// failed write is indistinguishable from a successful one.
+TEST_F(ShellProfileFileTest, ReportsFailureWhenTheProfilePathIsUnusable) {
+    auto blocker = dir / "Documents";
+    write(blocker, "not a directory\n");
+    auto prof = blocker / "PowerShell" / "profile.ps1";
+
+    EXPECT_EQ(sp::hook(prof, "# xlings-profile"), HookResult::Failed);
+}

--- a/tests/unit/test_shell_profile.cpp
+++ b/tests/unit/test_shell_profile.cpp
@@ -25,22 +25,27 @@ namespace fs = std::filesystem;
 namespace sp = xlings::xself::shell_profile;
 
 using sp::HookResult;
+using sp::ProbeStatus;
 
 namespace {
 
 // Answers each probe command from a scripted table and records what it was
-// asked. Anything not in the table is "host not installed" (nullopt), which
-// is what a real runner reports for a missing pwsh.
+// asked. Anything not in the table exits non-zero with the message cmd.exe
+// produces for a missing executable — what a real runner reports for a box
+// without pwsh.
 struct FakeRunner {
-    std::map<std::string, std::string>  replies;
-    mutable std::vector<std::string>    ran;
+    std::map<std::string, std::pair<int, std::string>> replies;
+    mutable std::vector<std::string>                   ran;
 
-    std::optional<std::string> operator()(const std::string& cmd) const {
+    std::pair<int, std::string> operator()(const std::string& cmd) const {
         ran.push_back(cmd);
         if (auto it = replies.find(cmd); it != replies.end()) return it->second;
-        return std::nullopt;
+        return {1, "'" + cmd.substr(0, cmd.find(' ')) +
+                       "' is not recognized as an internal or external command"};
     }
 };
+
+std::pair<int, std::string> ok(std::string out) { return {0, std::move(out)}; }
 
 // A scratch directory per test, removed on teardown.
 class ShellProfileFileTest : public ::testing::Test {
@@ -94,6 +99,23 @@ TEST(ShellProfileProbe, ProbeCommandTagsTheAnswer) {
               std::string::npos);
 }
 
+// The command reaches powershell.exe through _popen -> cmd.exe, and each
+// layer re-parses quotes by its own rules — powershell.exe 5.1 does not even
+// use argv for -Command, it takes the rest of the line and strips quotes.
+// So the command carries NO quote of either kind: PowerShell's argument mode
+// expands `XLINGS_PROFILE=$PROFILE` as a bare word, which removes the whole
+// class of quoting bugs instead of working around one of them.
+TEST(ShellProfileProbe, ProbeCommandHasNoQuotesForAShellToReparse) {
+    for (auto host : sp::kPowerShellHosts) {
+        auto cmd = sp::probe_command(host);
+        EXPECT_EQ(cmd.find('"'), std::string::npos) << cmd;
+        EXPECT_EQ(cmd.find('\''), std::string::npos) << cmd;
+        // …and the tag stays glued to $PROFILE, so it survives argument mode.
+        EXPECT_NE(cmd.find(std::string(sp::kProbePrefix) + "$PROFILE"),
+                  std::string::npos) << cmd;
+    }
+}
+
 // ─── parse_probe_output ─────────────────────────────────────────────
 
 TEST(ShellProfileParse, ReadsTheTaggedPath) {
@@ -134,87 +156,113 @@ TEST(ShellProfileParse, RejectsBlankTaggedValue) {
     EXPECT_FALSE(sp::parse_probe_output("XLINGS_PROFILE=   \r\n").has_value());
 }
 
-// ─── resolve_targets ────────────────────────────────────────────────
+// ─── probe_hosts ────────────────────────────────────────────────────
 
-TEST(ShellProfileResolve, ReturnsOneTargetPerHostThatAnswers) {
+TEST(ShellProfileProbeHosts, ReportsThePathEachHostAnswered) {
     FakeRunner run {{
-        {sp::probe_command("powershell"), "XLINGS_PROFILE=C:\\ps5\\profile.ps1\r\n"},
-        {sp::probe_command("pwsh"),       "XLINGS_PROFILE=C:\\ps7\\profile.ps1\r\n"},
+        {sp::probe_command("powershell"), ok("XLINGS_PROFILE=C:\\ps5\\profile.ps1\r\n")},
+        {sp::probe_command("pwsh"),       ok("XLINGS_PROFILE=C:\\ps7\\profile.ps1\r\n")},
     }};
 
-    auto targets = sp::resolve_targets(kHosts, std::ref(run));
+    auto probes = sp::probe_hosts(kHosts, std::ref(run));
 
-    ASSERT_EQ(targets.size(), 2u);
-    EXPECT_EQ(targets[0].host, "powershell");
-    EXPECT_EQ(targets[0].path.string(), "C:\\ps5\\profile.ps1");
-    EXPECT_EQ(targets[1].host, "pwsh");
-    EXPECT_EQ(targets[1].path.string(), "C:\\ps7\\profile.ps1");
+    ASSERT_EQ(probes.size(), 2u);
+    EXPECT_EQ(probes[0].host, "powershell");
+    EXPECT_EQ(probes[0].status, ProbeStatus::Answered);
+    EXPECT_EQ(probes[0].path.string(), "C:\\ps5\\profile.ps1");
+    EXPECT_EQ(probes[1].host, "pwsh");
+    EXPECT_EQ(probes[1].status, ProbeStatus::Answered);
+    EXPECT_EQ(probes[1].path.string(), "C:\\ps7\\profile.ps1");
 }
 
 // The regression under test, from the other side: a machine WITH pwsh must
 // yield a pwsh target. Before the fix there was no pwsh entry to yield.
-TEST(ShellProfileResolve, HooksPwshEvenWhenItsProfileDiffersFromPowerShell5) {
+TEST(ShellProfileProbeHosts, HooksPwshEvenWhenItsProfileDiffersFromPowerShell5) {
     FakeRunner run {{
         {sp::probe_command("powershell"),
-         "XLINGS_PROFILE=C:\\U\\Documents\\WindowsPowerShell\\Microsoft.PowerShell_profile.ps1\r\n"},
+         ok("XLINGS_PROFILE=C:\\U\\Documents\\WindowsPowerShell\\Microsoft.PowerShell_profile.ps1\r\n")},
         {sp::probe_command("pwsh"),
-         "XLINGS_PROFILE=C:\\U\\Documents\\PowerShell\\Microsoft.PowerShell_profile.ps1\r\n"},
+         ok("XLINGS_PROFILE=C:\\U\\Documents\\PowerShell\\Microsoft.PowerShell_profile.ps1\r\n")},
     }};
 
-    auto targets = sp::resolve_targets(kHosts, std::ref(run));
+    auto probes = sp::probe_hosts(kHosts, std::ref(run));
 
-    ASSERT_EQ(targets.size(), 2u);
-    EXPECT_NE(targets[0].path, targets[1].path);
+    ASSERT_EQ(probes.size(), 2u);
+    EXPECT_NE(probes[0].path, probes[1].path);
 }
 
-TEST(ShellProfileResolve, SkipsHostThatIsNotInstalled) {
+// A host that never started is a different fact from a host that started and
+// said something unusable: the first is the ordinary 5.1-only machine, the
+// second is a bug worth showing the user. They used to be the same silent
+// `continue`, which is how a whole missing host went unnoticed for a release.
+TEST(ShellProfileProbeHosts, DistinguishesNotInstalledFromUnusableAnswer) {
     FakeRunner run {{
-        {sp::probe_command("powershell"), "XLINGS_PROFILE=C:\\ps5\\profile.ps1\r\n"},
+        // pwsh absent -> FakeRunner's default: non-zero + cmd.exe's message.
+        {sp::probe_command("powershell"), ok("WARNING: something odd\r\n")},
     }};
 
-    auto targets = sp::resolve_targets(kHosts, std::ref(run));
+    auto probes = sp::probe_hosts(kHosts, std::ref(run));
 
-    ASSERT_EQ(targets.size(), 1u);
-    EXPECT_EQ(targets[0].host, "powershell");
+    ASSERT_EQ(probes.size(), 2u);
+    EXPECT_EQ(probes[0].status, ProbeStatus::Unusable);
+    EXPECT_EQ(probes[1].status, ProbeStatus::NotInstalled);
 }
 
-TEST(ShellProfileResolve, SkipsHostWhoseAnswerIsUnusable) {
+// The raw text is what a maintainer needs to see when a host answers
+// something unexpected — without it the report is "it did not work".
+TEST(ShellProfileProbeHosts, KeepsTheUnusableAnswerForTheReport) {
     FakeRunner run {{
-        {sp::probe_command("powershell"), "XLINGS_PROFILE=C:\\ps5\\profile.ps1\r\n"},
-        {sp::probe_command("pwsh"),       "pwsh: command not found\r\n"},
+        {sp::probe_command("powershell"), ok("Missing expression after unary operator\r\n")},
     }};
 
-    auto targets = sp::resolve_targets(kHosts, std::ref(run));
+    auto probes = sp::probe_hosts(kHosts, std::ref(run));
 
-    ASSERT_EQ(targets.size(), 1u);
-    EXPECT_EQ(targets[0].host, "powershell");
+    ASSERT_FALSE(probes.empty());
+    EXPECT_EQ(probes[0].status, ProbeStatus::Unusable);
+    EXPECT_NE(probes[0].output.find("Missing expression"), std::string::npos);
+}
+
+// Every host gets an entry whatever happens. A host that vanishes from the
+// result cannot be reported on, and an unreported host is how #387 looked
+// from the outside: `self install` printed success and hooked nothing.
+TEST(ShellProfileProbeHosts, ReturnsOneEntryPerHostEvenWhenNoneAnswer) {
+    FakeRunner run {};
+
+    auto probes = sp::probe_hosts(kHosts, std::ref(run));
+
+    ASSERT_EQ(probes.size(), 2u);
+    EXPECT_EQ(probes[0].host, "powershell");
+    EXPECT_EQ(probes[1].host, "pwsh");
+    for (const auto& p : probes) EXPECT_EQ(p.status, ProbeStatus::NotInstalled);
 }
 
 // The shipped host list is the thing install.cppm actually passes, so assert
 // on it rather than only on the hand-rolled list the other cases use. pwsh
 // missing from it is the whole of #387.
-TEST(ShellProfileResolve, TheShippedHostListCoversBothWindowsPowerShellHosts) {
+TEST(ShellProfileProbeHosts, TheShippedHostListCoversBothWindowsPowerShellHosts) {
     FakeRunner run {{
-        {sp::probe_command("powershell"), "XLINGS_PROFILE=C:\\ps5\\profile.ps1\r\n"},
-        {sp::probe_command("pwsh"),       "XLINGS_PROFILE=C:\\ps7\\profile.ps1\r\n"},
+        {sp::probe_command("powershell"), ok("XLINGS_PROFILE=C:\\ps5\\profile.ps1\r\n")},
+        {sp::probe_command("pwsh"),       ok("XLINGS_PROFILE=C:\\ps7\\profile.ps1\r\n")},
     }};
 
-    auto targets = sp::resolve_targets(sp::kPowerShellHosts, std::ref(run));
+    auto probes = sp::probe_hosts(sp::kPowerShellHosts, std::ref(run));
 
-    ASSERT_EQ(targets.size(), 2u);
-    EXPECT_EQ(targets[0].host, "powershell");
-    EXPECT_EQ(targets[1].host, "pwsh");
+    ASSERT_EQ(probes.size(), 2u);
+    EXPECT_EQ(probes[0].host, "powershell");
+    EXPECT_EQ(probes[0].status, ProbeStatus::Answered);
+    EXPECT_EQ(probes[1].host, "pwsh");
+    EXPECT_EQ(probes[1].status, ProbeStatus::Answered);
 }
 
 // Each host is started once. Probing pwsh twice would double a ~1s startup
 // on every `self install` / `self update`.
-TEST(ShellProfileResolve, StartsEachHostExactlyOnce) {
+TEST(ShellProfileProbeHosts, StartsEachHostExactlyOnce) {
     FakeRunner run {{
-        {sp::probe_command("powershell"), "XLINGS_PROFILE=C:\\ps5\\profile.ps1\r\n"},
-        {sp::probe_command("pwsh"),       "XLINGS_PROFILE=C:\\ps7\\profile.ps1\r\n"},
+        {sp::probe_command("powershell"), ok("XLINGS_PROFILE=C:\\ps5\\profile.ps1\r\n")},
+        {sp::probe_command("pwsh"),       ok("XLINGS_PROFILE=C:\\ps7\\profile.ps1\r\n")},
     }};
 
-    sp::resolve_targets(kHosts, std::ref(run));
+    sp::probe_hosts(kHosts, std::ref(run));
 
     ASSERT_EQ(run.ran.size(), 2u);
     EXPECT_EQ(run.ran[0], sp::probe_command("powershell"));

--- a/tools/other/quick_install.ps1
+++ b/tools/other/quick_install.ps1
@@ -14,30 +14,6 @@ function Log-Info  { param([string]$Msg) Write-Host "[xlings]: $Msg" -Foreground
 function Log-Warn  { param([string]$Msg) Write-Host "[xlings]: $Msg" -ForegroundColor Yellow }
 function Log-Error { param([string]$Msg) Write-Host "[xlings]: $Msg" -ForegroundColor Red }
 
-function Ensure-XlingsProfile {
-    param(
-        [string]$ShellExe,
-        [string]$SourceLine,
-        [string]$Label
-    )
-    $prof = & $ShellExe -NoProfile -Command '$PROFILE' 2>$null
-    if (-not $prof) { return }
-    $dir = Split-Path $prof -Parent
-    if (!(Test-Path $dir)) {
-        New-Item -ItemType Directory -Force $dir | Out-Null
-    }
-    if (!(Test-Path $prof)) {
-        New-Item -ItemType File -Force $prof | Out-Null
-    }
-    $existing = Get-Content $prof -Raw -ErrorAction SilentlyContinue
-    if (!$existing -or $existing -notlike '*xlings-profile*') {
-        Add-Content $prof $SourceLine
-        Log-Info "$Label profile configured"
-    } else {
-        Log-Info "$Label profile already set"
-    }
-}
-
 $OFFICIAL_REPO = "openxlings/xlings"
 $RESOURCE_REPO = "xlings-res/xlings"
 $GITHUB_MIRROR = $env:XLINGS_GITHUB_MIRROR
@@ -384,22 +360,6 @@ try {
         }
     } finally {
         Pop-Location
-    }
-
-    try {
-        $xlHome = [System.Environment]::GetEnvironmentVariable('XLINGS_HOME', 'User')
-        if ($xlHome) {
-            $sourceLine = "`n# xlings`nif(Test-Path '$xlHome\config\shell\xlings-profile.ps1'){. '$xlHome\config\shell\xlings-profile.ps1'}"
-
-            Ensure-XlingsProfile -ShellExe powershell -SourceLine $sourceLine -Label "Windows PowerShell"
-
-            $pwshCmd = Get-Command pwsh -ErrorAction SilentlyContinue
-            if ($pwshCmd) {
-                Ensure-XlingsProfile -ShellExe pwsh -SourceLine $sourceLine -Label "pwsh 7+"
-            }
-        }
-    } catch {
-        Log-Warn "shell profile setup skipped: $($_.Exception.Message)"
     }
 } catch {
     Log-Error "Installation failed: $($_.Exception.Message)"

--- a/tools/other/quick_install.ps1
+++ b/tools/other/quick_install.ps1
@@ -14,6 +14,30 @@ function Log-Info  { param([string]$Msg) Write-Host "[xlings]: $Msg" -Foreground
 function Log-Warn  { param([string]$Msg) Write-Host "[xlings]: $Msg" -ForegroundColor Yellow }
 function Log-Error { param([string]$Msg) Write-Host "[xlings]: $Msg" -ForegroundColor Red }
 
+function Ensure-XlingsProfile {
+    param(
+        [string]$ShellExe,
+        [string]$SourceLine,
+        [string]$Label
+    )
+    $prof = & $ShellExe -NoProfile -Command '$PROFILE' 2>$null
+    if (-not $prof) { return }
+    $dir = Split-Path $prof -Parent
+    if (!(Test-Path $dir)) {
+        New-Item -ItemType Directory -Force $dir | Out-Null
+    }
+    if (!(Test-Path $prof)) {
+        New-Item -ItemType File -Force $prof | Out-Null
+    }
+    $existing = Get-Content $prof -Raw -ErrorAction SilentlyContinue
+    if (!$existing -or $existing -notlike '*xlings-profile*') {
+        Add-Content $prof $SourceLine
+        Log-Info "$Label profile configured"
+    } else {
+        Log-Info "$Label profile already set"
+    }
+}
+
 $OFFICIAL_REPO = "openxlings/xlings"
 $RESOURCE_REPO = "xlings-res/xlings"
 $GITHUB_MIRROR = $env:XLINGS_GITHUB_MIRROR
@@ -360,6 +384,22 @@ try {
         }
     } finally {
         Pop-Location
+    }
+
+    try {
+        $xlHome = [System.Environment]::GetEnvironmentVariable('XLINGS_HOME', 'User')
+        if ($xlHome) {
+            $sourceLine = "`n# xlings`nif(Test-Path '$xlHome\config\shell\xlings-profile.ps1'){. '$xlHome\config\shell\xlings-profile.ps1'}"
+
+            Ensure-XlingsProfile -ShellExe powershell -SourceLine $sourceLine -Label "Windows PowerShell"
+
+            $pwshCmd = Get-Command pwsh -ErrorAction SilentlyContinue
+            if ($pwshCmd) {
+                Ensure-XlingsProfile -ShellExe pwsh -SourceLine $sourceLine -Label "pwsh 7+"
+            }
+        }
+    } catch {
+        Log-Warn "shell profile setup skipped: $($_.Exception.Message)"
     }
 } catch {
     Log-Error "Installation failed: $($_.Exception.Message)"


### PR DESCRIPTION
## The bug (as reported by @ZheFeng7110)

Windows has **two** PowerShell hosts, and they read **different** startup files:

| host | product | `$PROFILE` |
|---|---|---|
| `powershell` | Windows PowerShell 5.1 | `Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1` |
| `pwsh` | PowerShell 7+ | `Documents\PowerShell\Microsoft.PowerShell_profile.ps1` |

`setup_shell_profiles()` hooked `powershell` only, while `use_spawn_shell()`
(`src/core/subos.cppm`) launches `pwsh.exe` **first**. So on any machine with
PowerShell 7, the one host xlings never hooked was the one xlings itself
starts: `xlings subos use <name>` came up with no prompt marker, no
`XLINGS_BIN`, and the subos `bin/` off `PATH`. Confirmed real. Closes #387.

## What changed relative to the first pass

The missing host was the symptom; the shape was the cause. The old block built
a file edit as a PowerShell script inside a C++ string inside a `-Command`
string inside `std::system()` — three escaping layers, one hardcoded host, exit
code discarded, and unreachable by any test. Adding a second `pwsh` copy of the
same block would have inherited all four. So the policy moved out instead:

**New module `xlings.core.xself.shell_profile`**

- **Hosts are data** — `kPowerShellHosts = { "powershell", "pwsh" }`. Adding a
  host is one array entry.
- **Location is asked, not computed** — each host reports its own `$PROFILE`
  via `<host> -NoProfile -NonInteractive -Command 'XLINGS_PROFILE='+$PROFILE`.
  That is correct under OneDrive Known Folder Redirection (where a hardcoded
  `Documents\PowerShell\` is not) and doubles as the is-it-installed probe, so
  no separate `where pwsh` is needed. The answer is **tagged** because
  `run_command_capture()` folds stderr into stdout — untagged, a warning banner
  would be adopted as a path and written to.

  The exact shape of that script cost three CI rounds, because the two hosts
  disagree about more than their profile paths:

  | script passed to `-Command` | pwsh 7 | Windows PowerShell 5.1 |
  |---|---|---|
  | `"Write-Output ('XLINGS_PROFILE=' + $PROFILE)"` | answers | **no answer** |
  | `Write-Output XLINGS_PROFILE=$PROFILE` (bare word) | answers | **`XLINGS_PROFILE=`**, value missing |
  | `'XLINGS_PROFILE='+$PROFILE` | answers | answers |

  Two rules fall out, both asserted by `ProbeCommandIsASingleUnquotedExpression`:
  **no double quote** (the command crosses `_popen` → `cmd.exe` →
  `powershell.exe`, and 5.1 does not use argv for `-Command` — it takes the
  rest of the line and strips double quotes itself), and **an expression, not a
  command with arguments** (the bare-word form needs argument-mode expansion,
  which pwsh 7 does and 5.1 does not).
- **Every host gets a verdict** — `probe_hosts()` returns one `Probe` per host
  (`Answered` / `NotInstalled` / `Unusable`) plus the raw reply. A host that
  quietly drops out of the result cannot be reported on, and an unreported host
  is exactly how #387 looked from outside: success printed, nothing hooked.
  `NotInstalled` is the ordinary 5.1-only machine and stays at debug;
  `Unusable` is a defect and is warned about with what the host actually said —
  which is what turned round two's failure into a diagnosis instead of another
  guess.
- **The edit is ordinary C++** — the same read → marker → append the POSIX
  branch already uses. Nothing crosses a shell, so a `'` in the home path can
  be escaped *and tested for* instead of silently corrupting the profile, and
  `hook()` returns `Added` / `AlreadyHooked` / `Failed` so a failed write stops
  looking exactly like a successful one.

`install.cppm` keeps only what belongs to it: spawning the probe, reporting
per host, and a manual `$PROFILE` hint when no host answers at all.

**Fallout fixed on the way** — `emit_shell_advisory_()` in `uninstall.cppm`
listed POSIX rc files by relative name, so on Windows uninstall reported
*nothing* while leaving a source line behind in one or two PowerShell profiles.
It now builds its list from the same registry, and matches the home path in
both its generic and native (backslash) spellings.

**`tools/other/quick_install.ps1` reverted to `main`.** The first pass added a
~40-line PowerShell reimplementation of the same policy there as a safety net.
`quick_install.ps1` runs `xlings self install` from the release it just
downloaded, so with the fix in xlings the net is dead weight — a second copy of
the policy, in a second language, free to drift from the first.

## Test plan

Not manual this time — the design change is what made it testable.

**`tests/unit/test_shell_profile.cpp` — 22 cases, run on every CI runner
including Linux.** The probe is injected, so Windows-only policy is testable
off Windows. Covers: probe command shape (`-NoProfile` so it does not source
the profile it is about to edit); tagged-answer parsing against noise, CRLF and
blank values; not-installed vs unusable answers being told apart; each host started
exactly once; `'` escaping in the snippet; append-preserving-content;
second-hook-is-a-no-op (byte-identical); profile + parent dirs created; and
failure reported rather than swallowed.

Falsifiability checked by mutation — dropping `pwsh` from `kPowerShellHosts`,
i.e. reintroducing #387, fails
`ShellProfileProbeHosts.TheShippedHostListCoversBothWindowsPowerShellHosts`.

**`tests/e2e/release_self_install_test.ps1`** — after `self install`, every
PowerShell host reachable on the runner must have a profile sourcing the
installed home's `xlings-profile.ps1`. Four details keep it honest:

- the install runs with the host directories explicitly on `PATH`
  (`Get-MinimalSystemPath` omits both `System32\WindowsPowerShell\v1.0` and
  `C:\Program Files\PowerShell\7`, and a host xlings cannot start is one it is
  *right* to skip — the assertion would be vacuous);
- each host's `$PROFILE` is resolved **inside** the redirected environment.
  It is not environment-independent: both hosts derive it from `USERPROFILE`,
  so resolving before the redirect measured the install's work against the
  wrong path. The sandbox home is also given a `Documents` folder first —
  Windows PowerShell 5.1 answers an empty `$PROFILE` without one (.NET
  Framework's `GetFolderPath` returns `""` for a missing folder; .NET Core
  does not), a shape no real user account has;
- the profiles are deleted first — the job installs a bootstrap xlings before
  this test, and hooking is correctly idempotent, so an already-hooked profile
  would be left alone and the assertion would measure nothing;
- anything found is snapshotted and restored in a `finally`, so a profile that
  did land outside the sandbox does not leave later CI steps sourcing a
  throwaway home.

The test asks with `-Command '$PROFILE'` rather than reusing
`probe_command()`. A test that phrases the question exactly as the production
code does agrees with it when it is wrong — with the bare-word form both would
have read an empty answer and the test would have passed against an install
that hooked nothing.

Idempotency is deliberately *not* re-asserted in the e2e: a second
`self install` of the same version stops at an interactive confirmation that CI
answers "no", so it would pass without running the code it claims to cover.

**Green on all seven checks.** The Windows run shows the fix doing its job on
a real runner, with two distinct startup files written:

```
probe: powershell ... 'XLINGS_PROFILE='+$PROFILE -> rc=0 out=...\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1
probe: pwsh       ... 'XLINGS_PROFILE='+$PROFILE -> rc=0 out=...\Documents\PowerShell\Microsoft.PowerShell_profile.ps1
[xlings:self] added profile (powershell)
[xlings:self] added profile (pwsh)
```

Design notes: `.agents/docs/2026-07-28-shell-profile-hosts-design.md`

Closes #387
