### PR TITLE
fix(config): serialize every home-config mutation behind the state lock

### DIFF
--- a/src/capabilities.cppm
+++ b/src/capabilities.cppm
@@ -9,6 +9,7 @@ import xlings.libs.json;
 import xlings.core.xim.commands;
 import xlings.core.xvm.commands;
 import xlings.core.config;
+import xlings.core.home_config;
 import xlings.core.subos;
 import xlings.core.xself;
 import xlings.platform;
@@ -387,29 +388,6 @@ public:
     }
 };
 
-// File-local repo config helpers. Keep these non-inline (avoiding the C++20
-// module + libstdc++ static-link pitfall where inline functions touching
-// nlohmann::json triggers an unresolved std::shared_ptr<output_adapter_protocol>
-// copy ctor across translation units).
-namespace repo_helpers {
-
-nlohmann::json load_global_json() {
-    auto path = Config::paths().homeDir / ".xlings.json";
-    if (!std::filesystem::exists(path)) return nlohmann::json::object();
-    try {
-        auto content = platform::read_file_to_string(path.string());
-        auto j = nlohmann::json::parse(content, nullptr, false);
-        return j.is_discarded() ? nlohmann::json::object() : j;
-    } catch (...) { return nlohmann::json::object(); }
-}
-
-void save_global_json(const nlohmann::json& j) {
-    auto path = Config::paths().homeDir / ".xlings.json";
-    platform::write_string_to_file(path.string(), j.dump());
-}
-
-}  // namespace repo_helpers
-
 class AddRepo : public Capability {
 public:
     auto spec() const -> CapabilitySpec override {
@@ -434,30 +412,29 @@ public:
             return exit_result(1);
         }
 
-        auto cfg = repo_helpers::load_global_json();
-        if (!cfg.contains("index_repos") || !cfg["index_repos"].is_array()) {
-            cfg["index_repos"] = nlohmann::json::array();
-        }
-        bool updated = false;
-        for (auto& entry : cfg["index_repos"]) {
-            if (entry.is_object() && entry.contains("name")
-                && entry["name"].get<std::string>() == name) {
-                entry["url"] = url;
-                updated = true;
-                break;
-            }
-        }
-        if (!updated) {
-            nlohmann::json entry;
-            entry["name"] = name;
-            entry["url"]  = url;
-            cfg["index_repos"].push_back(std::move(entry));
-        }
-        try { repo_helpers::save_global_json(cfg); }
-        catch (const std::exception& e) {
+        auto committed = update_home_config(
+            Config::paths().homeDir, [&](nlohmann::json& cfg) {
+                if (!cfg.contains("index_repos")
+                    || !cfg["index_repos"].is_array()) {
+                    cfg["index_repos"] = nlohmann::json::array();
+                }
+                for (auto& entry : cfg["index_repos"]) {
+                    if (entry.is_object() && entry.contains("name")
+                        && entry["name"].get<std::string>() == name) {
+                        entry["url"] = url;
+                        return true;
+                    }
+                }
+                nlohmann::json entry;
+                entry["name"] = name;
+                entry["url"]  = url;
+                cfg["index_repos"].push_back(std::move(entry));
+                return true;
+            });
+        if (!committed) {
             stream.emit(ErrorEvent{
                 .code = ErrorCode::Permission,
-                .message = std::string("write .xlings.json failed: ") + e.what(),
+                .message = "write .xlings.json failed: " + committed.error(),
                 .recoverable = false,
             });
             return exit_result(1);
@@ -489,38 +466,40 @@ public:
             return exit_result(1);
         }
 
-        auto cfg = repo_helpers::load_global_json();
-        if (!cfg.contains("index_repos") || !cfg["index_repos"].is_array()) {
-            stream.emit(ErrorEvent{
-                .code = ErrorCode::NotFound,
-                .message = "no repo named '" + name + "'",
-                .recoverable = true,
+        // "not found" is decided inside the lock too. Deciding it from an
+        // earlier read could report success for a repo another process had
+        // already deleted, or -- worse -- write back an index_repos array
+        // that predates a repo it had just added.
+        auto committed = update_home_config(
+            Config::paths().homeDir, [&](nlohmann::json& cfg) {
+                if (!cfg.contains("index_repos")
+                    || !cfg["index_repos"].is_array()) {
+                    return false;
+                }
+                auto& arr = cfg["index_repos"];
+                bool removed = false;
+                for (auto it = arr.begin(); it != arr.end(); ) {
+                    if (it->is_object() && it->contains("name")
+                        && (*it)["name"].get<std::string>() == name) {
+                        it = arr.erase(it);
+                        removed = true;
+                    } else { ++it; }
+                }
+                return removed;
             });
-            return exit_result(1);
-        }
-        auto& arr = cfg["index_repos"];
-        bool removed = false;
-        for (auto it = arr.begin(); it != arr.end(); ) {
-            if (it->is_object() && it->contains("name")
-                && (*it)["name"].get<std::string>() == name) {
-                it = arr.erase(it);
-                removed = true;
-            } else { ++it; }
-        }
-        if (!removed) {
-            stream.emit(ErrorEvent{
-                .code = ErrorCode::NotFound,
-                .message = "no repo named '" + name + "'",
-                .recoverable = true,
-            });
-            return exit_result(1);
-        }
-        try { repo_helpers::save_global_json(cfg); }
-        catch (const std::exception& e) {
+        if (!committed) {
             stream.emit(ErrorEvent{
                 .code = ErrorCode::Permission,
-                .message = std::string("write .xlings.json failed: ") + e.what(),
+                .message = "write .xlings.json failed: " + committed.error(),
                 .recoverable = false,
+            });
+            return exit_result(1);
+        }
+        if (!*committed) {
+            stream.emit(ErrorEvent{
+                .code = ErrorCode::NotFound,
+                .message = "no repo named '" + name + "'",
+                .recoverable = true,
             });
             return exit_result(1);
         }

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -11,6 +11,7 @@ import mcpplibs.cmdline;
 import mcpplibs.capi.lua;
 import mcpplibs.xpkg.executor;
 import xlings.core.config;
+import xlings.core.home_config;
 import xlings.libs.json;
 import xlings.core.log;
 import xlings.runtime;
@@ -458,46 +459,47 @@ void apply_global_opts_(const mcpplibs::cmdline::ParsedArgs& args) {
 }
 
 
-// Read-modify-write the global .xlings.json config file
-nlohmann::json load_global_config_json_() {
-    auto configPath = Config::paths().homeDir / ".xlings.json";
-    if (std::filesystem::exists(configPath)) {
-        try {
-            auto content = platform::read_file_to_string(configPath.string());
-            auto json = nlohmann::json::parse(content, nullptr, false);
-            if (!json.is_discarded()) return json;
-        } catch (...) {}
-    }
-    return nlohmann::json::object();
-}
-
-void save_global_config_json_(const nlohmann::json& json) {
-    auto configPath = Config::paths().homeDir / ".xlings.json";
-    platform::write_string_to_file(configPath.string(), json.dump(2));
-}
-
 // config subcommand handler
 int cmd_config_(const mcpplibs::cmdline::ParsedArgs& args, EventStream& stream) {
-    bool changed = false;
-    auto json = load_global_config_json_();
+    // Edits are collected rather than applied, then replayed against the
+    // document `update_home_config` re-reads under the state lock. Applying
+    // them to a copy read here instead would write back every *other* key as
+    // it looked before an install that finished in the meantime -- see
+    // core/home_config.cppm. Validation and the user-facing logging stay out
+    // here so a rejected argument never reaches the lock.
+    std::vector<std::function<void(nlohmann::json&)>> edits;
 
     // --lang
     if (auto lang = args.value("lang")) {
-        json["lang"] = std::string(*lang);
-        log::println("lang = {}", *lang);
-        changed = true;
+        std::string value(*lang);
+        edits.push_back([value](nlohmann::json& j) { j["lang"] = value; });
+        log::println("lang = {}", value);
     }
 
     // --mirror
     if (auto mirror = args.value("mirror")) {
-        json["mirror"] = std::string(*mirror);
-        log::println("mirror = {}", *mirror);
-        changed = true;
+        std::string value(*mirror);
+        edits.push_back([value](nlohmann::json& j) { j["mirror"] = value; });
+        log::println("mirror = {}", value);
     }
+
+    auto commit_edits = [&]() -> bool {
+        if (edits.empty()) return true;
+        auto committed = update_home_config(
+            Config::paths().homeDir, [&](nlohmann::json& j) {
+                for (const auto& edit : edits) edit(j);
+                return true;
+            });
+        if (!committed) {
+            log::error("{}", committed.error());
+            return false;
+        }
+        return true;
+    };
 
     // --add-xpkg
     if (auto xpkg = args.value("add-xpkg")) {
-        if (changed) save_global_config_json_(json);
+        if (!commit_edits()) return 1;
         return xim::cmd_add_xpkg(std::string(*xpkg), stream);
     }
 
@@ -519,32 +521,30 @@ int cmd_config_(const mcpplibs::cmdline::ParsedArgs& args, EventStream& stream) 
             return 1;
         }
 
-        if (!json.contains("index_repos") || !json["index_repos"].is_array()) {
-            json["index_repos"] = nlohmann::json::array();
-        }
-        // Check for existing repo with same name and update
-        bool found = false;
-        for (auto& entry : json["index_repos"]) {
-            if (entry.is_object() && entry.contains("name") &&
-                entry["name"].get<std::string>() == name) {
-                entry["url"] = url;
-                found = true;
-                break;
+        // Upsert against the freshly-read document: a repo another process
+        // added since we started must be updated in place, not duplicated.
+        edits.push_back([name, url](nlohmann::json& json) {
+            if (!json.contains("index_repos")
+                || !json["index_repos"].is_array()) {
+                json["index_repos"] = nlohmann::json::array();
             }
-        }
-        if (!found) {
+            for (auto& entry : json["index_repos"]) {
+                if (entry.is_object() && entry.contains("name") &&
+                    entry["name"].get<std::string>() == name) {
+                    entry["url"] = url;
+                    return;
+                }
+            }
             nlohmann::json entry;
             entry["name"] = name;
             entry["url"] = url;
             json["index_repos"].push_back(entry);
-        }
+        });
         log::println("index-repo {} = {}", name, url);
-        changed = true;
     }
 
-    if (changed) {
-        save_global_config_json_(json);
-        return 0;
+    if (!edits.empty()) {
+        return commit_edits() ? 0 : 1;
     }
 
     // No options: show current config via TUI info panel

--- a/src/core/home_config.cppm
+++ b/src/core/home_config.cppm
@@ -1,0 +1,112 @@
+export module xlings.core.home_config;
+
+import std;
+
+import xlings.libs.json;
+import xlings.platform;
+import xlings.core.xvm.lock;
+
+// Serialized read-modify-write of `<home>/.xlings.json`.
+//
+// One file, several owners. `versions` is written by install/remove/use,
+// `workspace` by the same three, `subos` and `activeSubos` by the subos
+// commands, `lang` by `xlings config`, `index_repos` by the MCP repo
+// capabilities, `mirror` and `version` by `xlings self install`. Each owner
+// reads the whole document, edits its own key and writes the whole document
+// back.
+//
+// That is safe only while the read and the write are one indivisible step.
+// They were not. Two effects, both silent:
+//
+//   Lost update. `xlings subos new big --storage image` reads the config,
+//   spends seconds in mkfs.ext4, then writes back what it read. An install
+//   that finished in between had its `versions` entry in the document the
+//   subos command never re-read, so the write puts the file back to its
+//   pre-install content. The package stays on disk with no record of it.
+//
+//   Torn state. Since 0.4.70 the version database and the workspace are two
+//   halves of one release (see xvm/lock.cppm). Reverting `versions` while
+//   `workspace` keeps the newer content leaves a group manifest naming a
+//   member the database no longer has, and the whole toolchain refuses to
+//   switch.
+//
+// install/remove/use already took the home-wide state lock. The other writers
+// did not, so the lock only protected them from each other.
+//
+// The rule this module enforces is narrower than "hold the lock for the whole
+// command", deliberately. `subos new` runs mkfs and `subos rm` runs
+// remove_all; holding the lock across either would make a routine install in
+// another terminal wait past its 30s timeout and fail. So the lock covers the
+// commit alone, and the document handed to `mutate` is re-read *inside* it.
+//
+// The consequence for callers is the part worth stating plainly: **anything
+// decided from a lock-free read may be stale by the time `mutate` runs.**
+// A caller that checked "this subos does not exist yet" before doing the slow
+// work has to check again inside `mutate`, and return false if the answer
+// changed.
+//
+// Not covered here: the *project* state file and the per-subos `.xlings.json`.
+// Those are scoped to one project tree or one subos rather than to the home,
+// and the state lock is per-home; giving them the home lock would serialize
+// unrelated projects against each other. They keep the pre-existing
+// last-writer-wins behavior.
+export namespace xlings {
+
+std::filesystem::path home_config_path(const std::filesystem::path& home) {
+    return home / ".xlings.json";
+}
+
+// Parse `<home>/.xlings.json`, or an empty object if it is absent, empty,
+// unreadable or malformed. Matches what every hand-rolled reader in the tree
+// did before this module existed: a corrupt config is treated as no config
+// rather than failing the command.
+nlohmann::json read_home_config(const std::filesystem::path& home) {
+    const auto path = home_config_path(home);
+    std::error_code ec;
+    if (!std::filesystem::exists(path, ec) || ec) return nlohmann::json::object();
+    try {
+        auto content = platform::read_file_to_string(path.string());
+        auto parsed = nlohmann::json::parse(content, nullptr, false);
+        if (parsed.is_discarded() || !parsed.is_object()) {
+            return nlohmann::json::object();
+        }
+        return parsed;
+    } catch (...) {
+        return nlohmann::json::object();
+    }
+}
+
+// Apply `mutate` to a freshly-read `<home>/.xlings.json` while holding the
+// home-wide state lock, then write it back.
+//
+// `mutate` returns whether the document changed. Returning false skips the
+// write entirely, which keeps a no-op `xlings config` from rewriting the file
+// and gives a caller that lost a race a way to abort without inventing an
+// error path.
+//
+// Returns the commit decision, or the reason the update could not happen:
+// another xlings holding the lock past the timeout, or the write failing.
+// Both are real failures the caller must surface -- reporting success after
+// either one tells the user a change landed that did not.
+std::expected<bool, std::string> update_home_config(
+        const std::filesystem::path& home,
+        const std::function<bool(nlohmann::json&)>& mutate,
+        std::chrono::milliseconds timeout = xvm::default_lock_timeout()) {
+    auto lock = xvm::acquire_state_lock(home, timeout);
+    if (!lock) return std::unexpected(lock.error());
+
+    auto json = read_home_config(home);
+    if (!mutate(json)) return false;
+
+    try {
+        platform::write_string_to_file(
+            home_config_path(home).string(), json.dump(2));
+    } catch (const std::exception& e) {
+        return std::unexpected(std::format(
+            "failed to write {}: {}",
+            home_config_path(home).string(), e.what()));
+    }
+    return true;
+}
+
+}  // namespace xlings

--- a/src/core/subos.cppm
+++ b/src/core/subos.cppm
@@ -20,6 +20,7 @@ export module xlings.core.subos;
 import std;
 
 import xlings.core.config;
+import xlings.core.home_config;
 import xlings.libs.json;
 import xlings.core.log;
 import xlings.platform;
@@ -388,9 +389,11 @@ export int create(const std::string& name, const fs::path& customDir,
         }
     }
 
-    auto configPath = p.homeDir / ".xlings.json";
-    auto json = read_config_json_(configPath);
-    if (json.contains("subos") && json["subos"].contains(name)) {
+    // Cheap pre-check so the common "already exists" mistake fails before we
+    // lay down directories or run mkfs. It is advisory only -- the binding
+    // check that actually decides is the one inside the locked commit below.
+    if (read_home_config(p.homeDir).value("subos", nlohmann::json::object())
+            .contains(name)) {
         stream.emit(ErrorEvent{
             .code = ErrorCode::InvalidInput,
             .message = "subos '" + name + "' already exists",
@@ -440,9 +443,45 @@ export int create(const std::string& name, const fs::path& customDir,
         xself::ensure_subos_shims(dir / "bin", xlingsBin, p.homeDir);
     }
 
-    if (!json.contains("subos")) json["subos"] = nlohmann::json::object();
-    json["subos"][name] = {{"dir", customDir.empty() ? "" : customDir.string()}};
-    write_config_json_(configPath, json);
+    // Everything above this point -- mkfs.ext4 for image storage in
+    // particular -- can take seconds. Reading the config before it and
+    // writing it after would put back a document that predates any install
+    // that finished meanwhile. Re-read under the lock and edit only our key.
+    bool raced = false;
+    auto committed = update_home_config(p.homeDir, [&](nlohmann::json& json) {
+        if (!json.contains("subos") || !json["subos"].is_object()) {
+            json["subos"] = nlohmann::json::object();
+        }
+        if (json["subos"].contains(name)) {
+            raced = true;
+            return false;
+        }
+        json["subos"][name] =
+            {{"dir", customDir.empty() ? "" : customDir.string()}};
+        return true;
+    });
+    if (!committed) {
+        stream.emit(ErrorEvent{
+            .code = ErrorCode::Internal,
+            .message = "subos '" + name + "' was created on disk but could "
+                       "not be recorded: " + committed.error(),
+            .recoverable = true,
+            .hint = "retry once the other xlings finishes; the directory at "
+                    + dir.string() + " is reused as-is",
+        });
+        return 1;
+    }
+    if (raced) {
+        // Another xlings registered this name while we were building. Its
+        // entry is the one on disk; ours would overwrite a directory the
+        // other command is using.
+        stream.emit(ErrorEvent{
+            .code = ErrorCode::InvalidInput,
+            .message = "subos '" + name + "' already exists",
+            .recoverable = false,
+        });
+        return 1;
+    }
 
     nlohmann::json payload;
     payload["name"] = name;
@@ -806,10 +845,21 @@ int use_global(const std::string& name, EventStream& stream) {
     if (auto rc = use_detail_::validate_subos_(name, stream); rc != 0) return rc;
 
     auto& p = Config::paths();
-    auto configPath = p.homeDir / ".xlings.json";
-    auto json = read_config_json_(configPath);
-    json["activeSubos"] = name;
-    write_config_json_(configPath, json);
+    // The window here is short, but a full-document rewrite is a full-document
+    // rewrite: an install committing between the read and the write loses its
+    // `versions` entry all the same.
+    auto committed = update_home_config(p.homeDir, [&](nlohmann::json& json) {
+        json["activeSubos"] = name;
+        return true;
+    });
+    if (!committed) {
+        stream.emit(ErrorEvent{
+            .code = ErrorCode::Internal,
+            .message = "failed to switch subos: " + committed.error(),
+            .recoverable = true,
+        });
+        return 1;
+    }
 
     auto dir = Config::subos_dir(name);
     update_current_symlink_(stream, p.homeDir, dir);
@@ -1873,10 +1923,8 @@ export int remove(const std::string& name, EventStream& stream) {
         return 1;
     }
 
-    auto configPath = p.homeDir / ".xlings.json";
-    auto json = read_config_json_(configPath);
-
-    if (!json.contains("subos") || !json["subos"].contains(name)) {
+    if (!read_home_config(p.homeDir).value("subos", nlohmann::json::object())
+             .contains(name)) {
         stream.emit(ErrorEvent{
             .code = ErrorCode::NotFound,
             .message = "subos '" + name + "' not found",
@@ -1925,8 +1973,23 @@ export int remove(const std::string& name, EventStream& stream) {
         }
     }
 
-    json["subos"].erase(name);
-    write_config_json_(configPath, json);
+    // remove_all above walks the whole subos tree and can run for a long
+    // time on a big one. Deleting our key out of a document read before that
+    // walk would resurrect every other key's pre-walk value.
+    auto committed = update_home_config(p.homeDir, [&](nlohmann::json& json) {
+        if (!json.contains("subos") || !json["subos"].is_object()) return false;
+        return json["subos"].erase(name) > 0;
+    });
+    if (!committed) {
+        stream.emit(ErrorEvent{
+            .code = ErrorCode::Internal,
+            .message = "subos '" + name + "' was deleted from disk but its "
+                       "entry could not be removed: " + committed.error(),
+            .recoverable = true,
+            .hint = "retry once the other xlings finishes",
+        });
+        return 1;
+    }
 
     nlohmann::json payload;
     payload["name"] = name;

--- a/src/core/xself/init.cppm
+++ b/src/core/xself/init.cppm
@@ -206,6 +206,12 @@ static void write_or_upgrade_profile_(const fs::path& path,
     platform::write_string_to_file(path.string(), std::string(content));
 }
 
+// Read-modify-writes `<home>/.xlings.json` without taking the state lock
+// itself. Both callers reach it through `ensure_home_layout`, and the only
+// caller of that is `xself::cmd_install`, which holds the lock for its whole
+// home-rewriting stretch. Acquiring here as well would be harmless (the lock
+// is re-entrant within a process) but would suggest this is safe to call
+// from somewhere unlocked, which it is not.
 static void ensure_home_config_defaults_(const fs::path& home_dir) {
     auto config_path = home_dir / ".xlings.json";
     nlohmann::json json = nlohmann::json::object();

--- a/src/core/xself/install.cppm
+++ b/src/core/xself/install.cppm
@@ -4,6 +4,7 @@ import std;
 import xlings.core.xself.init;
 
 import xlings.core.config;
+import xlings.core.xvm.lock;
 import xlings.libs.json;
 import xlings.libs.tinyhttps;
 import xlings.core.log;
@@ -458,6 +459,11 @@ export int cmd_install() {
     // Skip if source == target and not temp — "fix links" in place (e.g. dev from source).
     if (!cmp_ec && sameDir && !fromTempExtract) {
         log::println("\n[xlings:self] already in target dir, fixing links");
+        auto lock = xvm::acquire_state_lock(targetHome);
+        if (!lock) {
+            log::error("[xlings:self] {}", lock.error());
+            return 1;
+        }
         if (!ensure_home_layout(targetHome)) {
             log::error("[xlings:self] failed to initialize {}", targetHome.string());
             return 1;
@@ -485,6 +491,28 @@ export int cmd_install() {
                 return 0;
             }
         }
+    }
+
+    // Everything past this point rewrites the home: the binary, the layout,
+    // and three separate read-modify-writes of `.xlings.json` (mirror,
+    // version, subos defaults). An install running in another terminal reads
+    // and writes the same file, so hold the home-wide state lock across the
+    // lot -- one lock rather than three, since the writes are interleaved
+    // with the tree replacement and only the whole sequence is meaningful.
+    //
+    // Taken here rather than at the top of the function on purpose: the
+    // confirmation prompts above would otherwise hold the lock for as long as
+    // the user takes to answer, and a lock held on human time is a lock that
+    // makes `xlings install` fail in the next terminal over.
+    //
+    // The patchelf-runtime-dep step below spawns `xlings install -g`. That
+    // child inherits the re-entrancy marker (xvm/lock.cppm) and works under
+    // this lock instead of waiting for one this process cannot release until
+    // the child returns.
+    auto stateLock = xvm::acquire_state_lock(targetHome);
+    if (!stateLock) {
+        log::error("[xlings:self] {}", stateLock.error());
+        return 1;
     }
 
     // Selective install: preserve data/ and subos/ unless user chose to overwrite

--- a/src/core/xself/migrate.cppm
+++ b/src/core/xself/migrate.cppm
@@ -3,6 +3,7 @@ export module xlings.core.xself.migrate;
 import std;
 
 import xlings.core.config;
+import xlings.core.home_config;
 import xlings.libs.json;
 import xlings.core.log;
 import xlings.platform;
@@ -53,20 +54,22 @@ export int cmd_migrate() {
     fs::create_directories(defaultDir / "usr");
     fs::create_directories(defaultDir / "generations");
 
-    auto configPath = p.homeDir / ".xlings.json";
-    nlohmann::json json;
-    if (fs::exists(configPath)) {
-        try {
-            auto content = platform::read_file_to_string(configPath.string());
-            json = nlohmann::json::parse(content, nullptr, false);
-            if (json.is_discarded()) json = nlohmann::json::object();
-        } catch (...) { json = nlohmann::json::object(); }
+    // The data-tree move above is the slow part; commit the config edit
+    // afterwards under the state lock rather than rewriting a document read
+    // before it. See core/home_config.cppm.
+    auto committed = update_home_config(p.homeDir, [](nlohmann::json& json) {
+        json["activeSubos"] = "default";
+        if (!json.contains("subos") || !json["subos"].is_object()) {
+            json["subos"] = nlohmann::json::object();
+        }
+        json["subos"]["default"] = {{"dir", ""}};
+        return true;
+    });
+    if (!committed) {
+        log::error("migration moved the data tree but could not update "
+                   "the config: {}", committed.error());
+        return 1;
     }
-
-    json["activeSubos"] = "default";
-    if (!json.contains("subos")) json["subos"] = nlohmann::json::object();
-    json["subos"]["default"] = {{"dir", ""}};
-    platform::write_string_to_file(configPath.string(), json.dump(2));
 
     auto currentLink = subosDir / "current";
     std::error_code lec;

--- a/tests/e2e/home_config_lock_test.sh
+++ b/tests/e2e/home_config_lock_test.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# E2E test: commands that rewrite `~/.xlings.json` take the state lock.
+#
+# `~/.xlings.json` has several owners. install/remove/use write `versions`
+# and `workspace`; the subos commands write `subos` and `activeSubos`;
+# `xlings config` writes `lang`, `mirror` and `index_repos`. Each of them
+# reads the whole document and writes the whole document back.
+#
+# Only the first group took the home-wide state lock. So `xlings subos new`
+# would read the config, spend its time laying down directories (seconds, if
+# the subos uses image storage and has to run mkfs.ext4), and then write back
+# the document it read at the start -- silently reverting whatever an install
+# committed in between. The payload stayed on disk with no record of it, and
+# because `versions` and `workspace` are two halves of one release since
+# 0.4.70, reverting one of them is enough to make a whole toolchain refuse to
+# switch.
+#
+# The unit tests cover the locked-commit helper. What this covers is the
+# wiring: that the real CLI paths actually go through it. An unrelated holder
+# of the lock must make each of these commands fail, and fail without having
+# touched the file.
+#
+# Scenarios:
+#   1. subos new     — refused while the lock is held, nothing registered
+#   2. subos use -g  — refused, activeSubos unchanged
+#   3. subos rm      — refused, the entry survives
+#   4. config --lang — refused, lang unchanged
+#   5. all four succeed once the lock is released, and none of them lose the
+#      `versions`/`workspace` keys they do not own
+#
+# Scenario 5 also pins the retry behavior of `subos new`. The lock is taken at
+# the commit rather than around the whole command -- holding it across mkfs
+# would make a routine install in another terminal wait past its timeout -- so
+# a refused `subos new` has already laid down its directories. They are inert
+# until the entry is registered, and the retry reuses them, which is what
+# scenario 5 re-running the same `subos new` checks.
+
+set -euo pipefail
+
+# shellcheck source=./project_test_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
+
+RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/home_config_lock"
+HOME_DIR="$RUNTIME_DIR/home"
+CONFIG="$HOME_DIR/.xlings.json"
+LOCKFILE="$HOME_DIR/.xlings.lock"
+
+cleanup() {
+  # Release the holder before removing the tree: an flock'd descriptor left
+  # open would keep the file alive on some platforms and turn cleanup into a
+  # failure that says nothing about what was tested.
+  exec 9>&- 2>/dev/null || true
+  rm -rf "$RUNTIME_DIR"
+}
+trap cleanup EXIT
+cleanup
+
+XLINGS_BIN="$(find_xlings_bin)"
+
+# `env -i` on purpose: the lock is re-entrant for a child of its holder, via
+# XLINGS_STATE_LOCK_HELD. Inheriting that marker from this shell would make
+# every command below skip the lock and the test would pass vacuously.
+RUN() {
+  ( cd /tmp && env -i HOME="$HOME" PATH=/usr/bin:/bin \
+      XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@" )
+}
+
+json_get() {  # json_get <jq-ish path expr in python>
+  python3 -c "
+import json,sys
+d=json.load(open('$CONFIG'))
+print($1)
+" 2>/dev/null || echo "<unreadable>"
+}
+
+mkdir -p "$HOME_DIR"
+
+# Seed the two keys the subos and config commands do not own. If any of them
+# rewrites the document from a stale read, these are what disappears.
+cat > "$CONFIG" <<'JSON'
+{
+  "activeSubos": "default",
+  "subos": { "default": { "dir": "" }, "doomed": { "dir": "" } },
+  "lang": "zh",
+  "versions": { "gcc": { "16.1.0": { "path": "/store/gcc/16.1.0" } } },
+  "workspace": { "active": { "gcc": "16.1.0" } }
+}
+JSON
+mkdir -p "$HOME_DIR/subos/default" "$HOME_DIR/subos/doomed"
+
+BEFORE="$(cat "$CONFIG")"
+
+# ---------------------------------------------------------------- 1..4
+# Hold the lock as an unrelated process would. flock(1) keeps it for as long
+# as fd 9 is open in this shell.
+exec 9>"$LOCKFILE"
+if ! flock -n 9; then
+  echo "FAIL: could not take the lock the test needs to hold"
+  exit 1
+fi
+echo "holding $LOCKFILE"
+
+expect_refused() {
+  local what="$1"; shift
+  local out rc=0
+  out="$(RUN "$@" 2>&1)" || rc=$?
+  if [[ $rc -eq 0 ]]; then
+    echo "FAIL: [$what] succeeded while another process held the state lock"
+    echo "$out"
+    exit 1
+  fi
+  if ! grep -q "another xlings process" <<<"$out"; then
+    echo "FAIL: [$what] failed for some other reason than the lock:"
+    echo "$out"
+    exit 1
+  fi
+  if [[ "$(cat "$CONFIG")" != "$BEFORE" ]]; then
+    echo "FAIL: [$what] modified the config despite being refused"
+    diff <(echo "$BEFORE") "$CONFIG" || true
+    exit 1
+  fi
+  echo "  ok: [$what] refused, config untouched"
+}
+
+echo "--- 1..4: refused while the lock is held"
+expect_refused "subos new"    subos new probe
+expect_refused "subos use -g" subos use --global doomed
+expect_refused "subos rm"     subos rm doomed
+expect_refused "config"       config --lang en
+
+# ---------------------------------------------------------------- 5
+exec 9>&-
+echo "--- 5: the same commands succeed once the lock is free"
+
+RUN subos new probe        >/dev/null
+RUN config --lang en       >/dev/null
+RUN subos rm doomed        >/dev/null
+
+[[ "$(json_get "'probe' in d['subos']")"  == "True"  ]] || { echo "FAIL: subos new did not register"; exit 1; }
+[[ "$(json_get "'doomed' in d['subos']")" == "False" ]] || { echo "FAIL: subos rm did not deregister"; exit 1; }
+[[ "$(json_get "d['lang']")"              == "en"    ]] || { echo "FAIL: config --lang did not apply"; exit 1; }
+
+# The point of the whole exercise: keys these commands do not own survived
+# every one of them.
+[[ "$(json_get "d['versions']['gcc']['16.1.0']['path']")" == "/store/gcc/16.1.0" ]] \
+  || { echo "FAIL: 'versions' was lost by a subos/config write"; exit 1; }
+[[ "$(json_get "d['workspace']['active']['gcc']")" == "16.1.0" ]] \
+  || { echo "FAIL: 'workspace' was lost by a subos/config write"; exit 1; }
+
+echo "  ok: versions and workspace survived subos new / rm / config"
+echo
+echo "PASS: home config mutations are serialized by the state lock"

--- a/tests/e2e/run_all.sh
+++ b/tests/e2e/run_all.sh
@@ -82,6 +82,7 @@ TESTS=(
     "E2E-30 |custom_index_artifact_test.sh||"
     "E2E-31 |index_same_name_namespace_test.sh||"
     "E2E-32 |xvm_group_switch_test.sh||"
+    "E2E-33 |home_config_lock_test.sh||"
 )
 
 PASS=0; FAIL=0; SOFTFAIL=0

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -34,6 +34,7 @@ import xlings.core.xvm.shim;
 import xlings.core.xvm.commands;
 import xlings.core.compact;
 import xlings.core.config;
+import xlings.core.home_config;
 import xlings.platform;
 import xlings.libs.json;
 import xlings.core.xself;
@@ -11225,6 +11226,175 @@ TEST(XvmStateLock, LockFileContentsAreNeverRewritten) {
             << "something wrote to the lock file; the lock is held on the "
                "old inode";
     }
+    drop_lock_home_(home);
+}
+
+// ============================================================
+// update_home_config — one file, several owners
+//
+// `~/.xlings.json` carries `versions` and `workspace` (install/remove/use),
+// `subos` and `activeSubos` (the subos commands), `lang` and `mirror`
+// (`xlings config`), `index_repos` (the MCP repo capabilities) and `version`
+// (`self install`). Every one of them rewrites the whole document.
+//
+// install/remove/use took the state lock; nobody else did. So a subos
+// command that read the config, spent seconds in mkfs.ext4 and wrote back
+// what it read would put the file back to its pre-install state -- with the
+// installed payload still on disk and no record of it.
+// ============================================================
+
+namespace {
+
+std::filesystem::path home_config_test_home_(const char* name) {
+    namespace fs = std::filesystem;
+    auto home = fs::temp_directory_path()
+        / ("xlings_homecfg_" + std::string(name));
+    std::error_code ec;
+    fs::remove_all(home, ec);
+    fs::create_directories(home);
+    // Locks are re-entrant for a child of the holder; an earlier test in this
+    // binary may have left the marker set. Clear it so each case starts as an
+    // unrelated process.
+    xlings::platform::set_env_variable("XLINGS_STATE_LOCK_HELD", "");
+    return home;
+}
+
+void write_home_config_(const std::filesystem::path& home,
+                        const nlohmann::json& json) {
+    xlings::platform::write_string_to_file(
+        (home / ".xlings.json").string(), json.dump(2));
+}
+
+}  // namespace
+
+TEST(HomeConfig, ReadsAMissingOrCorruptConfigAsEmpty) {
+    const auto home = home_config_test_home_("read");
+    EXPECT_TRUE(xlings::read_home_config(home).empty());
+
+    xlings::platform::write_string_to_file(
+        (home / ".xlings.json").string(), "{not json");
+    EXPECT_TRUE(xlings::read_home_config(home).empty())
+        << "a corrupt config must read as no config, not throw";
+
+    // A JSON document that is valid but not an object is equally unusable as
+    // a config: every caller indexes it by key.
+    xlings::platform::write_string_to_file(
+        (home / ".xlings.json").string(), "[1, 2, 3]");
+    EXPECT_TRUE(xlings::read_home_config(home).empty());
+
+    drop_lock_home_(home);
+}
+
+// The regression this module exists for. A caller reads the config, does slow
+// work, and commits. Anything another process wrote in between must survive,
+// and the caller must not resurrect the values it read at the start.
+TEST(HomeConfig, CommitsAgainstTheDocumentAsItIsNowNotAsItWasRead) {
+    const auto home = home_config_test_home_("lost_update");
+    write_home_config_(home, nlohmann::json{
+        {"versions", {{"gcc", "15.1.0"}}},
+    });
+
+    // What a subos command would have read before starting its slow work.
+    const auto stale = xlings::read_home_config(home);
+    ASSERT_EQ(stale["versions"]["gcc"], "15.1.0");
+
+    // An install commits while that slow work is running.
+    write_home_config_(home, nlohmann::json{
+        {"versions", {{"gcc", "16.1.0"}}},
+        {"workspace", {{"active", {{"gcc", "16.1.0"}}}}},
+    });
+
+    auto committed = xlings::update_home_config(
+        home, [](nlohmann::json& json) {
+            json["subos"]["sandbox"] = {{"dir", ""}};
+            return true;
+        });
+    ASSERT_TRUE(committed.has_value()) << committed.error();
+    EXPECT_TRUE(*committed);
+
+    const auto after = xlings::read_home_config(home);
+    EXPECT_EQ(after["subos"]["sandbox"]["dir"], "");
+    EXPECT_EQ(after["versions"]["gcc"], "16.1.0")
+        << "the update reverted `versions` to the value it read before the "
+           "install committed";
+    EXPECT_TRUE(after.contains("workspace"))
+        << "`workspace` was dropped; the version database and the workspace "
+           "are two halves of one release and cannot diverge";
+
+    drop_lock_home_(home);
+}
+
+TEST(HomeConfig, DecliningToCommitLeavesTheFileByteForByte) {
+    const auto home = home_config_test_home_("declined");
+    write_home_config_(home, nlohmann::json{{"lang", "zh"}});
+    const auto before = xlings::platform::read_file_to_string(
+        (home / ".xlings.json").string());
+
+    auto committed = xlings::update_home_config(
+        home, [](nlohmann::json& json) {
+            json["lang"] = "en";  // discarded: the callback declines
+            return false;
+        });
+    ASSERT_TRUE(committed.has_value()) << committed.error();
+    EXPECT_FALSE(*committed);
+
+    EXPECT_EQ(xlings::platform::read_file_to_string(
+                  (home / ".xlings.json").string()),
+              before)
+        << "a declined update rewrote the file anyway";
+
+    drop_lock_home_(home);
+}
+
+// The mutation must not run at all while another process holds the lock --
+// otherwise the re-read it depends on is a re-read of a document that is
+// being replaced underneath it.
+TEST(HomeConfig, RefusesWhileAnUnrelatedProcessHoldsTheLock) {
+    const auto home = home_config_test_home_("contended");
+    write_home_config_(home, nlohmann::json{{"lang", "zh"}});
+
+    {
+        auto held = xlings::xvm::acquire_state_lock(
+            home, std::chrono::milliseconds{50});
+        ASSERT_TRUE(held.has_value()) << held.error();
+
+        // Stand in for an unrelated process: drop the re-entrancy marker the
+        // holder exported, so the update below is not treated as its child.
+        xlings::platform::set_env_variable("XLINGS_STATE_LOCK_HELD", "");
+
+        bool ran = false;
+        auto committed = xlings::update_home_config(
+            home,
+            [&](nlohmann::json& json) { ran = true; json["lang"] = "en"; return true; },
+            std::chrono::milliseconds{50});
+        ASSERT_FALSE(committed.has_value())
+            << "the update did not take the state lock";
+        EXPECT_NE(committed.error().find("another xlings process"),
+                  std::string::npos);
+        EXPECT_FALSE(ran) << "the mutation ran without the lock";
+    }
+
+    EXPECT_EQ(xlings::read_home_config(home)["lang"], "zh");
+    drop_lock_home_(home);
+}
+
+// A command that legitimately runs under an ancestor's lock -- a recipe hook
+// shelling out to xlings -- still gets to commit.
+TEST(HomeConfig, CommitsUnderAnAncestorsLock) {
+    const auto home = home_config_test_home_("reentrant");
+    {
+        auto outer = xlings::xvm::acquire_state_lock(
+            home, std::chrono::milliseconds{50});
+        ASSERT_TRUE(outer.has_value()) << outer.error();
+
+        auto committed = xlings::update_home_config(
+            home,
+            [](nlohmann::json& json) { json["lang"] = "en"; return true; },
+            std::chrono::milliseconds{50});
+        ASSERT_TRUE(committed.has_value()) << committed.error();
+        EXPECT_TRUE(*committed);
+    }
+    EXPECT_EQ(xlings::read_home_config(home)["lang"], "en");
     drop_lock_home_(home);
 }
 


### PR DESCRIPTION
Closes the first of the two gaps recorded during the PR #402 architecture review.

## The problem

`~/.xlings.json` has several owners and each one **rewrites the whole document**:

| key | writer |
|---|---|
| `versions`, `workspace` | `install` / `remove` / `use` |
| `subos`, `activeSubos` | `subos new` / `subos use -g` / `subos rm` / `self migrate` |
| `lang`, `mirror`, `index_repos` | `xlings config`, MCP `add_repo`/`remove_repo` |
| `mirror`, `version` | `self install` |

Only the first row took the home-wide state lock added in 0.4.70. So the lock protected `install`/`remove`/`use` from each other — and from nothing else.

`xlings subos new big --storage image` reads the config, spends seconds in `mkfs.ext4`, then writes back the document it read at the start. An install that committed in between is **silently reverted**: the payload stays on disk with no record of it. `subos rm` does the same across a `remove_all` of an entire subos tree.

That used to cost a stale entry. Since 0.4.70 it costs more: `versions` and `workspace` are two halves of one release, so reverting one of them alone leaves a group manifest naming a member the database no longer has — and the whole toolchain refuses to switch.

## The audit

Nine read-modify-writes of `<home>/.xlings.json`:

| site | command | verdict |
|---|---|---|
| `config.cppm:save_versions` | install/remove/use | already locked |
| `subos.cppm:create` | `subos new` | **fixed** — mkfs in the window |
| `subos.cppm:use_global` | `subos use -g` | **fixed** |
| `subos.cppm:remove` | `subos rm` | **fixed** — `remove_all` in the window |
| `cli.cppm:cmd_config_` | `xlings config` | **fixed** |
| `capabilities.cppm` ×2 | MCP `add_repo`/`remove_repo` | **fixed** |
| `xself/migrate.cppm` | `self migrate` | **fixed** |
| `xself/install.cppm` ×2 + `xself/init.cppm` | `self install` | **fixed** — one lock for the whole stretch |

## The design

New `src/core/home_config.cppm`. `update_home_config(home, mutate)` takes the lock, **re-reads** the document inside it, applies the caller's delta and writes.

**The lock covers the commit, not the command.** Holding it across `mkfs` or `remove_all` would make a routine install in the next terminal wait past its 30s timeout and fail. The cost of that choice is stated in the API doc and honored at every call site: anything decided from a lock-free read may be stale, so `subos new` re-checks that the name is still free inside the callback, and `remove_repo` re-checks that the repo is still there.

`self install` is different — its three writes are interleaved with replacing the binary and laying down the home, so it takes **one** lock across that whole stretch. Placed after the confirmation prompts on purpose: a lock held on human time is a lock that makes `xlings install` fail in the next terminal. The `xlings install -g` it spawns for the patchelf step inherits the re-entrancy marker and works under the same lock rather than deadlocking against it.

### Deliberately not covered

The **project** state file and the **per-subos** `.xlings.json`. Both are scoped to one project tree or one subos, while the state lock is per-home; giving them the home lock would serialize unrelated projects against each other. They keep last-writer-wins.

## Verification

- 5 new unit cases (`HomeConfig`) — 421 total, all green
- **E2E-33** `home_config_lock_test.sh` — an unrelated `flock` holder must make `subos new`, `subos use -g`, `subos rm` and `config --lang` each fail **without touching the file**; then all of them succeed once released, with `versions` and `workspace` intact
- Red-phase confirmed: reverting the lock acquisition in the helper fails `HomeConfig.RefusesWhileAnUnrelatedProcessHoldsTheLock`. The test gates the fix rather than describing it.
- Regression: E2E subos_events / subos_workspace_c2_schema / subos_install_remove_isolation / subos_xpkg_use_cmd / legacy_config / xvm_group_switch all pass locally

## Known side effect, documented

A `subos new` refused by the lock has already created its directories. They are inert until the entry is registered and the retry reuses them; the error hint says so, and E2E-33 scenario 5 checks the retry. Avoiding it would mean holding the lock across `mkfs`, which is the trade this PR explicitly declines.