### PR TITLE
feat(xvm): tell the user why an install or removal was refused

### DIFF
--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -20,6 +20,7 @@ import xlings.core.xvm.types;
 import xlings.core.xvm.db;
 import xlings.core.xvm.removal;
 import xlings.core.xvm.registration;
+import xlings.core.xvm.errors;
 import xlings.core.xvm.commands;
 import xlings.core.xvm.shim;
 import xlings.core.xim.libxpkg.types.script;
@@ -1364,14 +1365,14 @@ bool process_xvm_operations_(const PlanNode& node,
             registration->batch.provider,
             registration->batch.providerVersion);
         if (!snapshot) {
-            log::warn(
-                "xvm removal selection failed for {}@{}: {} "
-                "(target='{}', version='{}')",
-                registration->batch.provider,
-                registration->batch.providerVersion,
-                snapshot.error().message,
-                snapshot.error().target,
-                snapshot.error().version);
+            // Selection runs before any mutation, so nothing has moved yet.
+            log::error("{}", xvm::render(
+                xvm::describe(
+                    snapshot.error(),
+                    std::format("{}@{}",
+                                registration->batch.provider,
+                                registration->batch.providerVersion)),
+                /*nothingChanged=*/true));
             return false;
         }
         removalContext = std::move(*snapshot);
@@ -1386,30 +1387,22 @@ bool process_xvm_operations_(const PlanNode& node,
         removalContext,
         *registration);
     if (!metadata) {
+        const auto owner = std::format("{}@{}",
+                                       registration->batch.provider,
+                                       registration->batch.providerVersion);
+        // apply_xpkg_xvm_metadata_batch works on copies and only swaps them
+        // in on success, so a failure here has left the stored state alone.
         if (std::holds_alternative<xvm::RemovalError>(
                 metadata.error())) {
-            const auto& error =
-                std::get<xvm::RemovalError>(metadata.error());
-            log::warn(
-                "xvm removal batch failed for {}@{}: {} "
-                "(target='{}', version='{}')",
-                registration->batch.provider,
-                registration->batch.providerVersion,
-                error.message,
-                error.target,
-                error.version);
+            log::error("{}", xvm::render(
+                xvm::describe(
+                    std::get<xvm::RemovalError>(metadata.error()), owner),
+                /*nothingChanged=*/true));
         } else {
-            const auto& error =
-                std::get<xvm::RegistrationError>(metadata.error());
-            log::warn(
-                "xvm registration batch failed for {}@{}: {} "
-                "(path='{}', target='{}', version='{}')",
-                registration->batch.provider,
-                registration->batch.providerVersion,
-                error.message,
-                error.path,
-                error.target,
-                error.version);
+            log::error("{}", xvm::render(
+                xvm::describe(
+                    std::get<xvm::RegistrationError>(metadata.error()), owner),
+                /*nothingChanged=*/true));
         }
         return false;
     }

--- a/src/core/xvm.cppm
+++ b/src/core/xvm.cppm
@@ -3,6 +3,7 @@ export module xlings.core.xvm;
 export import xlings.core.xvm.types;
 export import xlings.core.xvm.db;
 export import xlings.core.xvm.bindings;
+export import xlings.core.xvm.errors;
 export import xlings.core.xvm.registration;
 export import xlings.core.xvm.shim;
 export import xlings.core.xvm.commands;

