### PR TITLE
feat(xvm): tell sysroot entries xlings placed from ones it merely found

### DIFF
--- a/src/core/xself/doctor.cppm
+++ b/src/core/xself/doctor.cppm
@@ -381,7 +381,39 @@ export int cmd_doctor(EventStream& stream, bool fix,
     // Read-only for now: reporting is what removes the dead end. Repair
     // lands separately, because deactivating a group or dropping metadata
     // is a decision the user should see spelled out before it happens.
-    const auto bindingFindings = xvm::inspect_binding_state(db, ws);
+    auto bindingFindings = xvm::inspect_binding_state(db, ws);
+
+    // Sysroot ownership. Reported only for destinations a package declares,
+    // not for the whole tree: the subos carries the host image, so listing
+    // every unmanaged entry would bury the two or three that matter under
+    // hundreds that are simply not ours to manage. Drift on a declared
+    // destination is the actionable case, and that is what this finds.
+    {
+        std::vector<xvm::SysrootEntry> entries;
+        for (const auto& [target, version] : ws) {
+            auto infoIt = db.find(target);
+            if (infoIt == db.end()) continue;
+            auto dataIt = infoIt->second.versions.find(version);
+            if (dataIt == infoIt->second.versions.end()) continue;
+            const auto& dst = dataIt->second.fileDst;
+            if (dst.empty()) continue;
+            const auto abs = p.subosDir / dst;
+            std::error_code ec;
+            if (!fs::exists(abs, ec) && !fs::is_symlink(abs, ec)) continue;
+            xvm::SysrootEntry entry{.path = dst};
+            if (fs::is_symlink(abs, ec)) {
+                entry.linkTarget = fs::read_symlink(abs, ec).string();
+                if (ec) entry.linkTarget.clear();
+            }
+            entries.push_back(std::move(entry));
+        }
+        auto ownership = xvm::inspect_sysroot_ownership(
+            db, ws, entries, (p.dataDir / "xpkgs").string());
+        bindingFindings.insert(bindingFindings.end(),
+                               std::make_move_iterator(ownership.begin()),
+                               std::make_move_iterator(ownership.end()));
+    }
+
     for (const auto& finding : bindingFindings) {
         const bool notice =
             finding.severity == xvm::BindingSeverity::Notice;

--- a/src/core/xvm/inspect.cppm
+++ b/src/core/xvm/inspect.cppm
@@ -278,6 +278,89 @@ std::vector<BindingFinding> inspect_binding_state(
     return findings;
 }
 
+// One entry found in the subos, as the caller read it off disk.
+struct SysrootEntry {
+    // Relative to the subos root, e.g. "usr/include/openssl".
+    std::string path;
+    // Where the symlink points, absolute. Empty when the entry is a real
+    // file or directory rather than a link.
+    std::string linkTarget;
+};
+
+// Which sysroot entries xlings put there, and which it merely found.
+//
+// The 0.4.70 design calls for a persisted ledger, and also says why one is
+// not required to answer this question: "ledger 是派生数据（可由扫描 +
+// Selection 重建），存盘只是为了避免每次全量扫描 sysroot". The saved copy is
+// an optimisation for the reconciler, and the reconciler does not exist yet.
+// Deriving the answer instead means there is no second record that can drift
+// from the filesystem -- which, for a question that is *about* whether the
+// filesystem matches the records, would be the wrong kind of state to add.
+//
+// The rule is decidable from one readlink: everything xlings materializes is
+// a link into the payload store -- declared file assets, libraries and the
+// header farm alike. So an entry that is not such a link is not ours.
+//
+// Pure over (db, workspace, entries), like the rest of this module: the
+// caller does the reading, every case below is reachable from a unit test.
+std::vector<BindingFinding> inspect_sysroot_ownership(
+        const VersionDB& db,
+        const Workspace& workspace,
+        const std::vector<SysrootEntry>& entries,
+        std::string_view payloadRoot) {
+    std::vector<BindingFinding> findings;
+    if (payloadRoot.empty()) return findings;
+
+    // Destinations the active selection says should be ours.
+    std::map<std::string, std::pair<std::string, std::string>> claimed;
+    for (const auto& [target, version] : workspace) {
+        auto infoIt = db.find(target);
+        if (infoIt == db.end()) continue;
+        auto dataIt = infoIt->second.versions.find(version);
+        if (dataIt == infoIt->second.versions.end()) continue;
+        if (!dataIt->second.fileDst.empty()) {
+            claimed.emplace(dataIt->second.fileDst,
+                            std::pair{target, version});
+        }
+    }
+
+    for (const auto& entry : entries) {
+        const bool ours = !entry.linkTarget.empty()
+            && std::string_view{entry.linkTarget}.starts_with(payloadRoot);
+        if (ours) continue;
+
+        if (auto it = claimed.find(entry.path); it != claimed.end()) {
+            // Declared, but what is on disk is not the link we would have
+            // made. Something replaced it after the fact.
+            findings.push_back({
+                .code = "xvm-sysroot-drift",
+                .summary = std::format(
+                    "'{}' is declared by {}@{} but is not the link xlings "
+                    "placed", entry.path, it->second.first,
+                    it->second.second),
+                .target = it->second.first,
+                .version = it->second.second,
+                .hint = std::format(
+                    "run `xlings use {} {}` to put it back",
+                    it->second.first, it->second.second),
+            });
+            continue;
+        }
+
+        // Nothing claims it. Could be the host image, could be a package
+        // that placed it by hand and is now gone -- either way xlings will
+        // not move it on a version switch, and cannot remove it.
+        findings.push_back({
+            .code = "xvm-sysroot-unmanaged",
+            .summary = std::format(
+                "'{}' is in the subos but no package declares it", entry.path),
+            .hint = "left as-is; xlings only moves what a package declares",
+            .severity = BindingSeverity::Notice,
+        });
+    }
+    return findings;
+}
+
 struct DeactivationPlan {
     // Targets to drop from the active workspace, and the release each
     // belonged to, so the caller can tell the user what to re-select.

--- a/tests/unit/test_xvm_doctor.cpp
+++ b/tests/unit/test_xvm_doctor.cpp
@@ -672,3 +672,93 @@ TEST(LegacyHeaderDir, IgnoresNonHeaderEffects) {
     EXPECT_EQ(xlings::xim::attach_legacy_header_dir(db, "gcc", "15.1.0", effects), 0u);
     EXPECT_TRUE(db.at("gcc").versions.at("15.1.0").includedir.empty());
 }
+
+// ============================================================
+// Sysroot ownership: what xlings put there vs what it found
+//
+// Derived rather than recorded. The 0.4.70 design asks for a persisted
+// ledger and in the same breath says it is derived data, kept only so the
+// reconciler can skip a full scan -- and there is no reconciler yet. For a
+// question that is *about* whether the filesystem matches the records, a
+// second record that can drift from both is the wrong thing to add.
+// ============================================================
+
+namespace {
+
+constexpr std::string_view kPayloadRoot = "/home/u/.xlings/data/xpkgs";
+
+xlings::xvm::VersionDB owned_db_() {
+    xlings::xvm::VersionDB db;
+    auto& files = db["demo.files.1"];
+    files.type = "files";
+    auto& data = files.versions["1.0.0"];
+    data.kind = "files";
+    data.path = "/home/u/.xlings/data/xpkgs/xim-x-demo/1.0.0";
+    data.fileSrc = "include/demo.h";
+    data.fileDst = "usr/include/demo.h";
+    return db;
+}
+
+}  // namespace
+
+TEST(XvmSysrootOwnership, ALinkIntoThePayloadStoreIsOurs) {
+    const std::vector<xlings::xvm::SysrootEntry> entries{
+        {.path = "usr/include/demo.h",
+         .linkTarget = "/home/u/.xlings/data/xpkgs/xim-x-demo/1.0.0/include/demo.h"},
+    };
+    const auto findings = xlings::xvm::inspect_sysroot_ownership(
+        owned_db_(), {{"demo.files.1", "1.0.0"}}, entries, kPayloadRoot);
+    EXPECT_TRUE(findings.empty())
+        << "a materialized asset was reported as someone else's";
+}
+
+TEST(XvmSysrootOwnership, ARealFileWhereALinkWasDeclaredIsDrift) {
+    // Declared, but what is on disk is not our link -- something replaced it.
+    const std::vector<xlings::xvm::SysrootEntry> entries{
+        {.path = "usr/include/demo.h", .linkTarget = ""},
+    };
+    const auto findings = xlings::xvm::inspect_sysroot_ownership(
+        owned_db_(), {{"demo.files.1", "1.0.0"}}, entries, kPayloadRoot);
+    ASSERT_EQ(findings.size(), 1u);
+    EXPECT_EQ(findings[0].code, "xvm-sysroot-drift");
+    // Drift is actionable and current, so it is not a mere notice.
+    EXPECT_EQ(findings[0].severity, xlings::xvm::BindingSeverity::Broken);
+    EXPECT_NE(findings[0].hint.find("xlings use demo.files.1"),
+              std::string::npos);
+}
+
+TEST(XvmSysrootOwnership, AnUnclaimedEntryIsANoticeNotABreak) {
+    const std::vector<xlings::xvm::SysrootEntry> entries{
+        {.path = "usr/include/stdio.h", .linkTarget = ""},
+    };
+    const auto findings = xlings::xvm::inspect_sysroot_ownership(
+        owned_db_(), {}, entries, kPayloadRoot);
+    ASSERT_EQ(findings.size(), 1u);
+    EXPECT_EQ(findings[0].code, "xvm-sysroot-unmanaged");
+    // The host image accounts for most of these. Counting them broken would
+    // paint every installation red.
+    EXPECT_EQ(findings[0].severity, xlings::xvm::BindingSeverity::Notice);
+}
+
+TEST(XvmSysrootOwnership, ALinkPointingOutsideTheStoreIsNotOurs) {
+    // Same shape as ours, different destination -- e.g. a hand-made alias.
+    const std::vector<xlings::xvm::SysrootEntry> entries{
+        {.path = "etc/ssl/cert.pem", .linkTarget = "/etc/ssl/certs/ca.crt"},
+    };
+    const auto findings = xlings::xvm::inspect_sysroot_ownership(
+        owned_db_(), {}, entries, kPayloadRoot);
+    ASSERT_EQ(findings.size(), 1u);
+    EXPECT_EQ(findings[0].code, "xvm-sysroot-unmanaged");
+}
+
+TEST(XvmSysrootOwnership, AnInactiveVersionDoesNotClaimTheDestination) {
+    // Only the active selection can be drifting: an inactive version's
+    // assets are not supposed to be materialized at all.
+    const std::vector<xlings::xvm::SysrootEntry> entries{
+        {.path = "usr/include/demo.h", .linkTarget = ""},
+    };
+    const auto findings = xlings::xvm::inspect_sysroot_ownership(
+        owned_db_(), {}, entries, kPayloadRoot);
+    ASSERT_EQ(findings.size(), 1u);
+    EXPECT_EQ(findings[0].code, "xvm-sysroot-unmanaged");
+}


### PR DESCRIPTION
doctor 能说"这个版本的 sysroot 文件早于跟踪机制"，但说不出**现在盘上的东西是不是 xlings 放的那个链接**。一个被别的东西覆盖掉的声明式资产，看起来和健康的一模一样。

## 没有引入 ledger，是推导出来的

0.4.70 的设计要求一个持久化 ledger，**同一段里就写着**它是派生数据、存盘只为让 reconciler 跳过全量扫描 —— 而 reconciler 还不存在。

对一个**本身就是在问"文件系统和记录对不对得上"**的问题，再加一份会同时和两边漂移的记录，是错误的状态。

判定只需要一次 readlink：xlings 物化的一切（声明式资产、库、头文件农场）都是**指向 payload 库的链接**，所以不是这种链接的条目就不是我们的。

## 两类发现

| code | 含义 | 级别 |
|---|---|---|
| `xvm-sysroot-drift` | 声明过的目标，但盘上不是我们的链接 | **Broken** —— 可操作 |
| `xvm-sysroot-unmanaged` | 没有包声明它 | Notice —— subos 带着 host 镜像，绝大多数本来就不归我们管 |

doctor **只检查被声明过的目标**，不遍历整棵树：否则那两三条值得看的会被几百条本来就没问题的埋掉。

## 测试

纯函数（db, workspace, entries），与 inspect.cppm 其余部分一致 —— 文件系统由调用方读，5 个用例全部可单测。22 个测试目标全绿。