### PR TITLE
fix(xvm): move a whole surviving release, or none, after removal

### DIFF
--- a/src/core/xvm/db.cppm
+++ b/src/core/xvm/db.cppm
@@ -236,34 +236,42 @@ remove_version(VersionDB& db,
 // then by component count). Namespace prefix is stripped before comparison, but the
 // original key is returned so callers can write it back to the workspace as-is.
 // Returns empty string if the map is empty.
-std::string pick_highest_version(const std::map<std::string, VData>& versions) {
-    if (versions.empty()) return {};
-
-    auto split = [](const std::string& s) -> std::vector<std::string> {
+// Order two version keys highest-first: dotted numeric components descending,
+// then the longer component list, then the raw key as a total tiebreak.
+//
+// The raw-key tiebreak is what makes this a strict weak ordering. Without it
+// two keys that differ only by namespace ("15.1.0" vs "musl:15.1.0") compare
+// equal in both directions, so which one a sort leaves in front depends on the
+// input order. Callers that pick "the highest" would then return different
+// answers for the same set depending on how it happened to be built.
+bool version_key_greater(const std::string& lhs, const std::string& rhs) {
+    const auto split = [](const std::string& s) {
         std::vector<std::string> parts;
         std::istringstream iss(s);
         std::string part;
-        while (std::getline(iss, part, '.')) {
-            parts.push_back(part);
-        }
+        while (std::getline(iss, part, '.')) parts.push_back(part);
         return parts;
     };
+    const auto pa = split(strip_namespace(lhs));
+    const auto pb = split(strip_namespace(rhs));
+    for (std::size_t i = 0; i < std::min(pa.size(), pb.size()); ++i) {
+        int na = 0, nb = 0;
+        std::from_chars(pa[i].data(), pa[i].data() + pa[i].size(), na);
+        std::from_chars(pb[i].data(), pb[i].data() + pb[i].size(), nb);
+        if (na != nb) return na > nb;
+    }
+    if (pa.size() != pb.size()) return pa.size() > pb.size();
+    return lhs < rhs;
+}
+
+std::string pick_highest_version(const std::map<std::string, VData>& versions) {
+    if (versions.empty()) return {};
 
     std::vector<std::string> keys;
     keys.reserve(versions.size());
     for (auto& [k, _] : versions) keys.push_back(k);
 
-    std::ranges::sort(keys, [&](const std::string& a, const std::string& b) {
-        auto pa = split(strip_namespace(a));
-        auto pb = split(strip_namespace(b));
-        for (std::size_t i = 0; i < std::min(pa.size(), pb.size()); ++i) {
-            int na = 0, nb = 0;
-            std::from_chars(pa[i].data(), pa[i].data() + pa[i].size(), na);
-            std::from_chars(pb[i].data(), pb[i].data() + pb[i].size(), nb);
-            if (na != nb) return na > nb;
-        }
-        return pa.size() > pb.size();
-    });
+    std::ranges::sort(keys, version_key_greater);
 
     return keys.front();
 }

--- a/src/core/xvm/removal.cppm
+++ b/src/core/xvm/removal.cppm
@@ -309,18 +309,68 @@ apply_removal_batch(VersionDB& db,
         }
     }
 
+    // ── Group-coherent reactivation ──────────────────────────────────
+    //
+    // Removing the active release leaves its members with no active version.
+    // Choosing a replacement per target independently is how `gcc` ends up on
+    // GCC 15 while `g++` lands on musl's 15: two targets, two searches, no
+    // shared answer. That is the mixed-toolchain state this whole model
+    // exists to prevent, reintroduced at the moment of removal.
+    //
+    // Move a whole surviving release at once or move nothing. A candidate
+    // qualifies only when every member of its group is still registered, is
+    // opted into this subos, and does not contradict an already-active
+    // version. Otherwise the group stays inactive and the user re-selects
+    // explicitly -- an inactive toolchain is a visible problem, an
+    // incoherent one is not.
+    const auto memberAvailable =
+        [&](const std::string& target, const std::string& version) {
+            auto dbIt = candidateDb.find(target);
+            if (dbIt == candidateDb.end()
+                || !dbIt->second.versions.contains(version)) {
+                return false;
+            }
+            auto installedIt = candidateInstalled.find(target);
+            if (installedIt == candidateInstalled.end()
+                || std::ranges::find(installedIt->second, version)
+                       == installedIt->second.end()) {
+                return false;
+            }
+            auto activeIt = candidateWorkspace.find(target);
+            return activeIt == candidateWorkspace.end()
+                || activeIt->second == version;
+        };
+
     for (const auto& target : touchedTargets) {
         if (candidateWorkspace.contains(target)) continue;
         auto installedIt = candidateInstalled.find(target);
         if (installedIt == candidateInstalled.end()) continue;
-        for (auto versionIt = installedIt->second.rbegin();
-             versionIt != installedIt->second.rend(); ++versionIt) {
-            auto targetIt = candidateDb.find(target);
-            if (targetIt != candidateDb.end()
-                && targetIt->second.versions.contains(*versionIt)) {
-                candidateWorkspace[target] = *versionIt;
-                break;
+
+        // Highest surviving release first, by version rather than by the
+        // order the user happened to install things in.
+        auto candidates = installedIt->second;
+        std::ranges::sort(candidates, version_key_greater);
+
+        for (const auto& candidate : candidates) {
+            auto dbIt = candidateDb.find(target);
+            if (dbIt == candidateDb.end()
+                || !dbIt->second.versions.contains(candidate)) {
+                continue;
             }
+            auto selection =
+                resolve_binding_selection(candidateDb, target, candidate);
+            if (!selection) continue;
+            if (!std::ranges::all_of(
+                    selection->members, [&](const auto& member) {
+                        return memberAvailable(member.first, member.second);
+                    })) {
+                continue;
+            }
+            for (const auto& [memberTarget, memberVersion] :
+                 selection->members) {
+                candidateWorkspace[memberTarget] = memberVersion;
+            }
+            break;
         }
     }
 

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -6512,6 +6512,192 @@ TEST(XvmExactRemovalTest, UnpairedIncomingEdgeFailsWithoutMutation) {
     EXPECT_EQ(xlings::xvm::versions_to_json(db), before);
 }
 
+// ── Group-coherent reactivation after removal ────────────────────────
+//
+// Removing the active release has to leave the workspace coherent: every
+// member of a toolchain either moves to the same surviving release together,
+// or the whole group goes inactive. Picking a replacement per target is how
+// `gcc` ends up on GCC 15 while `g++` lands on musl's 15 -- the mixed state
+// the whole binding-group model exists to prevent, reintroduced at the moment
+// of removal.
+
+namespace {
+
+// Register `members` as one provider release, rooted at the first entry.
+void add_provider_group_(xlings::xvm::VersionDB& db,
+                         std::string_view provider,
+                         std::string_view providerVersion,
+                         std::string_view group,
+                         const std::vector<std::pair<std::string, std::string>>& members) {
+    const auto& [rootTarget, rootVersion] = members.front();
+    const xlings::xvm::BindingGroupRef ref{
+        .provider = std::string(provider),
+        .providerVersion = std::string(providerVersion),
+        .group = std::string(group),
+        .rootTarget = rootTarget,
+        .rootVersion = rootVersion,
+    };
+    std::map<std::string, std::string> manifest;
+    for (const auto& [target, version] : members) manifest[target] = version;
+
+    for (const auto& [target, version] : members) {
+        auto& info = db[target];
+        if (info.type.empty()) info.type = "program";
+        auto& data = info.versions[version];
+        data.path = std::string("/pkg/") + std::string(provider);
+        data.kind = "program";
+        data.sourceName = target;
+        data.destinationName = target;
+        data.bindingGroup = ref;
+    }
+    auto& root = db[rootTarget].versions[rootVersion];
+    root.bindingMembers = manifest;
+    root.bindingMembersDeclared = true;
+}
+
+}  // namespace
+
+TEST(XvmRemovalFallbackTest, IncoherentSurvivorDeactivatesTheWholeGroup) {
+    xlings::xvm::VersionDB db;
+    add_provider_group_(db, "pkgindex:gcc", "16.1.0", "gcc",
+                        {{"gcc", "16.1.0"}, {"g++", "16.1.0"}});
+    add_provider_group_(db, "pkgindex:gcc", "15.1.0", "gcc",
+                        {{"gcc", "15.1.0"}, {"g++", "15.1.0"}});
+    // musl also provides a `g++`. It is installed, but its own group is not
+    // complete here -- only the g++ member of it is present.
+    add_provider_group_(db, "pkgindex:musl", "1.2.5", "musl",
+                        {{"g++", "musl:15.1.0"}});
+
+    xlings::xvm::Workspace workspace{{"gcc", "16.1.0"}, {"g++", "16.1.0"}};
+    // g++ lists the musl build last on purpose: an insertion-order-driven
+    // fallback picks it, which is exactly the bug.
+    xlings::xvm::WorkspaceInstalled installed{
+        {"gcc", {"15.1.0", "16.1.0"}},
+        {"g++", {"15.1.0", "16.1.0", "musl:15.1.0"}},
+    };
+    const std::vector<xlings::xvm::RemovalOperation> operations{
+        {.op = "remove", .name = "gcc", .version = "16.1.0"},
+        {.op = "remove", .name = "g++", .version = "16.1.0"},
+    };
+
+    auto result = xlings::xvm::apply_removal_batch(
+        db, workspace, installed, operations, {});
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+
+    ASSERT_TRUE(workspace.contains("gcc"));
+    ASSERT_TRUE(workspace.contains("g++"));
+    EXPECT_EQ(workspace.at("gcc"), "15.1.0");
+    EXPECT_EQ(workspace.at("g++"), "15.1.0")
+        << "g++ fell back to a different provider than gcc";
+}
+
+TEST(XvmRemovalFallbackTest, CoherentSurvivingGroupIsActivatedWholesale) {
+    xlings::xvm::VersionDB db;
+    add_provider_group_(db, "pkgindex:gcc", "16.1.0", "gcc",
+                        {{"gcc", "16.1.0"}, {"g++", "16.1.0"}, {"gcc-ar", "16.1.0"}});
+    add_provider_group_(db, "pkgindex:gcc", "15.1.0", "gcc",
+                        {{"gcc", "15.1.0"}, {"g++", "15.1.0"}, {"gcc-ar", "15.1.0"}});
+    xlings::xvm::Workspace workspace{
+        {"gcc", "16.1.0"}, {"g++", "16.1.0"}, {"gcc-ar", "16.1.0"}};
+    xlings::xvm::WorkspaceInstalled installed{
+        {"gcc", {"15.1.0", "16.1.0"}},
+        {"g++", {"15.1.0", "16.1.0"}},
+        {"gcc-ar", {"15.1.0", "16.1.0"}},
+    };
+    const std::vector<xlings::xvm::RemovalOperation> operations{
+        {.op = "remove", .name = "gcc", .version = "16.1.0"},
+        {.op = "remove", .name = "g++", .version = "16.1.0"},
+        {.op = "remove", .name = "gcc-ar", .version = "16.1.0"},
+    };
+
+    auto result = xlings::xvm::apply_removal_batch(
+        db, workspace, installed, operations, {});
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+
+    EXPECT_EQ(workspace.at("gcc"), "15.1.0");
+    EXPECT_EQ(workspace.at("g++"), "15.1.0");
+    EXPECT_EQ(workspace.at("gcc-ar"), "15.1.0");
+}
+
+TEST(XvmRemovalFallbackTest, NoCompleteSurvivorLeavesEveryMemberInactive) {
+    xlings::xvm::VersionDB db;
+    add_provider_group_(db, "pkgindex:gcc", "16.1.0", "gcc",
+                        {{"gcc", "16.1.0"}, {"g++", "16.1.0"}});
+    // 15 is only half installed: its manifest names gcc and g++, but only
+    // g++ is registered. Rooted at g++ so the manifest survives the gap.
+    add_provider_group_(db, "pkgindex:gcc", "15.1.0", "gcc",
+                        {{"g++", "15.1.0"}, {"gcc", "15.1.0"}});
+    db.at("gcc").versions.erase("15.1.0");
+    xlings::xvm::Workspace workspace{{"gcc", "16.1.0"}, {"g++", "16.1.0"}};
+    xlings::xvm::WorkspaceInstalled installed{
+        {"gcc", {"16.1.0"}},
+        {"g++", {"15.1.0", "16.1.0"}},
+    };
+    const std::vector<xlings::xvm::RemovalOperation> operations{
+        {.op = "remove", .name = "gcc", .version = "16.1.0"},
+        {.op = "remove", .name = "g++", .version = "16.1.0"},
+    };
+
+    auto result = xlings::xvm::apply_removal_batch(
+        db, workspace, installed, operations, {});
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+
+    // g++ 15 survives on disk, but activating it alone would leave a `g++`
+    // with no matching `gcc`. Better inactive than incoherent.
+    EXPECT_FALSE(workspace.contains("gcc"));
+    EXPECT_FALSE(workspace.contains("g++"))
+        << "a lone member was activated without the rest of its group";
+}
+
+TEST(XvmRemovalFallbackTest, ResultDoesNotDependOnInstalledOrder) {
+    const auto run = [](std::vector<std::string> gccOrder) {
+        xlings::xvm::VersionDB db;
+        for (const auto* v : {"14.1.0", "15.1.0", "16.1.0"}) {
+            add_provider_group_(db, "pkgindex:gcc", v, "gcc",
+                                {{"gcc", v}, {"g++", v}});
+        }
+        xlings::xvm::Workspace workspace{{"gcc", "16.1.0"}, {"g++", "16.1.0"}};
+        xlings::xvm::WorkspaceInstalled installed{
+            {"gcc", gccOrder},
+            {"g++", {"14.1.0", "15.1.0", "16.1.0"}},
+        };
+        const std::vector<xlings::xvm::RemovalOperation> operations{
+            {.op = "remove", .name = "gcc", .version = "16.1.0"},
+            {.op = "remove", .name = "g++", .version = "16.1.0"},
+        };
+        auto result = xlings::xvm::apply_removal_batch(
+            db, workspace, installed, operations, {});
+        EXPECT_TRUE(result.has_value());
+        return workspace;
+    };
+
+    // installed[] is append-ordered by whatever the user happened to install
+    // first. The surviving release must not depend on it.
+    const auto ascending = run({"14.1.0", "15.1.0", "16.1.0"});
+    const auto descending = run({"16.1.0", "15.1.0", "14.1.0"});
+    EXPECT_EQ(ascending, descending);
+    EXPECT_EQ(ascending.at("gcc"), "15.1.0") << "expected the highest survivor";
+}
+
+TEST(XvmRemovalFallbackTest, UngroupedLegacyTargetStillFallsBack) {
+    xlings::xvm::VersionDB db;
+    db["tool"].type = "program";
+    db["tool"].versions["1.0.0"].path = "/pkg/tool";
+    db["tool"].versions["2.0.0"].path = "/pkg/tool";
+    xlings::xvm::Workspace workspace{{"tool", "2.0.0"}};
+    xlings::xvm::WorkspaceInstalled installed{{"tool", {"1.0.0", "2.0.0"}}};
+    const std::vector<xlings::xvm::RemovalOperation> operations{
+        {.op = "remove", .name = "tool", .version = "2.0.0"},
+    };
+
+    auto result = xlings::xvm::apply_removal_batch(
+        db, workspace, installed, operations, {});
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+
+    // A target with no group is a group of one, so it can always fall back.
+    EXPECT_EQ(workspace.at("tool"), "1.0.0");
+}
+
 TEST(XvmRemovalBatchTest, RawEmptyOperationNeverMeansAllVersions) {
     xlings::xvm::VersionDB db;
     db["sibling"].versions["repo-a:1.0.0"].path = "/pkg/a";
@@ -6723,9 +6909,17 @@ TEST(XvmRemovalBatchTest,
     auto& providerB = db["cc"].versions["repo-b:9.0.0"];
     providerB.path = "/pkg/b/9";
     providerB.kind = "program";
+    // Self-rooted, with a manifest. This entry is the one the workspace is
+    // expected to fall back to, and reactivation now requires the candidate's
+    // group to actually resolve -- a group whose root is not registered is
+    // exactly the dangling state that used to get written into the active
+    // workspace. The other entries stay minimal: they are only ever removal
+    // subjects here, never fallback candidates.
     providerB.bindingGroup = make_binding_group_ref(
         "repo-b:provider", "9.0.0", "cc-b-9",
-        "root-b-9", "repo-b:9.0.0");
+        "cc", "repo-b:9.0.0");
+    providerB.bindingMembers = {{"cc", "repo-b:9.0.0"}};
+    providerB.bindingMembersDeclared = true;
     db["cc"].versions["legacy:0.9.0"].path = "/pkg/legacy";
 
     xlings::xvm::Workspace workspace{


### PR DESCRIPTION
> P0.3 of the 0.4.70 release train — 补上 #384 设计文档承诺但未实现的一致性回退。

## Problem

#384 的设计文档 §7.1 承诺：

> switches an active group to a **complete surviving group**… otherwise clears all removed members **coherently**

实现（`removal.cppm:312-325`）是：

```cpp
for (auto versionIt = installedIt->second.rbegin(); ...)   // 逐 target，按 installed[] 插入序取最后一个
```

**逐 target 独立搜索，无 group 校验。** 两个 target、两次独立搜索、没有共同答案。

红阶段实测的三种故障（这些正是本 PR 的测试对旧实现的失败输出）：

```
Which is: "musl:15.1.0"
g++ fell back to a different provider than gcc          ← 混合工具链，原样重现

a lone member was activated without the rest of its group

Which is: { ("g++", "15.1.0"), ("gcc", "15.1.0") }      ← installed[] 升序
Which is: { ("g++", "15.1.0"), ("gcc", "14.1.0") }      ← installed[] 降序，结果不同
```

第三条意味着**同一份数据库在两台机器上可以解析出不同结果** —— `installed[]` 只是用户碰巧的安装顺序。

## Change

**整组迁移，或者不迁移。** 候选合格的条件：其 group 能解析，且每个成员都已注册、已加入本 subos 的 `installed[]`、且不与已激活的版本冲突。候选按**版本**降序（不再按 `installed[]` 顺序）。

无完整组存活时，成员保持**未激活**，由用户显式重选。

> 未激活的工具链是**看得见**的问题；不一致的工具链不是 —— `gcc --version` 报的是对的，要到链接期才炸。

顺带修了一层更深的不确定性：`pick_highest_version` 里的内联比较器**不是严格弱序** —— 仅 namespace 不同的键（`15.1.0` vs `musl:15.1.0`）双向比较都返回 false，谁排在前面取决于输入顺序。提取为 `xvm::version_key_greater` 并补了全序 tiebreak。

## Tests

5 条，其中 **3 条经验证对旧实现为红**（失败输出即上文的 bug 原文）：

| 测试 | 旧实现 |
|---|---|
| `IncoherentSurvivorDeactivatesTheWholeGroup` | ❌ g++ 回退到 musl |
| `NoCompleteSurvivorLeavesEveryMemberInactive` | ❌ 激活了孤立成员 |
| `ResultDoesNotDependOnInstalledOrder` | ❌ 结果随插入序变化 |
| `CoherentSurvivingGroupIsActivatedWholesale` | ✅ 双方都过（护栏） |
| `UngroupedLegacyTargetStillFallsBack` | ✅ 双方都过（护栏，确认 legacy 单例不受影响） |

## 一处既有测试改的是 fixture 而非期望

`RemoveAllDeletesOnlyExecutingProviderAcrossReleases` 构造的回退候选 `cc@repo-b:9.0.0`，其 binding-group root（`root-b-9`）**从未注册** —— 一个悬空组。该测试依赖这个悬空条目被激活，而这正是新回退拒绝的状态，也正是评审里"use 沿着残缺边继续遍历，最后把不存在的版本写入 active workspace"那条根因。

把该条目改成自根（self-rooted）并带 manifest。测试的主题 —— provider 范围内的 `remove_all` —— 未改动，断言原样保留。

如果保留原 fixture 而放宽实现去迁就它，等于把要修的 bug 重新引入。

## Verification

```
mcpp build   →  Finished release [optimized] in 44.98s
mcpp test    →  test result ok. 11 passed; 0 failed
XvmRemovalFallbackTest  →  5 passed
```

CI 状态为已知上游拉取签名（见 #386），依计划 §3.1.1 合入集成分支。