### PR TITLE
feat(xvm): reconstruct binding groups as first-class records (P2.1)

### DIFF
--- a/src/core/xvm.cppm
+++ b/src/core/xvm.cppm
@@ -2,6 +2,7 @@ export module xlings.core.xvm;
 
 export import xlings.core.xvm.types;
 export import xlings.core.xvm.db;
+export import xlings.core.xvm.groups;
 export import xlings.core.xvm.bindings;
 export import xlings.core.xvm.errors;
 export import xlings.core.xvm.inspect;

--- a/src/core/xvm/groups.cppm
+++ b/src/core/xvm/groups.cppm
@@ -1,0 +1,239 @@
+export module xlings.core.xvm.groups;
+
+import std;
+import xlings.core.xvm.types;
+
+export namespace xlings::xvm {
+
+// A binding group as a first-class record.
+//
+// P2.1 of the 0.4.70 group-transaction design (§2.3). Today a group's
+// properties -- its member table and its header assets -- live on the entry
+// that happens to be one of its members, the "root". That placement is what
+// creates three classes of problem the design enumerates: the root must
+// reference itself (two separate invariants), every member carries a full
+// copy of the group identity that can drift from it, and deleting the root
+// deletes the whole manifest so removal needs a root-migration step.
+//
+// Here the group owns its own members and members point at it, which is what
+// rpm, dpkg and Nix all do. Nothing downstream reads this yet -- resolver,
+// registration and removal keep their current paths until P2.2 -- so this
+// change adds a representation without altering behaviour.
+struct BindingGroup {
+    std::string id;
+    std::string provider;
+    std::string providerVersion;
+    std::string group;
+    std::map<std::string, std::string> members;  // target -> version
+    std::vector<HeaderAsset> headers;
+
+    // Which on-disk form this was reconstructed from. Kept because the three
+    // forms do not carry the same information -- a legacy component has no
+    // recorded provider at all -- and a caller deciding whether a group can
+    // be trusted needs to know which it is looking at.
+    std::string origin;  // "root-manifest" | "legacy-edges"
+};
+
+// groupId -> group. Sibling to VersionDB rather than a member of it, the same
+// way Workspace is: VersionDB is a bare map alias that ~120 call sites take by
+// reference, and changing its shape to carry a second table would touch every
+// one of them for no gain at this step.
+using BindingGroupTable = std::map<std::string, BindingGroup>;
+
+// Group identity is (provider, providerVersion, group) -- the same triple
+// `same_group_identity_` in bindings.cppm compares. rootTarget/rootVersion are
+// deliberately NOT part of it: which member happens to hold the manifest is
+// exactly the accident this normalization removes.
+std::string binding_group_id(const BindingGroupRef& ref) {
+    return ref.provider + "@" + ref.providerVersion + "/" + ref.group;
+}
+
+// A legacy edge component has no recorded provider, so it gets one derived
+// from its own content. Deterministic and independent of iteration order: the
+// lexicographically smallest member names the group, so the same component
+// yields the same id on every load, which is what makes the normalized table
+// comparable across runs.
+std::string legacy_group_id(const std::map<std::string, std::string>& members) {
+    if (members.empty()) return {};
+    const auto& [target, version] = *members.begin();
+    return "legacy:" + target + "@" + version;
+}
+
+namespace detail_ {
+
+// The component of legacy pairwise edges reachable from (target, version).
+//
+// The nesting is `bindings[peerTarget][ownVersion] = peerVersion` -- peer
+// first, own version second. Worth stating because it reads backwards and
+// getting it wrong is not loud: db.cppm writes both directions of every edge
+//
+//     db[peer].bindings[target][peer_ver] = ver_key;
+//     db[target].bindings[peer][ver_key]  = peer_ver;
+//
+// so a traversal that transposes the first two levels still finds *something*
+// to walk and still returns plausible components. Against a real 246-target
+// database the transposed version produced 398 overlapping "components" where
+// there are 47 real ones.
+//
+// The relation is symmetric, so the component is closed under it. Iterative
+// rather than recursive: a corrupt state file can describe a component as
+// large as the whole database, and this runs on every load.
+std::map<std::string, std::string>
+legacy_component(const VersionDB& db,
+                 const std::string& startTarget,
+                 const std::string& startVersion) {
+    std::map<std::string, std::string> members;
+    std::vector<std::pair<std::string, std::string>> queue;
+    queue.emplace_back(startTarget, startVersion);
+
+    while (!queue.empty()) {
+        auto [target, version] = queue.back();
+        queue.pop_back();
+        if (!members.emplace(target, version).second) continue;
+
+        auto infoIt = db.find(target);
+        if (infoIt == db.end()) continue;
+        for (const auto& [peerTarget, ownVersions] : infoIt->second.bindings) {
+            auto it = ownVersions.find(version);
+            if (it == ownVersions.end()) continue;
+            if (!members.contains(peerTarget)) {
+                queue.emplace_back(peerTarget, it->second);
+            }
+        }
+    }
+    return members;
+}
+
+} // namespace detail_
+
+// Reconstruct every group in the database, from whichever form recorded it.
+//
+// Read-three-write-one (design §2.4), with one correction: the design assumed
+// the root-manifest form had never shipped, because P0-P4 were to land on a
+// single integration branch. P2 was then deferred to 0.4.71 and 0.4.70 went
+// out, so root-manifest IS released -- a real installation on 2026-07-27
+// carried 62 `bindingGroup` entries, 7 `bindingMembers` and 221 targets with
+// legacy edges, all in the same file. All three are live and none can be
+// dropped without a deprecation window.
+//
+// Precedence: root-manifest wins over legacy edges for the same identity. A
+// state file that has both is one an upgraded client wrote over a legacy
+// home, and the newer form is the one that carries the provider.
+//
+// Pure over `db`, like inspect.cppm: no reads of the filesystem or the clock,
+// so every branch is reachable from a unit test.
+BindingGroupTable normalize_binding_groups(const VersionDB& db) {
+    BindingGroupTable table;
+
+    // Pass 1 -- root manifests. The manifest lives on one member; find it and
+    // lift it into a group of its own.
+    for (const auto& [target, info] : db) {
+        for (const auto& [version, data] : info.versions) {
+            if (!data.bindingGroup) continue;
+            if (data.bindingMembers.empty()
+                && !data.bindingMembersDeclared) continue;
+
+            auto id = binding_group_id(*data.bindingGroup);
+            if (id == "@/") continue;  // identity entirely blank: not a group
+
+            auto& g = table[id];
+            if (!g.id.empty()) {
+                // Two entries claim the same identity. Union the members
+                // rather than letting iteration order pick a winner -- a
+                // disagreement here is exactly the drift the top-level table
+                // exists to make visible, and dropping half of it would hide
+                // the evidence.
+                for (const auto& [t, v] : data.bindingMembers) g.members.emplace(t, v);
+                continue;
+            }
+            g.id              = id;
+            g.provider        = data.bindingGroup->provider;
+            g.providerVersion = data.bindingGroup->providerVersion;
+            g.group           = data.bindingGroup->group;
+            g.members         = data.bindingMembers;
+            g.headers         = data.bindingHeaders;
+            g.origin          = "root-manifest";
+            // The holder is a member even when the manifest forgot to say so.
+            // Under the old model that omission was an error
+            // (RootMissingFromManifest); here the fact that the entry carries
+            // the manifest already establishes membership.
+            g.members.emplace(target, version);
+        }
+    }
+
+    // Which (target, version) pairs pass 1 already accounts for. A legacy
+    // component overlapping any of them describes a group that has since been
+    // rewritten in the newer form, so it is not a second group.
+    std::set<std::pair<std::string, std::string>> claimed;
+    for (const auto& [_, g] : table) {
+        for (const auto& [t, v] : g.members) claimed.emplace(t, v);
+    }
+
+    // Pass 2 -- legacy pairwise edges (<= 0.4.69).
+    std::set<std::pair<std::string, std::string>> seen;
+    for (const auto& [target, info] : db) {
+        // Seeds are (target, ownVersion). The own version is the SECOND key --
+        // `bindings[peerTarget][ownVersion]` -- so it has to be collected from
+        // the inner maps. Reading it off the first key instead names a peer,
+        // and every component then starts from a pair that does not exist.
+        std::set<std::string> ownVersions;
+        for (const auto& [peerTarget, versionMap] : info.bindings) {
+            for (const auto& [ownVersion, peerVersion] : versionMap) {
+                ownVersions.insert(ownVersion);
+            }
+        }
+        for (const auto& version : ownVersions) {
+            if (claimed.contains({target, version})) continue;
+            if (seen.contains({target, version})) continue;
+
+            auto members = detail_::legacy_component(db, target, version);
+            for (const auto& [t, v] : members) seen.emplace(t, v);
+            if (members.size() < 2) continue;  // an edge to nowhere is not a group
+
+            // Overlap with a newer-form group anywhere in the component means
+            // the component is a stale remnant of it, not a group of its own.
+            bool overlaps = false;
+            for (const auto& [t, v] : members) {
+                if (claimed.contains({t, v})) { overlaps = true; break; }
+            }
+            if (overlaps) continue;
+
+            auto id = legacy_group_id(members);
+
+            // Components are disjoint, so their smallest members are distinct
+            // and a collision here cannot happen. It is still handled by
+            // merging rather than by `continue`: an earlier draft of the walk
+            // transposed the edge nesting, which made components overlap, and
+            // the `continue` then discarded 351 of 398 of them without a word.
+            // Dropping on a should-be-impossible condition is how that stayed
+            // invisible; unioning keeps the evidence if the invariant breaks.
+            auto [it, inserted] = table.try_emplace(id);
+            if (!inserted) {
+                for (auto& [t, v] : members) it->second.members.emplace(t, v);
+                continue;
+            }
+            it->second.id      = id;
+            it->second.group   = id;
+            it->second.members = std::move(members);
+            it->second.origin  = "legacy-edges";
+        }
+    }
+
+    return table;
+}
+
+// The group a given entry belongs to, or nullptr.
+//
+// What `resolve_provider_group_`'s 105 lines of cross-checking degrade to once
+// the group owns its members: one lookup and one membership test.
+const BindingGroup* find_binding_group(const BindingGroupTable& table,
+                                       const std::string& target,
+                                       const std::string& version) {
+    for (const auto& [_, g] : table) {
+        auto it = g.members.find(target);
+        if (it != g.members.end() && it->second == version) return &g;
+    }
+    return nullptr;
+}
+
+} // namespace xlings::xvm

