### PR TITLE
fix(xvm): a peer at an unregistered version is not a group member

### DIFF
--- a/src/core/xvm/groups.cppm
+++ b/src/core/xvm/groups.cppm
@@ -96,9 +96,26 @@ legacy_component(const VersionDB& db,
         for (const auto& [peerTarget, ownVersions] : infoIt->second.bindings) {
             auto it = ownVersions.find(version);
             if (it == ownVersions.end()) continue;
-            if (!members.contains(peerTarget)) {
-                queue.emplace_back(peerTarget, it->second);
-            }
+            if (members.contains(peerTarget)) continue;
+
+            // A peer whose version is not registered is not a member. The
+            // edge names something nobody can switch to, so admitting it
+            // would build a group with a hole in it -- and a `use` that
+            // "succeeds" onto a version that does not exist is worse than the
+            // refusal it replaced.
+            //
+            // This is the difference between the two shapes that both look
+            // like a broken edge. `gcc@15.1.0 -> xim-gnu-gcc@15.1.0` where
+            // xim-gnu-gcc exists only at 16.1.0 is a dangling edge, and
+            // dropping it is repair (see XvmDanglingEdge). A pair where both
+            // versions exist but only one direction of the edge was written
+            // is a partial write, and reading it as a group is repair too.
+            // Membership, not reverse-reachability, is what tells them apart.
+            auto peerIt = db.find(peerTarget);
+            if (peerIt == db.end()) continue;
+            if (!peerIt->second.versions.contains(it->second)) continue;
+
+            queue.emplace_back(peerTarget, it->second);
         }
     }
     return members;

--- a/tests/unit/test_xvm_bindings.cpp
+++ b/tests/unit/test_xvm_bindings.cpp
@@ -7351,6 +7351,65 @@ TEST(XvmGroupNormalize, TransposedEdgeNestingDoesNotFormAGroup) {
     }
 }
 
