### PR TITLE
fix(xvm): let a package's own target own its ungrouped headers

### DIFF
--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -235,6 +235,11 @@ normalize_xpkg_registration_plan(
                 ? canonical_package_name(node.namespaceName, node.name)
                 : node.canonicalName,
             .providerVersion = node.version,
+            // Owner hint for headers that do not name a group. Recipes
+            // conventionally register a target under the package's own name,
+            // so that target identifies which group the package's headers
+            // belong to when several groups exist.
+            .primaryTarget = node.name,
             .useAfterInstall = useAfterInstall,
         },
     };

--- a/src/core/xvm/registration.cppm
+++ b/src/core/xvm/registration.cppm
@@ -34,6 +34,12 @@ struct RegistrationHeader {
 struct RegistrationBatch {
     std::string provider;
     std::string providerVersion;
+    // The package's own target name. Used only to decide which group owns a
+    // header that does not name one: headers shipped by package `p` belong
+    // with `p`. Empty means "no hint", which is not an error -- it just
+    // leaves an ungrouped header ambiguous when there is more than one
+    // candidate group.
+    std::string primaryTarget;
     std::vector<RegistrationNode> nodes;
     std::vector<RegistrationHeader> headers;
     bool useAfterInstall { false };
@@ -560,16 +566,46 @@ apply_registration_batch(
                         "registration header group '{}' does not exist",
                         header.group)));
             }
+        } else if (groups.size() == 1) {
+            groupIt = groups.begin();
         } else {
-            if (groups.size() != 1) {
+            // More than one candidate. A recipe registering several
+            // independent targets (a program plus a library, say) makes every
+            // ungrouped node its own singleton group, so requiring exactly one
+            // candidate would reject perfectly ordinary recipes. Break the tie
+            // with the package's own target: headers shipped by package `p`
+            // belong with `p`.
+            //
+            // Only when that target resolves to exactly one group. If it is
+            // absent, or registered at versions that landed in different
+            // groups, naming it identifies no single owner and guessing would
+            // attach the headers to an arbitrary group.
+            std::string_view resolved;
+            bool spansGroups = false;
+            if (!batch.primaryTarget.empty()) {
+                for (const auto& [key, label] : nodeGroups) {
+                    if (key.first != batch.primaryTarget) continue;
+                    if (resolved.empty()) {
+                        resolved = label;
+                    } else if (resolved != label) {
+                        spansGroups = true;
+                        break;
+                    }
+                }
+            }
+            if (resolved.empty() || spansGroups) {
                 return std::unexpected(detail_::registration_error_(
                     RegistrationErrorKind::HeaderAmbiguous,
-                    headerPath + "/group", {}, {},
+                    headerPath + "/group", batch.primaryTarget, {},
                     std::format(
-                        "ungrouped registration header has {} candidate groups",
-                        groups.size())));
+                        "ungrouped registration header has {} candidate "
+                        "groups and primaryTarget '{}' {}; name the owning "
+                        "group on the header",
+                        groups.size(), batch.primaryTarget,
+                        spansGroups ? "spans several of them"
+                                    : "is not one of them")));
             }
