### PR TITLE
fix(platform): replace state files atomically instead of truncating

### DIFF
--- a/src/platform.cppm
+++ b/src/platform.cppm
@@ -4,6 +4,10 @@ module;
 #include <cstdlib>
 #if !defined(_WIN32)
 #include <sys/wait.h>
+#include <unistd.h>
+#include <fcntl.h>
+#else
+#include <io.h>
 #endif
 
 export module xlings.platform;
@@ -259,13 +263,105 @@ namespace platform {
         return content;
     }
 
-    export void write_string_to_file(const std::string& filepath, const std::string& content) {
-        std::FILE* fp = std::fopen(filepath.c_str(), "w");
+    // ── Atomic state-file replace ────────────────────────────────────
+    //
+    // Every persisted xlings state file is written through here: the whole
+    // version database in ~/.xlings.json, each subos workspace, profile
+    // generations, and the shell rc files xself edits by read-modify-write.
+    // All of them are full-content rewrites, so a plain fopen("w") truncates
+    // the destination before the first new byte lands — an interruption at
+    // that point does not corrupt the file, it empties it.
+    //
+    // Write to a staging file in the same directory, flush it to stable
+    // storage, then rename over the destination. rename(2) within a
+    // directory is atomic, so a reader sees either the whole old file or
+    // the whole new one, and an interruption before the rename leaves the
+    // old content untouched.
+
+    // fsync the data we just wrote. Without it the rename can reach the disk
+    // before the staging file's contents do, which on a power loss yields an
+    // atomically-renamed *empty* file — the exact failure we are removing.
+    inline bool sync_file_handle_(std::FILE* fp) {
+#if defined(_WIN32)
+        return ::_commit(::_fileno(fp)) == 0;
+#else
+        return ::fsync(::fileno(fp)) == 0;
+#endif
+    }
+
+    // fsync the directory so the rename itself is durable. Best-effort: not
+    // all filesystems support it, and failing here does not make the result
+    // any less correct than the non-atomic write it replaces.
+    inline void sync_directory_(const std::filesystem::path& dir) {
+#if !defined(_WIN32)
+        int fd = ::open(dir.c_str(), O_RDONLY | O_DIRECTORY);
+        if (fd < 0) return;
+        ::fsync(fd);
+        ::close(fd);
+#else
+        (void)dir;  // no directory-handle fsync equivalent on Windows
+#endif
+    }
+
+    export void write_file_atomic(const std::string& filepath, const std::string& content) {
+        namespace fs = std::filesystem;
+        std::error_code ec;
+
+        // Resolve symlinks and write through to the real file. Shell rc files
+        // are commonly symlinks into a dotfiles repo; renaming over the link
+        // would replace it with a regular file and silently detach the user's
+        // dotfiles. The hop limit keeps a symlink cycle from spinning.
+        fs::path target(filepath);
+        for (int hops = 0; hops < 16; ++hops) {
+            ec.clear();
+            if (!fs::is_symlink(target, ec) || ec) break;
+            auto next = fs::read_symlink(target, ec);
+            if (ec) break;
+            target = next.is_absolute() ? next : target.parent_path() / next;
+        }
+
+        auto dir = target.parent_path();
+        if (dir.empty()) dir = fs::path(".");
+
+        auto staging = dir / ("." + target.filename().string() + ".xlings-tmp." +
+                              std::to_string(platform_impl::get_pid()));
+
+        std::FILE* fp = std::fopen(staging.string().c_str(), "wb");
         if (!fp) {
             throw std::runtime_error("Failed to write file: " + filepath);
         }
-        std::fwrite(content.data(), 1, content.size(), fp);
+        bool ok = std::fwrite(content.data(), 1, content.size(), fp) == content.size();
+        if (ok) ok = std::fflush(fp) == 0;
+        if (ok) ok = sync_file_handle_(fp);
         std::fclose(fp);
+        if (!ok) {
+            ec.clear();
+            fs::remove(staging, ec);
+            throw std::runtime_error("Failed to write file: " + filepath);
+        }
+
+        // Carry over the destination's mode. A fresh staging file is created
+        // under the current umask, so without this an overwrite would quietly
+        // drop an executable bit or widen the mode of the file it replaces.
+        ec.clear();
+        if (auto st = fs::status(target, ec); !ec && fs::exists(st)) {
+            std::error_code permEc;
+            fs::permissions(staging, st.permissions(),
+                            fs::perm_options::replace, permEc);
+        }
+
+        ec.clear();
+        fs::rename(staging, target, ec);
+        if (ec) {
+            std::error_code rmEc;
+            fs::remove(staging, rmEc);
+            throw std::runtime_error("Failed to write file: " + filepath);
+        }
+        sync_directory_(dir);
+    }
+
+    export void write_string_to_file(const std::string& filepath, const std::string& content) {
+        write_file_atomic(filepath, content);
     }
 
     // Wrap directory_iterator for range-for compatibility across compilers.

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -3,6 +3,9 @@
 #ifdef __unix__
 #include <sys/wait.h>
 #endif
+#if !defined(_WIN32)
+#include <unistd.h>  // geteuid — AtomicWriteTest skips permission cases as root
+#endif
 
 import std;
 import xlings.core.i18n;
@@ -4368,6 +4371,179 @@ TEST(DownloaderArchiveSniff, WorksWithFullPaths) {
     // look at the basename only, ignoring directory components.
     EXPECT_TRUE(looks_like_archive_filename_("/var/tmp/runtimedir/llvm-20.1.7-linux-x86_64.tar.gz"));
     EXPECT_FALSE(looks_like_archive_filename_("/path/to/tar.gz/file.lua"));  // tar.gz only in dir name
+}
+
+// ============================================================
+// platform::write_string_to_file — atomic replace
+//
+// Every persisted xlings state file goes through this function:
+// ~/.xlings.json (the whole version database), each subos workspace,
+// profile generations, and the shell rc files that xself edits by
+// read-modify-write. It used to be fopen("w") + fwrite + fclose, which
+// truncates the destination before any new byte is written — an
+// interruption at that point loses the file's entire previous content.
+// These tests pin the replace-or-leave-untouched contract.
+
+namespace {
+
+class AtomicWriteTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        namespace fs = std::filesystem;
+        dir_ = fs::temp_directory_path() /
+               ("xlings_atomic_write_" +
+                std::string(::testing::UnitTest::GetInstance()
+                                ->current_test_info()
+                                ->name()));
+        std::error_code ec;
+        fs::remove_all(dir_, ec);
+        fs::create_directories(dir_);
+    }
+    void TearDown() override {
+        std::error_code ec;
+#if !defined(_WIN32)
+        // A test may leave the directory unwritable; restore before cleanup.
+        std::filesystem::permissions(dir_, std::filesystem::perms::owner_all,
+                                     std::filesystem::perm_options::add, ec);
+#endif
+        std::filesystem::remove_all(dir_, ec);
+    }
+
+    // Anything left beside the destination is a leaked staging file.
+    std::size_t entry_count() const {
+        std::size_t n = 0;
+        for ([[maybe_unused]] auto& e : std::filesystem::directory_iterator(dir_)) ++n;
+        return n;
+    }
+
+    std::filesystem::path dir_;
+};
+
+}  // namespace
+
+TEST_F(AtomicWriteTest, WritesContentAndLeavesNoStagingFile) {
+    auto target = dir_ / "state.json";
+    xlings::platform::write_string_to_file(target.string(), "{\"a\":1}");
+
+    EXPECT_EQ(xlings::platform::read_file_to_string(target.string()), "{\"a\":1}");
+    EXPECT_EQ(entry_count(), 1u) << "staging file leaked into the directory";
+}
+
+TEST_F(AtomicWriteTest, OverwriteReplacesContentAndLeavesNoStagingFile) {
+    auto target = dir_ / "state.json";
+    xlings::platform::write_string_to_file(target.string(), "old-and-longer");
+    xlings::platform::write_string_to_file(target.string(), "new");
+
+    EXPECT_EQ(xlings::platform::read_file_to_string(target.string()), "new");
+    EXPECT_EQ(entry_count(), 1u);
+}
+
+TEST_F(AtomicWriteTest, FailedWriteLeavesPreviousContentIntact) {
+#if defined(_WIN32)
+    GTEST_SKIP() << "directory permission semantics differ on Windows";
+#else
+    if (::geteuid() == 0) {
+        GTEST_SKIP() << "root bypasses directory permission checks";
+    }
+    namespace fs = std::filesystem;
+    auto target = dir_ / "state.json";
+    xlings::platform::write_string_to_file(target.string(), "committed");
+
+    // Staging cannot be created in a non-writable directory. The point of the
+    // test is what happens to the destination when the write cannot complete:
+    // it must still hold the previously committed bytes. The old truncating
+    // implementation would have destroyed them before discovering the failure.
+    std::error_code ec;
+    fs::permissions(dir_, fs::perms::owner_write, fs::perm_options::remove, ec);
+    ASSERT_FALSE(ec);
+
+    EXPECT_THROW(
+        xlings::platform::write_string_to_file(target.string(), "replacement"),
+        std::runtime_error);
+
+    fs::permissions(dir_, fs::perms::owner_write, fs::perm_options::add, ec);
+    EXPECT_EQ(xlings::platform::read_file_to_string(target.string()), "committed");
+    EXPECT_EQ(entry_count(), 1u);
+#endif
+}
+
+TEST_F(AtomicWriteTest, ReplacesTheInodeInsteadOfMutatingTheCommittedOne) {
+#if defined(_WIN32)
+    GTEST_SKIP() << "hard link semantics differ on Windows";
+#else
+    namespace fs = std::filesystem;
+    auto target = dir_ / "state.json";
+    auto witness = dir_ / "witness.json";
+    xlings::platform::write_string_to_file(target.string(), "committed");
+
+    // The witness shares the destination's inode. If the write mutated that
+    // inode in place -- truncate, then fill -- the witness would follow along,
+    // which is exactly the window where an interruption leaves an empty file.
+    // An atomic replace writes a *new* inode and renames it over the name, so
+    // the committed bytes are never touched.
+    std::error_code ec;
+    fs::create_hard_link(target, witness, ec);
+    ASSERT_FALSE(ec) << "cannot hard link on this filesystem: " << ec.message();
+
+    xlings::platform::write_string_to_file(target.string(), "replacement");
+
+    EXPECT_EQ(xlings::platform::read_file_to_string(target.string()), "replacement");
+    EXPECT_EQ(xlings::platform::read_file_to_string(witness.string()), "committed")
+        << "the committed inode was mutated in place";
+#endif
+}
+
+TEST_F(AtomicWriteTest, PreservesExistingPermissionBits) {
+#if defined(_WIN32)
+    GTEST_SKIP() << "POSIX permission bits do not apply on Windows";
+#else
+    namespace fs = std::filesystem;
+    auto target = dir_ / "hook.sh";
+    xlings::platform::write_string_to_file(target.string(), "#!/bin/sh\n");
+
+    std::error_code ec;
+    fs::permissions(target, fs::perms::owner_all | fs::perms::group_read |
+                                fs::perms::others_read,
+                    fs::perm_options::replace, ec);
+    ASSERT_FALSE(ec);
+    const auto before = fs::status(target).permissions();
+
+    xlings::platform::write_string_to_file(target.string(), "#!/bin/sh\necho hi\n");
+
+    // Replacing through a fresh staging file must not silently drop the
+    // executable bit (or widen the mode) of the file it replaces.
+    EXPECT_EQ(fs::status(target).permissions(), before);
+#endif
+}
+
+TEST_F(AtomicWriteTest, WritesThroughSymlinkInsteadOfReplacingIt) {
+#if defined(_WIN32)
+    GTEST_SKIP() << "symlink semantics differ on Windows";
+#else
+    namespace fs = std::filesystem;
+    auto real = dir_ / "real.rc";
+    auto link = dir_ / "link.rc";
+    xlings::platform::write_string_to_file(real.string(), "original\n");
+    std::error_code ec;
+    fs::create_symlink(real, link, ec);
+    ASSERT_FALSE(ec);
+
+    xlings::platform::write_string_to_file(link.string(), "updated\n");
+
+    // xself edits shell rc files by read-modify-write. Those are commonly
+    // symlinks into a dotfiles repo; a rename-based replace that did not
+    // resolve the link would swap the symlink for a regular file and
+    // silently detach the user's dotfiles.
+    EXPECT_TRUE(fs::is_symlink(link)) << "symlink was replaced by a regular file";
+    EXPECT_EQ(xlings::platform::read_file_to_string(real.string()), "updated\n");
+#endif
+}
+
+TEST_F(AtomicWriteTest, ThrowsWhenParentDirectoryIsMissing) {
+    auto target = dir_ / "nope" / "state.json";
+    EXPECT_THROW(xlings::platform::write_string_to_file(target.string(), "x"),
+                 std::runtime_error);
+    EXPECT_EQ(entry_count(), 0u) << "staging file leaked on failure";
 }
 
 // ============================================================


