### PR TITLE
fix(xim): stop reading a freed VersionDB in `xlings remove`

### DIFF
--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -902,6 +902,16 @@ public:
     // caller). Empty => default xlings-res raw-pointer + release-artifact path.
     [[nodiscard]] static std::string index_base() { return instance_().indexBase_; }
 
+    // Returns BY VALUE -- global and project state are merged into a fresh
+    // map, so there is no long-lived object to hand out a reference to.
+    //
+    // Bind it to a named local before taking any pointer or reference into
+    // it. `get_vinfo(Config::versions(), name)` compiles, and returns a
+    // pointer into a temporary that dies at the end of that full expression;
+    // the next line then reads freed memory. That was a real crash --
+    // `xlings remove glibc` SIGSEGV'd on the musl-static release build and
+    // threw bad_alloc on a glibc one, reported 2026-07-28 and present since
+    // the fallback was written.
     [[nodiscard]] static xvm::VersionDB versions() {
         auto& self = instance_();
         return merged_versions(self.globalVersions_, self.projectVersions_);

--- a/src/core/xim/commands.cppm
+++ b/src/core/xim/commands.cppm
@@ -645,7 +645,19 @@ int cmd_remove(const std::string& target, bool yes, EventStream& stream) {
         // "✓ removed" anyway. Picking from the xvm DB instead anchors
         // the resolution to reality.
         if (active.empty()) {
-            const auto* vinfo = xvm::get_vinfo(Config::versions(), bareName);
+            // The database has to outlive the pointer into it.
+            // Config::versions() returns by VALUE, so passing the call
+            // directly to get_vinfo() handed back a pointer into a temporary
+            // that died at the end of that full expression -- and the next
+            // line read it. Use-after-free: `xlings remove glibc` on a home
+            // where glibc is registered but not active SIGSEGV'd on the
+            // released musl-static build and threw bad_alloc on a glibc one,
+            // from pick_highest_version walking a map that was gone.
+            //
+            // Reported 2026-07-28; reproduces identically on 2026.7.27.2,
+            // .3 and .4, so it is as old as this fallback.
+            const auto db = Config::versions();
+            const auto* vinfo = xvm::get_vinfo(db, bareName);
             if (vinfo && !vinfo->versions.empty()) {
                 active = xvm::pick_highest_version(vinfo->versions);
             }

--- a/src/core/xvm/db.cppm
+++ b/src/core/xvm/db.cppm
@@ -417,6 +417,32 @@ const VInfo* get_vinfo(const VersionDB& db, const std::string& target) {
     return &it->second;
 }
 
+// Both accessors above hand back a pointer INTO the map, so passing a
+// temporary map is a use-after-free every time -- the map dies at the end of
+// the full expression and the caller is left holding a pointer into freed
+// storage.
+//
+// That is not hypothetical. `Config::versions()` and
+// `Config::effective_workspace()` return BY VALUE (global and project state
+// are merged into a fresh map), and
+//
+//     const auto* vinfo = xvm::get_vinfo(Config::versions(), name);
+//
+// compiled cleanly, shipped in three releases, and SIGSEGV'd in the field
+// (#432) when the next line walked the freed map and read a stack address as
+// a string length.
+//
+// A `const&` parameter binds to a temporary, so nothing stopped it. Deleting
+// the rvalue overload does: the same line is now a compile error at every
+// call site, present and future. `const VersionDB&&` rather than
+// `VersionDB&&` so a const temporary is caught too.
+//
+// The point fix in #432 corrected one call site; this is what makes the class
+// of bug unwritable instead of a comment someone has to remember to read.
+const VData* get_vdata(const VersionDB&&, const std::string&,
+                       const std::string&) = delete;
+const VInfo* get_vinfo(const VersionDB&&, const std::string&) = delete;
+
 // Get binding for a target (e.g., g++ -> g++-15 for gcc version 15.1.0)
 std::string get_binding(const VersionDB& db,
                         const std::string& target,


### PR DESCRIPTION
Field report:

```
$ xlings remove glibc
fish: Job 1, 'xlings remove glibc' terminated by signal SIGSEGV (Address boundary error)
```

## Cause

`Config::versions()` returns **by value** — global and project state are merged into a fresh map. `cmd_remove` passed the call straight into `get_vinfo()`:

```cpp
const auto* vinfo = xvm::get_vinfo(Config::versions(), bareName);
if (vinfo && !vinfo->versions.empty()) {          // ← temporary already dead
    active = xvm::pick_highest_version(vinfo->versions);
}
```

The pointer refers into a temporary that dies at the end of that full expression. `pick_highest_version` then walked a freed map and tried to build a string of length `0x7FFFF7EA3D10` — a stack address read as a size:

```
#13 xvm::pick_highest_version   src/core/xvm/db.cppm:272
#14 xim::cmd_remove             src/core/xim/commands.cppm:650
```

## Why nobody hit it before

The branch only runs when the target is **registered but has no active version** — exactly the state `doctor --fix` leaves after deactivating an incoherent release. The reporter's `glibc` and `ldd` were in it.

## Not a regression

Reproduces identically on released **2026.7.27.2, .3 and .4** against the reporter's state. As old as the fallback.

musl-static release builds SIGSEGV; a glibc build throws `bad_alloc` from the same frame — which is what made the backtrace readable.

## No hermetic regression test, on purpose

A use-after-free only manifests when the freed storage is reused, so whether it crashes is up to the allocator:

| database | crashes on released .3? |
|---|---|
| reporter's, 376 targets | **yes, every time** |
| synthesized, 405 targets | no |
| small fixture | no |

A test that passes because the allocator left the bytes alone is worse than no test — it would read as coverage. The fix is correct by inspection (a pointer into a by-value temporary is a use-after-free whether or not it shows), and recurrence is guarded by a note at `Config::versions()` plus a scan confirming no other call site takes a pointer into either by-value getter.

A sanitizer build in CI is the tool that would actually catch this class; filed separately rather than bolted on here.

## Verification

Against the reporter's state in an isolated `XLINGS_HOME`: **SIGSEGV before, `remove` completes after.** `mcpp test` 22/22.