### PR TITLE
feat(xvm): make `self doctor` see the binding state

### DIFF
--- a/src/core/xself/doctor.cppm
+++ b/src/core/xself/doctor.cppm
@@ -14,6 +14,7 @@ import xlings.runtime;
 import xlings.core.xvm.types;
 import xlings.core.xvm.db;
 import xlings.core.xvm.shim;
+import xlings.core.xvm.inspect;
 
 namespace xlings::xself {
 
@@ -336,6 +337,33 @@ export int cmd_doctor(EventStream& stream, bool fix) {
                 name, version, alias_prog, expanded);
             add_field("⚠ alias unresolved", std::move(detail));
         }
+    }
+
+    // Check 4: the binding state itself.
+    //
+    // Everything above looks at shims and payloads. None of it can see a
+    // release whose members disagree about which release they are, or an
+    // active toolchain whose members drifted apart -- and those are exactly
+    // the states that make `xlings use` refuse. Without this, a user hitting
+    // that refusal has nowhere to look but versions.json.
+    //
+    // Read-only for now: reporting is what removes the dead end. Repair
+    // lands separately, because deactivating a group or dropping metadata
+    // is a decision the user should see spelled out before it happens.
+    const auto bindingFindings = xvm::inspect_binding_state(db, ws);
+    for (const auto& finding : bindingFindings) {
+        ++broken;
+        std::string detail = finding.summary;
+        if (!finding.target.empty()) {
+            detail += std::format(" [{}{}{}]", finding.target,
+                                  finding.version.empty() ? "" : "@",
+                                  finding.version);
+        }
+        if (!finding.field.empty()) {
+            detail += std::format(" at {}", finding.field);
+        }
+        detail += std::format(" — {} — {}", finding.code, finding.hint);
+        add_field("✗ binding state", std::move(detail));
     }
 
     // Note: there is intentionally no --fix loop for broken payloads here.

--- a/src/core/xvm.cppm
+++ b/src/core/xvm.cppm
@@ -4,6 +4,7 @@ export import xlings.core.xvm.types;
 export import xlings.core.xvm.db;
 export import xlings.core.xvm.bindings;
 export import xlings.core.xvm.errors;
+export import xlings.core.xvm.inspect;
 export import xlings.core.xvm.registration;
 export import xlings.core.xvm.shim;
 export import xlings.core.xvm.commands;

