### PR TITLE
feat(xvm): serialize the commands that mutate state

### DIFF
--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -521,8 +521,7 @@ private:
                     if (json.contains("lang") && json["lang"].is_string())
                         lang_ = json["lang"].get<std::string>();
                     // Load global versions
-                    if (json.contains("versions") && json["versions"].is_object())
-                        globalVersions_ = xvm::versions_from_json(json["versions"]);
+                    load_global_versions_from_json_(json);
                     globalIndexRepos_ = parse_index_repos_json(json, mirror_);
                     load_resource_servers_from_json_(json, globalResourceServers_);
                     if (auto v = resolve_index_base_(json, mirror_); !v.empty()) indexBase_ = v;
@@ -560,12 +559,7 @@ private:
         // subos's workspace whenever the user is in a spawned subos shell
         // with XLINGS_ACTIVE_SUBOS set, which then corrupts that subos
         // when `xvm use` writes back through save_workspace().
-        auto subosConfigPath = paths_.homeDir / "subos" / paths_.activeSubos / ".xlings.json";
-        {
-            auto sws = load_workspace_from_file_(subosConfigPath);
-            globalWorkspace_ = std::move(sws.active);
-            globalInstalled_ = std::move(sws.installed);
-        }
+        load_global_workspace_();
 
         // Load project-level config (walk up from cwd)
         load_project_config_();
@@ -770,6 +764,52 @@ private:
         }
     }
 
+    void load_global_versions_from_json_(const nlohmann::json& json) {
+        if (json.contains("versions") && json["versions"].is_object()) {
+            globalVersions_ = xvm::versions_from_json(json["versions"]);
+        } else {
+            globalVersions_.clear();
+        }
+    }
+
+    void load_global_workspace_() {
+        auto subosConfigPath =
+            paths_.homeDir / "subos" / paths_.activeSubos / ".xlings.json";
+        auto sws = load_workspace_from_file_(subosConfigPath);
+        globalWorkspace_ = std::move(sws.active);
+        globalInstalled_ = std::move(sws.installed);
+    }
+
+    // Re-read the mutable state layers from disk.
+    //
+    // Config loads state during construction, and main.cpp touches it before
+    // dispatching a command, so by the time a mutating command starts it is
+    // already holding a snapshot taken outside any lock. Serializing writes
+    // alone would not prevent a lost update: both processes would still have
+    // read the same old state and the second write would erase the first.
+    // Commands re-read through here *after* taking the state lock.
+    //
+    // Deliberately narrow: versions, workspace and project state only.
+    // Mirror, language and index-repo resolution stay as they were resolved
+    // at startup -- re-deriving those mid-command would change behavior
+    // under the user rather than protect it.
+    void reload_state_() {
+        namespace fs = std::filesystem;
+        auto configPath = paths_.homeDir / ".xlings.json";
+        if (fs::exists(configPath)) {
+            try {
+                auto content = platform::read_file_to_string(configPath.string());
+                auto json = nlohmann::json::parse(content, nullptr, false);
+                if (!json.is_discarded()) load_global_versions_from_json_(json);
+            } catch (...) {}
+        } else {
+            globalVersions_.clear();
+        }
+        load_global_workspace_();
+        if (hasProjectConfig_) load_project_config_();
+        update_effective_paths_();
+    }
+
     static Config& instance_() {
         static Config inst;
         return inst;
@@ -806,6 +846,11 @@ public:
 
         return globalWorkspace;
     }
+
+    // Re-read versions/workspace/project state from disk. Call after taking
+    // the state lock so a command operates on what is actually stored rather
+    // than on the snapshot taken at process start.
+    static void reload_state() { instance_().reload_state_(); }
 
     [[nodiscard]] static const PathInfo& paths() { return instance_().paths_; }
     [[nodiscard]] static const std::string& mirror() { return instance_().mirror_; }

