### PR TITLE
fix(xvm): materialize the group's declared headers, not one member's includedir

### DIFF
--- a/.agents/docs/2026-07-26-release-0470-notes.md
+++ b/.agents/docs/2026-07-26-release-0470-notes.md
@@ -30,6 +30,8 @@
 | 安装非激活版本不再覆盖 sysroot | 覆盖了 active 版本的头文件，且 `use` 修不回来 |
 | 状态文件原子替换 | 写入中断会**清空** `~/.xlings.json`（整个版本库）或用户的 `~/.bashrc` |
 | `install`/`remove`/`use` 互斥 | 并发运行时后写的抹掉先写的 |
+| `subos` / `config` / `self install` 也走同一把锁 | 它们读改写同一个 `~/.xlings.json`，`subos new` 在 mkfs 期间会把并发 install 的 `versions` 写回旧值 |
+| 一个发布声明的**每个**头文件目录都随切换移动 | 只记住最后一个，切换后 sysroot 里混着两个版本的头文件 |
 | 失败时给出 code 与可执行 hint | 只有一句 `install failed` |
 | `self doctor` 能看见 binding 状态 | 只看 shim 和 payload |
 | `self doctor --fix` 可停用不一致的发布 | 无法处理 |
@@ -51,6 +53,10 @@
 - 指向状态文件的**硬链接不再跟随更新**（原子替换换掉了 inode，这正是安全性的来源）
 - 在**不可写目录**中改写已存在的状态文件现在会失败（暂存文件需要在该目录创建）
 - `XLINGS_NO_LOCK=1` 可绕过状态锁（仅用于诊断卡住的锁，会告警）
+- 另一个 xlings 正在改这个安装时，`xlings subos new/rm/use -g`、`xlings config`、
+  `xlings self install` 会**明确失败**并提示等待，而不再静默覆盖对方的写入。
+  被拒绝的 `subos new` 已经建好了目录 —— 它在注册前是惰性的，重试会直接复用
+  （锁只覆盖提交，不覆盖 mkfs，否则隔壁终端的一次普通 install 会被拖到超时）
 
 ---
 
@@ -85,6 +91,13 @@
 
 - 存储格式仍是 #384 的 root-manifest 形态。group 归一化为顶层表推迟到 0.4.71，
   届时需要一个兼容读窗口（详见 plan §0.15 的决策与代价记录）。
+- 头文件物化改为读 group 声明的 `bindingHeaders`（原先只读单个 `includedir`）。
+  `includedir` 仍然写入，作为降级到 0.4.69 的兼容镜像 —— 0.4.69 不认识
+  `bindingHeaders`，不写它会让回滚静默停止搬头文件。
+  注意：当前官方索引里**没有**任何 recipe 声明头文件目录，`xvm.setup` 每次调用
+  也只能声明一个（调用两次会被判为重复注册）。所以这条修的是模型允许、公开
+  API 目前还产生不出来的状态 —— 但它已经被持久化、已经会 round-trip，
+  留着不消费就是下一个"写了没人读"的字段。
 - 六个 CI workflow 现在也在 `release/**` 分支上运行。
 - CI 不再在恢复 mcpp 缓存后立即删除其中的 payload —— 此前每次运行都必须重新从各上游
   主机拉取全部传递依赖，任何一个不可达就全线失败。

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -18,6 +18,7 @@ import xlings.core.common;
 import xlings.core.xself;
 import xlings.core.xvm.types;
 import xlings.core.xvm.db;
+import xlings.core.xvm.bindings;
 import xlings.core.xvm.removal;
 import xlings.core.xvm.registration;
 import xlings.core.xvm.errors;
@@ -151,16 +152,20 @@ struct XpkgXvmMetadataResult {
     std::vector<XpkgFilesystemEffect> effects;
 };
 
-// Keep `xlings use` able to swap sysroot headers.
+// Keep the release readable by an older xlings.
 //
-// xvm::cmd_use reads VData::includedir of the target it was handed to decide
-// whether to move headers (commands.cppm). Before registration batches the
-// installer wrote that field directly on every `headers` op; the batch models
-// headers as group assets instead and does not carry it. Until the
-// materialization work consumes those group assets, the field still has to be
-// written or switching versions silently stops moving headers — and because
-// the install-time copy still happens, the breakage only surfaces on the
-// *second* version a user installs.
+// Materialization now resolves headers through `xvm::group_header_assets`,
+// which reads the group's declared assets from the root and only falls back
+// to this field when there are none. So this is no longer what makes
+// `xlings use` move headers -- the group assets are.
+//
+// It is still written, for one reason: 0.4.69 knows nothing about
+// `bindingHeaders` and switches headers by reading `includedir` alone.
+// Dropping it would make a downgrade from 0.4.70 silently stop moving
+// headers, and the release notes promise the rollback is safe. It records
+// only the last of the declared directories, which is exactly the limitation
+// 0.4.69 had before -- a downgrade gets the old behavior back, not a worse
+// one.
 //
 // One deliberate difference from the pre-batch behavior: this never brings a
 // target or a version into existence. The old code indexed both maps with
