### PR TITLE
test(e2e): prove a release switches whole, and fix what that exposed

### DIFF
--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -92,6 +92,18 @@ resolve_xpkg_filesystem_effect(
     };
     if (effect.kind == XpkgFilesystemEffectKind::InstallHeaders
         || effect.kind == XpkgFilesystemEffectKind::RemoveHeaders) {
+        // Headers have no program payload to resolve, but they do have an
+        // owner, and whether that owner is the active version decides
+        // whether these headers belong in the sysroot right now.
+        if (!effect.target.empty()) {
+            auto headerActiveIt = workspace.find(effect.target);
+            resolved.active = headerActiveIt != workspace.end()
+                && headerActiveIt->second == effect.version;
+        } else {
+            // No owner recorded (older plan shape): keep the previous
+            // unconditional behavior rather than silently skipping.
+            resolved.active = true;
+        }
         return resolved;
     }
 
@@ -251,8 +263,15 @@ normalize_xpkg_registration_plan(
             plan.batch.headers.push_back({
                 .sourceDir = operation.includedir,
             });
+            // Carry the owning target and version so materialization can be
+            // gated on the version actually becoming active. Installing a
+            // version that does not become active used to copy its headers
+            // into the sysroot anyway, leaving the active release's headers
+            // overwritten by an inactive one.
             plan.effects.push_back({
                 .kind = XpkgFilesystemEffectKind::InstallHeaders,
+                .target = node.name,
+                .version = xvm::make_ns_version(versionNamespace, node.version),
                 .sourceDir = operation.includedir,
             });
             continue;
@@ -1379,6 +1398,7 @@ bool process_xvm_operations_(const PlanNode& node,
     }
 
     const auto dbBeforeRemoval = scopedDb;
+    const auto workspaceBeforeRemoval = scopedWorkspace;
     auto metadata = apply_xpkg_xvm_metadata_batch(
         scopedDb,
         scopedWorkspace,
@@ -1413,6 +1433,29 @@ bool process_xvm_operations_(const PlanNode& node,
         scopedDb,
         metadata->removal);
 
+    // Removal takes the removed release's headers out of the sysroot. When
+    // it then falls back to a surviving release, nothing put that release's
+    // headers back -- the sysroot ended up with none at all, and `xlings use`
+    // could not repair it because switching to an already-active version is
+    // a no-op. Re-materialize whatever the fallback made active.
+    for (const auto& [target, version] : scopedWorkspace) {
+        auto beforeIt = workspaceBeforeRemoval.find(target);
+        if (beforeIt != workspaceBeforeRemoval.end()
+            && beforeIt->second == version) {
+            continue;  // unchanged
+        }
+        auto infoIt = scopedDb.find(target);
+        if (infoIt == scopedDb.end()) continue;
+        auto dataIt = infoIt->second.versions.find(version);
+        if (dataIt == infoIt->second.versions.end()) continue;
+        if (!dataIt->second.includedir.empty()) {
+            xvm::install_headers(dataIt->second.includedir, sysroot_include);
+        }
+        if (!dataIt->second.libdir.empty()) {
+            xvm::install_libdir(dataIt->second.libdir, sysroot_lib);
+        }
+    }
+
     // Written after the batch, not inside it: the batch owns the group model
     // and must not be taught a legacy field. This runs against the committed
     // scopedDb, so a package whose own name is not a registered target simply
@@ -1445,6 +1488,15 @@ bool process_xvm_operations_(const PlanNode& node,
         }
         if (resolved->kind
             == XpkgFilesystemEffectKind::InstallHeaders) {
+            if (!resolved->active) {
+                // Installing a non-active version must not disturb the
+                // sysroot: `xlings use` is what moves headers, and it cannot
+                // undo this because switching to an already-active version
+                // is a no-op.
+                log::debug("[xim] headers for {}@{} not installed: not the "
+                           "active version", resolved->target, resolved->version);
+                continue;
+            }
             xvm::install_headers(
                 resolved->sourceDir, sysroot_include);
             continue;

--- a/src/core/xvm/switch_plan.cppm
+++ b/src/core/xvm/switch_plan.cppm
@@ -80,7 +80,24 @@ std::expected<UseSwitchPlan, XvmUserError> plan_use_switch(
         const auto activeIt = workspace.find(memberTarget);
         const std::string previous =
             activeIt == workspace.end() ? std::string{} : activeIt->second;
-        if (previous == memberVersion) continue;  // already where it should be
+
+        const auto& current = db.at(memberTarget).versions.at(memberVersion);
+        if (previous == memberVersion) {
+            // Already the active version, but the sysroot may not reflect it:
+            // a removal that fell back to this release takes the removed
+            // release's headers out and puts nothing back. Re-materializing
+            // is idempotent, so `use` doubles as the repair for that -- and
+            // as a no-op when nothing is wrong. Nothing to remove first.
+            if (current.includedir.empty() && current.libdir.empty()) continue;
+            plan.switches.push_back({
+                .target = memberTarget,
+                .version = memberVersion,
+                .previousVersion = previous,
+                .installIncludeDir = current.includedir,
+                .installLibDir = current.libdir,
+            });
+            continue;
+        }
 
         MemberSwitch change{
             .target = memberTarget,
@@ -97,9 +114,8 @@ std::expected<UseSwitchPlan, XvmUserError> plan_use_switch(
                 }
             }
         }
-        const auto& data = db.at(memberTarget).versions.at(memberVersion);
-        change.installIncludeDir = data.includedir;
-        change.installLibDir = data.libdir;
+        change.installIncludeDir = current.includedir;
+        change.installLibDir = current.libdir;
         plan.switches.push_back(std::move(change));
     }
 

--- a/tests/e2e/run_all.sh
+++ b/tests/e2e/run_all.sh
@@ -81,6 +81,7 @@ TESTS=(
     "E2E-29 |interface_multi_repo_error_visibility_test.sh||"
     "E2E-30 |custom_index_artifact_test.sh||"
     "E2E-31 |index_same_name_namespace_test.sh||"
+    "E2E-32 |xvm_group_switch_test.sh||"
 )
 
 PASS=0; FAIL=0; SOFTFAIL=0

--- a/tests/e2e/xvm_group_switch_test.sh
+++ b/tests/e2e/xvm_group_switch_test.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# E2E test: `xlings use` moves a whole toolchain release, or none of it.
+#
+# The bug this pins down: switching one member of a bound release used to
+# leave the others behind. `gcc --version` reported the version the user
+# asked for while `g++` stayed on the previous release, and the sysroot
+# headers stayed on the previous release too -- so the failure surfaced much
+# later, as an ABI or header mismatch during a build, with nothing to connect
+# it back to the `use` that caused it.
+#
+# The fixture mirrors the real shape without needing a real toolchain: two
+# programs bound into one release, plus headers, at two versions.
+#
+# Scenarios:
+#   1. use <root> v1              → every member and the headers move to v1
+#   2. use <member> v2            → entering from a bound member moves the
+#                                   whole release, identically
+#   3. remove v2                  → the surviving release comes back as a
+#                                   whole, never mixed
+#   4. use with a missing member  → refused, and nothing has changed
+
+set -euo pipefail
+
+# shellcheck source=./project_test_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
+
+require_fixture_index
+
+RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/xvm_group_switch"
+HOME_DIR="$RUNTIME_DIR/home"
+LOCAL_INDEX_DIR="$RUNTIME_DIR/xim-pkgindex"
+
+FIXTURE_PKG="$LOCAL_INDEX_DIR/pkgs/t/toolchain-fixture.lua"
+
+cleanup() { rm -rf "$RUNTIME_DIR"; }
+trap cleanup EXIT
+cleanup
+
+XLINGS_BIN="$(find_xlings_bin)"
+
+RUN() {
+  ( cd /tmp && env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@" )
+}
+
+mkdir -p "$HOME_DIR"
+
+cp -r "$FIXTURE_INDEX_DIR" "$LOCAL_INDEX_DIR"
+printf 'xim_indexrepos = {}\n' > "$LOCAL_INDEX_DIR/xim-indexrepos.lua"
+rm -f "$LOCAL_INDEX_DIR/.xlings-index-cache.json"
+mkdir -p "$(dirname "$FIXTURE_PKG")"
+
+# Two programs bound into one release, plus a version-stamped header. `tcxx`
+# binds to `tcc`, so they form one group per version -- the same shape as
+# gcc/g++ and their headers.
+cat > "$FIXTURE_PKG" <<'LUA'
+package = {
+    spec = "1",
+    name = "toolchain-fixture",
+    description = "Local fixture for tests/e2e/xvm_group_switch_test.sh",
+    authors = {"xlings-ci"},
+    licenses = {"MIT"},
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"test-fixture"},
+
+    xpm = {
+        linux   = { ["1.0.0"] = {}, ["2.0.0"] = {} },
+        macosx  = { ["1.0.0"] = {}, ["2.0.0"] = {} },
+        windows = { ["1.0.0"] = {}, ["2.0.0"] = {} },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local dir = pkginfo.install_dir()
+    local version = pkginfo.version()
+    os.tryrm(dir)
+    os.mkdir(path.join(dir, "bin"))
+    os.mkdir(path.join(dir, "include"))
+    -- Each version ships a header stamped with its own version, so the
+    -- sysroot can be checked for which release is actually materialized.
+    io.writefile(path.join(dir, "include", "tcver.h"),
+                 "#define TC_VERSION \"" .. version .. "\"\n")
+    -- Plain files: this test checks which release the workspace and the
+    -- sysroot point at, not that the programs run. (os.runv is not in the
+    -- libxpkg Lua sandbox, so there is no chmod here anyway.)
+    for _, name in ipairs({"tcc", "tcxx"}) do
+        io.writefile(path.join(dir, "bin", name),
+                     "#!/bin/sh\necho " .. name .. " " .. version .. "\n")
+    end
+    return true
+end
+
+function config()
+    -- xvm.setup is the shape real toolchain recipes use: a root node, the
+    -- programs bound to it, and a header directory, all one release.
+    xvm.setup("toolchain-fixture", {
+        bindir     = "bin",
+        includedir = "include",
+        programs   = {"tcc", "tcxx"},
+    })
+    return true
+end
+
+function uninstall()
+    xvm.teardown("toolchain-fixture", {
+        includedir = "include",
+        programs   = {"tcc", "tcxx"},
+    })
+    return true
+end
+LUA
+
+mkdir -p "$HOME_DIR/subos/default/bin"
+cp "$XLINGS_BIN" "$HOME_DIR/xlings"
+cat > "$HOME_DIR/.xlings.json" <<EOF
+{
+  "mirror": "GLOBAL",
+  "index_repos": [
+    { "name": "xim", "url": "$LOCAL_INDEX_DIR" }
+  ]
+}
+EOF
+
+log "Initializing sandbox XLINGS_HOME at $HOME_DIR"
+RUN self init >/dev/null 2>&1 || fail "self init failed"
+mkdir -p "$HOME_DIR/data/xim-index-repos"
+printf '{}\n' > "$HOME_DIR/data/xim-index-repos/xim-indexrepos.json"
+
+SYSROOT_HEADER="$HOME_DIR/subos/default/usr/include/tcver.h"
+
+active_version() {
+  # Read the active version of $1 straight out of the subos workspace.
+  python3 - "$HOME_DIR/subos/default/.xlings.json" "$1" <<'PY'
+import json, sys
+try:
+    with open(sys.argv[1]) as fh:
+        data = json.load(fh)
+except (OSError, ValueError):
+    print("")
+    sys.exit(0)
+entry = (data.get("workspace", {}) or {}).get(sys.argv[2]) or {}
+print(entry.get("active", "") if isinstance(entry, dict) else str(entry))
+PY
+}
+
+header_version() {
+  [[ -f "$SYSROOT_HEADER" ]] || { echo ""; return; }
+  sed -n 's/.*TC_VERSION "\([^"]*\)".*/\1/p' "$SYSROOT_HEADER"
+}
+
+expect_group_at() {
+  local want="$1" ctx="$2" got_tcc got_tcxx got_hdr
+  got_tcc="$(active_version tcc)"
+  got_tcxx="$(active_version tcxx)"
+  got_hdr="$(header_version)"
+  [[ "$got_tcc" == "$want" ]] \
+    || fail "$ctx: tcc is '$got_tcc', expected '$want'"
+  # The whole point: a member left behind is the bug.
+  [[ "$got_tcxx" == "$want" ]] \
+    || fail "$ctx: tcxx is '$got_tcxx' while tcc is '$want' — release split"
+  [[ "$got_hdr" == "$want" ]] \
+    || fail "$ctx: sysroot header is '$got_hdr', expected '$want' — headers did not follow"
+}
+
+log "Installing both releases"
+RUN install toolchain-fixture@1.0.0 -y > "$RUNTIME_DIR/install1.log" 2>&1 \
+  || { cat "$RUNTIME_DIR/install1.log"; fail "install 1.0.0 failed"; }
+RUN install toolchain-fixture@2.0.0 -y >/dev/null 2>&1 \
+  || fail "install 2.0.0 failed"
+
+# ── Scenario 1: switch from the root ──────────────────────────────
+log "S1: use tcc 1.0.0 → whole release on 1.0.0"
+RUN use tcc 1.0.0 >/dev/null 2>&1 || fail "S1: use failed"
+expect_group_at "1.0.0" "S1"
+
+# ── Scenario 2: switch by entering from a bound member ────────────
+log "S2: use tcxx 2.0.0 → whole release on 2.0.0"
+RUN use tcxx 2.0.0 >/dev/null 2>&1 || fail "S2: use failed"
+expect_group_at "2.0.0" "S2"
+
+# Entering from either member must land in the same place.
+log "S3: use tcc 1.0.0 again → identical to entering from tcxx"
+RUN use tcc 1.0.0 >/dev/null 2>&1 || fail "S3: use failed"
+expect_group_at "1.0.0" "S3"
+
+# ── Scenario 4: removal falls back as a whole ─────────────────────
+log "S4: switch to 2.0.0, remove it → fall back to 1.0.0 coherently"
+RUN use tcc 2.0.0 >/dev/null 2>&1 || fail "S4: use failed"
+expect_group_at "2.0.0" "S4 (before remove)"
+RUN remove toolchain-fixture@2.0.0 -y >/dev/null 2>&1 \
+  || fail "S4: remove failed"
+
+TCC_AFTER="$(active_version tcc)"
+TCXX_AFTER="$(active_version tcxx)"
+# Either the whole surviving release came back, or nothing did. A mix is the
+# failure this release exists to prevent.
+if [[ -n "$TCC_AFTER" || -n "$TCXX_AFTER" ]]; then
+  [[ "$TCC_AFTER" == "$TCXX_AFTER" ]] \
+    || fail "S4: fell back to a split release — tcc='$TCC_AFTER' tcxx='$TCXX_AFTER'"
+  [[ "$TCC_AFTER" == "1.0.0" ]] \
+    || fail "S4: fell back to '$TCC_AFTER', expected the surviving 1.0.0"
+  log "S4: fell back to 1.0.0 as a whole"
+else
+  log "S4: whole release deactivated (acceptable — never mixed)"
+fi
+
+# ── Scenario 5: a broken release is refused, changing nothing ─────
+log "S5: break a member's payload record → use is refused, nothing changes"
+RUN use tcc 1.0.0 >/dev/null 2>&1 || fail "S5: setup use failed"
+expect_group_at "1.0.0" "S5 (before)"
+
+WS_BEFORE="$(cat "$HOME_DIR/subos/default/.xlings.json")"
+HDR_BEFORE="$(header_version)"
+
+# Drop tcxx@1.0.0 from the version database, leaving the release's manifest
+# still naming it. This is the dangling state a stale edge used to produce.
+python3 - "$HOME_DIR/.xlings.json" <<'PY'
+import json, sys
+path = sys.argv[1]
+with open(path) as fh:
+    data = json.load(fh)
+versions = data.get("versions", {})
+if "tcxx" in versions:
+    versions["tcxx"].get("versions", {}).pop("1.0.0", None)
+with open(path, "w") as fh:
+    json.dump(data, fh, indent=2)
+PY
+
+if RUN use tcc 1.0.0 >/dev/null 2>&1; then
+  fail "S5: use succeeded despite a missing member"
+fi
+[[ "$(cat "$HOME_DIR/subos/default/.xlings.json")" == "$WS_BEFORE" ]] \
+  || fail "S5: refused but the workspace changed anyway"
+[[ "$(header_version)" == "$HDR_BEFORE" ]] \
+  || fail "S5: refused but the sysroot headers changed anyway"
+log "S5: refused with the workspace and sysroot untouched"
+
+log "PASS: xvm group switch"

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -10880,7 +10880,7 @@ TEST(XvmSwitchPlan, SwapsHeadersAndLibsForEveryMovingMember) {
     }
 }
 
-TEST(XvmSwitchPlan, MembersAlreadyInPlaceProduceNoChange) {
+TEST(XvmSwitchPlan, AnAlreadyActiveMemberIsRematerializedButNotUnwound) {
     xlings::xvm::VersionDB db;
     switch_group_(db, "15.1.0", {"gcc", "g++"}, "15.1.0");
     const xlings::xvm::Workspace ws{{"gcc", "15.1.0"}};
@@ -10888,9 +10888,38 @@ TEST(XvmSwitchPlan, MembersAlreadyInPlaceProduceNoChange) {
     auto plan = xlings::xvm::plan_use_switch(db, ws, "gcc", "15.1.0");
 
     ASSERT_TRUE(plan.has_value()) << plan.error().what;
-    ASSERT_EQ(plan->switches.size(), 1u);
-    EXPECT_EQ(plan->switches.front().target, "g++")
-        << "an already-active member must not be re-swapped";
+    ASSERT_EQ(plan->switches.size(), 2u);
+
+    const auto gccChange = std::ranges::find_if(
+        plan->switches, [](const auto& c) { return c.target == "gcc"; });
+    ASSERT_NE(gccChange, plan->switches.end());
+    // gcc is already active, so there is nothing to take out of the sysroot.
+    EXPECT_TRUE(gccChange->removeIncludeDir.empty());
+    EXPECT_TRUE(gccChange->removeLibDir.empty());
+    // But its headers are re-installed anyway. A removal that fell back to
+    // this release took the removed release's headers out and put nothing
+    // back; `use` could not repair that, because switching to the version
+    // that is already active was a no-op. install_headers is idempotent, so
+    // re-materializing costs nothing when nothing is wrong.
+    EXPECT_FALSE(gccChange->installIncludeDir.empty());
+
+    const auto cxxChange = std::ranges::find_if(
+        plan->switches, [](const auto& c) { return c.target == "g++"; });
+    ASSERT_NE(cxxChange, plan->switches.end());
+    EXPECT_TRUE(cxxChange->previousVersion.empty());
+}
+
+TEST(XvmSwitchPlan, AMemberWithNoMaterializedAssetsEmitsNothing) {
+    xlings::xvm::VersionDB db;
+    switch_group_(db, "15.1.0", {"gcc", "g++"}, "15.1.0", /*withDirs=*/false);
+    const xlings::xvm::Workspace ws{{"gcc", "15.1.0"}, {"g++", "15.1.0"}};
+
+    auto plan = xlings::xvm::plan_use_switch(db, ws, "gcc", "15.1.0");
+
+    ASSERT_TRUE(plan.has_value()) << plan.error().what;
+    // Re-materializing is only worth emitting when there is something to
+    // materialize; a program-only release in place is a genuine no-op.
+    EXPECT_TRUE(plan->switches.empty());
 }
 
 TEST(XvmSwitchPlan, EveryEntryPointYieldsTheSamePlan) {


### PR DESCRIPTION
> P4.2 of the 0.4.70 release train。

## 新增 E2E-32

两个程序绑成一个 release，加上带版本戳的头文件，两个版本，在隔离 HOME 里驱动**真实二进制**。

**同时检查 workspace 和 sysroot** —— 只查其中一个正是原 bug 能藏住的原因：`gcc --version` 报的是用户要的版本，头文件却留在原地。

| 场景 | 覆盖 |
|---|---|
| S1 `use tcc 1.0.0` | 整组 + 头文件都到 1.0.0（A1/A2） |
| S2 `use tcxx 2.0.0` | **从绑定成员进入**，整组同样移动（A5） |
| S3 再从 root 进入 | 与从成员进入结果一致 |
| S4 删除 active release | 整组一致回退，绝不混搭（A7） |
| S5 破坏成员的 payload 记录 | 拒绝，**workspace 与 sysroot 逐字节未变**（A4） |

## 写这个测试暴露了两个真实缺陷

两者是同一个形状：**sysroot 由"最后一个碰它的人"决定，没有任何一方负责让它与 active release 一致。**

### 1. 安装一个不会变成 active 的版本，仍然覆盖了 sysroot

`install 2.0.0`（不激活）把 2.0.0 的头文件拷进 sysroot，盖掉 active 的 1.0.0。而 `xlings use tcc 1.0.0` **修不回来** —— 切换到本就 active 的版本是 no-op。

修法：header effect 现在携带 owning target/version，只在该版本确实 active 时物化。

### 2. 删除 active release 后，回退的那个 release 头文件没被放回去

sysroot 最后**一个头文件都不剩**。修法：删除路径在回退后重新物化新 active 的头文件与库。

### 顺带：`use` 现在对已 active 的成员也重新物化

没有需要撤销的东西，且 `install_headers` 本就幂等 —— 无事时零代价，有漂移时 `use` 就是修复手段。这也向设计里 "materialization = f(selection)" 的方向靠了一步。

## 一条既有单测随之改写

`MembersAlreadyInPlaceProduceNoChange` 编码的是旧行为，改为 `AnAlreadyActiveMemberIsRematerializedButNotUnwound`，断言真正重要的区分：**不移除，但重新安装**。另加一条 `AMemberWithNoMaterializedAssetsEmitsNothing`，钉住"没东西可物化时仍然是 no-op"。

## 两个 fixture 细节（记录备查）

- `os.runv` **不在** libxpkg 的 Lua 沙箱里
- header 注册是 `xvm.setup{includedir=...}`，没有独立的 `xvm.headers`

## Verification

```
mcpp build                       →  Finished release [optimized] in 19.21s
mcpp test                        →  test result ok. 11 passed; 0 failed
bash tests/e2e/xvm_group_switch_test.sh
    S1 ✓  S2 ✓  S3 ✓  S4 ✓  S5 ✓  →  PASS: xvm group switch
```

已注册为 `run_all.sh` 的 E2E-32。

CI 状态为已知上游拉取签名（见 #386），依计划 §3.1.1 合入集成分支。
