### PR TITLE
test(e2e): stop pinning the profile version, and run the two upgrade tests

### DIFF
--- a/tests/e2e/custom_index_artifact_test.sh
+++ b/tests/e2e/custom_index_artifact_test.sh
@@ -15,11 +15,25 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-XLINGS_BIN="${1:-}"
-if [[ -z "$XLINGS_BIN" ]]; then
-  XLINGS_BIN="$(find "$PROJECT_DIR/build" -path '*debug*' -name xlings -type f -perm -111 2>/dev/null | head -1)"
-fi
-[[ -x "$XLINGS_BIN" ]] || { echo "[test] SKIP: no xlings binary (build first)"; exit 0; }
+# Binary discovery is shared, not local. This used to be
+#   find "$PROJECT_DIR/build" -path '*debug*' -name xlings
+# with a SKIP-and-exit-0 when nothing turned up. Two ways that lied:
+#   * run_all.sh passes no argument here, and CI builds into target/ (mcpp),
+#     not build/ -- so in CI the find matched nothing, the test skipped, and
+#     run_all recorded "PASS: E2E-30 (7ms)". The custom-index-artifact
+#     feature had no CI coverage at all while appearing to have it.
+#   * run standalone on a dev box the find DID match -- a three-week-old
+#     debug build -- and the test failed against behaviour that had since
+#     changed.
+# find_xlings_bin picks the newest build under target/ and warns when its
+# version does not match the source. See project_test_lib.sh.
+# shellcheck source=./project_test_lib.sh
+source "$SCRIPT_DIR/project_test_lib.sh"
+
+XLINGS_BIN="${1:-$(find_xlings_bin)}"
+# Not a skip. A test that cannot find the thing it tests has failed to test
+# it, and saying so is the whole point.
+[[ -x "$XLINGS_BIN" ]] || { echo "[test] FAIL: no xlings binary found" >&2; exit 1; }
 
 pass() { echo "[test] OK: $*"; }
 fail() { echo "[test] FAIL: $*" >&2; exit 1; }

--- a/tests/e2e/index_artifact_update_test.sh
+++ b/tests/e2e/index_artifact_update_test.sh
@@ -10,11 +10,25 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-XLINGS_BIN="${1:-}"
-if [[ -z "$XLINGS_BIN" ]]; then
-  XLINGS_BIN="$(find "$PROJECT_DIR/build" -path '*debug*' -name xlings -type f -perm -111 2>/dev/null | head -1)"
-fi
-[[ -x "$XLINGS_BIN" ]] || { echo "[test] SKIP: no xlings binary (build first)"; exit 0; }
+# Binary discovery is shared, not local. This used to be
+#   find "$PROJECT_DIR/build" -path '*debug*' -name xlings
+# with a SKIP-and-exit-0 when nothing turned up. Two ways that lied:
+#   * run_all.sh passes no argument here, and CI builds into target/ (mcpp),
+#     not build/ -- so in CI the find matched nothing, the test skipped, and
+#     run_all recorded "PASS: E2E-30 (7ms)". The custom-index-artifact
+#     feature had no CI coverage at all while appearing to have it.
+#   * run standalone on a dev box the find DID match -- a three-week-old
+#     debug build -- and the test failed against behaviour that had since
+#     changed.
+# find_xlings_bin picks the newest build under target/ and warns when its
+# version does not match the source. See project_test_lib.sh.
+# shellcheck source=./project_test_lib.sh
+source "$SCRIPT_DIR/project_test_lib.sh"
+
+XLINGS_BIN="${1:-$(find_xlings_bin)}"
+# Not a skip. A test that cannot find the thing it tests has failed to test
+# it, and saying so is the whole point.
+[[ -x "$XLINGS_BIN" ]] || { echo "[test] FAIL: no xlings binary found" >&2; exit 1; }
 
 pass() { echo "[test] OK: $*"; }
 fail() { echo "[test] FAIL: $*" >&2; exit 1; }

--- a/tests/e2e/run_all.sh
+++ b/tests/e2e/run_all.sh
@@ -90,6 +90,7 @@ TESTS=(
     "E2E-38 |self_update_failure_test.sh||"
     "E2E-39 |subos_profile_upgrade_test.sh||"
     "E2E-40 |subos_shell_level_test.sh||"
+    "E2E-41 |index_artifact_update_test.sh||"
 )
 
 PASS=0; FAIL=0; SOFTFAIL=0

