### PR TITLE
fix(xvm): let doctor repair a dangling legacy binding edge

### DIFF
--- a/.agents/docs/2026-07-26-release-0470-notes.md
+++ b/.agents/docs/2026-07-26-release-0470-notes.md
@@ -51,6 +51,7 @@
 | 失败时给出 code 与可执行 hint | 只有一句 `install failed` |
 | `self doctor` 能看见 binding 状态 | 只看 shim 和 payload |
 | `self doctor --fix` 可停用不一致的发布 | 无法处理 |
+| **`self doctor --fix` 可剪除悬空的 legacy binding 边** | 一条指向不存在版本的旧边会让整个发布拒绝切换，而 doctor 看不见、`--fix` 修不了，只能重装 |
 | **`type = "files"` 资产声明** | recipe 只能说"这个目录变成 sysroot 的 include"，别的都表达不了 —— 索引因此长出 7 种各自为政的写文件方式，其中 4 种 xlings 完全看不见 |
 
 ### 行为变化（可能被感知为倒退）
@@ -98,6 +99,18 @@
 | `use` 的文件系统副作用非事务 | 决策已与执行分离，失败不再半切换；但提交点之后的文件系统操作仍非原子 | 0.4.71 |
 | 无物化台账 | 无法识别 sysroot 中不属于任何包的文件 | 0.4.71 |
 | `profile rollback` 不覆盖 xvm 状态 | 回滚不会还原激活的工具链 | 0.4.71 |
+
+### 从 0.4.68/0.4.69 升级后如果某个 `use` 被拒绝
+
+先跑 **`xlings self doctor --fix`**。
+
+老版本写下的 binding 是"成对边"形式，其中可能有指向已不存在版本的悬空边 ——
+例如 `gcc@15.1.0` 指向只注册了 16.1.0 的 `xim-gnu-gcc`。0.4.70 的 fail-closed 解析
+会因此拒绝整个发布（`xvm-binding-version-missing`），而这在 0.4.68 上是能切的。
+
+这类边描述不出任何可切换的成员，只会造成拒绝，所以 `--fix` 直接剪除，不需要重装。
+在一台真实机器上剪除 20 条后 `xlings use gcc 15.1.0` 恢复可用，且 16.1.0
+仍然作为完整发布解析。
 
 **元数据损坏的自救方式**：`xlings self doctor` 会打印出错条目与精确到字段的 JSON Pointer
 （例如 `/bindingGroup/rootVersion`），据此手工编辑 `~/.xlings.json` 后即可恢复。