-            groupIt = groups.begin();
+            groupIt = groups.find(std::string(resolved));
         }
         groupIt->second.headers.push_back({
             .sourceDir = header.sourceDir,

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -5104,6 +5104,93 @@ TEST(XvmRegistrationHeaderTest, AcceptsUngroupedHeaderForSingleGroup) {
     EXPECT_TRUE(data.bindingHeadersDeclared);
 }
 
+// A recipe that registers several independent targets and then declares
+// headers is ordinary — a package exposing both a program and a library, for
+// instance. Every ungrouped node becomes its own singleton group, so the
+// "exactly one candidate group" rule alone rejects those recipes outright.
+// The package's own target breaks the tie: headers shipped by package `p`
+// belong with `p`.
+TEST(XvmRegistrationHeaderTest, UngroupedHeaderFallsBackToThePrimaryTarget) {
+    auto program = make_registration_node("openssl", "repo:3.1.5");
+    auto library = make_registration_node("libssl", "repo:3.1.5");
+    library.kind = "lib";
+    auto batch = make_registration_batch({program, library});
+    batch.primaryTarget = "openssl";
+    batch.headers = {{.sourceDir = "include"}};
+    xlings::xvm::VersionDB db;
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, batch);
+
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    const auto& owner = db.at("openssl").versions.at("repo:3.1.5");
+    ASSERT_EQ(owner.bindingHeaders.size(), 1u);
+    EXPECT_EQ(owner.bindingHeaders[0].sourceDir, "include");
+    EXPECT_TRUE(db.at("libssl").versions.at("repo:3.1.5").bindingHeaders.empty())
+        << "headers leaked onto a group that does not own them";
+}
+
+// The tie-break is the package's own target, not "pick the first group".
+// When the package registers nothing under its own name there is genuinely
+// no owner to infer, and guessing would attach headers to an arbitrary group.
+TEST(XvmRegistrationHeaderTest,
+     UngroupedHeaderStaysAmbiguousWhenPrimaryTargetIsNotRegistered) {
+    auto first = make_registration_node("first", "repo:first");
+    auto second = make_registration_node("second", "repo:second");
+    auto batch = make_registration_batch({first, second});
+    batch.primaryTarget = "not-registered";
+    batch.headers = {{.sourceDir = "include"}};
+    xlings::xvm::VersionDB db;
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, batch);
+
+    expect_registration_error(
+        result, xlings::xvm::RegistrationErrorKind::HeaderAmbiguous,
+        "/headers/0/group", "not-registered");
+    EXPECT_NE(result.error().message.find("primaryTarget"), std::string::npos)
+        << "the error must say how to resolve it, got: " << result.error().message;
+}
+
+// The same target bound into two different groups: naming it no longer
+// identifies one owner, so the header is still ambiguous. (Registering one
+// target at two versions *without* bindings is rejected earlier as a
+// GroupConflict, so two roots are what actually reaches this branch.)
+TEST(XvmRegistrationHeaderTest,
+     UngroupedHeaderStaysAmbiguousWhenPrimaryTargetSpansGroups) {
+    auto rootA = make_registration_node("root-a", "repo:a", "group");
+    rootA.sourceName.clear();
+    rootA.destinationName.clear();
+    auto rootB = make_registration_node("root-b", "repo:b", "group");
+    rootB.sourceName.clear();
+    rootB.destinationName.clear();
+    auto toolA = make_registration_node("tool", "repo:1.0.0");
+    toolA.binding = xlings::xvm::RegistrationBinding{
+        .rootTarget = "root-a", .rootVersion = "repo:a"};
+    auto toolB = make_registration_node("tool", "repo:2.0.0");
+    toolB.binding = xlings::xvm::RegistrationBinding{
+        .rootTarget = "root-b", .rootVersion = "repo:b"};
+    auto batch = make_registration_batch({rootA, rootB, toolA, toolB});
+    batch.primaryTarget = "tool";
+    batch.headers = {{.sourceDir = "include"}};
+    xlings::xvm::VersionDB db;
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, batch);
+
+    expect_registration_error(
+        result, xlings::xvm::RegistrationErrorKind::HeaderAmbiguous,
+        "/headers/0/group", "tool");
+    EXPECT_NE(result.error().message.find("spans"), std::string::npos)
+        << result.error().message;
+}
+
 TEST(XvmRegistrationHeaderErrorTest,
      RejectsAmbiguousUngroupedHeaderWithoutMutation) {
     auto first = make_registration_node("first", "repo:first");
@@ -7243,6 +7330,39 @@ TEST(XimXvmRegistrationAdapterTest,
     ASSERT_EQ(root.bindingHeaders.size(), 1u);
     EXPECT_EQ(root.bindingHeaders[0].sourceDir, "/payload/include");
     EXPECT_TRUE(root.bindingHeaders[0].destinationPrefix.empty());
+}
+
+// The shape this actually unblocks: a package that registers a program and a
+// library under no binding, then declares headers. Both nodes become
+// singleton groups, so before the primaryTarget tie-break this recipe failed
+// to install outright. Goes through the normalizer, so it also covers the
+// wiring -- that the batch carries the package's own name as the hint.
+TEST(XimXvmRegistrationAdapterTest,
+     UngroupedHeaderRoutesToThePackagesOwnTarget) {
+    xlings::xim::PlanNode provider;
+    provider.name = "openssl";
+    provider.version = "3.1.5";
+    const std::vector<mcpplibs::xpkg::XvmOp> operations{
+        {.op = "add", .name = "openssl"},
+        {.op = "add", .name = "libssl", .type = "lib", .filename = "libssl.so"},
+        {.op = "headers", .includedir = "/payload/include"},
+    };
+    auto plan = xlings::xim::normalize_xpkg_registration_plan(
+        provider, operations, "", "/data", false);
+    ASSERT_TRUE(plan.has_value()) << plan.error().message;
+    EXPECT_EQ(plan->batch.primaryTarget, "openssl");
+
+    xlings::xvm::VersionDB db;
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, plan->batch);
+
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    const auto& owner = db.at("openssl").versions.at("3.1.5");
+    ASSERT_EQ(owner.bindingHeaders.size(), 1u);
+    EXPECT_EQ(owner.bindingHeaders[0].sourceDir, "/payload/include");
+    EXPECT_TRUE(db.at("libssl").versions.at("3.1.5").bindingHeaders.empty());
 }
 
 TEST(XimXvmRegistrationAdapterTest,


### PR DESCRIPTION
> P0.2 of the 0.4.70 release train — 修复 #384 引入的第二个回归。

## Problem

`normalize_xpkg_registration_plan` 构造 header 时从不设 `.group`：

```cpp
plan.batch.headers.push_back({ .sourceDir = operation.includedir });
```

而 `apply_registration_batch` 对无 group 的 header 要求 `groups.size() == 1`，否则 `HeaderAmbiguous` 硬失败。

由于每个无 binding 的节点都会各自成为一个单例 group，任何**注册了多个独立 target 再声明 headers** 的 recipe 都会直接装不上 —— program + lib 是最常见的形态：

```lua
xvm.add("openssl")
xvm.add("libssl", { type = "lib", filename = "libssl.so" })
xvm.headers(...)          -- ← 2 个候选 group → HeaderAmbiguous → 装不上
```

这在 `origin/main` 上是能装的。

## Change

用**包自身的 target** 打破平局：包 `p` 发布的头文件属于 `p`。recipe 惯例上都会注册一个与包同名的 target，所以这解决了常规情形而不需要猜。

`RegistrationBatch` 增加 `primaryTarget`，由 normalizer 填 `node.name`。

**保持歧义（有意为之）** 的两种情况：

- 该 target 不在批次里 → 无从推断归属
- 该 target 被绑进了多个 group → 指名它也定位不到唯一 owner

这两种情况下随便挑一个 group，正是"头文件挂到不发布它的组上"的成因。错误信息现在会说明尝试过的 hint 以及怎么解决（在 header 上显式指定 group）。

## Tests

| 测试 | 覆盖 |
|---|---|
| `UngroupedHeaderFallsBackToThePrimaryTarget` | 解决常规情形 |
| `UngroupedHeaderStaysAmbiguousWhenPrimaryTargetIsNotRegistered` | target 缺席仍拒绝 |
| `UngroupedHeaderStaysAmbiguousWhenPrimaryTargetSpansGroups` | target 跨组仍拒绝 |
| `UngroupedHeaderRoutesToThePackagesOwnTarget` | **适配器层**，走 normalizer，形状同真实 recipe（program + lib + headers） |

最后一条同时钉住了接线（批次确实携带包名）—— 这正是 P0.1 里我无法覆盖的那类缺口，这次补上了。

构造第三条测试时发现：**同一 target 注册两个版本且都无 binding，会在更早的 `GroupConflict` 就被拒**（两者的 label 都是 target 名，root 不同）。所以能真正走到"跨组"分支的是两个不同 root 的绑定，测试已按此构造。

两条既有的 `HeaderAmbiguous` 测试保持通过 —— 它们都没有注册与包同名的 target，因此本来就无 owner 可推断。

## Verification

```
mcpp build   →  Finished release [optimized] in 43.99s
mcpp test    →  test result ok. 11 passed; 0 failed
*UngroupedHeader* / *PrimaryTarget*  →  8 passed
```

CI 状态为已知上游拉取签名（见 #386），依计划 §3.1.1 合入集成分支。