@@ -1275,10 +1280,15 @@ void detach_current_subos_(const std::string& target,
         auto db = Config::versions();
         auto sysroot_include = Config::paths().subosDir / "usr" / "include";
         auto sysroot_lib = Config::paths().libDir;
+        // The whole release's headers, not just whatever single directory
+        // landed in this entry's `includedir`: a release declaring more than
+        // one header directory would otherwise leave all but the last behind
+        // in the sysroot, pointing into a payload that is being deleted.
+        for (const auto& asset :
+                 xvm::group_header_assets(db, target, version)) {
+            xvm::remove_headers(asset, sysroot_include);
+        }
         if (auto* vdata = xvm::get_vdata(db, target, version)) {
-            if (!vdata->includedir.empty()) {
-                xvm::remove_headers(vdata->includedir, sysroot_include);
-            }
             if (!vdata->libdir.empty()) {
                 xvm::remove_libdir(vdata->libdir, sysroot_lib);
             }
@@ -1448,8 +1458,9 @@ bool process_xvm_operations_(const PlanNode& node,
         if (infoIt == scopedDb.end()) continue;
         auto dataIt = infoIt->second.versions.find(version);
         if (dataIt == infoIt->second.versions.end()) continue;
-        if (!dataIt->second.includedir.empty()) {
-            xvm::install_headers(dataIt->second.includedir, sysroot_include);
+        for (const auto& asset :
+                 xvm::group_header_assets(scopedDb, target, version)) {
+            xvm::install_headers(asset, sysroot_include);
         }
         if (!dataIt->second.libdir.empty()) {
             xvm::install_libdir(dataIt->second.libdir, sysroot_lib);

--- a/src/core/xvm/bindings.cppm
+++ b/src/core/xvm/bindings.cppm
@@ -46,6 +46,33 @@ resolve_binding_selection(const VersionDB& db,
                           const std::string& target,
                           const std::string& version);
 
+// The header directories a release puts into the sysroot.
+//
+// Headers are a property of the *group*, not of a member: `gcc` and `g++`
+// share one set of C++ headers, and which member the user happened to name is
+// not supposed to change what lands in the sysroot. So the declaration lives
+// on the group root as `bindingHeaders`, and this resolves any member of the
+// release to the same list.
+//
+// Until now nothing read that list. Materialization went through
+// `VData::includedir` instead, a single string the installer writes on the
+// root with last-op-wins semantics. For a recipe declaring one header
+// directory the two agree. For a recipe declaring two -- a toolchain with
+// `include/c++/<ver>` alongside `include-fixed`, or one calling `xvm.setup`
+// more than once -- they do not: install materializes both (it walks the
+// effect list), while `xlings use` only ever remembers the last. Switching
+// away therefore left the other directories' headers in the sysroot and
+// switching in never put the new release's copies there. The sysroot held a
+// mix of two releases, which is the exact state the binding-group work exists
+// to make unrepresentable.
+//
+// Falls back to `includedir` when the entry has no group headers to report:
+// state written by 0.4.69 has no `bindingHeaders` at all, and neither does a
+// registration that is not part of a provider group.
+std::vector<HeaderAsset> group_header_assets(const VersionDB& db,
+                                             const std::string& target,
+                                             const std::string& version);
+
 }  // namespace xlings::xvm
 
 namespace xlings::xvm::detail_ {
@@ -534,6 +561,39 @@ resolve_binding_selection(const VersionDB& db,
             db, target, version, *versionIt->second.bindingGroup);
     }
     return detail_::resolve_legacy_graph_(db, target, version);
+}
+
+std::vector<HeaderAsset> group_header_assets(const VersionDB& db,
+                                             const std::string& target,
+                                             const std::string& version) {
+    auto targetIt = db.find(target);
+    if (targetIt == db.end()) return {};
+    auto versionIt = targetIt->second.versions.find(version);
+    if (versionIt == targetIt->second.versions.end()) return {};
+    const VData& entry = versionIt->second;
+
+    const VData* root = &entry;
+    if (entry.bindingGroup) {
+        const auto& ref = *entry.bindingGroup;
+        if (auto rootTargetIt = db.find(ref.rootTarget);
+            rootTargetIt != db.end()) {
+            if (auto rootVersionIt =
+                    rootTargetIt->second.versions.find(ref.rootVersion);
+                rootVersionIt != rootTargetIt->second.versions.end()) {
+                root = &rootVersionIt->second;
+            }
+        }
+        // A dangling root reference is not repaired here. The selection layer
+        // already refuses such a release, and this is only ever called for
+        // one that resolved -- so falling back to the member's own view is
+        // the conservative answer rather than a second opinion on validity.
+    }
+
+    if (!root->bindingHeaders.empty()) return root->bindingHeaders;
+    if (!entry.includedir.empty()) {
+        return {HeaderAsset{.sourceDir = entry.includedir}};
+    }
+    return {};
 }
 
 }  // namespace xlings::xvm

--- a/src/core/xvm/commands.cppm
+++ b/src/core/xvm/commands.cppm
@@ -42,6 +42,25 @@ void create_link_(const fs::path& src, const fs::path& dst) {
     if (ec) log::warn("[xvm] link failed: {} -> {}", dst.string(), src.string());
 }
 
+// Where a header asset lands: `<sysroot>/include/<destinationPrefix>`, or
+// `<sysroot>/include` when the asset declares no prefix.
+//
+// The prefix exists because a source directory's name is not always the name
+// the compiler looks under -- a toolchain's `include/c++/15.1.0` has to appear
+// as `c++/15.1.0`, not as a flattened pile of its contents. Every asset the
+// current recipe API can produce has an empty prefix (libxpkg's `xvm.setup`
+// takes a single `includedir` and no destination), so today this is always
+// the sysroot include root; it is honored anyway because the field is part of
+// the persisted model and round-trips through the version database. A
+// serialized field that materialization ignores is exactly the kind of state
+// this release is removing, not adding.
+fs::path header_destination_(const HeaderAsset& asset,
+                             const fs::path& sysroot_include) {
+    return asset.destinationPrefix.empty()
+        ? sysroot_include
+        : sysroot_include / fs::path(asset.destinationPrefix);
+}
+
 // Install header symlinks from source includedir into sysroot include/
 void install_headers(const std::string& includedir, const fs::path& sysroot_include) {
     fs::create_directories(sysroot_include);
@@ -87,6 +106,24 @@ void remove_headers(const std::string& includedir, const fs::path& sysroot_inclu
             fs::remove_all(target, ec);
 #endif
         }
+    }
+}
+
+// Same two operations, addressed by header asset rather than by bare source
+// directory, so the destination prefix is honored.
+void install_headers(const HeaderAsset& asset, const fs::path& sysroot_include) {
+    install_headers(asset.sourceDir, header_destination_(asset, sysroot_include));
+}
+
+void remove_headers(const HeaderAsset& asset, const fs::path& sysroot_include) {
+    const auto destination = header_destination_(asset, sysroot_include);
+    remove_headers(asset.sourceDir, destination);
+    // A prefix directory that only ever held this release's links is litter
+    // once they are gone. remove() on a non-empty directory fails, so this
+    // cannot take anything else with it.
+    if (!asset.destinationPrefix.empty()) {
+        std::error_code ec;
+        fs::remove(destination, ec);
     }
 }
 
@@ -254,13 +291,22 @@ int cmd_use(const std::string& target, const std::string& version, EventStream& 
     // filesystem. Members that are already where they belong emit no change.
     auto sysroot_include = p.subosDir / "usr" / "include";
     auto sysroot_lib     = p.subosDir / "usr" / "lib";
+    // Headers first, and as two whole passes rather than per member: they are
+    // an asset of the release, not of any one member of it. Interleaving the
+    // passes -- remove one member's, install the next member's -- let the
+    // outgoing release's removal delete a link the incoming release had
+    // already put down, for every header name the two versions share. The
+    // plan has the two lists deduplicated and disjoint already.
+    for (const auto& asset : plan->removeHeaders) {
+        remove_headers(asset, sysroot_include);
+    }
+    for (const auto& asset : plan->installHeaders) {
+        install_headers(asset, sysroot_include);
+    }
+
     for (const auto& change : plan->switches) {
-        if (!change.removeIncludeDir.empty())
-            remove_headers(change.removeIncludeDir, sysroot_include);
         if (!change.removeLibDir.empty())
             remove_libdir(change.removeLibDir, sysroot_lib);
-        if (!change.installIncludeDir.empty())
-            install_headers(change.installIncludeDir, sysroot_include);
         if (!change.installLibDir.empty())
             install_libdir(change.installLibDir, sysroot_lib);
         log::debug("switching {}: {} -> {}", change.target,

--- a/src/core/xvm/switch_plan.cppm
+++ b/src/core/xvm/switch_plan.cppm
@@ -24,19 +24,37 @@ import xlings.core.xvm.errors;
 export namespace xlings::xvm {
 
 // What has to change on disk for one member of the release.
+//
+// Libraries are per member -- each has its own libdir. Headers are not: they
+// belong to the release as a whole and live on the plan, below.
 struct MemberSwitch {
     std::string target;
     std::string version;
     std::string previousVersion;   // empty when the member was not active
-    std::string removeIncludeDir;  // empty when there is nothing to remove
-    std::string removeLibDir;
-    std::string installIncludeDir;
+    std::string removeLibDir;      // empty when there is nothing to remove
     std::string installLibDir;
 };
 
 struct UseSwitchPlan {
     std::map<std::string, std::string> members;  // target -> version
     std::vector<MemberSwitch> switches;          // only members that move
+
+    // Header assets for the whole release, deduplicated, with the two lists
+    // already disjoint.
+    //
+    // Per-member header lists would be wrong twice over. Every member of a
+    // group resolves to the same declaration, so the same directory would be
+    // linked once per member. Worse, the loop that applied them removed and
+    // installed one member at a time: member B's removal of the outgoing
+    // release could delete links member A had just installed for the incoming
+    // one, whenever the two releases share a header name -- which for two
+    // versions of one toolchain is every header it ships.
+    //
+    // Hoisting them here makes the order unambiguous: everything the outgoing
+    // release put in the sysroot comes out, then everything the incoming one
+    // needs goes in.
+    std::vector<HeaderAsset> removeHeaders;
+    std::vector<HeaderAsset> installHeaders;
 };
 
 // Resolve the release and work out the filesystem changes.
@@ -76,24 +94,36 @@ std::expected<UseSwitchPlan, XvmUserError> plan_use_switch(
         }
     }
 
+    // Accumulate the release's header assets while walking the members, then
+    // reconcile the two sets once at the end. Appending to a vector and
+    // deduplicating afterwards keeps the declaration order the recipe wrote,
+    // which decides which copy wins when two assets ship a header of the same
+    // name.
+    std::vector<HeaderAsset> incoming;
+    std::vector<HeaderAsset> outgoing;
+
     for (const auto& [memberTarget, memberVersion] : plan.members) {
         const auto activeIt = workspace.find(memberTarget);
         const std::string previous =
             activeIt == workspace.end() ? std::string{} : activeIt->second;
 
         const auto& current = db.at(memberTarget).versions.at(memberVersion);
+        auto currentHeaders =
+            group_header_assets(db, memberTarget, memberVersion);
+        incoming.insert(incoming.end(),
+                        currentHeaders.begin(), currentHeaders.end());
+
         if (previous == memberVersion) {
             // Already the active version, but the sysroot may not reflect it:
             // a removal that fell back to this release takes the removed
             // release's headers out and puts nothing back. Re-materializing
             // is idempotent, so `use` doubles as the repair for that -- and
             // as a no-op when nothing is wrong. Nothing to remove first.
-            if (current.includedir.empty() && current.libdir.empty()) continue;
+            if (current.libdir.empty()) continue;
             plan.switches.push_back({
                 .target = memberTarget,
                 .version = memberVersion,
                 .previousVersion = previous,
-                .installIncludeDir = current.includedir,
                 .installLibDir = current.libdir,
             });
             continue;
@@ -105,19 +135,50 @@ std::expected<UseSwitchPlan, XvmUserError> plan_use_switch(
             .previousVersion = previous,
         };
         if (!previous.empty()) {
+            auto previousHeaders =
+                group_header_assets(db, memberTarget, previous);
+            outgoing.insert(outgoing.end(),
+                            previousHeaders.begin(), previousHeaders.end());
             auto infoIt = db.find(memberTarget);
             if (infoIt != db.end()) {
                 auto prevIt = infoIt->second.versions.find(previous);
                 if (prevIt != infoIt->second.versions.end()) {
-                    change.removeIncludeDir = prevIt->second.includedir;
                     change.removeLibDir = prevIt->second.libdir;
                 }
             }
         }
-        change.installIncludeDir = current.includedir;
         change.installLibDir = current.libdir;
         plan.switches.push_back(std::move(change));
     }
+
+    auto dedup = [](std::vector<HeaderAsset>& assets) {
+        std::set<std::pair<std::string, std::string>> seen;
+        std::erase_if(assets, [&](const HeaderAsset& asset) {
+            return asset.sourceDir.empty()
+                || !seen.emplace(asset.sourceDir,
+                                 asset.destinationPrefix).second;
+        });
+    };
+    dedup(incoming);
+    dedup(outgoing);
+
+    // An asset the incoming release also needs must not be taken out first.
+    // Two releases of the same toolchain can share a header directory, and
+    // `use` re-materializes the active release on every call to repair a
+    // drifted sysroot -- removing and relinking would open a window on every
+    // one of those calls where the header is simply absent, long enough for a
+    // concurrent build to fail on it. install_headers already skips a link
+    // that is correct; this makes sure nothing removes it beforehand.
+    std::set<std::pair<std::string, std::string>> kept;
+    for (const auto& asset : incoming) {
+        kept.emplace(asset.sourceDir, asset.destinationPrefix);
+    }
+    std::erase_if(outgoing, [&](const HeaderAsset& asset) {
+        return kept.contains({asset.sourceDir, asset.destinationPrefix});
+    });
+
+    plan.installHeaders = std::move(incoming);
+    plan.removeHeaders = std::move(outgoing);
 
     return plan;
 }

--- a/tests/e2e/xvm_group_switch_test.sh
+++ b/tests/e2e/xvm_group_switch_test.sh
@@ -80,10 +80,17 @@ function install()
     os.tryrm(dir)
     os.mkdir(path.join(dir, "bin"))
     os.mkdir(path.join(dir, "include"))
+    os.mkdir(path.join(dir, "include-fixed"))
     -- Each version ships a header stamped with its own version, so the
     -- sysroot can be checked for which release is actually materialized.
     io.writefile(path.join(dir, "include", "tcver.h"),
                  "#define TC_VERSION \"" .. version .. "\"\n")
+    -- A second header directory, which is what real toolchains have:
+    -- `include/` alongside `include-fixed/`. Only the last-declared one used
+    -- to be remembered for switching, so this is the one that catches a
+    -- release whose headers half-moved.
+    io.writefile(path.join(dir, "include-fixed", "tcfixed.h"),
+                 "#define TC_FIXED \"" .. version .. "\"\n")
     -- Plain files: this test checks which release the workspace and the
     -- sysroot point at, not that the programs run. (os.runv is not in the
     -- libxpkg Lua sandbox, so there is no chmod here anyway.)
@@ -102,6 +109,21 @@ function config()
         includedir = "include",
         programs   = {"tcc", "tcxx"},
     })
+    -- A second header directory for the same release, which is what
+    -- `bindingHeaders` is a list for. `xvm.setup` takes one `includedir` per
+    -- call and re-registers the root on every call, so calling it twice is
+    -- refused as a duplicate registration -- the op is pushed directly
+    -- instead. Nothing in the official index does this today; the point is
+    -- that the persisted model allows it, and materialization has to agree
+    -- with the model rather than with the single legacy `includedir` field.
+    --
+    -- Before the fix: install linked both directories, `xlings use` only
+    -- remembered the last, so switching moved `include-fixed/` and left
+    -- `include/` pointing at the other release.
+    table.insert(_XVM_OPS, {
+        op = "headers",
+        includedir = path.join(pkginfo.install_dir(), "include-fixed"),
+    })
     return true
 end
 
@@ -109,6 +131,10 @@ function uninstall()
     xvm.teardown("toolchain-fixture", {
         includedir = "include",
         programs   = {"tcc", "tcxx"},
+    })
+    table.insert(_XVM_OPS, {
+        op = "remove_headers",
+        includedir = path.join(pkginfo.install_dir(), "include-fixed"),
     })
     return true
 end
@@ -131,6 +157,7 @@ mkdir -p "$HOME_DIR/data/xim-index-repos"
 printf '{}\n' > "$HOME_DIR/data/xim-index-repos/xim-indexrepos.json"
 
 SYSROOT_HEADER="$HOME_DIR/subos/default/usr/include/tcver.h"
+SYSROOT_FIXED_HEADER="$HOME_DIR/subos/default/usr/include/tcfixed.h"
 
 active_version() {
   # Read the active version of $1 straight out of the subos workspace.
@@ -152,11 +179,17 @@ header_version() {
   sed -n 's/.*TC_VERSION "\([^"]*\)".*/\1/p' "$SYSROOT_HEADER"
 }
 
+fixed_header_version() {
+  [[ -f "$SYSROOT_FIXED_HEADER" ]] || { echo ""; return; }
+  sed -n 's/.*TC_FIXED "\([^"]*\)".*/\1/p' "$SYSROOT_FIXED_HEADER"
+}
+
 expect_group_at() {
-  local want="$1" ctx="$2" got_tcc got_tcxx got_hdr
+  local want="$1" ctx="$2" got_tcc got_tcxx got_hdr got_fixed
   got_tcc="$(active_version tcc)"
   got_tcxx="$(active_version tcxx)"
   got_hdr="$(header_version)"
+  got_fixed="$(fixed_header_version)"
   [[ "$got_tcc" == "$want" ]] \
     || fail "$ctx: tcc is '$got_tcc', expected '$want'"
   # The whole point: a member left behind is the bug.
@@ -164,6 +197,12 @@ expect_group_at() {
     || fail "$ctx: tcxx is '$got_tcxx' while tcc is '$want' — release split"
   [[ "$got_hdr" == "$want" ]] \
     || fail "$ctx: sysroot header is '$got_hdr', expected '$want' — headers did not follow"
+  # Both declared header directories have to move, not just the last one the
+  # recipe declared. A sysroot holding one release's `include/` beside another
+  # release's `include-fixed/` is the same class of split as a member left
+  # behind, and it used to be the default outcome for any recipe declaring two.
+  [[ "$got_fixed" == "$want" ]] \
+    || fail "$ctx: sysroot include-fixed header is '$got_fixed', expected '$want' — only one of the two declared header directories moved"
 }
 
 log "Installing both releases"
@@ -215,6 +254,7 @@ expect_group_at "1.0.0" "S5 (before)"
 
 WS_BEFORE="$(cat "$HOME_DIR/subos/default/.xlings.json")"
 HDR_BEFORE="$(header_version)"
+FIXED_BEFORE="$(fixed_header_version)"
 
 # Drop tcxx@1.0.0 from the version database, leaving the release's manifest
 # still naming it. This is the dangling state a stale edge used to produce.
@@ -237,6 +277,8 @@ fi
   || fail "S5: refused but the workspace changed anyway"
 [[ "$(header_version)" == "$HDR_BEFORE" ]] \
   || fail "S5: refused but the sysroot headers changed anyway"
+[[ "$(fixed_header_version)" == "$FIXED_BEFORE" ]] \
+  || fail "S5: refused but the second header directory changed anyway"
 log "S5: refused with the workspace and sysroot untouched"
 
 log "PASS: xvm group switch"

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -3033,6 +3033,68 @@ TEST_F(XvmHeaderSymlinkTest, RemoveHeadersNonexistentDir) {
     xlings::xvm::remove_headers("", sysrootInclude);
 }
 
+// A header asset's destination prefix decides the subdirectory it appears
+// under. The source directory's own name is not always the name the compiler
+// looks for: a toolchain's `include/c++/15.1.0` has to show up as
+// `c++/15.1.0`, not as its contents flattened into the include root.
+//
+// No recipe can set the prefix today -- libxpkg's `xvm.setup` takes a bare
+// `includedir` -- but the field is serialized and round-trips through the
+// version database, so materialization honoring it is what keeps it from
+// being another persisted-and-ignored value.
+TEST_F(XvmHeaderSymlinkTest, ADestinationPrefixDecidesWhereHeadersLand) {
+    namespace fs = std::filesystem;
+
+    auto srcInclude = testDir_ / "pkg" / "include" / "c++" / "15.1.0";
+    fs::create_directories(srcInclude);
+    xlings::platform::write_string_to_file(
+        (srcInclude / "vector").string(), "/* vector */");
+
+    auto sysrootInclude = testDir_ / "sysroot" / "usr" / "include";
+    const xlings::xvm::HeaderAsset asset{
+        .sourceDir = srcInclude.string(),
+        .destinationPrefix = "c++/15.1.0",
+    };
+
+    xlings::xvm::install_headers(asset, sysrootInclude);
+    EXPECT_TRUE(fs::exists(sysrootInclude / "c++" / "15.1.0" / "vector"));
+    EXPECT_FALSE(fs::exists(sysrootInclude / "vector"))
+        << "the prefix was ignored and the headers were flattened into the "
+           "include root";
+
+    xlings::xvm::remove_headers(asset, sysrootInclude);
+    EXPECT_FALSE(fs::exists(sysrootInclude / "c++" / "15.1.0" / "vector"));
+    // The prefix directory only ever held this release's links, so it goes
+    // too rather than accumulating as litter.
+    EXPECT_FALSE(fs::exists(sysrootInclude / "c++" / "15.1.0"));
+}
+
+TEST_F(XvmHeaderSymlinkTest, APrefixDirectoryWithOtherContentSurvivesRemoval) {
+    namespace fs = std::filesystem;
+
+    auto srcInclude = testDir_ / "pkg" / "include";
+    fs::create_directories(srcInclude);
+    xlings::platform::write_string_to_file(
+        (srcInclude / "vector").string(), "/* vector */");
+
+    auto sysrootInclude = testDir_ / "sysroot" / "usr" / "include";
+    const xlings::xvm::HeaderAsset asset{
+        .sourceDir = srcInclude.string(),
+        .destinationPrefix = "c++",
+    };
+    xlings::xvm::install_headers(asset, sysrootInclude);
+
+    // Something else lives under the same prefix -- another package's
+    // headers, or a file the user put there.
+    xlings::platform::write_string_to_file(
+        (sysrootInclude / "c++" / "keep.h").string(), "/* not ours */");
+
+    xlings::xvm::remove_headers(asset, sysrootInclude);
+    EXPECT_FALSE(fs::exists(sysrootInclude / "c++" / "vector"));
+    EXPECT_TRUE(fs::exists(sysrootInclude / "c++" / "keep.h"))
+        << "removing a header asset deleted a directory it did not own";
+}
+
 // ============================================================
 // xim sub-index repos tests
 // ============================================================
@@ -10936,10 +10998,18 @@ TEST(XvmSwitchPlan, SwapsHeadersAndLibsForEveryMovingMember) {
     // compile fails anyway.
     for (const auto& change : plan->switches) {
         EXPECT_EQ(change.previousVersion, "16.1.0");
-        EXPECT_NE(change.removeIncludeDir.find("16.1.0"), std::string::npos);
-        EXPECT_NE(change.installIncludeDir.find("15.1.0"), std::string::npos);
         EXPECT_NE(change.removeLibDir.find("16.1.0"), std::string::npos);
         EXPECT_NE(change.installLibDir.find("15.1.0"), std::string::npos);
+    }
+    // Headers belong to the release, so they are planned once for the whole
+    // of it rather than once per member.
+    ASSERT_EQ(plan->removeHeaders.size(), 2u);
+    ASSERT_EQ(plan->installHeaders.size(), 2u);
+    for (const auto& asset : plan->removeHeaders) {
+        EXPECT_NE(asset.sourceDir.find("16.1.0"), std::string::npos);
+    }
+    for (const auto& asset : plan->installHeaders) {
+        EXPECT_NE(asset.sourceDir.find("15.1.0"), std::string::npos);
     }
 }
 
@@ -10957,14 +11027,14 @@ TEST(XvmSwitchPlan, AnAlreadyActiveMemberIsRematerializedButNotUnwound) {
         plan->switches, [](const auto& c) { return c.target == "gcc"; });
     ASSERT_NE(gccChange, plan->switches.end());
     // gcc is already active, so there is nothing to take out of the sysroot.
-    EXPECT_TRUE(gccChange->removeIncludeDir.empty());
     EXPECT_TRUE(gccChange->removeLibDir.empty());
-    // But its headers are re-installed anyway. A removal that fell back to
+    EXPECT_TRUE(plan->removeHeaders.empty());
+    // But the headers are re-installed anyway. A removal that fell back to
     // this release took the removed release's headers out and put nothing
     // back; `use` could not repair that, because switching to the version
     // that is already active was a no-op. install_headers is idempotent, so
     // re-materializing costs nothing when nothing is wrong.
-    EXPECT_FALSE(gccChange->installIncludeDir.empty());
+    EXPECT_FALSE(plan->installHeaders.empty());
 
     const auto cxxChange = std::ranges::find_if(
         plan->switches, [](const auto& c) { return c.target == "g++"; });
@@ -10983,6 +11053,170 @@ TEST(XvmSwitchPlan, AMemberWithNoMaterializedAssetsEmitsNothing) {
     // Re-materializing is only worth emitting when there is something to
     // materialize; a program-only release in place is a genuine no-op.
     EXPECT_TRUE(plan->switches.empty());
+    EXPECT_TRUE(plan->installHeaders.empty());
+    EXPECT_TRUE(plan->removeHeaders.empty());
+}
+
+// ============================================================
+// Header assets are resolved from the group, not from one member's
+// `includedir`
+//
+// `bindingHeaders` records every header directory a release declares. Nothing
+// read it: materialization went through `VData::includedir`, which the
+// installer writes on the group root with last-op-wins semantics. A recipe
+// declaring two header directories -- a toolchain shipping `include/c++/<ver>`
+// alongside `include-fixed`, or one calling `xvm.setup` twice -- had both
+// materialized at install time (the effect list carries all of them) and only
+// the last one remembered for switching. So `xlings use` left the others'
+// headers in the sysroot and never brought the incoming release's copies in:
+// a sysroot mixing two releases, which is the state this whole release exists
+// to make unrepresentable.
+// ============================================================
+
+namespace {
+
+// A release declaring several header directories, as `xvm.setup` called more
+// than once would produce.
+void multi_header_group_(xlings::xvm::VersionDB& db,
+                         std::string_view version,
+                         const std::vector<std::string>& sourceDirs) {
+    const xlings::xvm::BindingGroupRef ref{
+        .provider = "pkgindex:gcc",
+        .providerVersion = std::string(version),
+        .group = "gcc",
+        .rootTarget = "gcc",
+        .rootVersion = std::string(version),
+    };
+    for (const auto& t : {"gcc", "g++"}) {
+        auto& info = db[t];
+        info.type = "program";
+        auto& data = info.versions[std::string(version)];
+        data.path = std::format("/pkg/{}/{}", t, version);
+        data.kind = "program";
+        data.bindingGroup = ref;
+    }
+    auto& root = db["gcc"].versions[std::string(version)];
+    root.bindingMembers = {{"gcc", std::string(version)},
+                           {"g++", std::string(version)}};
+    root.bindingMembersDeclared = true;
+    for (const auto& dir : sourceDirs) {
+        root.bindingHeaders.push_back({.sourceDir = dir});
+    }
+    root.bindingHeadersDeclared = !sourceDirs.empty();
+    // What attach_legacy_header_dir writes: the last declared directory only,
+    // kept so a downgrade to 0.4.69 still switches something.
+    if (!sourceDirs.empty()) root.includedir = sourceDirs.back();
+}
+
+}  // namespace
+
+TEST(XvmGroupHeaders, EveryDeclaredDirectoryIsSwitchedNotJustTheLast) {
+    xlings::xvm::VersionDB db;
+    multi_header_group_(db, "15.1.0",
+                        {"/pkg/gcc/15.1.0/include/c++/15.1.0",
+                         "/pkg/gcc/15.1.0/include-fixed"});
+    multi_header_group_(db, "16.1.0",
+                        {"/pkg/gcc/16.1.0/include/c++/16.1.0",
+                         "/pkg/gcc/16.1.0/include-fixed"});
+    const xlings::xvm::Workspace ws{{"gcc", "16.1.0"}, {"g++", "16.1.0"}};
+
+    auto plan = xlings::xvm::plan_use_switch(db, ws, "gcc", "15.1.0");
+    ASSERT_TRUE(plan.has_value()) << plan.error().what;
+
+    auto sources = [](const std::vector<xlings::xvm::HeaderAsset>& assets) {
+        std::set<std::string> out;
+        for (const auto& a : assets) out.insert(a.sourceDir);
+        return out;
+    };
+    EXPECT_EQ(sources(plan->removeHeaders),
+              (std::set<std::string>{"/pkg/gcc/16.1.0/include/c++/16.1.0",
+                                     "/pkg/gcc/16.1.0/include-fixed"}))
+        << "the outgoing release left header directories in the sysroot";
+    EXPECT_EQ(sources(plan->installHeaders),
+              (std::set<std::string>{"/pkg/gcc/15.1.0/include/c++/15.1.0",
+                                     "/pkg/gcc/15.1.0/include-fixed"}))
+        << "the incoming release did not bring all its headers in";
+}
+
+TEST(XvmGroupHeaders, TheSameAssetIsPlannedOncePerReleaseNotOncePerMember) {
+    xlings::xvm::VersionDB db;
+    multi_header_group_(db, "15.1.0", {"/pkg/gcc/15.1.0/include"});
+
+    auto plan = xlings::xvm::plan_use_switch(db, {}, "gcc", "15.1.0");
+    ASSERT_TRUE(plan.has_value()) << plan.error().what;
+
+    // gcc and g++ both resolve to the group's one declaration.
+    EXPECT_EQ(plan->installHeaders.size(), 1u);
+}
+
+// The reason headers are hoisted out of MemberSwitch. Applied per member, the
+// second member's removal of the outgoing release would delete links the
+// first member had just installed for the incoming one -- for every header
+// name the two versions share, which for two versions of one toolchain is all
+// of them.
+TEST(XvmGroupHeaders, AnAssetBothReleasesShareIsNeverRemoved) {
+    xlings::xvm::VersionDB db;
+    // A directory that does not move between the two releases: a vendored
+    // sysroot both of them link against.
+    multi_header_group_(db, "15.1.0",
+                        {"/pkg/gcc/15.1.0/include", "/shared/include"});
+    multi_header_group_(db, "16.1.0",
+                        {"/pkg/gcc/16.1.0/include", "/shared/include"});
+    const xlings::xvm::Workspace ws{{"gcc", "16.1.0"}, {"g++", "16.1.0"}};
+
+    auto plan = xlings::xvm::plan_use_switch(db, ws, "gcc", "15.1.0");
+    ASSERT_TRUE(plan.has_value()) << plan.error().what;
+
+    for (const auto& asset : plan->removeHeaders) {
+        EXPECT_NE(asset.sourceDir, "/shared/include")
+            << "an asset the incoming release also needs was taken out; "
+               "`use` would leave a window with the header missing";
+    }
+    EXPECT_EQ(plan->removeHeaders.size(), 1u);
+}
+
+TEST(XvmGroupHeaders, StateWithoutGroupHeadersStillUsesIncludedir) {
+    // 0.4.69 wrote no `bindingHeaders` at all. Its state has to keep
+    // switching headers after the upgrade -- the release notes promise there
+    // is no migration step.
+    xlings::xvm::VersionDB db;
+    auto& info = db["openssl"];
+    info.type = "lib";
+    auto& data = info.versions["3.1.5"];
+    data.path = "/pkg/openssl/3.1.5";
+    data.kind = "lib";
+    data.includedir = "/pkg/openssl/3.1.5/include";
+
+    const auto assets =
+        xlings::xvm::group_header_assets(db, "openssl", "3.1.5");
+    ASSERT_EQ(assets.size(), 1u);
+    EXPECT_EQ(assets[0].sourceDir, "/pkg/openssl/3.1.5/include");
+    EXPECT_TRUE(assets[0].destinationPrefix.empty());
+}
+
+TEST(XvmGroupHeaders, AMemberResolvesToTheGroupsDeclarationNotItsOwn) {
+    xlings::xvm::VersionDB db;
+    multi_header_group_(db, "15.1.0",
+                        {"/pkg/gcc/15.1.0/include", "/pkg/gcc/15.1.0/fixed"});
+    // g++ carries no headers of its own; before this it contributed nothing.
+    const auto fromMember =
+        xlings::xvm::group_header_assets(db, "g++", "15.1.0");
+    const auto fromRoot =
+        xlings::xvm::group_header_assets(db, "gcc", "15.1.0");
+    ASSERT_EQ(fromMember.size(), 2u);
+    ASSERT_EQ(fromRoot.size(), fromMember.size());
+    for (std::size_t i = 0; i < fromMember.size(); ++i) {
+        EXPECT_EQ(fromMember[i].sourceDir, fromRoot[i].sourceDir);
+        EXPECT_EQ(fromMember[i].destinationPrefix,
+                  fromRoot[i].destinationPrefix);
+    }
+}
+
+TEST(XvmGroupHeaders, AnUnknownEntryResolvesToNothing) {
+    xlings::xvm::VersionDB db;
+    multi_header_group_(db, "15.1.0", {"/pkg/gcc/15.1.0/include"});
+    EXPECT_TRUE(xlings::xvm::group_header_assets(db, "clang", "15.1.0").empty());
+    EXPECT_TRUE(xlings::xvm::group_header_assets(db, "gcc", "9.9.9").empty());
 }
 
 TEST(XvmSwitchPlan, EveryEntryPointYieldsTheSamePlan) {


### PR DESCRIPTION
Closes the second of the two gaps recorded during the PR #402 architecture review. Stacked on #405 conceptually but touches disjoint files.

## The problem

`bindingHeaders` records **every** header directory a release declares, on the group root. #384 serialized it, parsed it, validated it, and round-tripped it through the version database.

**Nothing ever read it.**

Materialization went through `VData::includedir` instead — a single string the installer writes on the root with *last-op-wins* semantics:

| | install | `xlings use` |
|---|---|---|
| release declares 1 header dir | materialized | switched |
| release declares 2 header dirs | **both** materialized | **only the last** switched |

So switching away left the other directories' headers in the sysroot, and switching in never brought the incoming release's copies. The sysroot ended up holding a mix of two releases — the exact state the binding-group work exists to make unrepresentable, reached through the header path rather than the member path.

## The fix

`xvm::group_header_assets(db, target, version)` resolves any member of a release to the group's declared list, falling back to `includedir` when there is none (0.4.69 state has no `bindingHeaders`; neither does a registration outside a provider group). The switch planner, the removal teardown and the removal fallback all go through it.

### Headers move from `MemberSwitch` to `UseSwitchPlan`

They belong to the release, not to any member of it. Per-member lists would be wrong twice:

1. Every member of a group resolves to the same declaration → the same directory linked once per member.
2. Worse — the loop applied them **one member at a time**. Member B's removal of the outgoing release could delete links member A had just installed for the incoming one, for every header name the two versions share. For two versions of one toolchain, that is all of them.

The plan now carries `removeHeaders` and `installHeaders` deduplicated and **disjoint**, and `cmd_use` applies all removals before any install. An asset both releases need is never removed at all — which matters because `use` re-materializes the active release on every call to repair a drifted sysroot, and remove-then-relink would open a missing-header window on every one of those calls.

### `destinationPrefix` is honored

`<sysroot>/include/<prefix>` rather than flattening into the include root, and an emptied prefix directory is cleaned up (via `remove`, so it cannot take a directory it does not own).

### `includedir` is still written

Now for exactly one reason: **0.4.69 switches headers by reading it** and knows nothing about `bindingHeaders`. Dropping it would make a downgrade silently stop moving headers, and the release notes promise the rollback is safe. It records only the last declared directory — which is the limitation 0.4.69 already had, so a downgrade gets the old behavior back, not a worse one.

## Reachability, stated plainly

**No recipe in the official index declares header directories at all**, and `xvm.setup` can only declare one per call — calling it twice is refused as a duplicate registration (correctly, by #384's registration layer). So the multiplicity this fixes is currently **unreachable through the public recipe API**.

It is still worth fixing: the field is persisted, validated and round-tripped today. Leaving it unconsumed is the next "written but never read" value, and the first recipe that needs two header directories would hit a silent half-switch instead of an error.

The E2E fixture pushes the second `headers` op onto `_XVM_OPS` directly to exercise the path.

## Verification

- 6 new unit cases (`XvmGroupHeaders`) + 2 for the destination prefix
- **E2E-32** extended: the fixture now ships `include/` **and** `include-fixed/`, both version-stamped, and every scenario asserts both moved
- Red-phase confirmed:
  - reverting the resolver fails 3 unit cases
  - and fails E2E-32 scenario 2 with `sysroot header is '1.0.0', expected '2.0.0'` — the workspace and `include-fixed/` on 2.0.0 while `include/` stayed on 1.0.0, i.e. the split this PR removes
- Regression: E2E xvm_group_switch / remove_multi_version / xpkg_snapshot_remove / subos_xpkg_install / install_idempotent all pass locally; 11 unit binaries green

## Also in this PR

Release-notes update covering **both** review findings (this one and #405's lock coverage), including the honest note about reachability above.