### PR DESCRIPTION
> P1.1 of the 0.4.70 release train — see #385 for the plan.

## Problem

`platform::write_string_to_file` was:

```cpp
std::FILE* fp = std::fopen(filepath.c_str(), "w");   // ← truncates here
std::fwrite(content.data(), 1, content.size(), fp);
std::fclose(fp);
```

`fopen(…, "w")` truncates the destination **before** the first new byte is written. An interruption in that window doesn't corrupt the file — it **empties** it.

每一个持久化的 xlings 状态文件都走这个函数：

| 文件 | 位置 | 丢失后果 |
|---|---|---|
| `~/.xlings.json` | `config.cppm:1018` | **整个版本数据库** |
| `<subos>/.xlings.json` | `config.cppm:1116` | 该 subos 的全部 workspace |
| `generations/NNN.json` | `profile.cppm:105` | profile 历史 |
| `~/.bashrc` / `.zshrc` / `config.fish` | `xself/install.cppm:297,314,342` | 用户的 shell rc |

最后一行值得单独说明：xself 是用 **read-modify-write 整个文件**的方式改 rc 的（读全文 → 拼接 → 整体写回），不是追加。所以崩溃会截断用户的 `~/.bashrc`。

全部 27 个调用点都是全文件重写，因此把函数本身做成原子的，一次覆盖所有调用点，无需改动任何调用方。