--- a/src/core/xvm/errors.cppm
+++ b/src/core/xvm/errors.cppm
@@ -1,0 +1,289 @@
+export module xlings.core.xvm.errors;
+
+import std;
+
+import xlings.core.xvm.bindings;
+import xlings.core.xvm.db;
+import xlings.core.xvm.registration;
+
+// User-facing rendering for XVM failures.
+//
+// The validation layers fail closed, which is only useful if the person on
+// the other side is told what happened and what to do about it. Before this,
+// a rejected install surfaced as `log::warn` plus a bare `install failed`:
+// at the default log level the reason was invisible, and there was no way
+// out. "It used to install and now it doesn't" reads as xlings breaking,
+// not as the package being malformed.
+//
+// Every error kind maps to a stable, searchable code and a hint that names
+// an action. No hint means the error is not ready to be shown to a user.
+export namespace xlings::xvm {
+
+struct XvmUserError {
+    std::string code;      // stable, searchable, documentable
+    std::string what;      // one line: what happened
+    std::string provider;  // owning package release, when known
+    std::string target;
+    std::string version;
+    std::string path;      // JSON Pointer into the offending structure
+    std::string hint;      // one actionable way out
+};
+
+// Returned when a kind has no mapping. Asserted against in tests so a new
+// enumerator cannot reach users unexplained.
+inline constexpr std::string_view kUnclassifiedCode = "xvm-unclassified";
+inline constexpr std::string_view kUnclassifiedHint =
+    "this failure has no user-facing description yet; please report it with "
+    "the command you ran";
+
+struct CodeAndHint {
+    std::string_view code;
+    std::string_view hint;
+};
+
+CodeAndHint describe_kind(RegistrationErrorKind kind) {
+    switch (kind) {
+    case RegistrationErrorKind::InvalidBatchIdentity:
+        return {"xvm-batch-identity-invalid",
+                "the package did not declare who owns these registrations; "
+                "this is a recipe defect -- please report it upstream"};
+    case RegistrationErrorKind::InvalidNodeIdentity:
+        return {"xvm-node-identity-invalid",
+                "a recipe registered something with no name or no version; "
+                "check the xvm.add calls in the package recipe"};
+    case RegistrationErrorKind::InvalidNodePayload:
+        return {"xvm-node-payload-invalid",
+                "a recipe registered an entry with an unusable kind or "
+                "filename; check the type/filename of that xvm.add call"};
+    case RegistrationErrorKind::InvalidBindingIdentity:
+        return {"xvm-binding-identity-invalid",
+                "a recipe declared a binding with no target; check the "
+                "binding argument of that xvm.add call"};
+    case RegistrationErrorKind::DuplicateNode:
+        return {"xvm-duplicate-registration",
+                "the recipe registers the same name and version twice; "
+                "remove the duplicate xvm.add"};
+    case RegistrationErrorKind::RootNotInBatch:
+        return {"xvm-binding-root-missing",
+                "a binding points at something the recipe never registers; "
+                "register the binding target in the same recipe"};
+    case RegistrationErrorKind::SelfBinding:
+        return {"xvm-self-binding",
+                "an entry binds to itself; drop the binding argument"};
+    case RegistrationErrorKind::GroupConflict:
+        return {"xvm-group-conflict",
+                "the recipe puts one release under two different roots; "
+                "give the members a single common binding target"};
+    case RegistrationErrorKind::TargetVersionConflict:
+        return {"xvm-group-version-conflict",
+                "one release selects two versions of the same program; "
+                "a toolchain release must pin exactly one version per name"};
+    case RegistrationErrorKind::OwnershipConflict:
+        return {"xvm-ownership-conflict",
+                "another package already owns this exact name and version; "
+                "uninstall that package first, or install this one at a "
+                "different version"};
+    case RegistrationErrorKind::LegacyPayloadMismatch:
+        return {"xvm-legacy-payload-mismatch",
+                "this name and version is already installed with different "
+                "contents; uninstall it before reinstalling"};
+    case RegistrationErrorKind::IncompleteLegacyComponent:
+        return {"xvm-legacy-component-incomplete",
+                "the install would rewrite part of an existing bound group; "
+                "uninstall the whole package first"};
+    case RegistrationErrorKind::IncompleteOwnedGroup:
+        return {"xvm-owned-group-incomplete",
+                "reinstalling this release would drop a member it already "
+                "owns; uninstall it first, then install again"};
+    case RegistrationErrorKind::InvalidHeader:
+        return {"xvm-header-invalid",
+                "a recipe declared headers with no source directory; check "
+                "the xvm.headers call"};
+    case RegistrationErrorKind::HeaderGroupNotFound:
+        return {"xvm-header-group-unknown",
+                "the headers name a group the recipe does not create; fix "
+                "the group name on the xvm.headers call"};
+    case RegistrationErrorKind::HeaderAmbiguous:
+        return {"xvm-header-owner-ambiguous",
+                "the recipe registers several groups and nothing says which "
+                "one ships these headers; name the group on xvm.headers"};
+    case RegistrationErrorKind::BindingValidationFailed:
+        return {"xvm-binding-validation-failed",
+                "the resulting version database would not be self-consistent; "
+                "run `xlings self doctor` to see the offending entries"};
+    }
+    return {kUnclassifiedCode, kUnclassifiedHint};
+}
+
+CodeAndHint describe_kind(RemovalErrorKind kind) {
+    switch (kind) {
+    case RemovalErrorKind::VersionNotFound:
+        return {"xvm-remove-version-unknown",
+                "that version is not registered; run `xlings list` to see "
+                "what is installed"};
+    case RemovalErrorKind::AmbiguousVersion:
+        return {"xvm-remove-version-ambiguous",
+                "several installed versions match; pass the fully qualified "
+                "version, including its namespace prefix"};
+    case RemovalErrorKind::AsymmetricEdge:
+        return {"xvm-remove-edge-asymmetric",
+                "the stored binding is one-sided, so removal cannot tell what "
+                "else to detach; run `xlings self doctor`"};
+    case RemovalErrorKind::SelectionInvalid:
+        return {"xvm-remove-selection-invalid",
+                "the release to remove does not resolve to a coherent set; "
+                "run `xlings self doctor`"};
+    case RemovalErrorKind::ProviderRequired:
+        return {"xvm-remove-provider-required",
+                "removing every version of a name requires knowing which "
+                "package owns them; remove the package instead of the name"};
+    case RemovalErrorKind::ProviderMismatch:
+        return {"xvm-remove-provider-mismatch",
+                "that version belongs to a different package; uninstall the "
+                "package that owns it"};
+    case RemovalErrorKind::ProviderVersionNotFound:
+        return {"xvm-remove-provider-version-unknown",
+                "this package owns no such version of that name; run "
+                "`xlings list` to see what it installed"};
+    case RemovalErrorKind::VersionMismatch:
+        return {"xvm-remove-version-mismatch",
+                "the recipe asks to remove a version other than the one it "
+                "owns; this is a recipe defect -- please report it upstream"};
+    }
+    return {kUnclassifiedCode, kUnclassifiedHint};
+}
+
+CodeAndHint describe_kind(BindingErrorKind kind) {
+    switch (kind) {
+    case BindingErrorKind::InvalidGraph:
+        return {"xvm-binding-graph-invalid",
+                "the stored bindings do not form a usable group; run "
+                "`xlings self doctor`"};
+    case BindingErrorKind::TargetNotFound:
+        return {"xvm-binding-target-missing",
+                "a member of this release is not registered; reinstall the "
+                "package to restore it"};
+    case BindingErrorKind::VersionNotFound:
+        return {"xvm-binding-version-missing",
+                "a member of this release is registered at no such version; "
+                "reinstall the package to restore it"};
+    case BindingErrorKind::RootReferenceMismatch:
+        return {"xvm-binding-root-mismatch",
+                "the release root does not point at itself; reinstall the "
+                "package, or run `xlings self doctor`"};
+    case BindingErrorKind::GroupIdentityMismatch:
+        return {"xvm-binding-identity-mismatch",
+                "members of this release disagree about which release they "
+                "belong to; reinstall the package"};
+    case BindingErrorKind::RootMissingFromManifest:
+        return {"xvm-binding-root-unlisted",
+                "the release root is absent from its own member list; "
+                "reinstall the package"};
+    case BindingErrorKind::StartMemberMissing:
+        return {"xvm-binding-member-unlisted",
+                "this name is not listed as a member of the release it "
+                "claims; reinstall the package"};
+    case BindingErrorKind::MemberReferenceMismatch:
+        return {"xvm-binding-member-mismatch",
+                "a member points back at a different release; reinstall the "
+                "package"};
+    case BindingErrorKind::UnsupportedKind:
+        return {"xvm-binding-kind-unsupported",
+                "a member is registered as something xvm cannot switch; this "
+                "is a recipe defect -- please report it upstream"};
+    case BindingErrorKind::SelfEdge:
+        return {"xvm-binding-self-edge",
+                "a stored binding points at itself; run `xlings self doctor`"};
+    case BindingErrorKind::AsymmetricEdge:
+        return {"xvm-binding-edge-asymmetric",
+                "a stored binding is one-sided; run `xlings self doctor`"};
+    case BindingErrorKind::ConflictingTargetVersion:
+        return {"xvm-binding-version-conflict",
+                "following the bindings reaches two versions of one name; "
+                "run `xlings self doctor`"};
+    case BindingErrorKind::PartialProviderMetadata:
+        return {"xvm-binding-metadata-partial",
+                "this entry carries a member list but no release identity; "
+                "reinstall the package"};
+    case BindingErrorKind::ProviderMetadataInLegacyGraph:
+        return {"xvm-binding-metadata-mixed",
+                "an entry mixes the current and the pre-0.4.70 binding "
+                "formats; reinstall the package"};
+    case BindingErrorKind::MetadataIntegrityIssue:
+        return {"xvm-binding-metadata-corrupt",
+                "the stored binding metadata could not be parsed; run "
+                "`xlings self doctor` to see the offending field"};
+    }
+    return {kUnclassifiedCode, kUnclassifiedHint};
+}
+
+XvmUserError describe(const RegistrationError& error,
+                      std::string provider = {}) {
+    const auto [code, hint] = describe_kind(error.kind);
+    return {
+        .code = std::string(code),
+        .what = error.message,
+        .provider = std::move(provider),
+        .target = error.target,
+        .version = error.version,
+        .path = error.path,
+        .hint = std::string(hint),
+    };
+}
+
+XvmUserError describe(const RemovalError& error, std::string provider = {}) {
+    const auto [code, hint] = describe_kind(error.kind);
+    auto what = error.message;
+    if (!error.peerTarget.empty()) {
+        what += std::format(" (peer {}@{})", error.peerTarget, error.peerVersion);
+    }
+    return {
+        .code = std::string(code),
+        .what = std::move(what),
+        .provider = std::move(provider),
+        .target = error.target,
+        .version = error.version,
+        .hint = std::string(hint),
+    };
+}
+
+XvmUserError describe(const BindingError& error, std::string provider = {}) {
+    const auto [code, hint] = describe_kind(error.kind);
+    return {
+        .code = std::string(code),
+        .what = error.message,
+        .provider = std::move(provider),
+        .target = error.target,
+        .version = error.version,
+        .hint = std::string(hint),
+    };
+}
+
+// One block suitable for a single log::error call: the summary first, then
+// indented detail. The logger supplies the "[error]" marker, so this does not
+// add one of its own.
+//
+// `nothingChanged` is a promise, not decoration: pass true only where the
+// caller has actually left the stored state alone.
+std::string render(const XvmUserError& error, bool nothingChanged) {
+    std::string out = error.what;
+    out += std::format("\n          code:     {}", error.code);
+    if (!error.provider.empty()) {
+        out += std::format("\n          provider: {}", error.provider);
+    }
+    if (!error.target.empty()) {
+        out += std::format("\n          at:       {}{}{}", error.target,
+                           error.version.empty() ? "" : "@",
+                           error.version);
+    }
+    if (!error.path.empty()) {
+        out += std::format("\n          field:    {}", error.path);
+    }
+    out += std::format("\n          hint:     {}", error.hint);
+    if (nothingChanged) {
+        out += "\n          nothing was changed";
+    }
+    return out;
+}
+
+}  // namespace xlings::xvm

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -26,6 +26,7 @@ import xlings.core.xvm.db;
 import xlings.core.xvm.bindings;
 import xlings.core.xvm.removal;
 import xlings.core.xvm.registration;
