### PR TITLE
fix(xvm): switch the whole release on `xlings use`, or none of it

### DIFF
--- a/src/core/xvm.cppm
+++ b/src/core/xvm.cppm
@@ -6,6 +6,7 @@ export import xlings.core.xvm.bindings;
 export import xlings.core.xvm.errors;
 export import xlings.core.xvm.inspect;
 export import xlings.core.xvm.lock;
+export import xlings.core.xvm.switch_plan;
 export import xlings.core.xvm.registration;
 export import xlings.core.xvm.shim;
 export import xlings.core.xvm.commands;

--- a/src/core/xvm/commands.cppm
+++ b/src/core/xvm/commands.cppm
@@ -13,6 +13,9 @@ import xlings.core.xself;
 import xlings.core.xvm.types;
 import xlings.core.xvm.db;
 import xlings.core.xvm.lock;
+import xlings.core.xvm.bindings;
+import xlings.core.xvm.errors;
+import xlings.core.xvm.switch_plan;
 import xlings.core.xvm.shim;
 
 export namespace xlings::xvm {
@@ -207,46 +210,46 @@ int cmd_use(const std::string& target, const std::string& version, EventStream& 
 
     log::debug("fuzzy version match: {} -> {}", version, resolved);
 
-    // Header & lib switching: remove old, install new
+    // Resolve the whole release before touching anything.
+    //
+    // This used to walk the binding edges by hand, keyed by target rather
+    // than by (target, version), and without checking that what it reached
+    // actually existed. A stale edge would take it to a version with no
+    // VData, which it then wrote into the active workspace -- the shim
+    // failed later, far from the command that caused it. Header and library
+    // switching ran *before* that walk and only for the entry target, so a
+    // failure part-way through left the sysroot holding one release and the
+    // workspace claiming another.
+    //
+    // resolve_binding_selection validates the whole group and fails closed.
+    // Running it first means a bad group costs the user an error message
+    // instead of a half-switched toolchain.
+    auto workspace = Config::effective_workspace();
+    auto plan = plan_use_switch(db, workspace, target, resolved);
+    if (!plan) {
+        log::error("{}", render(plan.error(), true));
+        return 1;
+    }
+    const auto& to_switch = plan->members;
+
+    // Everything above this line is a decision; everything below changes the
+    // filesystem. Members that are already where they belong emit no change.
     auto sysroot_include = p.subosDir / "usr" / "include";
     auto sysroot_lib     = p.subosDir / "usr" / "lib";
-    auto workspace = Config::effective_workspace();
-    auto old_active = get_active_version(workspace, target);
-    log::debug("switching headers: {} -> {}", old_active.empty() ? "(none)" : old_active, resolved);
-    if (!old_active.empty() && old_active != resolved) {
-        auto old_vdata = get_vdata(db, target, old_active);
-        if (old_vdata && !old_vdata->includedir.empty())
-            remove_headers(old_vdata->includedir, sysroot_include);
-        if (old_vdata && !old_vdata->libdir.empty())
-            remove_libdir(old_vdata->libdir, sysroot_lib);
+    for (const auto& change : plan->switches) {
+        if (!change.removeIncludeDir.empty())
+            remove_headers(change.removeIncludeDir, sysroot_include);
+        if (!change.removeLibDir.empty())
+            remove_libdir(change.removeLibDir, sysroot_lib);
+        if (!change.installIncludeDir.empty())
+            install_headers(change.installIncludeDir, sysroot_include);
+        if (!change.installLibDir.empty())
+            install_libdir(change.installLibDir, sysroot_lib);
+        log::debug("switching {}: {} -> {}", change.target,
+                   change.previousVersion.empty() ? "(none)"
+                                                  : change.previousVersion,
+                   change.version);
     }
-    auto new_vdata = get_vdata(db, target, resolved);
-    if (new_vdata && !new_vdata->includedir.empty())
-        install_headers(new_vdata->includedir, sysroot_include);
-    if (new_vdata && !new_vdata->libdir.empty())
-        install_libdir(new_vdata->libdir, sysroot_lib);
-
-    // Collect all (target, version) pairs by traversing the binding tree
-    std::map<std::string, std::string> to_switch;
-    std::set<std::string> visited;
-
-    std::function<void(const std::string&, const std::string&)> collect_bindings;
-    collect_bindings = [&](const std::string& node, const std::string& node_ver) {
-        if (visited.contains(node)) return;
-        visited.insert(node);
-        to_switch[node] = node_ver;
-
-        auto info = get_vinfo(db, node);
-        if (!info) return;
-        for (auto& [peer_name, vermap] : info->bindings) {
-            auto it = vermap.find(node_ver);
-            if (it != vermap.end()) {
-                collect_bindings(peer_name, it->second);
-            }
-        }
-    };
-
-    collect_bindings(target, resolved);
 
     // Update workspace for all nodes in the binding tree, and opt this
     // subos into the version's installed[] set if it wasn't already.

--- a/src/core/xvm/switch_plan.cppm
+++ b/src/core/xvm/switch_plan.cppm
@@ -1,0 +1,109 @@
+export module xlings.core.xvm.switch_plan;
+
+import std;
+
+import xlings.core.xvm.types;
+import xlings.core.xvm.bindings;
+import xlings.core.xvm.errors;
+
+// Decide what `xlings use` should do, without doing any of it.
+//
+// The old path interleaved the decision with the work: it swapped the entry
+// target's headers, then walked binding edges by hand to find everything else.
+// Two consequences. The walk was keyed by target rather than by
+// (target, version) and never checked that what it reached existed, so a
+// stale edge put a version with no payload into the active workspace and the
+// shim failed later, far from the command that caused it. And because the
+// swap ran first, a failure part-way through left the sysroot holding one
+// release while the workspace claimed another.
+//
+// Separating the two makes the failure mode "an error message" rather than
+// "a half-switched toolchain", and makes the interesting logic reachable from
+// a unit test -- cmd_use needs a Config singleton and a real filesystem, so
+// nothing inside it was testable before.
+export namespace xlings::xvm {
+
+// What has to change on disk for one member of the release.
+struct MemberSwitch {
+    std::string target;
+    std::string version;
+    std::string previousVersion;   // empty when the member was not active
+    std::string removeIncludeDir;  // empty when there is nothing to remove
+    std::string removeLibDir;
+    std::string installIncludeDir;
+    std::string installLibDir;
+};
+
+struct UseSwitchPlan {
+    std::map<std::string, std::string> members;  // target -> version
+    std::vector<MemberSwitch> switches;          // only members that move
+};
+
+// Resolve the release and work out the filesystem changes.
+//
+// Fails closed: an unresolvable group, or a member with no payload record,
+// yields an error and no plan. Callers have not touched anything yet, so the
+// error is safe to report as "nothing was changed".
+std::expected<UseSwitchPlan, XvmUserError> plan_use_switch(
+        const VersionDB& db,
+        const Workspace& workspace,
+        const std::string& target,
+        const std::string& resolvedVersion) {
+    auto selection = resolve_binding_selection(db, target, resolvedVersion);
+    if (!selection) {
+        return std::unexpected(describe(selection.error()));
+    }
+
+    UseSwitchPlan plan{.members = selection->members};
+
+    // Preflight every member before emitting any change, so "the third of
+    // five members is missing" is an error rather than a toolchain switched
+    // two fifths of the way.
+    for (const auto& [memberTarget, memberVersion] : plan.members) {
+        auto infoIt = db.find(memberTarget);
+        if (infoIt == db.end()
+            || !infoIt->second.versions.contains(memberVersion)) {
+            return std::unexpected(XvmUserError{
+                .code = "xvm-switch-member-missing",
+                .what = std::format(
+                    "cannot switch to {}@{}: member '{}@{}' has no payload "
+                    "record", target, resolvedVersion, memberTarget,
+                    memberVersion),
+                .target = memberTarget,
+                .version = memberVersion,
+                .hint = "run `xlings self doctor` to see the offending entry",
+            });
+        }
+    }
+
+    for (const auto& [memberTarget, memberVersion] : plan.members) {
+        const auto activeIt = workspace.find(memberTarget);
+        const std::string previous =
+            activeIt == workspace.end() ? std::string{} : activeIt->second;
+        if (previous == memberVersion) continue;  // already where it should be
+
+        MemberSwitch change{
+            .target = memberTarget,
+            .version = memberVersion,
+            .previousVersion = previous,
+        };
+        if (!previous.empty()) {
+            auto infoIt = db.find(memberTarget);
+            if (infoIt != db.end()) {
+                auto prevIt = infoIt->second.versions.find(previous);
+                if (prevIt != infoIt->second.versions.end()) {
+                    change.removeIncludeDir = prevIt->second.includedir;
+                    change.removeLibDir = prevIt->second.libdir;
+                }
+            }
+        }
+        const auto& data = db.at(memberTarget).versions.at(memberVersion);
+        change.installIncludeDir = data.includedir;
+        change.installLibDir = data.libdir;
+        plan.switches.push_back(std::move(change));
+    }
+
+    return plan;
+}
+
+}  // namespace xlings::xvm

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -29,6 +29,7 @@ import xlings.core.xvm.registration;
 import xlings.core.xvm.errors;
 import xlings.core.xvm.inspect;
 import xlings.core.xvm.lock;
+import xlings.core.xvm.switch_plan;
 import xlings.core.xvm.shim;
 import xlings.core.xvm.commands;
 import xlings.core.compact;
@@ -10801,6 +10802,151 @@ TEST_F(AtomicWriteTest, ThrowsWhenParentDirectoryIsMissing) {
     EXPECT_THROW(xlings::platform::write_string_to_file(target.string(), "x"),
                  std::runtime_error);
     EXPECT_EQ(entry_count(), 0u) << "staging file leaked on failure";
+}
+
+// ============================================================
+// plan_use_switch — `xlings use` moves a whole release or nothing
+//
+// cmd_use needs a Config singleton and a real filesystem, so none of its
+// logic was reachable from a test. The decision now lives in a pure
+// function and cmd_use just carries it out.
+
+namespace {
+
+void switch_group_(xlings::xvm::VersionDB& db,
+                   std::string_view providerVersion,
+                   const std::vector<std::string>& targets,
+                   std::string_view version,
+                   bool withDirs = true) {
+    const xlings::xvm::BindingGroupRef ref{
+        .provider = "pkgindex:gcc",
+        .providerVersion = std::string(providerVersion),
+        .group = "gcc",
+        .rootTarget = targets.front(),
+        .rootVersion = std::string(version),
+    };
+    std::map<std::string, std::string> manifest;
+    for (const auto& t : targets) manifest[t] = std::string(version);
+    for (const auto& t : targets) {
+        auto& info = db[t];
+        if (info.type.empty()) info.type = "program";
+        auto& data = info.versions[std::string(version)];
+        data.path = std::format("/pkg/{}/{}", t, version);
+        data.kind = "program";
+        data.bindingGroup = ref;
+        if (withDirs) {
+            data.includedir = std::format("/pkg/{}/{}/include", t, version);
+            data.libdir = std::format("/pkg/{}/{}/lib", t, version);
+        }
+    }
+    auto& root = db[targets.front()].versions[std::string(version)];
+    root.bindingMembers = manifest;
+    root.bindingMembersDeclared = true;
+}
+
+}  // namespace
+
+TEST(XvmSwitchPlan, PlansEveryMemberNotJustTheEntryPoint) {
+    xlings::xvm::VersionDB db;
+    switch_group_(db, "15.1.0", {"gcc", "g++", "libstdc++"}, "15.1.0");
+
+    auto plan = xlings::xvm::plan_use_switch(db, {}, "gcc", "15.1.0");
+
+    ASSERT_TRUE(plan.has_value()) << plan.error().what;
+    EXPECT_EQ(plan->members.size(), 3u);
+    EXPECT_TRUE(plan->members.contains("g++"));
+    EXPECT_TRUE(plan->members.contains("libstdc++"));
+}
+
+TEST(XvmSwitchPlan, SwapsHeadersAndLibsForEveryMovingMember) {
+    xlings::xvm::VersionDB db;
+    switch_group_(db, "15.1.0", {"gcc", "g++"}, "15.1.0");
+    switch_group_(db, "16.1.0", {"gcc", "g++"}, "16.1.0");
+    const xlings::xvm::Workspace ws{{"gcc", "16.1.0"}, {"g++", "16.1.0"}};
+
+    auto plan = xlings::xvm::plan_use_switch(db, ws, "gcc", "15.1.0");
+
+    ASSERT_TRUE(plan.has_value()) << plan.error().what;
+    ASSERT_EQ(plan->switches.size(), 2u);
+    // Switching gcc while leaving the previous release's libstdc++ headers
+    // in the sysroot is how `gcc --version` reports the right thing and the
+    // compile fails anyway.
+    for (const auto& change : plan->switches) {
+        EXPECT_EQ(change.previousVersion, "16.1.0");
+        EXPECT_NE(change.removeIncludeDir.find("16.1.0"), std::string::npos);
+        EXPECT_NE(change.installIncludeDir.find("15.1.0"), std::string::npos);
+        EXPECT_NE(change.removeLibDir.find("16.1.0"), std::string::npos);
+        EXPECT_NE(change.installLibDir.find("15.1.0"), std::string::npos);
+    }
+}
+
+TEST(XvmSwitchPlan, MembersAlreadyInPlaceProduceNoChange) {
+    xlings::xvm::VersionDB db;
+    switch_group_(db, "15.1.0", {"gcc", "g++"}, "15.1.0");
+    const xlings::xvm::Workspace ws{{"gcc", "15.1.0"}};
+
+    auto plan = xlings::xvm::plan_use_switch(db, ws, "gcc", "15.1.0");
+
+    ASSERT_TRUE(plan.has_value()) << plan.error().what;
+    ASSERT_EQ(plan->switches.size(), 1u);
+    EXPECT_EQ(plan->switches.front().target, "g++")
+        << "an already-active member must not be re-swapped";
+}
+
+TEST(XvmSwitchPlan, EveryEntryPointYieldsTheSamePlan) {
+    xlings::xvm::VersionDB db;
+    switch_group_(db, "15.1.0", {"gcc", "g++", "libstdc++"}, "15.1.0");
+
+    const auto fromRoot = xlings::xvm::plan_use_switch(db, {}, "gcc", "15.1.0");
+    const auto fromMember = xlings::xvm::plan_use_switch(db, {}, "g++", "15.1.0");
+    const auto fromLib =
+        xlings::xvm::plan_use_switch(db, {}, "libstdc++", "15.1.0");
+
+    ASSERT_TRUE(fromRoot.has_value());
+    ASSERT_TRUE(fromMember.has_value());
+    ASSERT_TRUE(fromLib.has_value());
+    EXPECT_EQ(fromRoot->members, fromMember->members);
+    EXPECT_EQ(fromRoot->members, fromLib->members);
+}
+
+TEST(XvmSwitchPlan, AMissingMemberIsAnErrorNotAPartialSwitch) {
+    xlings::xvm::VersionDB db;
+    switch_group_(db, "15.1.0", {"gcc", "g++", "libstdc++"}, "15.1.0");
+    // Resolution succeeds from the manifest; the payload record is what is
+    // gone. The old path would have swapped gcc's headers first and only
+    // then walked into the gap.
+    db.at("libstdc++").versions.erase("15.1.0");
+
+    auto plan = xlings::xvm::plan_use_switch(db, {}, "gcc", "15.1.0");
+
+    ASSERT_FALSE(plan.has_value());
+    EXPECT_FALSE(plan.error().code.empty());
+    EXPECT_FALSE(plan.error().hint.empty())
+        << "a refusal without a way out is not an improvement";
+}
+
+TEST(XvmSwitchPlan, AnUnresolvableGroupIsRefusedBeforeAnyChange) {
+    xlings::xvm::VersionDB db;
+    switch_group_(db, "15.1.0", {"gcc", "g++"}, "15.1.0");
+    db.at("g++").versions.at("15.1.0").bindingGroup->providerVersion = "bogus";
+
+    auto plan = xlings::xvm::plan_use_switch(db, {}, "gcc", "15.1.0");
+
+    ASSERT_FALSE(plan.has_value());
+    EXPECT_FALSE(plan.error().hint.empty());
+}
+
+TEST(XvmSwitchPlan, AnUngroupedTargetSwitchesOnItsOwn) {
+    xlings::xvm::VersionDB db;
+    db["editor"].type = "program";
+    auto& data = db["editor"].versions["1.0.0"];
+    data.path = "/pkg/editor";
+    data.kind = "program";
+
+    auto plan = xlings::xvm::plan_use_switch(db, {}, "editor", "1.0.0");
+
+    ASSERT_TRUE(plan.has_value()) << plan.error().what;
+    EXPECT_EQ(plan->members.size(), 1u);
 }
 
 // ============================================================


### PR DESCRIPTION
> P3.3 of the 0.4.70 release train — **本轮的 headline 修复**。

## Problem

`cmd_use` 把**决策和执行混在一起**：先换入口 target 的头文件和库，再手工遍历 binding 边去找其它成员。这个顺序带来两个问题。

**1. 遍历不安全。** 以 target（而非 `(target, version)`）为 visited key，且从不检查抵达的东西是否存在。一条残缺边把它带到一个没有 payload 的版本，它照样写进 active workspace —— shim 在 exec 时才失败，离肇事命令已经很远。

**2. 顺序错误。** 交换在遍历之前、且只对入口 target 执行。中途失败就留下 sysroot 是一个 release、workspace 声称另一个。

> 换了 gcc 却把上个 release 的 libstdc++ 头文件留在 sysroot 里，正是"`gcc --version` 报得对、编译照样炸"的成因。

## Change

**把决策和执行拆开。**

`plan_use_switch`（纯函数）通过 `resolve_binding_selection` 解析整个 release、预检每个成员的 payload，返回需要做的文件系统改动 —— 或者返回错误，**且什么都没碰**。`cmd_use` 只负责执行这个 plan。

plan 覆盖的一切现在都是**逐成员**而非逐入口：

- 头文件和库为整个 release 移动
- 已经就位的成员不产生改动
- 从 `gcc`、`g++` 或 `libstdc++` 进入，得到**同一个 plan**

## 这个拆分也是可测性的来源

`cmd_use` 需要 Config 单例和真实文件系统，它内部的逻辑此前**没有一行能被单测触及**。现在 7 条用例跑在纯函数上：

| 测试 | 覆盖 |
|---|---|
| `PlansEveryMemberNotJustTheEntryPoint` | 整组进入 plan |
| `SwapsHeadersAndLibsForEveryMovingMember` | 逐成员换 include/lib |
| `MembersAlreadyInPlaceProduceNoChange` | 不重复交换 |
| `EveryEntryPointYieldsTheSamePlan` | **多入口一致（A5）** |
| `AMissingMemberIsAnErrorNotAPartialSwitch` | 预检拦住半切换 |
| `AnUnresolvableGroupIsRefusedBeforeAnyChange` | fail-closed + 有 hint |
| `AnUngroupedTargetSwitchesOnItsOwn` | legacy 单包不受影响 |

## 场景验收进度

这解决了评审 §5.1 的目标输出：

```console
$ xlings use gcc 15.1.0
✓ gcc / g++ / gcc-ar / libstdc++ / headers  → 15.1.0
```

或者**什么都不发生** + 具名原因 + hint。

对应 A1（切换程序）、A2/A3（切换头文件/库）、A4（失败零改动）、A5（多入口一致）。端到端证明仍在 P4.2。

## Verification

```
mcpp build   →  Finished release [optimized] in 19.35s
mcpp test    →  test result ok. 11 passed; 0 failed
XvmSwitchPlan → 7 passed
```

CI 状态为已知上游拉取签名（见 #386），依计划 §3.1.1 合入集成分支。