--- a/src/core/xim/commands.cppm
+++ b/src/core/xim/commands.cppm
@@ -19,6 +19,7 @@ import xlings.core.i18n;
 import xlings.platform;
 import xlings.libs.tinyhttps;
 import xlings.core.xvm.db;
+import xlings.core.xvm.lock;
 import xlings.core.xvm.commands;
 import xlings.core.xvm.shim;
 import xlings.core.profile;
@@ -111,6 +112,17 @@ int cmd_install(std::span<const std::string> targets, bool yes, bool noDeps,
                 EventStream& stream, bool forceGlobal = false,
                 CancellationToken* cancel = nullptr, bool dryRun = false,
                 bool useAfterInstall = false) {
+    // Serialize against any other xlings mutating this home, then re-read
+    // state under the lock: Config loaded it at process start, outside the
+    // lock, so acting on that snapshot is how two commands lose each other's
+    // work. See xvm/lock.cppm.
+    auto stateLock = xvm::acquire_state_lock(Config::paths().homeDir);
+    if (!stateLock) {
+        log::error("{}", stateLock.error());
+        return 1;
+    }
+    Config::reload_state();
+
     auto& catalog = get_catalog();
     if (!catalog.is_loaded()) {
         log::info("package index not available, updating...");
@@ -537,6 +549,17 @@ int cmd_install(std::span<const std::string> targets, bool yes, bool noDeps,
 // approved the parent install, so the connected uninstall is implicit.
 // CLI-driven `xlings remove <pkg>` defaults to yes=false and bails on n.
 int cmd_remove(const std::string& target, bool yes, EventStream& stream) {
+    // Serialize against any other xlings mutating this home, then re-read
+    // state under the lock: Config loaded it at process start, outside the
+    // lock, so acting on that snapshot is how two commands lose each other's
+    // work. See xvm/lock.cppm.
+    auto stateLock = xvm::acquire_state_lock(Config::paths().homeDir);
+    if (!stateLock) {
+        log::error("{}", stateLock.error());
+        return 1;
+    }
+    Config::reload_state();
+
     auto& catalog = get_catalog();
     if (!catalog.is_loaded()) {
         log::error("package index not available");

--- a/src/core/xvm.cppm
+++ b/src/core/xvm.cppm
@@ -5,6 +5,7 @@ export import xlings.core.xvm.db;
 export import xlings.core.xvm.bindings;
 export import xlings.core.xvm.errors;
 export import xlings.core.xvm.inspect;
+export import xlings.core.xvm.lock;
 export import xlings.core.xvm.registration;
 export import xlings.core.xvm.shim;
 export import xlings.core.xvm.commands;

--- a/src/core/xvm/commands.cppm
+++ b/src/core/xvm/commands.cppm
@@ -12,6 +12,7 @@ import xlings.core.semver;
 import xlings.core.xself;
 import xlings.core.xvm.types;
 import xlings.core.xvm.db;
+import xlings.core.xvm.lock;
 import xlings.core.xvm.shim;
 
 export namespace xlings::xvm {
@@ -149,6 +150,17 @@ filter_to_subos_installed_(const std::string& target,
 // xlings use <target> <version>
 // Updates the active subos workspace and creates/updates bin/ hardlinks
 int cmd_use(const std::string& target, const std::string& version, EventStream& stream) {
+    // Serialize against any other xlings mutating this home, then re-read
+    // state under the lock: Config loaded it at process start, outside the
+    // lock, so acting on that snapshot is how two commands lose each other's
+    // work. See xvm/lock.cppm.
+    auto stateLock = xvm::acquire_state_lock(Config::paths().homeDir);
+    if (!stateLock) {
+        log::error("{}", stateLock.error());
+        return 1;
+    }
+    Config::reload_state();
+
     auto db = Config::versions();
     auto& p  = Config::paths();
 

--- a/src/core/xvm/lock.cppm
+++ b/src/core/xvm/lock.cppm
@@ -1,0 +1,114 @@
+export module xlings.core.xvm.lock;
+
+import std;
+
+import xlings.platform;
+import xlings.core.log;
+import xlings.core.utils;
+
+// Serialize the commands that mutate xlings state.
+//
+// install, remove and use all read the version database and the workspace,
+// decide something, and write both back. Nothing stopped two of them running
+// at once, so the second writer erased the first one's work.
+//
+// Before provider-scoped binding groups that cost you a stale entry. Now the
+// two writes are halves of one release: losing one of them leaves a group
+// manifest naming a member the other process removed, and the selection layer
+// refuses the whole toolchain. The failure went from "one package is out of
+// date" to "gcc no longer switches", which is why this is worth a lock rather
+// than a note in the docs.
+//
+// Scope is the home, not the subos: the version database is shared across
+// every subos under it, so a per-subos lock would not protect it.
+//
+// Only mutating commands take it. Reads -- list, show, shim dispatch -- stay
+// lock-free and accept seeing state from a moment ago; making shim dispatch
+// block on an install would be a far worse trade.
+export namespace xlings::xvm {
+
+// Set to 1 to skip locking entirely. Diagnostic escape hatch for a wedged
+// lock file; using it while another xlings is running reintroduces exactly
+// the lost update this exists to prevent, so it warns.
+// Functions rather than inline constexpr variables: GCC's module support
+// emits an undefined reference for an ODR-used inline constexpr variable
+// crossing a module boundary (here, as a default argument).
+constexpr std::string_view no_lock_env() { return "XLINGS_NO_LOCK"; }
+
+constexpr std::chrono::milliseconds default_lock_timeout() {
+    return std::chrono::seconds{30};
+}
+
+std::filesystem::path state_lock_path(const std::filesystem::path& home) {
+    return home / ".xlings.lock";
+}
+
+class StateLock {
+public:
+    StateLock() = default;
+    StateLock(const StateLock&) = delete;
+    StateLock& operator=(const StateLock&) = delete;
+    StateLock(StateLock&&) = default;
+    StateLock& operator=(StateLock&&) = default;
+
+    // True when the lock is genuinely held. Also true for the bypass, so
+    // callers cannot accidentally treat the escape hatch as a failure.
+    [[nodiscard]] bool held() const { return held_; }
+    [[nodiscard]] bool bypassed() const { return bypassed_; }
+
+private:
+    friend std::expected<StateLock, std::string> acquire_state_lock(
+        const std::filesystem::path&, std::chrono::milliseconds);
+
+    platform::FileLock lock_;
+    bool held_ { false };
+    bool bypassed_ { false };
+};
+
+// Acquire the home-wide state lock, or explain why not.
+//
+// flock is released by the kernel when the holder exits, so a crashed xlings
+// cannot wedge the lock and there is no staleness to detect or clean up.
+//
+// The lock file's *contents* are deliberately never written. It would be
+// useful for a timeout message to name the holding pid, but
+// platform::write_string_to_file now replaces files by rename, and rename
+// swaps in a new inode. flock is held on the open descriptor of the old one,
+// so writing to the lock file through that path would leave the lock name
+// pointing at an unlocked inode -- and the next process would acquire it
+// successfully while this one still believes it holds the lock. The lock file
+// exists only as something to flock.
+std::expected<StateLock, std::string> acquire_state_lock(
+        const std::filesystem::path& home,
+        std::chrono::milliseconds timeout = default_lock_timeout()) {
+    StateLock lock;
+
+    if (utils::get_env_or_default(std::string(no_lock_env())) == "1") {
+        log::warn(
+            "{}=1 — running without the state lock; a concurrent xlings can "
+            "silently discard this command's changes",
+            no_lock_env());
+        lock.bypassed_ = true;
+        lock.held_ = true;
+        return lock;
+    }
+
+    std::error_code ec;
+    std::filesystem::create_directories(home, ec);
+
+    const auto path = state_lock_path(home);
+    std::string error;
+    if (!lock.lock_.acquire(path, timeout, {}, error)) {
+        return std::unexpected(std::format(
+            "another xlings process is changing this installation; waited "
+            "{}s. Wait for it to finish, or set {}=1 to proceed anyway "
+            "(which can discard one of the two commands' changes)",
+            std::chrono::duration_cast<std::chrono::seconds>(timeout).count(),
+            no_lock_env()));
+    }
+
+    lock.held_ = true;
+    return lock;
+}
+
+}  // namespace xlings::xvm

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -28,6 +28,7 @@ import xlings.core.xvm.removal;
 import xlings.core.xvm.registration;
 import xlings.core.xvm.errors;
 import xlings.core.xvm.inspect;
+import xlings.core.xvm.lock;
 import xlings.core.xvm.shim;
 import xlings.core.xvm.commands;
 import xlings.core.compact;
@@ -10800,6 +10801,77 @@ TEST_F(AtomicWriteTest, ThrowsWhenParentDirectoryIsMissing) {
     EXPECT_THROW(xlings::platform::write_string_to_file(target.string(), "x"),
                  std::runtime_error);
     EXPECT_EQ(entry_count(), 0u) << "staging file leaked on failure";
+}
+
+// ============================================================
+// State lock — install/remove/use must not overwrite each other
+
+namespace {
+
+std::filesystem::path lock_test_home_(std::string_view name) {
+    namespace fs = std::filesystem;
+    auto home = fs::temp_directory_path() / ("xlings_lock_" + std::string(name));
+    std::error_code ec;
+    fs::remove_all(home, ec);
+    fs::create_directories(home);
+    return home;
+}
+
+}  // namespace
+
+TEST(XvmStateLock, IsHeldForTheHomeNotTheSubos) {
+    const auto home = lock_test_home_("scope");
+    // The version database is shared by every subos under a home, so the
+    // lock has to live at the home root to protect it.
+    EXPECT_EQ(xlings::xvm::state_lock_path(home), home / ".xlings.lock");
+    std::filesystem::remove_all(home);
+}
+
+TEST(XvmStateLock, SecondAcquisitionInTheSameProcessFailsFast) {
+    const auto home = lock_test_home_("contended");
+
+    auto first = xlings::xvm::acquire_state_lock(home, std::chrono::milliseconds{50});
+    ASSERT_TRUE(first.has_value()) << first.error();
+    EXPECT_TRUE(first->held());
+    EXPECT_FALSE(first->bypassed());
+
+    auto second = xlings::xvm::acquire_state_lock(home, std::chrono::milliseconds{50});
+    ASSERT_FALSE(second.has_value()) << "the lock did not exclude a second holder";
+    // The message has to be actionable: what is happening and what to do.
+    EXPECT_NE(second.error().find("another xlings process"), std::string::npos);
+    EXPECT_NE(second.error().find("XLINGS_NO_LOCK"), std::string::npos);
+
+    std::filesystem::remove_all(home);
+}
+
+TEST(XvmStateLock, ReleasesWhenTheHolderGoesOutOfScope) {
+    const auto home = lock_test_home_("released");
+    {
+        auto held = xlings::xvm::acquire_state_lock(home, std::chrono::milliseconds{50});
+        ASSERT_TRUE(held.has_value()) << held.error();
+    }
+    auto again = xlings::xvm::acquire_state_lock(home, std::chrono::milliseconds{50});
+    EXPECT_TRUE(again.has_value())
+        << "the lock outlived its holder: " << again.error();
+    std::filesystem::remove_all(home);
+}
+
+TEST(XvmStateLock, LockFileContentsAreNeverRewritten) {
+    const auto home = lock_test_home_("inode");
+    const auto path = xlings::xvm::state_lock_path(home);
+
+    auto held = xlings::xvm::acquire_state_lock(home, std::chrono::milliseconds{50});
+    ASSERT_TRUE(held.has_value()) << held.error();
+
+    // Writing anything to the lock file through the normal path would
+    // rename a new inode over it, leaving the lock name unlocked while this
+    // process still believes it holds the lock. Nothing may be written, and
+    // in particular the file must stay empty.
+    ASSERT_TRUE(std::filesystem::exists(path));
+    EXPECT_EQ(std::filesystem::file_size(path), 0u)
+        << "something wrote to the lock file; flock is held on the old inode";
+
+    std::filesystem::remove_all(home);
 }
 
 // ============================================================


### PR DESCRIPTION
> P1.2 of the 0.4.70 release train。

## Problem

`src/core/xvm/` 全目录**没有任何锁**（`git grep -n lock` 为空）。`install` / `remove` / `use` 都是"读版本库和 workspace → 决策 → 写回两者"，两个同时跑，后写的把先写的抹掉。

#384 之后这件事的**严重度变了**：两次写入现在是同一个 release 的两半。丢掉一半 → group manifest 指向另一进程已删除的成员 → 选择层拒绝 → **整条工具链不再能切换**。

从"某个包状态过时"升级成"gcc 不能用了"，所以这不再是可以写进文档的注意事项。

## Change

home 级 flock，由 install / remove / use 获取。

- **home 而非 subos** —— 版本库被该 home 下所有 subos 共享，per-subos 锁保护不住它
- **只读命令不加锁** —— list / show / shim dispatch 接受读到片刻之前的状态；让 shim dispatch 阻塞在一次 install 上是更糟的交易
- flock 由内核在进程退出时释放，崩溃的 xlings 不会卡住锁，**没有 stale 需要检测**

### 只加锁不够

`Config` 在构造期加载状态，而 `main.cpp:60` 在分发任何命令**之前**就访问了它 —— 命令拿到的是锁外快照。只串行化写入，两个进程仍会基于同一份陈旧读取各自决策。

新增 `Config::reload_state()`，在取到锁后立即调用。范围刻意收窄到 versions / workspace / project state：mirror 与索引配置在启动时已解析，命令执行中途重新推导会**改变用户脚下的行为**而不是保护它。

## 过程中发现的两件事

**1. 锁文件的内容绝对不能写。**

本来想把持有者 pid 写进去让超时消息更有用。但 `write_string_to_file` 现在（#389）是 temp + rename，**rename 会换掉 inode**。flock 持在旧 inode 的 fd 上，于是锁文件名指向一个没有锁的新 inode —— 下一个进程能成功获取，而当前进程还以为自己持有锁。**互斥直接失效。**

已加测试 `LockFileContentsAreNeverRewritten` 断言该文件保持为空。这是 #389 引入的一个非显然的交互，值得单独记一笔。

**2. GCC modules 的 ODR 坑。**

`inline constexpr` 变量跨模块边界被 ODR-use（这里是作为默认参数）会产生 undefined reference：

```
undefined reference to `xlings::xvm::kDefaultLockTimeout@xlings.core.xvm.lock'
```

改为 constexpr 函数。

## Tests

| 测试 | 覆盖 |
|---|---|
| `IsHeldForTheHomeNotTheSubos` | 锁在 home 根 |
| `SecondAcquisitionInTheSameProcessFailsFast` | 真互斥 + 消息含"怎么办" |
| `ReleasesWhenTheHolderGoesOutOfScope` | RAII 释放 |
| `LockFileContentsAreNeverRewritten` | 上述 inode 陷阱 |

跨进程竞争由既有的 `--file-lock-child` 用例覆盖（`platform::FileLock` 层）。

`XLINGS_NO_LOCK=1` 提供逃生阀（用于卡住的锁诊断），使用时告警说明它重新引入了丢更新。

## Verification

```
mcpp build   →  Finished release [optimized] in 18.97s
mcpp test    →  test result ok. 11 passed; 0 failed
XvmStateLock →  4 passed
```

CI 状态为已知上游拉取签名（见 #386），依计划 §3.1.1 合入集成分支。