+import xlings.core.xvm.errors;
 import xlings.core.xvm.shim;
 import xlings.core.xvm.commands;
 import xlings.core.compact;
@@ -10798,6 +10799,126 @@ TEST_F(AtomicWriteTest, ThrowsWhenParentDirectoryIsMissing) {
     EXPECT_THROW(xlings::platform::write_string_to_file(target.string(), "x"),
                  std::runtime_error);
     EXPECT_EQ(entry_count(), 0u) << "staging file leaked on failure";
+}
+
+// ============================================================
+// XvmUserError — every failure kind is explainable
+//
+// Failing closed is only useful if the person on the other side is told what
+// happened and what to do. These tests hold the line that no error kind can
+// reach a user as an unexplained "install failed": each maps to a stable
+// code and a hint that names an action.
+
+namespace {
+
+template <typename Kind>
+void expect_every_kind_described_(const std::vector<Kind>& kinds,
+                                  std::string_view label) {
+    std::set<std::string_view> codes;
+    for (const auto kind : kinds) {
+        const auto described = xlings::xvm::describe_kind(kind);
+        EXPECT_NE(described.code, xlings::xvm::kUnclassifiedCode)
+            << label << " kind " << static_cast<int>(kind)
+            << " has no user-facing description";
+        EXPECT_FALSE(described.hint.empty())
+            << label << " kind " << static_cast<int>(kind) << " has no hint";
+        EXPECT_TRUE(described.code.starts_with("xvm-"))
+            << "code should be namespaced: " << described.code;
+        EXPECT_TRUE(codes.insert(described.code).second)
+            << "duplicate code " << described.code
+            << " — codes are searchable identifiers and must be unique";
+    }
+    EXPECT_EQ(codes.size(), kinds.size());
+}
+
+}  // namespace
+
+TEST(XvmUserError, EveryRegistrationKindHasACodeAndHint) {
+    using K = xlings::xvm::RegistrationErrorKind;
+    expect_every_kind_described_<K>(
+        {K::InvalidBatchIdentity, K::InvalidNodeIdentity, K::InvalidNodePayload,
+         K::InvalidBindingIdentity, K::DuplicateNode, K::RootNotInBatch,
+         K::SelfBinding, K::GroupConflict, K::TargetVersionConflict,
+         K::OwnershipConflict, K::LegacyPayloadMismatch,
+         K::IncompleteLegacyComponent, K::IncompleteOwnedGroup,
+         K::InvalidHeader, K::HeaderGroupNotFound, K::HeaderAmbiguous,
+         K::BindingValidationFailed},
+        "RegistrationErrorKind");
+}
+
+TEST(XvmUserError, EveryRemovalKindHasACodeAndHint) {
+    using K = xlings::xvm::RemovalErrorKind;
+    expect_every_kind_described_<K>(
+        {K::VersionNotFound, K::AmbiguousVersion, K::AsymmetricEdge,
+         K::SelectionInvalid, K::ProviderRequired, K::ProviderMismatch,
+         K::ProviderVersionNotFound, K::VersionMismatch},
+        "RemovalErrorKind");
+}
+
+TEST(XvmUserError, EveryBindingKindHasACodeAndHint) {
+    using K = xlings::xvm::BindingErrorKind;
+    expect_every_kind_described_<K>(
+        {K::InvalidGraph, K::TargetNotFound, K::VersionNotFound,
+         K::RootReferenceMismatch, K::GroupIdentityMismatch,
+         K::RootMissingFromManifest, K::StartMemberMissing,
+         K::MemberReferenceMismatch, K::UnsupportedKind, K::SelfEdge,
+         K::AsymmetricEdge, K::ConflictingTargetVersion,
+         K::PartialProviderMetadata, K::ProviderMetadataInLegacyGraph,
+         K::MetadataIntegrityIssue},
+        "BindingErrorKind");
+}
+
+TEST(XvmUserError, RenderCarriesEveryFieldTheUserNeeds) {
+    const xlings::xvm::RegistrationError error{
+        .kind = xlings::xvm::RegistrationErrorKind::OwnershipConflict,
+        .path = "/nodes/2",
+        .target = "gcc",
+        .version = "15.1.0",
+        .message = "exact registration is owned by 'pkgindex:llvm@20.1.7'",
+    };
+
+    const auto rendered = xlings::xvm::render(
+        xlings::xvm::describe(error, "pkgindex:gcc@15.1.0"), true);
+
+    EXPECT_NE(rendered.find("owned by 'pkgindex:llvm@20.1.7'"), std::string::npos);
+    EXPECT_NE(rendered.find("xvm-ownership-conflict"), std::string::npos);
+    EXPECT_NE(rendered.find("pkgindex:gcc@15.1.0"), std::string::npos);
+    EXPECT_NE(rendered.find("gcc@15.1.0"), std::string::npos);
+    EXPECT_NE(rendered.find("/nodes/2"), std::string::npos);
+    EXPECT_NE(rendered.find("uninstall that package first"), std::string::npos);
+    EXPECT_NE(rendered.find("nothing was changed"), std::string::npos);
+}
+
+TEST(XvmUserError, NothingWasChangedIsOnlyClaimedWhenAsked) {
+    const xlings::xvm::RemovalError error{
+        .kind = xlings::xvm::RemovalErrorKind::AmbiguousVersion,
+        .target = "cc",
+        .version = "1.0",
+        .message = "bare removal version '1.0' matches 2 stored versions",
+    };
+
+    // The line is a promise about stored state, so it must never appear
+    // unless the caller vouched for it.
+    EXPECT_EQ(xlings::xvm::render(xlings::xvm::describe(error), false)
+                  .find("nothing was changed"),
+              std::string::npos);
+}
+
+TEST(XvmUserError, PeerOfAnAsymmetricEdgeIsShown) {
+    const xlings::xvm::RemovalError error{
+        .kind = xlings::xvm::RemovalErrorKind::AsymmetricEdge,
+        .target = "gcc",
+        .version = "15.1.0",
+        .peerTarget = "g++",
+        .peerVersion = "15.1.0",
+        .message = "removal binding edge is not reciprocal",
+    };
+
+    // Without the peer the message names only one side of a two-sided
+    // problem, which is not enough to go look at anything.
+    EXPECT_NE(xlings::xvm::render(xlings::xvm::describe(error), true)
+                  .find("peer g++@15.1.0"),
+              std::string::npos);
 }
 
 // ============================================================