--- a/tests/unit/test_xvm_bindings.cpp
+++ b/tests/unit/test_xvm_bindings.cpp
@@ -40,6 +40,7 @@ import xlings.core.xim.repo;
 import xlings.core.xim.extract;
 import xlings.core.xvm.types;
 import xlings.core.xvm.db;
+import xlings.core.xvm.groups;
 import xlings.core.xvm.bindings;
 import xlings.core.xvm.removal;
 import xlings.core.xvm.registration;
@@ -7178,6 +7179,178 @@ TEST(XvmRemovalDangling, AResolvableReleaseStillRemovesEveryMember) {
 // ============================================================
 
 // The production-path test re-executes this binary; the child mode has to
+
+// ── group normalization (P2.1) ─────────────────────────────────────────
+//
+// Three on-disk forms describe the same thing, and all three are live: a
+// real installation on 2026-07-27 carried 62 `bindingGroup` entries, 7
+// `bindingMembers` and 221 targets with legacy edges in one file. These
+// assert they normalize to one in-memory table.
+
+namespace {
+
+xlings::xvm::VData make_group_root_(const std::string& provider,
+                                    const std::string& providerVersion,
+                                    const std::string& group,
+                                    const std::string& rootTarget,
+                                    const std::string& rootVersion,
+                                    std::map<std::string, std::string> members) {
+    xlings::xvm::VData d;
+    d.bindingGroup = xlings::xvm::BindingGroupRef{
+        .provider = provider, .providerVersion = providerVersion,
+        .group = group, .rootTarget = rootTarget, .rootVersion = rootVersion};
+    d.bindingMembers = std::move(members);
+    d.bindingMembersDeclared = true;
+    return d;
+}
+
+} // namespace
+
+TEST(XvmGroupNormalize, RootManifestBecomesOneGroup) {
+    xlings::xvm::VersionDB db;
+    db["gcc"].type = "program";
+    db["gcc"].versions["15.1.0"] = make_group_root_(
+        "gcc", "15.1.0", "toolchain", "gcc", "15.1.0",
+        {{"gcc", "15.1.0"}, {"g++", "15.1.0"}, {"libstdc++.so.6", "15.1.0"}});
+    db["g++"].type = "program";
+    db["g++"].versions["15.1.0"] = xlings::xvm::VData{};
+
+    auto table = xlings::xvm::normalize_binding_groups(db);
+    ASSERT_EQ(table.size(), 1u);
+    const auto& g = table.begin()->second;
+    EXPECT_EQ(g.id, "gcc@15.1.0/toolchain");
+    EXPECT_EQ(g.provider, "gcc");
+    EXPECT_EQ(g.origin, "root-manifest");
+    EXPECT_EQ(g.members.size(), 3u);
+    EXPECT_EQ(g.members.at("g++"), "15.1.0");
+}
+
+TEST(XvmGroupNormalize, RootIsAMemberEvenIfManifestOmitsIt) {
+    // Under the old model this omission was RootMissingFromManifest. Holding
+    // the manifest is itself proof of membership, so it is no longer an error.
+    xlings::xvm::VersionDB db;
+    db["gcc"].versions["15.1.0"] = make_group_root_(
+        "gcc", "15.1.0", "toolchain", "gcc", "15.1.0",
+        {{"g++", "15.1.0"}});
+
+    auto table = xlings::xvm::normalize_binding_groups(db);
+    ASSERT_EQ(table.size(), 1u);
+    EXPECT_EQ(table.begin()->second.members.at("gcc"), "15.1.0");
+}
+
+TEST(XvmGroupNormalize, LegacyEdgesBecomeOneGroup) {
+    // <= 0.4.69 star edges. bindings[version][peer] = peerVersion.
+    // bindings[peerTarget][ownVersion] = peerVersion -- peer first. db.cppm
+    // writes both directions of every edge, which is why a transposed reading
+    // still walks something and still looks plausible.
+    xlings::xvm::VersionDB db;
+    db["gcc"].versions["15.1.0"] = xlings::xvm::VData{};
+    db["gcc"].bindings["g++"]["15.1.0"] = "15.1.0";
+    db["gcc"].bindings["cpp"]["15.1.0"] = "15.1.0";
+    db["g++"].versions["15.1.0"] = xlings::xvm::VData{};
+    db["g++"].bindings["gcc"]["15.1.0"] = "15.1.0";
+    db["cpp"].versions["15.1.0"] = xlings::xvm::VData{};
+    db["cpp"].bindings["gcc"]["15.1.0"] = "15.1.0";
+
+    auto table = xlings::xvm::normalize_binding_groups(db);
+    ASSERT_EQ(table.size(), 1u);
+    const auto& g = table.begin()->second;
+    EXPECT_EQ(g.origin, "legacy-edges");
+    EXPECT_EQ(g.members.size(), 3u);
+    EXPECT_TRUE(g.members.contains("cpp"));
+}
+
+TEST(XvmGroupNormalize, LegacyComponentIdIsStableAcrossInsertionOrder) {
+    // The id must not depend on which member the walk happened to start from,
+    // or the same component would get a different name on the next load.
+    auto build = [](bool reversed) {
+        xlings::xvm::VersionDB db;
+        db["aaa"].versions["1"] = xlings::xvm::VData{};
+        db["zzz"].versions["1"] = xlings::xvm::VData{};
+        if (reversed) {
+            db["zzz"].bindings["aaa"]["1"] = "1";
+        } else {
+            db["aaa"].bindings["zzz"]["1"] = "1";
+        }
+        return xlings::xvm::normalize_binding_groups(db);
+    };
+    auto a = build(false);
+    auto b = build(true);
+    ASSERT_EQ(a.size(), 1u);
+    ASSERT_EQ(b.size(), 1u);
+    EXPECT_EQ(a.begin()->first, b.begin()->first);
+}
+
+TEST(XvmGroupNormalize, NewerFormWinsOverLegacyRemnant) {
+    // An upgraded client rewrote the group in the newer form but the old
+    // pairwise edges are still in the file. That is one group, not two.
+    xlings::xvm::VersionDB db;
+    db["gcc"].versions["15.1.0"] = make_group_root_(
+        "gcc", "15.1.0", "toolchain", "gcc", "15.1.0",
+        {{"gcc", "15.1.0"}, {"g++", "15.1.0"}});
+    db["gcc"].bindings["g++"]["15.1.0"] = "15.1.0";
+    db["g++"].versions["15.1.0"] = xlings::xvm::VData{};
+    db["g++"].bindings["gcc"]["15.1.0"] = "15.1.0";
+
+    auto table = xlings::xvm::normalize_binding_groups(db);
+    ASSERT_EQ(table.size(), 1u);
+    EXPECT_EQ(table.begin()->second.origin, "root-manifest");
+}
+
+TEST(XvmGroupNormalize, LoneEdgeIsNotAGroup) {
+    xlings::xvm::VersionDB db;
+    db["solo"].versions["1"] = xlings::xvm::VData{};
+    auto table = xlings::xvm::normalize_binding_groups(db);
+    EXPECT_TRUE(table.empty());
+}
+
+TEST(XvmGroupNormalize, FindLocatesMemberByExactVersion) {
+    xlings::xvm::VersionDB db;
+    db["gcc"].versions["15.1.0"] = make_group_root_(
+        "gcc", "15.1.0", "toolchain", "gcc", "15.1.0",
+        {{"gcc", "15.1.0"}, {"g++", "15.1.0"}});
+    db["g++"].versions["15.1.0"] = xlings::xvm::VData{};
+
+    auto table = xlings::xvm::normalize_binding_groups(db);
+    EXPECT_NE(xlings::xvm::find_binding_group(table, "g++", "15.1.0"), nullptr);
+    // A different version of a member name is not in the group.
+    EXPECT_EQ(xlings::xvm::find_binding_group(table, "g++", "14.0.0"), nullptr);
+}
+
+TEST(XvmGroupNormalize, TwoEntriesClaimingOneIdentityUnionRatherThanRace) {
+    // Drift the top-level table exists to expose: keeping only whichever the
+    // map iterated to first would hide half the evidence.
+    xlings::xvm::VersionDB db;
+    db["gcc"].versions["15.1.0"] = make_group_root_(
+        "gcc", "15.1.0", "toolchain", "gcc", "15.1.0", {{"g++", "15.1.0"}});
+    db["clang"].versions["20.0.0"] = make_group_root_(
+        "gcc", "15.1.0", "toolchain", "gcc", "15.1.0", {{"lld", "20.0.0"}});
+
+    auto table = xlings::xvm::normalize_binding_groups(db);
+    ASSERT_EQ(table.size(), 1u);
+    const auto& m = table.begin()->second.members;
+    EXPECT_TRUE(m.contains("g++"));
+    EXPECT_TRUE(m.contains("lld"));
+}
+
+
+
+TEST(XvmGroupNormalize, TransposedEdgeNestingDoesNotFormAGroup) {
+    // Guard against the misreading that made all of the above pass while the
+    // walk was wrong: with the levels swapped, "g++" is read as a version and
+    // "15.1.0" as a peer target, so nothing real is reachable.
+    xlings::xvm::VersionDB db;
+    db["gcc"].versions["15.1.0"] = xlings::xvm::VData{};
+    db["g++"].versions["15.1.0"] = xlings::xvm::VData{};
+    db["gcc"].bindings["15.1.0"]["g++"] = "15.1.0";   // transposed on purpose
+
+    auto table = xlings::xvm::normalize_binding_groups(db);
+    for (const auto& [id, g] : table) {
+        EXPECT_FALSE(g.members.contains("g++"))
+            << "transposed nesting must not resolve g++ as a member (" << id << ")";
+    }
+}
+
 // live in the same translation unit as the function it calls.
 #ifndef XLINGS_USE_GTEST_MAIN
 int main(int argc, char** argv) {


### PR DESCRIPTION
J3 / P2.1 of the group-transaction design. **No behaviour change** — this adds a representation; nothing downstream reads it yet (that is P2.2).

## Why

A group's members and header assets live on whichever member holds the manifest, the "root". Design §2.3 names what that costs: the root must reference itself (two invariants), every member carries a copy of the identity that can drift from it, and removing the root removes the manifest so removal needs a root-migration step. **Five of fifteen `BindingErrorKind` values exist only to police that placement.**

`normalize_binding_groups()` reconstructs every group into a table where the group owns its members — what rpm, dpkg and Nix all do.

## Correction to the design

§2.4 assumed the root-manifest form had never shipped, since P0–P4 were to land on one integration branch. **P2 was deferred to 0.4.71 and 0.4.70 shipped**, so all three forms are live. Measured on a real installation:

| form | count |
|---|---|
| `bindingGroup` entries | 62 |
| `bindingMembers` entries | 7 |
| legacy edge entries | 398 |

All in one file. None can be dropped without a deprecation window.

## The bug real data caught

The legacy nesting is `bindings[peerTarget][ownVersion] = peerVersion` — **peer first**. I read it version-first. It did not fail loudly, because `db.cppm` writes both directions of every edge:

```cpp
db[peer].bindings[target][peer_ver] = ver_key;
db[target].bindings[peer][ver_key]  = peer_ver;
```

so a transposed traversal still walks something and still returns plausible components. It produced **398 overlapping components where there are 35**, and the id derived from each component's smallest member then collided — 351 components discarded by `if (table.contains(id)) continue`, without a word.

**All eight unit tests passed the whole time, because they encoded the same misreading.** Synthetic tests written from a wrong model confirm the wrong model.

Three things changed as a result:

1. the traversal reads the levels in the right order;
2. a new test, `TransposedEdgeNestingDoesNotFormAGroup`, fails if they are swapped again;
3. an id collision — impossible once components are disjoint — **unions instead of dropping**. Discarding on a should-be-impossible condition is precisely how this stayed invisible.

## Verification

Against a real 246-target database, cross-checked with an independent implementation. Exact agreement:

```
                        C++    independent
root-manifest groups      7        7
legacy components        33       33   (35 found, 2 absorbed by newer-form groups)
members total           252      252
```

Runs in 10ms on that database — fine for load-time.

9 unit tests covering all three input forms, precedence, id stability across insertion order, the root-omitted-from-its-own-manifest case, and identity collision. `mcpp test` 22/22.

## Next

P2.2 switches resolver / registration / removal onto the table and deletes what it makes unreachable — the design projects `bindings.cppm` 539 → ~180 lines and `BindingErrorKind` 15 → ~7. Kept separate deliberately: this PR cannot change behaviour, that one can.