### PR TITLE
feat(xvm): let `self doctor --fix` take down an incoherent release

### DIFF
--- a/src/core/xself/doctor.cppm
+++ b/src/core/xself/doctor.cppm
@@ -15,6 +15,7 @@ import xlings.core.xvm.types;
 import xlings.core.xvm.db;
 import xlings.core.xvm.shim;
 import xlings.core.xvm.inspect;
+import xlings.core.xvm.lock;
 
 namespace xlings::xself {
 
@@ -364,6 +365,41 @@ export int cmd_doctor(EventStream& stream, bool fix) {
         }
         detail += std::format(" — {} — {}", finding.code, finding.hint);
         add_field("✗ binding state", std::move(detail));
+    }
+
+    // --fix for the one binding problem that can be repaired without
+    // guessing: an active release whose members disagree. Deactivate the
+    // whole release and let the user re-select. Choosing a survivor here
+    // would mean deciding which member was "right", which is exactly the
+    // silent decision that produces incoherent state to begin with.
+    //
+    // Unresolvable and corrupt entries are reported but not touched: fixing
+    // those means dropping stored metadata, which needs the user's explicit
+    // consent rather than a flag they passed for shim repair.
+    if (fix) {
+        auto plan = xvm::plan_incoherent_deactivation(db, ws);
+        if (!plan.targets.empty()) {
+            auto lock = xvm::acquire_state_lock(Config::paths().homeDir);
+            if (!lock) {
+                add_field("✗ binding state", std::format(
+                    "cannot deactivate incoherent releases: {}", lock.error()));
+            } else {
+                Config::reload_state();
+                auto& mutableWs = Config::workspace_mut();
+                std::size_t dropped = 0;
+                for (const auto& [target, label] : plan.targets) {
+                    if (mutableWs.erase(target) == 0) continue;
+                    ++dropped;
+                    add_field("· deactivated", std::format(
+                        "{} (was part of {}) — run `xlings use {} <version>` "
+                        "to select a release", target, label, target));
+                }
+                if (dropped > 0) {
+                    Config::save_workspace();
+                    healed += static_cast<int>(dropped);
+                }
+            }
+        }
     }
 
     // Note: there is intentionally no --fix loop for broken payloads here.

--- a/src/core/xvm/inspect.cppm
+++ b/src/core/xvm/inspect.cppm
@@ -146,4 +146,58 @@ std::vector<BindingFinding> inspect_binding_state(
     return findings;
 }
 
+struct DeactivationPlan {
+    // Targets to drop from the active workspace, and the release each
+    // belonged to, so the caller can tell the user what to re-select.
+    std::map<std::string, std::string> targets;  // target -> "provider@version"
+};
+
+// Bring the workspace back to INV-2 by deactivating every release whose
+// members disagree.
+//
+// Deactivating rather than repairing is deliberate. Repair would mean
+// choosing which member is "right", and there is no basis for that choice:
+// the user may have meant either release, and picking one silently is how
+// the incoherent state arises in the first place. An inactive toolchain is a
+// visible problem the user resolves with one `xlings use`; an incoherent one
+// reports the right version from `gcc --version` and fails much later.
+//
+// Pure: returns the plan, applies nothing.
+DeactivationPlan plan_incoherent_deactivation(const VersionDB& db,
+                                              const Workspace& workspace) {
+    DeactivationPlan plan;
+    for (const auto& [target, version] : workspace) {
+        auto infoIt = db.find(target);
+        if (infoIt == db.end()) continue;
+        auto dataIt = infoIt->second.versions.find(version);
+        if (dataIt == infoIt->second.versions.end()) continue;
+        if (!dataIt->second.bindingGroup) continue;
+        auto selection = resolve_binding_selection(db, target, version);
+        if (!selection) continue;  // unresolvable is a different problem
+
+        const bool coherent = std::ranges::all_of(
+            selection->members, [&](const auto& member) {
+                auto activeIt = workspace.find(member.first);
+                return activeIt != workspace.end()
+                    && activeIt->second == member.second;
+            });
+        if (coherent) continue;
+
+        const auto& ref = *dataIt->second.bindingGroup;
+        const auto label =
+            std::format("{}@{}", ref.provider, ref.providerVersion);
+        // Take down every member of this release that is active, not just
+        // the entry point: leaving the rest behind would swap one
+        // incoherent state for another.
+        for (const auto& [memberTarget, memberVersion] : selection->members) {
+            auto activeIt = workspace.find(memberTarget);
+            if (activeIt == workspace.end()) continue;
+            if (activeIt->second != memberVersion) continue;
+            plan.targets.emplace(memberTarget, label);
+        }
+        plan.targets.emplace(target, label);
+    }
+    return plan;
+}
+
 }  // namespace xlings::xvm

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -11020,6 +11020,64 @@ TEST(XvmInspect, LegacyStateWithoutGroupsIsNotFlagged) {
         xlings::xvm::inspect_binding_state(db, {{"tool", "1.0.0"}}).empty());
 }
 
