### PR TITLE
fix(cli): stop the upgrade path from reporting success it did not have

### DIFF
--- a/src/core/xself/update.cppm
+++ b/src/core/xself/update.cppm
@@ -23,9 +23,27 @@ export int cmd_update() {
     log::info("installing xlings@latest...");
     rc = platform::exec("xlings install xlings@latest -y");
     if (rc != 0) {
-        log::warn("xlings package not available or install failed, skipping");
-    } else {
-        platform::exec("xlings use xlings latest");
+        // This used to warn and return 0. A failed upgrade then looked
+        // exactly like a successful one: the install error scrolled past
+        // under the progress bar, `self update` exited 0, and the user went
+        // on running the old binary believing they were current. Observed
+        // for real -- 0.4.69 against a CN mirror that had not been topped up
+        // yet answered 404, and the command still reported success.
+        //
+        // Whichever way it failed -- absent from the index, download error,
+        // hook failure -- the user asked to be upgraded and was not, so say
+        // so and exit non-zero.
+        log::error("could not install xlings@latest — you are still on the "
+                   "current version");
+        log::error("  hint: run `xlings install xlings@latest -y` to see why");
+        return rc;
+    }
+
+    rc = platform::exec("xlings use xlings latest");
+    if (rc != 0) {
+        log::error("installed xlings@latest but could not activate it");
+        log::error("  hint: run `xlings use xlings latest` to see why");
+        return rc;
     }
 
     return 0;

--- a/src/ui/banner.cppm
+++ b/src/ui/banner.cppm
@@ -21,7 +21,7 @@ std::string pad_to(std::string s, std::size_t width) {
 void render_rows_(ftxui::Elements rows) {
     using namespace ftxui;
     auto doc = vbox(std::move(rows));
-    auto screen = Screen::Create(Dimension::Full(), Dimension::Fit(doc));
+    auto screen = Screen::Create(Dimension::Full(), theme::fit_full_height(doc));
     Render(screen, doc);
     screen.Print();
     std::println("");
@@ -218,7 +218,7 @@ void print_tip(std::string_view message) {
         text("  " + std::string(theme::icon::info) + " ") | color(theme::cyan()),
         text(std::string(message)) | color(theme::dim_color()),
     });
-    auto screen = Screen::Create(Dimension::Full(), Dimension::Fit(doc));
+    auto screen = Screen::Create(Dimension::Full(), theme::fit_full_height(doc));
     Render(screen, doc);
     screen.Print();
     std::println("");
@@ -231,7 +231,7 @@ void print_usage(std::string_view usage) {
         text("  Usage: ") | color(theme::dim_color()),
         text(std::string(usage)) | color(theme::text_color()),
     });
-    auto screen = Screen::Create(Dimension::Full(), Dimension::Fit(doc));
+    auto screen = Screen::Create(Dimension::Full(), theme::fit_full_height(doc));
     Render(screen, doc);
     screen.Print();
     std::println("");

--- a/src/ui/info_panel.cppm
+++ b/src/ui/info_panel.cppm
@@ -79,7 +79,8 @@ void print_info_panel(std::string_view title,
     auto doc = vbox(std::move(rows));
     auto termDim = Dimension::Full();
     int width = std::max(termDim.dimx, minWidth);
-    auto screen = Screen::Create(Dimension::Fixed(width), Dimension::Fit(doc));
+    auto screen = Screen::Create(Dimension::Fixed(width),
+                                 theme::fit_full_height(doc));
     Render(screen, doc);
     screen.Print();
     std::println("");
@@ -120,7 +121,7 @@ void print_styled_list(std::string_view title,
     rows.push_back(text(""));
 
     auto doc = vbox(std::move(rows));
-    auto screen = Screen::Create(Dimension::Full(), Dimension::Fit(doc));
+    auto screen = Screen::Create(Dimension::Full(), theme::fit_full_height(doc));
     Render(screen, doc);
     screen.Print();
     std::println("");
@@ -140,6 +141,10 @@ void print_install_plan(std::span<const std::pair<std::string, std::string>> pac
     }));
     header.push_back(text(""));
 
+    // NOT fit_full_height: these lines are overwritten in place by the
+    // download progress renderer, which counts the rows it has to move the
+    // cursor back over. Printing more rows than the screen holds would put
+    // the cursor arithmetic and the visible output out of step.
     auto headerDoc = vbox(std::move(header));
     auto headerScreen = Screen::Create(Dimension::Full(), Dimension::Fit(headerDoc));
     Render(headerScreen, headerDoc);
@@ -190,7 +195,7 @@ void print_subos_list(
     rows.push_back(text(""));
 
     auto doc = vbox(std::move(rows));
-    auto screen = Screen::Create(Dimension::Full(), Dimension::Fit(doc));
+    auto screen = Screen::Create(Dimension::Full(), theme::fit_full_height(doc));
     Render(screen, doc);
     screen.Print();
     std::println("");
@@ -294,7 +299,7 @@ void print_install_summary(int success, int failed) {
     rows.push_back(text(""));
 
     auto doc = vbox(std::move(rows));
-    auto screen = Screen::Create(Dimension::Full(), Dimension::Fit(doc));
+    auto screen = Screen::Create(Dimension::Full(), theme::fit_full_height(doc));
     Render(screen, doc);
     screen.Print();
     std::println("");
@@ -330,7 +335,7 @@ void print_remove_plan(const std::string& subos,
     rows.push_back(text(""));
 
     auto doc = vbox(std::move(rows));
-    auto screen = Screen::Create(Dimension::Full(), Dimension::Fit(doc));
+    auto screen = Screen::Create(Dimension::Full(), theme::fit_full_height(doc));
     Render(screen, doc);
     screen.Print();
 }
@@ -355,7 +360,7 @@ void print_remove_summary(const std::string& subos,
     rows.push_back(text(""));
 
     auto doc = vbox(std::move(rows));
-    auto screen = Screen::Create(Dimension::Full(), Dimension::Fit(doc));
+    auto screen = Screen::Create(Dimension::Full(), theme::fit_full_height(doc));
     Render(screen, doc);
     screen.Print();
     std::println("");

--- a/src/ui/table.cppm
+++ b/src/ui/table.cppm
@@ -31,7 +31,7 @@ void print_table(std::span<const std::string> headers,
     table.SelectRow(0).BorderBottom(LIGHT);
 
     auto doc = table.Render();
-    auto screen = Screen::Create(Dimension::Full(), Dimension::Fit(doc));
+    auto screen = Screen::Create(Dimension::Full(), theme::fit_full_height(doc));
     Render(screen, doc);
     screen.Print();
     std::println("");
@@ -63,7 +63,7 @@ void print_search_results(
     }
 
     auto doc = table.Render();
-    auto screen = Screen::Create(Dimension::Full(), Dimension::Fit(doc));
+    auto screen = Screen::Create(Dimension::Full(), theme::fit_full_height(doc));
     Render(screen, doc);
     screen.Print();
     std::println("");

--- a/src/ui/theme.cppm
+++ b/src/ui/theme.cppm
@@ -175,4 +175,20 @@ namespace icon {
     inline constexpr auto package     = "\xe2\x97\x86";   // ◆ U+25C6
 } // namespace icon
 
+// Height for a document we intend to print in full.
+//
+// ftxui's Dimension::Fit(doc) takes extend_beyond_screen = false by default,
+// which clamps the fitted height to the terminal's. When stdout is not a tty
+// ftxui reports a default 80x24, so every row past 24 was dropped -- silently,
+// with no marker. `xlings list` on a home with 246 targets printed 25 lines;
+// `self doctor` printed its findings and lost the summary underneath them,
+// which is the one line saying how bad it is.
+//
+// A report is not a viewport. Print all of it and let the terminal scroll.
+// The redraw-in-place progress bars in :progress deliberately do NOT use this
+// -- they overwrite a known number of lines and must stay inside the screen.
+inline ftxui::Dimensions fit_full_height(ftxui::Element& doc) {
+    return ftxui::Dimension::Fit(doc, /*extend_beyond_screen=*/true);
+}
+
 } // namespace xlings::ui::theme

--- a/tests/e2e/run_all.sh
+++ b/tests/e2e/run_all.sh
@@ -87,6 +87,7 @@ TESTS=(
     "E2E-35 |xpkg_spec_gate_test.sh||"
     "E2E-36 |xvm_metadata_reset_test.sh||"
     "E2E-37 |xvm_files_probe_compat_test.sh||"
+    "E2E-38 |self_update_failure_test.sh||"
 )
 
 PASS=0; FAIL=0; SOFTFAIL=0

--- a/tests/e2e/self_doctor_test.sh
+++ b/tests/e2e/self_doctor_test.sh
@@ -315,4 +315,36 @@ vers = (data.get("versions") or {}).get("alias-fixture", {}).get("versions", {})
 assert "1.0.0" in vers, "S10: alias-fixture@1.0.0 should remain registered (warning is non-actionable)"
 PY
 
-log "PASS: self doctor scenarios 1-10 (S8 split into S8 fix-noop + alias S9/S10)"
+# ── S12: a long report prints in full ──────────────────────────────
+# Regression: the panel renderer asked ftxui for Dimension::Fit(doc), whose
+# extend_beyond_screen parameter defaults to false -- the fitted height gets
+# clamped to the terminal's, and with stdout on a pipe ftxui reports a
+# default 80x24. Every row past 24 was dropped with no marker. Findings
+# print first and the totals last, so what got cut was exactly the summary
+# telling the user how bad it is.
+log "S12: report longer than a screen prints past row 24, summary included"
+python3 - "$HOME_DIR" <<'PY'
+import json, pathlib, sys
+home = sys.argv[1]
+p = pathlib.Path(home, ".xlings.json")
+data = json.loads(p.read_text())
+versions = data.setdefault("versions", {})
+# 30 registered versions whose payload directory does not exist -> 30
+# `broken payload` findings, comfortably past the old 24-row ceiling.
+entry = versions.setdefault("bulk-fixture", {"type": "program", "versions": {}})
+for i in range(30):
+    entry["versions"][f"1.0.{i}"] = {
+        "path": f"{home}/data/xpkgs/xim-x-bulk-fixture/1.0.{i}/bin",
+    }
+p.write_text(json.dumps(data))
+PY
+
+rc=0
+out=$(RUN self doctor 2>&1) || rc=$?
+lines=$(printf '%s\n' "$out" | wc -l)
+[[ $lines -gt 24 ]] \
+  || fail "S12: report was clamped to a screen — got $lines lines, expected > 24"
+printf '%s\n' "$out" | grep -q "broken payloads" \
+  || fail "S12: the summary line must survive a long report; got $lines lines:\n$out"
+
+log "PASS: self doctor scenarios 1-10 + S12 (long report not clamped)"

--- a/tests/e2e/self_update_failure_test.sh
+++ b/tests/e2e/self_update_failure_test.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# E2E: `xlings self update` must fail loudly when the upgrade does not happen.
+#
+# Regression. cmd_update used to run `xlings install xlings@latest -y`, and on
+# a non-zero exit log a *warning* and `return 0`. A failed upgrade was then
+# indistinguishable from a successful one: the install error scrolled past
+# under the progress bar, the command exited 0, and the user carried on with
+# the old binary believing they were current.
+#
+# Seen in the field on 2026-07-27: a 0.4.69 client resolving xlings@2026.7.27.3
+# against a CN mirror that had not been topped up yet got HTTP 404, and
+# `self update` still reported success.
+#
+# The fixture makes the install hook fail outright, which is the same shape as
+# a 404 from cmd_update's point of view: `xlings install` exits non-zero.
+
+set -euo pipefail
+
+# shellcheck source=./project_test_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
+
+require_fixture_index
+
+RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/self_update_failure"
+HOME_DIR="$RUNTIME_DIR/home"
+LOCAL_INDEX_DIR="$RUNTIME_DIR/xim-pkgindex"
+FIXTURE_PKG="$LOCAL_INDEX_DIR/pkgs/x/xlings.lua"
+
+cleanup() { rm -rf "$RUNTIME_DIR"; }
+trap cleanup EXIT
+cleanup
+
+XLINGS_BIN="$(find_xlings_bin)"
+
+# `self update` shells out to `xlings ...` three times rather than calling
+# cmd_install/cmd_use directly (see core/xself/update.cppm on why), so the
+# bootstrap has to be reachable on PATH for the subprocesses to resolve.
+RUN() {
+  ( cd /tmp && env -i HOME="$HOME" PATH="$HOME_DIR/bin:/usr/bin:/bin" \
+      XLINGS_HOME="$HOME_DIR" "$HOME_DIR/bin/xlings" "$@" )
+}
+
+mkdir -p "$HOME_DIR/subos/default/bin" "$HOME_DIR/bin"
+
+cp -r "$FIXTURE_INDEX_DIR" "$LOCAL_INDEX_DIR"
+printf 'xim_indexrepos = {}\n' > "$LOCAL_INDEX_DIR/xim-indexrepos.lua"
+rm -f "$LOCAL_INDEX_DIR/.xlings-index-cache.json"
+mkdir -p "$(dirname "$FIXTURE_PKG")"
+
+# A published xlings@9.9.9 whose install hook fails. No URL, so nothing is
+# downloaded and the failure is deterministic and offline.
+cat > "$FIXTURE_PKG" <<'LUA'
+package = {
+    spec = "1",
+    name = "xlings",
+    description = "Local fixture for tests/e2e/self_update_failure_test.sh",
+    authors = {"xlings-ci"},
+    licenses = {"MIT"},
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"test-fixture"},
+
+    xpm = {
+        linux   = { ["latest"] = { ref = "9.9.9" }, ["9.9.9"] = {} },
+        macosx  = { ["latest"] = { ref = "9.9.9" }, ["9.9.9"] = {} },
+        windows = { ["latest"] = { ref = "9.9.9" }, ["9.9.9"] = {} },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    -- Stands in for "the download 404'd": install exits non-zero.
+    return false
+end
+
+function config()
+    xvm.add("xlings", { bindir = path.join(pkginfo.install_dir(), "bin") })
+    return true
+end
+
+function uninstall()
+    xvm.remove("xlings")
+    return true
+end
+LUA
+
+cp "$XLINGS_BIN" "$HOME_DIR/bin/xlings"
+chmod +x "$HOME_DIR/bin/xlings"
+cat > "$HOME_DIR/.xlings.json" <<EOF
+{
+  "mirror": "GLOBAL",
+  "index_repos": [
+    { "name": "xim", "url": "$LOCAL_INDEX_DIR" }
+  ]
+}
+EOF
+
+log "Initializing sandbox XLINGS_HOME at $HOME_DIR"
+RUN self init >/dev/null 2>&1 || fail "self init failed"
+mkdir -p "$HOME_DIR/data/xim-index-repos"
+printf '{}\n' > "$HOME_DIR/data/xim-index-repos/xim-indexrepos.json"
+
+# Premise: the install this exercises really does fail on its own.
+rc=0
+RUN install xlings@latest -y >/dev/null 2>&1 || rc=$?
+[[ $rc -ne 0 ]] \
+  || fail "premise broken: fixture install should fail, but exited 0"
+
+# ── S1: self update propagates the failure ─────────────────────────
+log "S1: self update with a failing install → non-zero exit"
+rc=0
+out=$(RUN self update 2>&1) || rc=$?
+[[ $rc -ne 0 ]] \
+  || fail "S1: self update must NOT report success when the upgrade failed (got 0)"
+
+# ── S2: and says so in words the user can act on ───────────────────
+log "S2: self update explains that the version did not change"
+printf '%s\n' "$out" | grep -qi "still on the current version" \
+  || fail "S2: output should state the version did not change; got:\n$out"
+printf '%s\n' "$out" | grep -q "xlings install xlings@latest" \
+  || fail "S2: output should point at the command that shows why; got:\n$out"
+
+log "PASS: self update failure propagation (S1-S2)"


### PR DESCRIPTION
## What

Two places where `xlings` reported success it did not have. Both found while measuring whether an existing 0.4.69 user reaches 2026.7.27.3 without noticing.

### 1. `self update` swallowed a failed upgrade

`cmd_update` ran `xlings install xlings@latest -y` and on non-zero **logged a warning and returned 0**. The error scrolled past under the progress bar; the command reported success; the user kept running the old binary.

Reproduced end to end — a 0.4.69 client resolving `2026.7.27.3` against a CN mirror not yet topped up got **HTTP 404**, and `self update` still exited 0:

```
[error] download failed for xim:xlings@2026.7.27.3: HTTP 404
[warn] xlings package not available or install failed, skipping
  self update 总耗时  13.0s  rc=0        ← reported success
  $H/bin/xlings     : xlings 0.4.69      ← still on the old version
```

Install and activation now both propagate, and the message says the version did not change.

### 2. Report panels clipped to one screen

`Dimension::Fit(doc)` takes `extend_beyond_screen = false` by default, clamping the fitted height to the terminal's. With stdout on a pipe ftxui reports a default 80×24, so **every row past 24 was dropped with no marker**.

Findings print first and totals last, so `self doctor` on a real home showed a wall of red and lost the line saying how bad it is:

| | before | after |
|---|---|---|
| `self doctor` (real DB) | 24 lines, no summary | 86 lines, `broken payloads 23` |
| `list --all` (246 targets) | 25 lines | full |

The redraw-in-place progress renderers keep the old behaviour on purpose — they overwrite a counted number of rows and must stay inside the screen.

## Not a regression from this release

0.4.69 and 2026.7.27.3 behave identically on both. Byte-for-byte on the truncation: 24 lines / 7007 bytes from each.

## Tests

- **E2E-38** `self_update_failure_test.sh` (new) — a fixture whose install hook fails; asserts non-zero exit and an actionable message
- **`self_doctor_test.sh` S12** — 30 broken-payload entries; asserts the report exceeds 24 rows and the summary survives

Both verified to **fail** against the released 2026.7.27.3 binary and **pass** against this branch. `mcpp test`: 22/22.

## Also checked, not changed

A `missing shim` report for library-only packages (zlib, openssl) looked like a third defect, but it only appears in a home with no binary at `<home>/bin/xlings`. On a faithful layout the unfixed binary reports `status OK`. It was an artifact of the test home, so the change I had written for it was reverted rather than shipped.