### PR TITLE
chore: bump version to 2026.7.27.4

### DIFF
--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "2026.7.27.3";
+    static constexpr std::string_view VERSION = "2026.7.27.4";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 


### PR DESCRIPTION
Version bump only. Five commits have accumulated on main since v2026.7.27.3:

| commit | what |
|---|---|
| #424 | **`self update` no longer reports success it did not have.** A failed upgrade logged a warning and returned 0 — observed for real: a 0.4.69 client got HTTP 404 from a CN mirror that had not been topped up, and the command still exited 0 with the user on the old binary. Also: report panels were clipped to 24 rows on a pipe, so `self doctor` lost its summary and `--help` lost the block telling AI agents to run `xlings agent` |
| #426 | Two e2e tests pinned `# xlings-profile-version: 9` while the profiles moved to 10, and neither was in `run_all.sh`. Also fixes E2E-30, which reported `PASS … 7ms` in CI without running a single assertion |
| #428 | P2.1 — binding groups reconstructed as first-class records. No call sites, no behaviour change |
| #429 | Pins that `profile rollback` moves a bound release as a whole |
| #430 | A peer at an unregistered version is not a group member — kept 11 phantom members and one invented group out of the table |

The one that matters for users is **#424**: until it ships, a failed `self update` is indistinguishable from a successful one, which is the worst possible bug to leave sitting on an unreleased branch.

Index side is already delivered and needs no client release — the glibc migration reached both client generations, verified against the live index (0.4.69 → legacy branch, 2026.7.27.3 → 130 declared file assets).