--- a/src/core/xvm/inspect.cppm
+++ b/src/core/xvm/inspect.cppm
@@ -1,0 +1,149 @@
+export module xlings.core.xvm.inspect;
+
+import std;
+
+import xlings.core.xvm.types;
+import xlings.core.xvm.bindings;
+import xlings.core.xvm.errors;
+
+// Read-only inspection of the stored binding state.
+//
+// The selection layer fails closed: a malformed or dangling group makes
+// `xlings use` refuse. That is the right call, but until something can *name*
+// the offending entry the refusal is a dead end -- `self doctor` reported
+// only shims and payloads, so a user whose group metadata went bad had
+// nothing to look at but versions.json.
+//
+// Deliberately a pure function over (db, workspace). It touches no Config, no
+// filesystem and no network, so every case below is reachable from a unit
+// test, and doctor stays a renderer.
+export namespace xlings::xvm {
+
+struct BindingFinding {
+    std::string code;     // shares the XvmUserError code space
+    std::string summary;
+    std::string target;
+    std::string version;
+    std::string field;    // JSON Pointer, when the problem is metadata-level
+    std::string hint;
+};
+
+// Invariants checked, in the order a user would want to hear about them:
+//
+//   INV-1  every active version is registered
+//   INV-4  every group member is registered and its group resolves
+//   INV-2  members of one release are active together, or not at all
+//
+// Metadata integrity comes first: a corrupt field explains every downstream
+// symptom, so reporting the symptoms above it would just be noise.
+std::vector<BindingFinding> inspect_binding_state(
+        const VersionDB& db,
+        const Workspace& workspace) {
+    std::vector<BindingFinding> findings;
+
+    // ── Metadata integrity ───────────────────────────────────────────
+    for (const auto& [target, info] : db) {
+        for (const auto& [version, data] : info.versions) {
+            for (const auto& issue : data.bindingIntegrityIssues) {
+                findings.push_back({
+                    .code = "xvm-binding-metadata-corrupt",
+                    .summary = std::format(
+                        "stored binding metadata is unreadable ({})",
+                        issue.code),
+                    .target = target,
+                    .version = version,
+                    .field = issue.path,
+                    .hint = "reinstall the package that owns this entry",
+                });
+            }
+        }
+    }
+
+    // ── INV-1: the workspace points at something that exists ─────────
+    for (const auto& [target, version] : workspace) {
+        auto infoIt = db.find(target);
+        if (infoIt != db.end() && infoIt->second.versions.contains(version)) {
+            continue;
+        }
+        findings.push_back({
+            .code = "xvm-active-version-missing",
+            .summary = "the active version is not registered",
+            .target = target,
+            .version = version,
+            .hint = std::format(
+                "run `xlings install {}` to restore it, or `xlings use {} "
+                "<other-version>`", target, target),
+        });
+    }
+
+    // ── INV-4: every group resolves ──────────────────────────────────
+    //
+    // One report per group rather than per member: a five-member toolchain
+    // with one missing member is one problem, and printing it five times
+    // buries the rest of the output.
+    std::set<std::tuple<std::string, std::string, std::string>> seenGroups;
+    for (const auto& [target, info] : db) {
+        for (const auto& [version, data] : info.versions) {
+            if (!data.bindingGroup) continue;
+            if (!data.bindingIntegrityIssues.empty()) continue;  // already reported
+            const auto& ref = *data.bindingGroup;
+            if (!seenGroups.emplace(ref.provider, ref.providerVersion,
+                                    ref.group).second) {
+                continue;
+            }
+            auto selection = resolve_binding_selection(db, target, version);
+            if (selection) continue;
+            const auto described = describe(selection.error());
+            findings.push_back({
+                .code = described.code,
+                .summary = std::format("release {}@{} does not resolve: {}",
+                                       ref.provider, ref.providerVersion,
+                                       described.what),
+                .target = described.target,
+                .version = described.version,
+                .hint = described.hint,
+            });
+        }
+    }
+
+    // ── INV-2: an active release is active as a whole ────────────────
+    std::set<std::string> reportedIncoherent;
+    for (const auto& [target, version] : workspace) {
+        auto infoIt = db.find(target);
+        if (infoIt == db.end()) continue;
+        auto dataIt = infoIt->second.versions.find(version);
+        if (dataIt == infoIt->second.versions.end()) continue;
+        if (!dataIt->second.bindingGroup) continue;
+        auto selection = resolve_binding_selection(db, target, version);
+        if (!selection) continue;  // reported by INV-4 already
+
+        for (const auto& [memberTarget, memberVersion] : selection->members) {
+            auto activeIt = workspace.find(memberTarget);
+            const bool coherent = activeIt != workspace.end()
+                && activeIt->second == memberVersion;
+            if (coherent) continue;
+            const auto key = dataIt->second.bindingGroup->provider + "@"
+                + dataIt->second.bindingGroup->providerVersion + "/"
+                + memberTarget;
+            if (!reportedIncoherent.insert(key).second) continue;
+            findings.push_back({
+                .code = "xvm-active-group-incoherent",
+                .summary = std::format(
+                    "'{}' is active at {} but '{}' of the same release is {}",
+                    target, version, memberTarget,
+                    activeIt == workspace.end()
+                        ? std::string("not active")
+                        : std::format("active at {}", activeIt->second)),
+                .target = memberTarget,
+                .version = memberVersion,
+                .hint = std::format(
+                    "run `xlings use {} {}` to bring the whole release back "
+                    "in step", target, version),
+            });
+        }
+    }
+
+    return findings;
+}
+
+}  // namespace xlings::xvm

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -27,6 +27,7 @@ import xlings.core.xvm.bindings;
 import xlings.core.xvm.removal;
 import xlings.core.xvm.registration;
 import xlings.core.xvm.errors;
+import xlings.core.xvm.inspect;
 import xlings.core.xvm.shim;
 import xlings.core.xvm.commands;
 import xlings.core.compact;
