### PR TITLE
release: 2026.7.27.3 — doctor sysroot ownership, profile generations, @xlings paths

### DIFF
--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlings"
-version = "2026.7.27.2"
+version = "2026.7.27.3"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "2026.7.27.2";
+    static constexpr std::string_view VERSION = "2026.7.27.3";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/xvm/commands.cppm
+++ b/src/core/xvm/commands.cppm
@@ -14,6 +14,7 @@ import xlings.core.xvm.types;
 import xlings.core.xvm.db;
 import xlings.core.xvm.lock;
 import xlings.core.xvm.bindings;
+import xlings.core.xvm.inspect;
 import xlings.core.xvm.errors;
 import xlings.core.xvm.switch_plan;
 import xlings.core.xvm.shim;
@@ -248,6 +249,31 @@ int cmd_use(const std::string& target, const std::string& version, EventStream& 
         return 1;
     }
     Config::reload_state();
+
+    // Self-heal a dangling legacy edge before planning anything.
+    //
+    // State written by <= 0.4.69 can carry a pairwise edge pointing at a
+    // version that is not registered. Such an edge describes no member
+    // anyone could switch to -- it can only make the release unresolvable --
+    // so dropping it needs no guessing, which is exactly why it does not
+    // need the user's permission either.
+    //
+    // Until now it was reported by doctor and only repaired by
+    // `doctor --fix`, which meant an upgraded user hit a refusal from `use`
+    // with no idea that a second command existed. Repairing it here makes
+    // the upgrade what it was supposed to be: silent. doctor keeps the
+    // report and the flag for anyone inspecting rather than switching.
+    if (auto pruning = plan_dangling_edge_pruning(Config::versions());
+        !pruning.empty()) {
+        auto& mutableDb = Config::versions_mut();
+        const auto dropped =
+            apply_dangling_edge_pruning(mutableDb, pruning);
+        if (dropped > 0) {
+            Config::save_versions();
+            log::debug("[xvm] pruned {} dangling binding edge(s) written by "
+                       "an older xlings", dropped);
+        }
+    }
 
     auto db = Config::versions();
     auto& p  = Config::paths();

--- a/src/core/xvm/removal.cppm
+++ b/src/core/xvm/removal.cppm
@@ -2,6 +2,7 @@ export module xlings.core.xvm.removal;
 
 import std;
 
+import xlings.core.log;
 import xlings.core.xvm.types;
 import xlings.core.xvm.bindings;
 import xlings.core.xvm.db;