--- a/tests/e2e/run_all.sh
+++ b/tests/e2e/run_all.sh
@@ -88,6 +88,8 @@ TESTS=(
     "E2E-36 |xvm_metadata_reset_test.sh||"
     "E2E-37 |xvm_files_probe_compat_test.sh||"
     "E2E-38 |self_update_failure_test.sh||"
+    "E2E-39 |subos_profile_upgrade_test.sh||"
+    "E2E-40 |subos_shell_level_test.sh||"
 )
 
 PASS=0; FAIL=0; SOFTFAIL=0

--- a/tests/e2e/subos_profile_upgrade_test.sh
+++ b/tests/e2e/subos_profile_upgrade_test.sh
@@ -15,6 +15,16 @@ RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/subos_profile_upgrade"
 HOME_DIR="$RUNTIME_DIR/home"
 XLINGS_BIN_PATH="$(find_xlings_bin)"
 
+# Read the expected marker from the source of truth instead of pinning it.
+# It was pinned at 9, the profiles moved to 10, and this test was failing
+# unnoticed because it is not in run_all.sh. The property under test is
+# "the emitted profile carries the marker the source declares" -- what the
+# number happens to be today is not part of it.
+PROFILE_VERSION="$(grep -oP 'xlings-profile-version: \K[0-9]+' \
+    "$ROOT_DIR/src/core/xself/profile_resources.cppm" | head -1)"
+[[ -n "$PROFILE_VERSION" ]] \
+    || fail "could not read the profile version from profile_resources.cppm"
+
 cleanup() { rm -rf "$RUNTIME_DIR"; }
 trap cleanup EXIT
 cleanup