@@ -10799,6 +10800,152 @@ TEST_F(AtomicWriteTest, ThrowsWhenParentDirectoryIsMissing) {
     EXPECT_THROW(xlings::platform::write_string_to_file(target.string(), "x"),
                  std::runtime_error);
     EXPECT_EQ(entry_count(), 0u) << "staging file leaked on failure";
+}
+
+// ============================================================
+// inspect_binding_state — name the entry that made `use` refuse
+//
+// The selection layer fails closed, so a bad group makes `xlings use`
+// refuse. Until doctor could name the offending entry that refusal was a
+// dead end: doctor reported shims and payloads only, and the user was left
+// reading versions.json by hand.
+
+namespace {
+
+// One provider release, rooted at the first member.
+void inspect_group_(xlings::xvm::VersionDB& db,
+                    std::string_view provider,
+                    std::string_view providerVersion,
+                    const std::vector<std::pair<std::string, std::string>>& members) {
+    const auto& [rootTarget, rootVersion] = members.front();
+    const xlings::xvm::BindingGroupRef ref{
+        .provider = std::string(provider),
+        .providerVersion = std::string(providerVersion),
+        .group = std::string(provider),
+        .rootTarget = rootTarget,
+        .rootVersion = rootVersion,
+    };
+    std::map<std::string, std::string> manifest;
+    for (const auto& [t, v] : members) manifest[t] = v;
+    for (const auto& [t, v] : members) {
+        auto& info = db[t];
+        if (info.type.empty()) info.type = "program";
+        auto& data = info.versions[v];
+        data.path = "/pkg";
+        data.kind = "program";
+        data.bindingGroup = ref;
+    }
+    auto& root = db[rootTarget].versions[rootVersion];
+    root.bindingMembers = manifest;
+    root.bindingMembersDeclared = true;
+}
+
+bool has_code_(const std::vector<xlings::xvm::BindingFinding>& findings,
+               std::string_view code) {
+    return std::ranges::any_of(findings, [&](const auto& f) {
+        return f.code == code;
+    });
+}
+
+}  // namespace
+
+TEST(XvmInspect, CleanStateReportsNothing) {
+    xlings::xvm::VersionDB db;
+    inspect_group_(db, "pkgindex:gcc", "15.1.0",
+                   {{"gcc", "15.1.0"}, {"g++", "15.1.0"}});
+    const xlings::xvm::Workspace ws{{"gcc", "15.1.0"}, {"g++", "15.1.0"}};
+
+    EXPECT_TRUE(xlings::xvm::inspect_binding_state(db, ws).empty());
+}
+
+TEST(XvmInspect, NamesTheCorruptFieldAndItsEntry) {
+    xlings::xvm::VersionDB db;
+    inspect_group_(db, "pkgindex:gcc", "15.1.0", {{"gcc", "15.1.0"}});
+    db.at("gcc").versions.at("15.1.0").bindingIntegrityIssues = {
+        {.code = "binding-group-field-invalid", .path = "/bindingGroup/rootVersion"},
+    };
+
+    const auto findings =
+        xlings::xvm::inspect_binding_state(db, {{"gcc", "15.1.0"}});
+
+    ASSERT_FALSE(findings.empty());
+    const auto& first = findings.front();
+    EXPECT_EQ(first.code, "xvm-binding-metadata-corrupt");
+    EXPECT_EQ(first.target, "gcc");
+    // The JSON Pointer is the whole point: it is what turns "your state is
+    // bad" into something a user can actually go and look at.
+    EXPECT_EQ(first.field, "/bindingGroup/rootVersion");
+    EXPECT_FALSE(first.hint.empty());
+}
+
+TEST(XvmInspect, ReportsAReleaseWithAMissingMember) {
+    xlings::xvm::VersionDB db;
+    inspect_group_(db, "pkgindex:gcc", "15.1.0",
+                   {{"gcc", "15.1.0"}, {"g++", "15.1.0"}});
+    db.at("g++").versions.erase("15.1.0");
+
+    const auto findings =
+        xlings::xvm::inspect_binding_state(db, {{"gcc", "15.1.0"}});
+
+    EXPECT_TRUE(has_code_(findings, "xvm-binding-version-missing"))
+        << "a dangling member must be named, not just make `use` refuse";
+}
+
+TEST(XvmInspect, ReportsAnIncoherentActiveRelease) {
+    xlings::xvm::VersionDB db;
+    inspect_group_(db, "pkgindex:gcc", "15.1.0",
+                   {{"gcc", "15.1.0"}, {"g++", "15.1.0"}});
+    inspect_group_(db, "pkgindex:gcc", "16.1.0",
+                   {{"gcc", "16.1.0"}, {"g++", "16.1.0"}});
+
+    // The exact state the release train exists to prevent: same names,
+    // different releases, and nothing on the surface says so.
+    const auto findings = xlings::xvm::inspect_binding_state(
+        db, {{"gcc", "15.1.0"}, {"g++", "16.1.0"}});
+
+    EXPECT_TRUE(has_code_(findings, "xvm-active-group-incoherent"));
+    const auto incoherent = std::ranges::find_if(findings, [](const auto& f) {
+        return f.code == "xvm-active-group-incoherent";
+    });
+    EXPECT_NE(incoherent->hint.find("xlings use"), std::string::npos)
+        << "the hint has to name the command that fixes it";
+}
+
+TEST(XvmInspect, ReportsAnActiveVersionThatIsNotRegistered) {
+    xlings::xvm::VersionDB db;
+    inspect_group_(db, "pkgindex:gcc", "15.1.0", {{"gcc", "15.1.0"}});
+
+    const auto findings =
+        xlings::xvm::inspect_binding_state(db, {{"gcc", "99.0.0"}});
+
+    EXPECT_TRUE(has_code_(findings, "xvm-active-version-missing"));
+}
+
+TEST(XvmInspect, ABrokenReleaseIsReportedOncePerRelease) {
+    xlings::xvm::VersionDB db;
+    inspect_group_(db, "pkgindex:gcc", "15.1.0",
+                   {{"gcc", "15.1.0"}, {"g++", "15.1.0"}, {"gcc-ar", "15.1.0"}});
+    db.at("gcc-ar").versions.erase("15.1.0");
+
+    const auto findings = xlings::xvm::inspect_binding_state(db, {});
+
+    // Five members short one member is one problem. Reporting it per member
+    // buries everything else in the output.
+    EXPECT_EQ(std::ranges::count_if(findings, [](const auto& f) {
+                  return f.code == "xvm-binding-version-missing";
+              }), 1);
+}
+
+TEST(XvmInspect, LegacyStateWithoutGroupsIsNotFlagged) {
+    xlings::xvm::VersionDB db;
+    db["tool"].type = "program";
+    db["tool"].versions["1.0.0"].path = "/pkg";
+    db["tool"].versions["1.0.0"].kind = "program";
+
+    // Pre-0.4.70 databases carry no group metadata at all. They are not
+    // broken, and doctor must not tell users otherwise.
+    EXPECT_TRUE(
+        xlings::xvm::inspect_binding_state(db, {{"tool", "1.0.0"}}).empty());
 }
 
 // ============================================================