## Change

新增 `platform::write_file_atomic()`，`write_string_to_file` 委托给它：

写入同目录的 staging 文件 → `fflush` → `fsync` → `rename` 覆盖目标 → `fsync` 目录。

同目录内的 `rename(2)` 是原子的：读者要么看到完整的旧文件、要么看到完整的新文件；rename 之前被打断则旧内容原封不动。

`fsync` 不是可选的 —— 没有它，rename 可能先于数据落盘，断电后得到一个"原子地重命名过的空文件"，正是要消除的那个故障。

三个朴素实现会踩的细节：

1. **先解析符号链接** —— xself 改的 rc 文件常常是指向 dotfiles 仓库的符号链接。直接 rename 覆盖会把链接换成普通文件，静默切断用户的 dotfiles
2. **继承目标的权限位** —— staging 文件按当前 umask 创建，不继承就会悄悄丢掉可执行位或放宽权限
3. **所有失败路径都清理 staging**

## Behavior changes

- 指向状态文件的**硬链接不再跟随更新**（名字现在指向新 inode）。这正是安全性的来源，有测试断言
- 在**不可写目录**中改写一个已存在的文件现在会失败（staging 需要在该目录创建），此前会成功

## Tests

7 条，`AtomicWriteTest`。**其中 2 条经过验证对旧实现会失败**（把 `write_string_to_file` 临时改回旧实现、重建后实测）：