### PR DESCRIPTION
> P0.4 of the 0.4.70 release train。

## Problem

#384 让校验层 fail-closed，但失败只走 `log::warn` + `return false`。默认日志级别下用户只看到 `install failed`，**看不到原因，也没有出口**。

这在两个意义上是新问题：

1. 有若干拒绝场景（`OwnershipConflict`、`HeaderAmbiguous`）在 `origin/main` 上是**静默覆盖成功**的。用户的第一感受会是"升级之后我原来能装的包装不上了"，而不是"我的包有问题"。
2. fail-closed 的价值主张只有在用户知道该怎么办时才成立。

## Change

新增 `xvm::XvmUserError` —— 稳定 code、所属 release、出错的 target 与 JSON Pointer、以及**一条指明动作的 hint**。

```
[error] exact registration is owned by 'pkgindex:llvm@20.1.7'
          code:     xvm-ownership-conflict
          provider: pkgindex:gcc@15.1.0
          at:       gcc@15.1.0
          field:    /nodes/2
          hint:     another package already owns this exact name and version;
                    uninstall that package first, or install this one at a
                    different version
          nothing was changed
```

三个错误枚举（`RegistrationErrorKind` 17 + `RemovalErrorKind` 8 + `BindingErrorKind` 15 = **40 个**）全部建立映射。