### PR DESCRIPTION
> P0.6 of the 0.4.70 release train。

## Problem

评审 §3.4 的"死路"场景：

```console
$ xlings use gcc 15.1.0
✗ binding metadata integrity issue 'binding-group-field-invalid'
  at '/bindingGroup/rootVersion'

$ xlings self doctor --fix
✓ workspace/shim consistency OK      # ← 它看不见这个问题

$ # 然后呢？
```

doctor 只检查 shim 和 payload，完全不认识 binding 元数据。校验层 fail-closed 是对的，但在 xlings 里没有任何东西能**说出是哪条条目坏了**，用户只能手读 `versions.json`。

## Change

新增 `xvm::inspect_binding_state` —— 对 `(db, workspace)` 的纯函数，检查选择层依赖的不变量：

- 每个 active 版本都已注册（INV-1）
- 每个 release 都能解析、成员齐全（INV-4）
- 同一 release 的成员要么一起 active、要么都不（INV-2）

每条 finding 带 `XvmUserError` 的 code、出错条目、metadata 级问题的 JSON Pointer、以及指明修复命令的 hint。

**纯函数**（不碰 Config / 文件系统 / 网络），所以每个分支都能单测覆盖，doctor 退化为渲染器。

只读。修复动作单独提交 —— 停用一个组或丢弃元数据，应该在发生前先讲清楚。

## Tests

7 条，含两条"不该误报"的护栏：

| 测试 | 覆盖 |
|---|---|
| `CleanStateReportsNothing` | 干净状态零输出 |
| `NamesTheCorruptFieldAndItsEntry` | JSON Pointer 精确到字段 |
| `ReportsAReleaseWithAMissingMember` | 悬空成员 |
| `ReportsAnIncoherentActiveRelease` | **gcc@15 + g++@16 同时 active** |
| `ReportsAnActiveVersionThatIsNotRegistered` | INV-1 |
| `ABrokenReleaseIsReportedOncePerRelease` | 五成员缺一，报一次不是五次 |
| `LegacyStateWithoutGroupsIsNotFlagged` | **0.4.69 数据库不被误判为损坏** |

## 计划中的一项没做，原因值得记录

计划 P1.3 要求停止序列化 `bindingIntegrityIssues`（理由：派生数据不该变成存储状态）。**实现后失败了 #384 的 7 条测试，而它们是对的。**

一条 `bindingGroup` 没解析成功的记录，内存里根本不持有那个 group。不写回 marker 就意味着保存时**把畸形值整个丢掉** —— 损坏条目被静默洗白成一条健康的无组条目，退回混合工具链风险，且不留任何痕迹。#384 的持久化正是在防这个。

真正的缺陷是：**重写一条没能解析的记录，无论写不写 marker 都会丢信息**。正确修法是为这类条目保留原始 JSON，那是独立的一次改动。已撤销该部分，序列化行为保持 #384 原样。

## Verification

```
mcpp build   →  Finished release [optimized] in 49.91s
mcpp test    →  test result ok. 11 passed; 0 failed
XvmInspect   →  7 passed
```

CI 状态为已知上游拉取签名（见 #386），依计划 §3.1.1 合入集成分支。