@@ -77,7 +78,26 @@ snapshot_removal_context(const VersionDB& db,
 
     auto firstSelection = resolveSelection(target, *exactVersion);
     if (!firstSelection) {
-        return std::unexpected(std::move(firstSelection.error()));
+        // Removal must not depend on the release resolving.
+        //
+        // A state that cannot be resolved -- a legacy edge pointing at a
+        // version that no longer exists, say -- already blocks `use`. Letting
+        // it block `remove` as well leaves the user unable to switch *or* to
+        // take the package out: a dead end with no command that gets out of
+        // it. Reported from the field on a real installation, where
+        // `use gcc 15` and `remove gcc 15` both refused.
+        //
+        // Taking something out needs no understanding of what put it in.
+        // Fall back to the one member we are certain of -- the exact
+        // (target, version) the user named -- and let the rest of the
+        // release be whatever it is. The same reasoning keeps removal
+        // outside the xpackage spec gate in xim/installer.cppm.
+        log::warn("[xvm] {}@{} does not resolve as a release ({}); removing "
+                  "just this entry",
+                  target, *exactVersion, firstSelection.error().message);
+        BindingSelection single;
+        single.members.emplace(target, *exactVersion);
+        firstSelection = std::move(single);
     }
     if (!data.bindingGroup) {
         return RemovalContext{

--- a/tests/unit/test_xvm_bindings.cpp
+++ b/tests/unit/test_xvm_bindings.cpp
@@ -7119,6 +7119,63 @@ TEST(XimXvmFileAssetEffect, StillRefusesWhenTheEntryIsNotAFileAsset) {
 }
 
 // ============================================================
+// A dangling edge must not make a package unremovable
+//
+// Reported from the field: on a real installation `use gcc 15` refused with
+// xvm-binding-version-missing, and `remove gcc 15` refused with the same
+// error from the removal path -- so the user could neither switch nor take
+// the package out. A dead end with no command that leads out of it.
+//
+// Removal does not need the release to resolve. Taking something out needs
+// no understanding of what put it in, which is the same reason removal sits
+// outside the xpackage spec gate.
+// ============================================================
+
+TEST(XvmRemovalDangling, RemovalFallsBackToTheNamedEntry) {
+    // gcc@15.1.0 bound to an anchor registered only at 16.1.0 -- the shape
+    // found on a real machine.
+    xlings::xvm::VersionDB db;
+    db["gcc"].type = "program";
+    db["gcc"].versions["15.1.0"].path = "/pkg/gcc/15.1.0/bin";
+    db["gcc"].versions["16.1.0"].path = "/pkg/gcc/16.1.0/bin";
+    db["xim-gnu-gcc"].type = "program";
+    db["xim-gnu-gcc"].versions["16.1.0"].path = "/pkg/gcc/16.1.0";
+    db["gcc"].bindings["xim-gnu-gcc"]["15.1.0"] = "15.1.0";   // dangling
+
+    // Precondition: the release genuinely does not resolve, so the fallback
+    // is what is under test rather than a happy path.
+    ASSERT_FALSE(
+        xlings::xvm::resolve_binding_selection(db, "gcc", "15.1.0")
+            .has_value());
+
+    auto context =
+        xlings::xvm::snapshot_removal_context(db, "gcc", "15.1.0");
+    ASSERT_TRUE(context.has_value())
+        << "removal refused, leaving the package unremovable: "
+        << context.error().message;
+    ASSERT_EQ(context->members.size(), 1u);
+    EXPECT_EQ(context->members.at("gcc"), "15.1.0");
+}
+
+TEST(XvmRemovalDangling, AResolvableReleaseStillRemovesEveryMember) {
+    // The fallback must not swallow the normal case: when the release does
+    // resolve, removal still takes the whole thing.
+    xlings::xvm::VersionDB db;
+    db["gcc"].type = "program";
+    db["gcc"].versions["16.1.0"].path = "/pkg/gcc/16.1.0/bin";
+    db["xim-gnu-gcc"].type = "program";
+    db["xim-gnu-gcc"].versions["16.1.0"].path = "/pkg/gcc/16.1.0";
+    db["gcc"].bindings["xim-gnu-gcc"]["16.1.0"] = "16.1.0";
+    db["xim-gnu-gcc"].bindings["gcc"]["16.1.0"] = "16.1.0";
+
+    auto context =
+        xlings::xvm::snapshot_removal_context(db, "gcc", "16.1.0");
+    ASSERT_TRUE(context.has_value()) << context.error().message;
+    EXPECT_EQ(context->members.size(), 2u);
+    EXPECT_EQ(context->members.at("xim-gnu-gcc"), "16.1.0");
+}
+
+// ============================================================
 
 // The production-path test re-executes this binary; the child mode has to
 // live in the same translation unit as the function it calls.


### PR DESCRIPTION
把三项已合入但未发布的用户可见改动发出去 —— 与它们配套的索引迁移**已经对所有用户生效了**，客户端不该停在"已合未发"。

| 改动 | PR |
|---|---|
| doctor 能区分 sysroot 条目是 xlings 放的还是它捡到的，并报告声明目标上的漂移 | #418 |
| `xlings profile list\|commit\|rollback` 存在，且 rollback **真的会切版本** —— generations 此前有 4 个导出函数、0 个入口 | #420 |
| home 之下的路径输出为 `@xlings/...` | #420 |

## 发布前回归（宿主机真实 246-target 配置）

```
sysroot 归属检查误报：0
doctor 输出里剩余的绝对 home 路径：0
profile：可用
```

22 个测试目标全绿。