--- a/src/core/xself/doctor.cppm
+++ b/src/core/xself/doctor.cppm
@@ -401,6 +401,38 @@ export int cmd_doctor(EventStream& stream, bool fix) {
     // those means dropping stored metadata, which needs the user's explicit
     // consent rather than a flag they passed for shim repair.
     if (fix) {
+        // Dangling pairwise edges first: they are repairable without
+        // guessing, and leaving one in place keeps the release it names
+        // unresolvable, which would make the deactivation pass below see a
+        // problem that is really this one.
+        if (auto pruning = xvm::plan_dangling_edge_pruning(db);
+            !pruning.empty()) {
+            auto lock = xvm::acquire_state_lock(Config::paths().homeDir);
+            if (!lock) {
+                add_field("✗ binding state", std::format(
+                    "cannot drop dangling binding edges: {}", lock.error()));
+            } else {
+                Config::reload_state();
+                auto& mutableDb = Config::versions_mut();
+                const auto replanned =
+                    xvm::plan_dangling_edge_pruning(mutableDb);
+                const auto dropped =
+                    xvm::apply_dangling_edge_pruning(mutableDb, replanned);
+                if (dropped > 0) {
+                    Config::save_versions();
+                    healed += static_cast<int>(dropped);
+                    for (const auto& edge : replanned.edges) {
+                        add_field("· edge dropped", std::format(
+                            "{}@{} no longer points at unregistered {}@{}",
+                            edge.target, edge.version,
+                            edge.peerTarget, edge.peerVersion));
+                    }
+                    // The database changed underneath the findings above.
+                    db = Config::versions();
+                }
+            }
+        }
+
         auto plan = xvm::plan_incoherent_deactivation(db, ws);
         if (!plan.targets.empty()) {
             auto lock = xvm::acquire_state_lock(Config::paths().homeDir);

--- a/src/core/xvm/inspect.cppm
+++ b/src/core/xvm/inspect.cppm
@@ -106,6 +106,48 @@ std::vector<BindingFinding> inspect_binding_state(
         }
     }
 
+    // ── Dangling legacy edges ────────────────────────────────────────
+    //
+    // The INV-4 pass above only looks at entries that carry a
+    // `bindingGroup`. Everything written before 0.4.70 does not, so its
+    // pairwise edges were never checked -- and a pairwise edge pointing at a
+    // version that no longer exists makes the whole release unresolvable.
+    //
+    // This is not hypothetical. On a real installation `gcc@15.1.0` carries
+    // an edge to `xim-gnu-gcc@15.1.0`, an anchor that only exists at 16.1.0,
+    // so `xlings use gcc 15.1.0` -- which worked on 0.4.68 -- is refused with
+    // "a member of this release is registered at no such version". Nothing
+    // reported it and `--fix` could not repair it, leaving reinstall as the
+    // only way out. That is the upgrade being anything but seamless.
+    //
+    // An edge whose destination does not exist carries no information: it
+    // cannot name a member to switch, it can only cause a refusal. Reporting
+    // it separately from INV-4 keeps the remedy separate too -- this one is
+    // repairable without guessing, and INV-4's is not.
+    for (const auto& [target, info] : db) {
+        for (const auto& [peerTarget, edges] : info.bindings) {
+            auto peerIt = db.find(peerTarget);
+            for (const auto& [ownVersion, peerVersion] : edges) {
+                if (!info.versions.contains(ownVersion)) continue;
+                if (peerIt != db.end()
+                    && peerIt->second.versions.contains(peerVersion)) {
+                    continue;
+                }
+                findings.push_back({
+                    .code = "xvm-legacy-edge-dangling",
+                    .summary = std::format(
+                        "a binding edge points at '{}@{}', which is not "
+                        "registered", peerTarget, peerVersion),
+                    .target = target,
+                    .version = ownVersion,
+                    .field = std::format("/bindings/{}", peerTarget),
+                    .hint = "run `xlings self doctor --fix` to drop the edge; "
+                            "it names nothing and only blocks switching",
+                });
+            }
+        }
+    }
+
     // ── INV-2: an active release is active as a whole ────────────────
     std::set<std::string> reportedIncoherent;
     for (const auto& [target, version] : workspace) {
@@ -198,6 +240,67 @@ DeactivationPlan plan_incoherent_deactivation(const VersionDB& db,
         plan.targets.emplace(target, label);
     }
     return plan;
+}
+
+// Edges to drop: (owner target, owner version, peer target, peer version).
+struct DanglingEdgePruning {
+    struct Edge {
+        std::string target;
+        std::string version;
+        std::string peerTarget;
+        std::string peerVersion;
+    };
+    std::vector<Edge> edges;
+
+    [[nodiscard]] bool empty() const { return edges.empty(); }
+};
+
+// Collect every pairwise binding edge whose destination is not registered.
+//
+// Safe to apply without guessing, which is what separates it from the
+// incoherent-release case: the edge names a version that does not exist, so
+// it cannot be describing a member anyone could switch to. Keeping it only
+// makes `resolve_binding_selection` refuse the release.
+//
+// Pure: returns the plan, applies nothing.
+DanglingEdgePruning plan_dangling_edge_pruning(const VersionDB& db) {
+    DanglingEdgePruning plan;
+    for (const auto& [target, info] : db) {
+        for (const auto& [peerTarget, edges] : info.bindings) {
+            auto peerIt = db.find(peerTarget);
+            for (const auto& [ownVersion, peerVersion] : edges) {
+                if (!info.versions.contains(ownVersion)) continue;
+                if (peerIt != db.end()
+                    && peerIt->second.versions.contains(peerVersion)) {
+                    continue;
+                }
+                plan.edges.push_back({target, ownVersion,
+                                      peerTarget, peerVersion});
+            }
+        }
+    }
+    return plan;
+}
+
+// Apply the pruning. Returns how many edges were dropped.
+std::size_t apply_dangling_edge_pruning(VersionDB& db,
+                                        const DanglingEdgePruning& plan) {
+    std::size_t dropped = 0;
+    for (const auto& edge : plan.edges) {
+        auto infoIt = db.find(edge.target);
+        if (infoIt == db.end()) continue;
+        auto peerIt = infoIt->second.bindings.find(edge.peerTarget);
+        if (peerIt == infoIt->second.bindings.end()) continue;
+        auto versionIt = peerIt->second.find(edge.version);
+        if (versionIt == peerIt->second.end()) continue;
+        if (versionIt->second != edge.peerVersion) continue;
+        peerIt->second.erase(versionIt);
+        ++dropped;
+        if (peerIt->second.empty()) {
+            infoIt->second.bindings.erase(peerIt);
+        }
+    }
+    return dropped;
 }
 
 }  // namespace xlings::xvm

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -11692,6 +11692,127 @@ TEST(XvmDateVersioning, ADateVersionOutranksEverySemanticVersion) {
 }
 
 // ============================================================
+// Dangling legacy binding edges
+//
+// Found by finally running the real-toolchain check the plan had carried
+// since the start and never executed. On a real installation `gcc@15.1.0`
+// carries a pairwise edge to `xim-gnu-gcc@15.1.0`, an anchor registered only
+// at 16.1.0. `xlings use gcc 15.1.0` works on 0.4.68 and is refused on
+// 0.4.70 with "a member of this release is registered at no such version" --
+// and `doctor` did not report it, `--fix` could not repair it, so reinstall
+// was the only way out. For an upgrade sold as seamless, that is the
+// opposite.
+//
+// The edge names a version that does not exist, so it cannot describe a
+// member anyone could switch to. Dropping it is repair without guessing,
+// which is what separates it from an incoherent release.
+// ============================================================
+
+namespace {
+
+// gcc@15.1.0 bound to an anchor that only exists at 16.1.0 -- the shape
+// found on a real machine.
+xlings::xvm::VersionDB dangling_edge_db_() {
+    xlings::xvm::VersionDB db;
+    db["gcc"].type = "program";
+    db["gcc"].versions["15.1.0"].path = "/pkg/gcc/15.1.0/bin";
+    db["gcc"].versions["16.1.0"].path = "/pkg/gcc/16.1.0/bin";
+    db["xim-gnu-gcc"].type = "program";
+    db["xim-gnu-gcc"].versions["16.1.0"].path = "/pkg/gcc/16.1.0";
+    // Legacy pairwise edges, as registration writes them.
+    db["gcc"].bindings["xim-gnu-gcc"]["15.1.0"] = "15.1.0";   // dangling
+    db["gcc"].bindings["xim-gnu-gcc"]["16.1.0"] = "16.1.0";   // fine
+    db["xim-gnu-gcc"].bindings["gcc"]["16.1.0"] = "16.1.0";   // fine
+    return db;
+}
+
+}  // namespace
+
+TEST(XvmDanglingEdge, TheRefusalIsReproducedBeforeAnythingIsFixed) {
+    const auto db = dangling_edge_db_();
+    // This is the user-visible symptom: a version that resolved on 0.4.68.
+    auto plan = xlings::xvm::plan_use_switch(db, {}, "gcc", "15.1.0");
+    ASSERT_FALSE(plan.has_value())
+        << "the failing state under test no longer reproduces";
+    EXPECT_EQ(plan.error().code, "xvm-binding-version-missing");
+}
+
+TEST(XvmDanglingEdge, DoctorReportsIt) {
+    const auto db = dangling_edge_db_();
+    const auto findings = xlings::xvm::inspect_binding_state(db, {});
+
+    const auto it = std::ranges::find_if(findings, [](const auto& f) {
+        return f.code == "xvm-legacy-edge-dangling";
+    });
+    ASSERT_NE(it, findings.end())
+        << "a state that blocks `use` was invisible to doctor";
+    EXPECT_EQ(it->target, "gcc");
+    EXPECT_EQ(it->version, "15.1.0");
+    EXPECT_FALSE(it->hint.empty())
+        << "a finding the user cannot act on is not an improvement";
+}
+
+TEST(XvmDanglingEdge, PruningDropsOnlyTheEdgeThatNamesNothing) {
+    auto db = dangling_edge_db_();
+    const auto plan = xlings::xvm::plan_dangling_edge_pruning(db);
+    ASSERT_EQ(plan.edges.size(), 1u) << "healthy edges must not be touched";
+    EXPECT_EQ(plan.edges[0].target, "gcc");
+    EXPECT_EQ(plan.edges[0].version, "15.1.0");
+    EXPECT_EQ(plan.edges[0].peerTarget, "xim-gnu-gcc");
+    EXPECT_EQ(plan.edges[0].peerVersion, "15.1.0");
+
+    EXPECT_EQ(xlings::xvm::apply_dangling_edge_pruning(db, plan), 1u);
+    // The 16.1.0 edges survive in both directions.
+    EXPECT_EQ(db.at("gcc").bindings.at("xim-gnu-gcc").at("16.1.0"), "16.1.0");
+    EXPECT_EQ(db.at("xim-gnu-gcc").bindings.at("gcc").at("16.1.0"), "16.1.0");
+    EXPECT_FALSE(db.at("gcc").bindings.at("xim-gnu-gcc").contains("15.1.0"));
+}
+
+TEST(XvmDanglingEdge, AfterPruningTheSwitchWorksAgain) {
+    auto db = dangling_edge_db_();
+    xlings::xvm::apply_dangling_edge_pruning(
+        db, xlings::xvm::plan_dangling_edge_pruning(db));
+
+    auto plan = xlings::xvm::plan_use_switch(db, {}, "gcc", "15.1.0");
+    ASSERT_TRUE(plan.has_value()) << plan.error().what;
+    // gcc@15.1.0 stands alone once the edge to the missing anchor is gone --
+    // which is what 0.4.68 did, and what the user expects.
+    EXPECT_EQ(plan->members.size(), 1u);
+    EXPECT_EQ(plan->members.at("gcc"), "15.1.0");
+    // 16.1.0 still resolves as a release, so pruning did not flatten
+    // everything into standalone entries.
+    auto still = xlings::xvm::plan_use_switch(db, {}, "gcc", "16.1.0");
+    ASSERT_TRUE(still.has_value()) << still.error().what;
+    EXPECT_EQ(still->members.size(), 2u);
+}
+
+// An edge recorded under a version that is not registered either can never be
+// reached: resolution always starts from a real (target, version). Leaving it
+// alone keeps the repair to what is demonstrably harmful.
+TEST(XvmDanglingEdge, UnreachableEdgesAreLeftAlone) {
+    auto db = dangling_edge_db_();
+    db["gcc"].bindings["ghost"]["9.9.9"] = "9.9.9";  // owner version absent
+
+    const auto plan = xlings::xvm::plan_dangling_edge_pruning(db);
+    for (const auto& edge : plan.edges) {
+        EXPECT_NE(edge.version, "9.9.9")
+            << "pruned an edge no resolution can reach";
+    }
+}
+
+TEST(XvmDanglingEdge, AHealthyDatabaseYieldsNoPruning) {
+    xlings::xvm::VersionDB db;
+    db["gcc"].type = "program";
+    db["gcc"].versions["16.1.0"].path = "/pkg/gcc/16.1.0/bin";
+    db["g++"].type = "program";
+    db["g++"].versions["16.1.0"].path = "/pkg/gcc/16.1.0/bin";
+    db["gcc"].bindings["g++"]["16.1.0"] = "16.1.0";
+    db["g++"].bindings["gcc"]["16.1.0"] = "16.1.0";
+
+    EXPECT_TRUE(xlings::xvm::plan_dangling_edge_pruning(db).empty());
+}
+
+// ============================================================
 // State lock — install/remove/use must not overwrite each other
 
 namespace {


### PR DESCRIPTION
**发布阻塞项。** 补跑计划里一直有、却从未执行的 P4.2（真实工具链验证）时发现的。

## 症状：真实安装上的行为回退

用真实的 `~/.xlings.json`（246 targets / 372 条目）在隔离 HOME 里测：

```
0.4.68（已发布）   xlings use gcc 15.1.0  →  gcc -> 15.1.0        ✓
2026.7.27.0        xlings use gcc 15.1.0  →  拒绝
                     "a member of this release is registered at no such version"
                     nothing was changed
```

原因：`gcc@15.1.0` 带一条指向 `xim-gnu-gcc@15.1.0` 的 legacy 成对边，而这个锚点**只注册了 16.1.0**。

## 为什么之前没被发现

- `doctor` **报不出来** —— 它的 INV-4 检查**只看有 `bindingGroup` 的条目**，而 0.4.70 之前写的状态全都没有
- `--fix` **修不了**
- 提示是"重装这个包"，能解决但太重，而且没有任何东西把用户引到那里

**对一个宣称无感升级的版本，这是反面。**

## 修法

指向不存在版本的边**不携带任何信息** —— 它描述不出任何可切换的成员，只会造成拒绝。所以剪掉它是**不需要猜测的修复**，这正是它区别于"发布内部不一致"（`--fix` 刻意不碰那种）的地方。

doctor 现在报 `xvm-legacy-edge-dangling`，`--fix` 剪除，且**排在停用扫描之前** —— 否则那一遍会看到同一个问题换了个样子。

## 刻意保守

**拥有者版本本身也不存在的边，不动。** 解析永远从真实的 `(target, version)` 出发，这类边不可达、造不成本次要修的拒绝。同一台真实机器上是 32 条里的 12 条 —— 惰性垃圾，动它们属于清理而非修复。

## 实测（真实配置）

| | |
|---|---|
| 剪除边数 | **20 条**（434 → 414） |
| `use gcc 15.1.0` | ✅ **恢复可用** |
| gcc 16.1.0 | ✅ 仍解析为两成员的发布，没被压平成独立条目 |

## 测试

6 个新用例（`XvmDanglingEdge`），其中**一个先复现拒绝**，保证修复不是空过。458 测试 / 11 二进制全绿。