**穷尽性双保险**：switch 不带 `default`（新增枚举值编译期告警）+ 单测逐个列举全部 40 个值，对任何未分类、无 hint、或 code 重复的一律失败。

## `nothing was changed` 是断言，不是修辞

三处接线全部传 `nothingChanged=true`，且**逐处核对过而非假设**：

- 选择阶段（`snapshot_xpkg_removal_context`）在任何变更之前运行
- `apply_xpkg_xvm_metadata_batch` 在 `candidateDb/Workspace/Installed` 副本上工作，只在成功时 `swap` 回去 —— 所有失败路径都在 swap 之前 return

测试 `NothingWasChangedIsOnlyClaimedWhenAsked` 保证这行字不会在没人担保时出现。

## Tests

| 测试 | 覆盖 |
|---|---|
| `EveryRegistrationKindHasACodeAndHint` | 17 个枚举值 |
| `EveryRemovalKindHasACodeAndHint` | 8 个 |
| `EveryBindingKindHasACodeAndHint` | 15 个 |
| `RenderCarriesEveryFieldTheUserNeeds` | 渲染含 what/code/provider/at/field/hint |
| `NothingWasChangedIsOnlyClaimedWhenAsked` | 不主动声称未改动 |
| `PeerOfAnAsymmetricEdgeIsShown` | 非对称边必须同时给出对端，否则只说了一半 |

## Verification

```
mcpp build   →  Finished release [optimized] in 44.76s
mcpp test    →  test result ok. 11 passed; 0 failed
XvmUserError →  6 passed
```

CI 状态为已知上游拉取签名（见 #386），依计划 §3.1.1 合入集成分支。