+
+
+TEST(XvmGroupNormalize, TableAndResolverDivergeOnAOneDirectionalEdge) {
+    // Documented divergence, not a fix. Shape from a real database on
+    // 2026-07-27:
+    //     xim-musl-gnu-gcc.bindings["gcc"]["15.1.0-musl"] = "15.1.0-musl"
+    //     gcc.bindings                                     -- no reverse edge
+    // Both versions exist. `xlings use gcc 15.1.0-musl` is refused with
+    // "legacy binding source version is missing".
+    //
+    // The component walk does not depend on which direction survived, so the
+    // table sees a group where the resolver sees nothing. It is deliberately
+    // NOT wired into resolution: a half-edge is equally readable as a stale
+    // remnant of a binding a later registration removed (registration does
+    // rewrite edges -- see ReplacesCurrentExactEdgesAndPreservesAnotherVersion),
+    // and accepting it would resurrect the removed relationship. Four tests
+    // in this file pin the refusal; they are the contract, and the state
+    // alone cannot distinguish the two readings.
+    //
+    // Pinned so that when P2.2 makes the table load-bearing, this divergence
+    // has to be decided rather than inherited.
+    xlings::xvm::VersionDB db;
+    db["gcc"].versions["15.1.0-musl"] = xlings::xvm::VData{};
+    db["xim-musl-gnu-gcc"].versions["15.1.0-musl"] = xlings::xvm::VData{};
+    db["xim-musl-gnu-gcc"].bindings["gcc"]["15.1.0-musl"] = "15.1.0-musl";
+
+    auto sel = xlings::xvm::resolve_binding_selection(db, "gcc", "15.1.0-musl");
+    EXPECT_FALSE(sel.has_value()) << "the resolver's refusal is the contract";
+
+    auto table = xlings::xvm::normalize_binding_groups(db);
+    const auto* g = xlings::xvm::find_binding_group(table, "gcc", "15.1.0-musl");
+    ASSERT_NE(g, nullptr);
+    EXPECT_EQ(g->members.size(), 2u);
+}
+
+TEST(XvmGroupNormalize, APeerAtAnUnregisteredVersionIsNotAMember) {
+    // The other shape that looks like a broken edge, and must NOT become a
+    // group: gcc@15.1.0 points at xim-gnu-gcc@15.1.0, which is registered
+    // only at 16.1.0. The edge names something nobody can switch to, so a
+    // group built around it would have a hole -- and a `use` that "succeeds"
+    // onto a version that does not exist is worse than the refusal. See
+    // XvmDanglingEdge in test_xvm_doctor.cpp, which pins the repair path.
+    xlings::xvm::VersionDB db;
+    db["gcc"].versions["15.1.0"] = xlings::xvm::VData{};
+    db["gcc"].versions["16.1.0"] = xlings::xvm::VData{};
+    db["xim-gnu-gcc"].versions["16.1.0"] = xlings::xvm::VData{};
+    db["gcc"].bindings["xim-gnu-gcc"]["15.1.0"] = "15.1.0";  // dangling
+    db["gcc"].bindings["xim-gnu-gcc"]["16.1.0"] = "16.1.0";  // fine
+    db["xim-gnu-gcc"].bindings["gcc"]["16.1.0"] = "16.1.0";
+
+    auto table = xlings::xvm::normalize_binding_groups(db);
+    EXPECT_EQ(xlings::xvm::find_binding_group(table, "gcc", "15.1.0"), nullptr)
+        << "a dangling edge must not produce a group";
+    const auto* good = xlings::xvm::find_binding_group(table, "gcc", "16.1.0");
+    ASSERT_NE(good, nullptr) << "the sound edge must still produce one";
+    EXPECT_EQ(good->members.size(), 2u);
+}
+
+
 // live in the same translation unit as the function it calls.
 #ifndef XLINGS_USE_GTEST_MAIN
 int main(int argc, char** argv) {


### PR DESCRIPTION
Follow-up to #428, found while attempting P2.2.

## The defect

`normalize_binding_groups()` admitted every peer an edge named, registered or not. On a real 246-target database that put **11 nonexistent members** in the table and invented **one whole group** out of dangling edges.

| | groups | members |
|---|---|---|
| before | 40 (7 root + 33 legacy) | 252 |
| after | 39 (7 root + **32** legacy) | **241** |

## Why it matters beyond the count

`gcc@15.1.0 → xim-gnu-gcc@15.1.0`, where `xim-gnu-gcc` exists only at `16.1.0`, is the shape `XvmDanglingEdge` already pins: the edge names something nobody can switch to, and **dropping it is repair**. A group built around it has a hole in it, and a `use` that "succeeds" onto a version that does not exist is worse than the refusal it would replace.

Membership — not reverse-reachability — separates that from the *other* shape that also looks like a broken edge:

| shape | peer version | reverse edge | group? |
|---|---|---|---|
| partial write | **exists** | missing | yes |
| dangling edge | **missing** | — | **no** |

## How it was found, and what is deliberately not here

By the existing suite. Four tests pin *"the legacy resolver refuses an incoming-only edge"*, and an attempt to make `resolve_binding_selection` fall back to the table tripped all four.

That fallback is **not in this PR**, and on reflection should not be: a half-edge reads equally well as a **stale remnant** of a binding a later registration removed — registration does rewrite edges, see `ReplacesCurrentExactEdgesAndPreservesAnotherVersion` — and accepting it would resurrect the removed relationship. The state alone cannot distinguish "partial write" from "deliberately unlinked", so the refusal stands.

The divergence is pinned by a test instead (`TableAndResolverDivergeOnAOneDirectionalEdge`), so that when P2.2 makes the table load-bearing the question has to be **decided** rather than inherited silently.

## Tests

Two added: the dangling-edge guard, and the pinned divergence. 11 in `XvmGroupNormalize`, `mcpp test` 22/22.

## Note on the differential in #428

That differential (374 entries, zero disagreements) was run **before** this fix, so its two "table resolves what the resolver refuses" cases were one real half-edge pair and one dangling-edge artifact. Only the first survives here.