### PR TITLE
fix(xim): keep `xlings use` able to swap sysroot headers

### DIFF
--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -138,6 +138,49 @@ struct XpkgXvmMetadataResult {
     std::vector<XpkgFilesystemEffect> effects;
 };
 
+// Keep `xlings use` able to swap sysroot headers.
+//
+// xvm::cmd_use reads VData::includedir of the target it was handed to decide
+// whether to move headers (commands.cppm). Before registration batches the
+// installer wrote that field directly on every `headers` op; the batch models
+// headers as group assets instead and does not carry it. Until the
+// materialization work consumes those group assets, the field still has to be
+// written or switching versions silently stops moving headers — and because
+// the install-time copy still happens, the breakage only surfaces on the
+// *second* version a user installs.
+//
+// One deliberate difference from the pre-batch behavior: this never brings a
+// target or a version into existence. The old code indexed both maps with
+// operator[], so a `headers` op from a package that registers no target of
+// its own materialized an entry with no path and no kind — precisely the
+// phantom state the binding-group work exists to prevent.
+//
+// Returns the number of entries updated (0 or 1), so callers can log the
+// no-op case instead of assuming it worked.
+std::size_t attach_legacy_header_dir(
+        xvm::VersionDB& db,
+        const std::string& target,
+        const std::string& version,
+        const std::vector<XpkgFilesystemEffect>& effects) {
+    const std::string* sourceDir = nullptr;
+    for (const auto& effect : effects) {
+        // Last one wins, matching how the installer used to assign per op.
+        if (effect.kind == XpkgFilesystemEffectKind::InstallHeaders
+            && !effect.sourceDir.empty()) {
+            sourceDir = &effect.sourceDir;
+        }
+    }
+    if (!sourceDir) return 0;
+
+    auto targetIt = db.find(target);
+    if (targetIt == db.end()) return 0;
+    auto versionIt = targetIt->second.versions.find(version);
+    if (versionIt == targetIt->second.versions.end()) return 0;
+
+    versionIt->second.includedir = *sourceDir;
+    return 1;
+}
+
 std::expected<XpkgRegistrationPlan, XpkgRegistrationError>
 normalize_xpkg_registration_plan(
         const PlanNode& node,
@@ -1371,6 +1414,26 @@ bool process_xvm_operations_(const PlanNode& node,
         dbBeforeRemoval,
         scopedDb,
         metadata->removal);
+
+    // Written after the batch, not inside it: the batch owns the group model
+    // and must not be taught a legacy field. This runs against the committed
+    // scopedDb, so a package whose own name is not a registered target simply
+    // gets no marker rather than a phantom entry.
+    if (const auto headerVersion =
+            xvm::make_ns_version(version_ns, node.version);
+        attach_legacy_header_dir(
+            scopedDb, node.name, headerVersion, metadata->effects) == 0) {
+        const bool declaresHeaders = std::ranges::any_of(
+            metadata->effects, [](const XpkgFilesystemEffect& effect) {
+                return effect.kind == XpkgFilesystemEffectKind::InstallHeaders;
+            });
+        if (declaresHeaders) {
+            log::debug(
+                "[xim] headers declared but '{}@{}' is not a registered "
+                "target; `xlings use` will not swap them",
+                node.name, headerVersion);
+        }
+    }
 
     for (const auto& effect : metadata->effects) {
         auto resolved = resolve_xpkg_filesystem_effect(

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -10487,6 +10487,112 @@ TEST_F(AtomicWriteTest, ThrowsWhenParentDirectoryIsMissing) {
 }
 
 // ============================================================
+// attach_legacy_header_dir — keep `xlings use` able to swap headers
+//
+// xvm::cmd_use decides whether to swap the sysroot headers by reading
+// VData::includedir of the target it was given (commands.cppm). Before the
+// registration batch existed, the installer set that field directly for
+// every `headers` op. The batch does not carry it, so without this the
+// field stays empty on every freshly installed package and switching
+// versions silently stops moving headers — the install-time copy still
+// happens, so the breakage only shows up on the *second* version.
+//
+// Restores the field with one deliberate difference from the pre-batch
+// behavior: it never brings a target or a version into existence. The old
+// code used operator[] on both maps, so a `headers` op for a package that
+// registers no target of its own would materialize a phantom entry with no
+// path and no kind. That is exactly the class of state the binding-group
+// work exists to prevent.
+
+namespace {
+
+xlings::xim::XpkgFilesystemEffect header_effect_(std::string sourceDir) {
+    return {
+        .kind = xlings::xim::XpkgFilesystemEffectKind::InstallHeaders,
+        .sourceDir = std::move(sourceDir),
+    };
+}
+
+xlings::xvm::VersionDB db_with_(const std::string& target,
+                                const std::string& version) {
+    xlings::xvm::VersionDB db;
+    auto& info = db[target];
+    info.type = "program";
+    auto& data = info.versions[version];
+    data.path = "/xpkgs/" + target + "/" + version;
+    data.kind = "program";
+    return db;
+}
+
+}  // namespace
+
+TEST(LegacyHeaderDir, SetsIncludedirOnThePackageVersion) {
+    auto db = db_with_("gcc", "15.1.0");
+    const std::vector<xlings::xim::XpkgFilesystemEffect> effects{
+        header_effect_("/xpkgs/gcc/15.1.0/include"),
+    };
+
+    EXPECT_EQ(xlings::xim::attach_legacy_header_dir(db, "gcc", "15.1.0", effects), 1u);
+    EXPECT_EQ(db.at("gcc").versions.at("15.1.0").includedir,
+              "/xpkgs/gcc/15.1.0/include");
+}
+
+TEST(LegacyHeaderDir, DoesNotCreateAPhantomTarget) {
+    xlings::xvm::VersionDB db;
+    const std::vector<xlings::xim::XpkgFilesystemEffect> effects{
+        header_effect_("/xpkgs/headers-only/1.0/include"),
+    };
+
+    EXPECT_EQ(
+        xlings::xim::attach_legacy_header_dir(db, "headers-only", "1.0", effects),
+        0u);
+    EXPECT_TRUE(db.empty()) << "a headers op invented a target entry";
+}
+
+TEST(LegacyHeaderDir, DoesNotCreateAPhantomVersion) {
+    auto db = db_with_("gcc", "16.1.0");
+    const std::vector<xlings::xim::XpkgFilesystemEffect> effects{
+        header_effect_("/xpkgs/gcc/15.1.0/include"),
+    };
+
+    EXPECT_EQ(xlings::xim::attach_legacy_header_dir(db, "gcc", "15.1.0", effects), 0u);
+    EXPECT_FALSE(db.at("gcc").versions.contains("15.1.0"))
+        << "a headers op invented a version entry";
+    EXPECT_EQ(db.at("gcc").versions.size(), 1u);
+}
+
+TEST(LegacyHeaderDir, LastHeadersEffectWins) {
+    auto db = db_with_("gcc", "15.1.0");
+    const std::vector<xlings::xim::XpkgFilesystemEffect> effects{
+        header_effect_("/first/include"),
+        header_effect_("/second/include"),
+    };
+
+    // Matches the pre-batch behavior: the installer assigned per op, so the
+    // last `headers` op of a recipe was the one that stuck.
+    EXPECT_EQ(xlings::xim::attach_legacy_header_dir(db, "gcc", "15.1.0", effects), 1u);
+    EXPECT_EQ(db.at("gcc").versions.at("15.1.0").includedir, "/second/include");
+}
+
+TEST(LegacyHeaderDir, IgnoresNonHeaderEffects) {
+    auto db = db_with_("gcc", "15.1.0");
+    const std::vector<xlings::xim::XpkgFilesystemEffect> effects{
+        {
+            .kind = xlings::xim::XpkgFilesystemEffectKind::ProgramShim,
+            .target = "gcc",
+            .version = "15.1.0",
+        },
+        {
+            .kind = xlings::xim::XpkgFilesystemEffectKind::RemoveHeaders,
+            .sourceDir = "/stale/include",
+        },
+    };
+
+    EXPECT_EQ(xlings::xim::attach_legacy_header_dir(db, "gcc", "15.1.0", effects), 0u);
+    EXPECT_TRUE(db.at("gcc").versions.at("15.1.0").includedir.empty());
+}
+
+// ============================================================
 
 #ifndef XLINGS_USE_GTEST_MAIN
 int main(int argc, char** argv) {


### PR DESCRIPTION
> P0.1 of the 0.4.70 release train — 修复 #384 引入的第一个静默回归。

## Problem

`xvm::cmd_use` 靠读取目标的 `VData::includedir` 决定是否切换 sysroot 头文件（`commands.cppm:206-215`）。批量注册引入前，installer 对每个 `headers` op 直接写这个字段：

```cpp
// origin/main:src/core/xim/installer.cppm:738-740
auto hdr_ver_key = xvm::make_ns_version(version_ns, node.version);
auto& vdata = Config::versions_mut()[node.name].versions[hdr_ver_key];
vdata.includedir = op.includedir;
```

#384 把 headers 建模成 group 资产（`bindingHeaders` 挂在 group root），`RegistrationNode` 不携带 `includedir`，**而 `bindingHeaders` 目前零消费者**。结果：新装的包这个字段永远是空的，切版本不再搬头文件。

**故障模式异常安静**：安装时的头文件拷贝仍然执行，所以第一次装看起来完全正常，只有装了**第二个版本**才暴露 —— `gcc --version` / `g++ --version` 都报正确版本，而 sysroot 里还是上一个 release 的头文件。用户唯一会检查的两条命令都是对的。

```console
$ xlings install gcc@15.1.0 && xlings use gcc 15.1.0
$ gcc --version && g++ --version
gcc 15.1.0
g++ 15.1.0                       # ✓
$ ls ~/.xlings/subos/.../usr/include/c++/
16.1.0                           # ← 还是上次的
```

## Change

从同一来源、用同一 key 推导恢复该字段，但**绝不凭空创建 target 或 version**。

旧代码对两层 map 都用 `operator[]`，所以一个不注册同名 target 的包发 `headers` op 会凭空造出一条没有 path、没有 kind 的条目 —— 正是 binding-group 工作要消灭的幽灵状态。无处可挂时记 debug 日志并跳过。

key 推导与 `origin/main` 逐字一致：`node.name` + `make_ns_version(version_ns, node.version)`。

写在批次**之后**而非之内：批次拥有 group 模型，不应被教会一个 legacy 字段。

## Transitional

这是过渡实现。等 P3 的物化收敛直接消费 group 资产后，本 helper 与 `includedir` 字段一并移除（计划 R.1）。

顺带确认：`libdir` 在 `origin/main` 上就**已经是死字段** —— installer 从不写它（`XvmOp` 也没有 `libdir` 成员），`cmd_use` 读到的永远是空。因此本 PR 只恢复 `includedir`，不为 `libdir` 补写路径。

## Tests

`LegacyHeaderDir` 五条：

| 测试 | 覆盖 |
|---|---|
| `SetsIncludedirOnThePackageVersion` | 正常恢复 |
| `DoesNotCreateAPhantomTarget` | db 为空 → 不创建 target |
| `DoesNotCreateAPhantomVersion` | 只有 16.1.0 → 不创建 15.1.0 |
| `LastHeadersEffectWins` | 与旧的逐 op 赋值语义一致 |
| `IgnoresNonHeaderEffects` | shim / remove_headers 不误触 |

**如实说明覆盖边界**：这五条测的是 helper 本身。installer 的接线（传入正确的 target 与 version key）不可单测（Config 单例 + 文件系统），依据是它与批次前代码使用**完全相同的表达式**；端到端覆盖在 P4.2 的工具链 E2E。

## Verification

```
mcpp build   →  Finished release [optimized] in 51.20s
mcpp test    →  test result ok. 11 passed; 0 failed
LegacyHeaderDir → 5 passed
```

> 注：`mcpp test` 必须在 `mcpp build` 之后跑 —— `test_interface_protocol` 驱动真实的 `xlings` 二进制，缺主二进制时 19 条全失败（`rc=-1`, out 为空）。本次已按序验证。

CI 状态为已知上游拉取签名（见 #386），依计划 §3.1.1 合入集成分支，不声称 CI 通过。