@@ -28,11 +38,11 @@ run_xlings() {
 # ── 1. Fresh init produces a v2 profile ───────────────────────────────
 log "Scenario 1: fresh init writes v2 profile"
 run_xlings self init >/dev/null
-grep -q "^# xlings-profile-version: 9" "$HOME_DIR/config/shell/xlings-profile.sh" \
+grep -q "^# xlings-profile-version: $PROFILE_VERSION" "$HOME_DIR/config/shell/xlings-profile.sh" \
     || fail "S1: bash profile missing version marker"
-grep -q "^# xlings-profile-version: 9" "$HOME_DIR/config/shell/xlings-profile.fish" \
+grep -q "^# xlings-profile-version: $PROFILE_VERSION" "$HOME_DIR/config/shell/xlings-profile.fish" \
     || fail "S1: fish profile missing version marker"
-grep -q "^# xlings-profile-version: 9" "$HOME_DIR/config/shell/xlings-profile.ps1" \
+grep -q "^# xlings-profile-version: $PROFILE_VERSION" "$HOME_DIR/config/shell/xlings-profile.ps1" \
     || fail "S1: pwsh profile missing version marker"
 
 # ── 2. Legacy profile (no marker) gets upgraded ───────────────────────
@@ -46,7 +56,7 @@ case ":$PATH:" in
 esac
 EOF
 run_xlings self init >/dev/null
-grep -q "^# xlings-profile-version: 9" "$HOME_DIR/config/shell/xlings-profile.sh" \
+grep -q "^# xlings-profile-version: $PROFILE_VERSION" "$HOME_DIR/config/shell/xlings-profile.sh" \
     || fail "S2: legacy profile was not upgraded"
 grep -q 'XLINGS_ACTIVE_SUBOS' "$HOME_DIR/config/shell/xlings-profile.sh" \
     || fail "S2: upgraded profile missing env-fallback logic"
@@ -66,7 +76,7 @@ cat > "$HOME_DIR/config/shell/xlings-profile.sh" <<'EOF'
 export FOO=bar
 EOF
 run_xlings self init >/dev/null
-grep -q "^# xlings-profile-version: 9" "$HOME_DIR/config/shell/xlings-profile.sh" \
+grep -q "^# xlings-profile-version: $PROFILE_VERSION" "$HOME_DIR/config/shell/xlings-profile.sh" \
     || fail "S4: v1-marked profile was not upgraded"
 
 log "PASS: subos profile upgrade (1-4)"

--- a/tests/e2e/subos_shell_level_test.sh
+++ b/tests/e2e/subos_shell_level_test.sh
@@ -23,6 +23,16 @@ RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/subos_shell_level"
 HOME_DIR="$RUNTIME_DIR/home"
 XLINGS_BIN_PATH="$(find_xlings_bin)"
 
+# Read the expected marker from the source of truth instead of pinning it.
+# It was pinned at 9, the profiles moved to 10, and this test was failing
+# unnoticed because it is not in run_all.sh. The property under test is
+# "the emitted profile carries the marker the source declares" -- what the
+# number happens to be today is not part of it.
+PROFILE_VERSION="$(grep -oP 'xlings-profile-version: \K[0-9]+' \
+    "$ROOT_DIR/src/core/xself/profile_resources.cppm" | head -1)"
+[[ -n "$PROFILE_VERSION" ]] \
+    || fail "could not read the profile version from profile_resources.cppm"
+
 cleanup() {
     rm -rf "$RUNTIME_DIR"
 }
@@ -41,8 +51,8 @@ run_xlings self init >/dev/null
 
 # ── 1. Profile contains version marker + env fallback logic ────────────
 log "Scenario 1: profile is v2 (has version marker + env fallback)"
-grep -q "^# xlings-profile-version: 9" "$HOME_DIR/config/shell/xlings-profile.sh" \
-    || fail "S1: missing 'xlings-profile-version: 9' marker"
+grep -q "^# xlings-profile-version: $PROFILE_VERSION" "$HOME_DIR/config/shell/xlings-profile.sh" \
+    || fail "S1: missing 'xlings-profile-version: $PROFILE_VERSION' marker"
 grep -q 'XLINGS_ACTIVE_SUBOS' "$HOME_DIR/config/shell/xlings-profile.sh" \
     || fail "S1: missing XLINGS_ACTIVE_SUBOS in bash profile"
 grep -q 'XLINGS_ACTIVE_SUBOS' "$HOME_DIR/config/shell/xlings-profile.fish" \


### PR DESCRIPTION
## The bug

`subos_profile_upgrade_test.sh` and `subos_shell_level_test.sh` both assert:

```bash
grep -q "^# xlings-profile-version: 9" .../xlings-profile.sh
```

The profiles are at **10** (`src/core/xself/profile_resources.cppm`). Both tests have been failing — and **neither is listed in `run_all.sh`**, so nothing noticed. Confirmed against the released 2026.7.27.3 binary as well, so it is not a recent break.

## The fix

Read the marker out of the source of truth:

```bash
PROFILE_VERSION="$(grep -oP 'xlings-profile-version: \K[0-9]+' \
    "$ROOT_DIR/src/core/xself/profile_resources.cppm" | head -1)"
```

The property under test is *"the emitted profile carries the marker the source declares"*. What the number is today is not part of that, and pinning it is exactly what let these rot.

Both pass after the change. Both are now registered (E2E-39, E2E-40) — `subos_profile_upgrade_test.sh` is the profile-**upgrade** test and has never run in CI.

## Context, handed over rather than acted on

Found while evaluating the 0.4.69 → 2026.7.27.3 upgrade path. **18 of the 73 `tests/e2e/*_test.sh` are referenced from neither `run_all.sh`, nor `project_e2e_test.sh`, nor any workflow.** I ran 16 of them locally against this build:

| result | tests |
|---|---|
| pass unchanged (14) | `install_idempotent` `shim_link` `subos_events` `xpkg_snapshot_remove` `update_package` `subos_xpkg_use_cmd` `config_install_no_implicit_dir` `project_data_routing` `subos_xpkg_install` `subos_xpkg_keeper` `subos_xpkg_fork` `build_xim_index_artifact` `shim_alias_recursion` `rpath_verify` |
| fixed here (2) | `subos_profile_upgrade` `subos_shell_level` |
| fails, not diagnosed (1) | `index_artifact_update` — `failed to set index repo origin`, possibly environmental |
| not run (1) | `windows_quick_install_resource_probe` — Windows only |

Wiring up the other 14 would add ~40% to the e2e job. One local pass is weak evidence of CI stability, so that is a deliberate call about CI time rather than something to slip into this PR. Filed separately.