### PR TITLE
fix(xim): let a declared file asset resolve as a filesystem effect (2026.7.27.2)

### DIFF
--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlings"
-version = "2026.7.27.1"
+version = "2026.7.27.2"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "2026.7.27.1";
+    static constexpr std::string_view VERSION = "2026.7.27.2";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -153,10 +153,20 @@ resolve_xpkg_filesystem_effect(
     const auto& data = versionIt->second;
     const auto kind =
         data.kind.empty() ? targetIt->second.type : data.kind;
+    // Three kinds, not two. This read `program` or else `lib`, which meant a
+    // FileAsset effect was compared against "lib" and could never match an
+    // entry registered as "files" -- so every declared file asset resolved to
+    // nullopt, the caller logged "validated xvm effect target disappeared or
+    // changed kind", and the FileAsset branch below was dead code. The assets
+    // still landed, because the activation pass places them separately, so
+    // the only visible symptom was a warning on a correct install. It stayed
+    // hidden until a real recipe declared one.
     const auto expectedKind =
         effect.kind == XpkgFilesystemEffectKind::ProgramShim
-        ? std::string_view{"program"}
-        : std::string_view{"lib"};
+            ? std::string_view{"program"}
+        : effect.kind == XpkgFilesystemEffectKind::FileAsset
+            ? std::string_view{"files"}
+            : std::string_view{"lib"};
     if (kind != expectedKind) return std::nullopt;
 
     resolved.path = data.path;

--- a/tests/unit/test_xvm_bindings.cpp
+++ b/tests/unit/test_xvm_bindings.cpp
@@ -7057,6 +7057,68 @@ TEST(XvmDbTest, BindingJsonRoundTrip) {
 
 
 // ============================================================
+// A declared file asset must resolve as an effect
+//
+// resolve_xpkg_filesystem_effect compared the entry's kind against exactly
+// two spellings -- "program" for a shim, "lib" for everything else -- so a
+// FileAsset effect was matched against "lib" and never resolved. Every
+// package declaring one logged "validated xvm effect target disappeared or
+// changed kind" on a perfectly correct install, and the FileAsset branch of
+// the caller, including its active gate, was unreachable.
+//
+// Only a real recipe declaring an asset surfaced it: the assets still land,
+// because the activation pass places them by a different route.
+// ============================================================
+
+TEST(XimXvmFileAssetEffect, ResolvesInsteadOfWarningAboutAChangedKind) {
+    xlings::xvm::VersionDB db;
+    auto& info = db["demo.files.1"];
+    info.type = "files";
+    auto& data = info.versions["1.0.0"];
+    data.kind = "files";
+    data.path = "/pkg/demo/1.0.0";
+    data.fileSrc = "include/demo.h";
+    data.fileDst = "usr/include/demo.h";
+    const xlings::xvm::Workspace workspace{{"demo.files.1", "1.0.0"}};
+
+    const xlings::xim::XpkgFilesystemEffect effect{
+        .kind = xlings::xim::XpkgFilesystemEffectKind::FileAsset,
+        .target = "demo.files.1",
+        .version = "1.0.0",
+    };
+
+    auto resolved =
+        xlings::xim::resolve_xpkg_filesystem_effect(db, workspace, effect);
+    ASSERT_TRUE(resolved.has_value())
+        << "a declared file asset did not resolve -- this is the warning on "
+           "an install that is actually fine";
+    EXPECT_EQ(resolved->kind,
+              xlings::xim::XpkgFilesystemEffectKind::FileAsset);
+    EXPECT_EQ(resolved->target, "demo.files.1");
+    // The active gate is what the caller reads to decide whether to place
+    // the asset; it was unreachable while this resolved to nullopt.
+    EXPECT_TRUE(resolved->active);
+}
+
+TEST(XimXvmFileAssetEffect, StillRefusesWhenTheEntryIsNotAFileAsset) {
+    // The kind check has to keep rejecting a mismatch; widening it to three
+    // spellings must not turn it into "anything goes".
+    xlings::xvm::VersionDB db;
+    db["demo.files.1"].type = "program";
+    db["demo.files.1"].versions["1.0.0"].kind = "program";
+    db["demo.files.1"].versions["1.0.0"].path = "/pkg/demo/1.0.0/bin";
+
+    const xlings::xim::XpkgFilesystemEffect effect{
+        .kind = xlings::xim::XpkgFilesystemEffectKind::FileAsset,
+        .target = "demo.files.1",
+        .version = "1.0.0",
+    };
+    EXPECT_FALSE(
+        xlings::xim::resolve_xpkg_filesystem_effect(db, {}, effect)
+            .has_value());
+}
+
+// ============================================================
 
 // The production-path test re-executes this binary; the child mode has to
 // live in the same translation unit as the function it calls.


### PR DESCRIPTION
**索引迁移的前置修复。** 迁移后的第一个真实 recipe 就把它照出来了。

## 症状

装一个声明了文件资产的包，安装完全正确，却报：

```
[warn] validated xvm effect target disappeared or changed kind: zlib.files.2@1.3.1
```

## 根因

`resolve_xpkg_filesystem_effect` 的 kind 比对只有**两种拼写**：

```cpp
const auto expectedKind =
    effect.kind == XpkgFilesystemEffectKind::ProgramShim
    ? std::string_view{"program"}
    : std::string_view{"lib"};        // ← FileAsset 落到这里
```

于是 `FileAsset` 效果被拿去和 `"lib"` 比，而条目登记的 kind 是 `"files"`，**永远不匹配** → 永远返回 `nullopt`。

两个后果：

1. 每个声明文件资产的包，在一次完全正确的安装上报一条假警告
2. 调用方的 `FileAsset` 分支 —— **连同那个决定"非激活版本的资产要不要进 sysroot"的 active 门禁** —— 是死代码

## 为什么 2026.7.27.0 带着它发出去了

资产**照样物化**，因为激活那一遍走的是另一条路径。所以唯一症状就是一条警告，而当时**索引里还没有任何 recipe 声明文件资产**。它只会在第一个真实迁移的 recipe 上现形。

这一条不是读代码看出来的，是在隔离 HOME 里装一个迁移后的 zlib 装出来的。

## 测试

两条：一条断言 FileAsset 效果**能**解析且 `active` 可读（此前不可达），一条断言把 kind 比对从两种放宽到三种**没有变成"什么都收"** —— 条目 kind 不是 `files` 时仍然拒绝。

全量 22 个测试目标通过。真实包复验：迁移后的 zlib 安装，**无警告**。