| 测试 | 对旧实现 |
|---|---|
| `FailedWriteLeavesPreviousContentIntact` | ❌ 红 —— `it throws nothing`，且内容已变成 `"replacement"`，即旧代码在发现写不成之前就已经毁掉了已提交内容 |
| `ReplacesTheInodeInsteadOfMutatingTheCommittedOne` | ❌ 红 —— 硬链接见证者跟着变了，说明是就地改写 |
| 其余 5 条 | ✅ 双方都过 |

那 5 条不是红阶段测试，是**防止本改动自身引入回归**的护栏：staging 泄漏、权限位丢失、符号链接被替换、父目录缺失时的行为。这里如实说明，不把它们算作"验证了修复"。

## Verification

```
mcpp build   →  Finished release [optimized] in 49.48s
mcpp test    →  test result ok. 11 passed; 0 failed
AtomicWriteTest → 7 passed
```

红阶段（临时改回旧实现，重建后）：

```
error: test result: FAILED. 10 passed; 1 failed
[  FAILED  ] AtomicWriteTest.FailedWriteLeavesPreviousContentIntact
```

fsync 开销实测 2–4ms/次，可忽略。

## Note

本 PR 的 CI 会受今天的上游拉取故障影响（见 #386）—— 多个互不相关的包（`compat.bzip2`、`gtest`、`ftxui`）在冷缓存路径上拉取失败，与本改动无关。