+TEST(XvmInspect, DeactivationTakesDownEveryMemberOfAnIncoherentRelease) {
+    xlings::xvm::VersionDB db;
+    inspect_group_(db, "pkgindex:gcc", "15.1.0",
+                   {{"gcc", "15.1.0"}, {"g++", "15.1.0"}, {"gcc-ar", "15.1.0"}});
+    inspect_group_(db, "pkgindex:gcc", "16.1.0",
+                   {{"gcc", "16.1.0"}, {"g++", "16.1.0"}, {"gcc-ar", "16.1.0"}});
+    const xlings::xvm::Workspace ws{
+        {"gcc", "15.1.0"}, {"g++", "16.1.0"}, {"gcc-ar", "15.1.0"}};
+
+    const auto plan = xlings::xvm::plan_incoherent_deactivation(db, ws);
+
+    // Leaving the agreeing members active would just swap one incoherent
+    // state for another, so the whole release comes down.
+    EXPECT_TRUE(plan.targets.contains("gcc"));
+    EXPECT_TRUE(plan.targets.contains("g++"));
+    EXPECT_TRUE(plan.targets.contains("gcc-ar"));
+    EXPECT_NE(plan.targets.at("gcc").find("pkgindex:gcc@"), std::string::npos)
+        << "the plan must say which release the target belonged to";
+}
+
+TEST(XvmInspect, DeactivationLeavesACoherentWorkspaceAlone) {
+    xlings::xvm::VersionDB db;
+    inspect_group_(db, "pkgindex:gcc", "15.1.0",
+                   {{"gcc", "15.1.0"}, {"g++", "15.1.0"}});
+    const xlings::xvm::Workspace ws{{"gcc", "15.1.0"}, {"g++", "15.1.0"}};
+
+    EXPECT_TRUE(xlings::xvm::plan_incoherent_deactivation(db, ws).targets.empty());
+}
+
+TEST(XvmInspect, DeactivationIgnoresUnresolvableReleases) {
+    xlings::xvm::VersionDB db;
+    inspect_group_(db, "pkgindex:gcc", "15.1.0",
+                   {{"gcc", "15.1.0"}, {"g++", "15.1.0"}});
+    db.at("g++").versions.erase("15.1.0");
+
+    // A release that does not resolve is a different problem, and repairing
+    // it means dropping stored metadata. --fix must not do that silently.
+    EXPECT_TRUE(
+        xlings::xvm::plan_incoherent_deactivation(db, {{"gcc", "15.1.0"}})
+            .targets.empty());
+}
+
+TEST(XvmInspect, DeactivationLeavesUngroupedTargetsAlone) {
+    xlings::xvm::VersionDB db;
+    inspect_group_(db, "pkgindex:gcc", "15.1.0",
+                   {{"gcc", "15.1.0"}, {"g++", "15.1.0"}});
+    db["editor"].type = "program";
+    db["editor"].versions["1.0.0"].path = "/pkg";
+    db["editor"].versions["1.0.0"].kind = "program";
+    const xlings::xvm::Workspace ws{
+        {"gcc", "15.1.0"}, {"g++", "16.1.0"}, {"editor", "1.0.0"}};
+
+    const auto plan = xlings::xvm::plan_incoherent_deactivation(db, ws);
+
+    // An unrelated single package must not be collateral damage.
+    EXPECT_FALSE(plan.targets.contains("editor"));
+}
+
 // ============================================================
 // XvmUserError — every failure kind is explainable
 //


### PR DESCRIPTION
> P1.3 (第一部分) of the 0.4.70 release train。

## Problem

#394 让 doctor 能**说出**哪个 release 的成员互相矛盾，但不能对它做任何事。指出一个自己拒绝处理的问题，只是半个出口。

## Change

`--fix` 现在会**停用**这样的 release：它的每个成员都退出 active workspace，用户用一条 `xlings use` 重新选择。

### 为什么是停用而不是修复

修复意味着要判定哪个成员是"对的"，而**没有依据做这个判断** —— 用户可能想要任一 release，而静默挑一个正是这个状态最初出错的方式。

> 未激活的工具链是看得见的问题；不一致的工具链会让 `gcc --version` 报出正确版本，然后在链接期才炸。

### 整组下线

不只是那些"不一致"的成员 —— 把一致的那些留在 active 只是把一种不一致换成另一种。

### 范围刻意收窄

无法解析的、以及元数据损坏的条目，仍然只报告不触碰。修复它们意味着**丢弃已存储的元数据**，那需要用户的明确同意，而不是一个他为了修 shim 而传的 flag。未分组的包永不波及。

修复路径与其它变更路径一样：取状态锁、重载、再写。

## Tests

| 测试 | 覆盖 |
|---|---|
| `DeactivationTakesDownEveryMemberOfAnIncoherentRelease` | 整组下线，且计划里带 release 标识 |
| `DeactivationLeavesACoherentWorkspaceAlone` | 不误伤一致状态 |
| `DeactivationIgnoresUnresolvableReleases` | 不静默丢元数据 |
| `DeactivationLeavesUngroupedTargetsAlone` | 无关单包不是附带损伤 |

## 剩余部分

元数据损坏条目的修复（`--reset-metadata`）仍未做，原因见 #394：需要先为未解析的记录保留原始 JSON，否则保存本身就会丢信息。那是独立的一次改动。

## Verification

```
mcpp build   →  Finished release [optimized] in 41.13s
mcpp test    →  test result ok. 11 passed; 0 failed
XvmInspect   →  11 passed
```

CI 状态为已知上游拉取签名（见 #386），依计划 §3.1.1 合入集成分支。