### PR TITLE
feat(xself): repair ladder behind `self doctor --fix`

### DIFF
--- a/.agents/docs/2026-07-28-release-2026.7.28.1-notes.md
+++ b/.agents/docs/2026-07-28-release-2026.7.28.1-notes.md
@@ -104,6 +104,20 @@ registered in its format
 | `xlings remove <pkg>` 不再崩溃 | 目标已注册但无 active 版本时 SIGSEGV（读了已释放的 VersionDB）|
 | 同形状的 use-after-free 编译不过 | `get_vinfo(Config::versions(), …)` 能编译，发过三个版本 |
 | doctor 汇总不再把 binding 问题算成 payload | 「broken payloads 1」但列表里一条 payload 都没有 |
+| 纯库包不再被当成「二进制丢了」 | `gcc-runtime@15.1.0` 每次都报坏、每次都修不好 |
+
+最后一条是发布前跑 10 包模拟拦下来的，值得单独说：`gcc-runtime` 没有可执行文件，
+xvm 默认把它类型化成 `program`，而原来的豁免判据是「是不是 binding root」——
+`is_binding_root` 会跳过条目自身，而 `gcc-runtime` 是它自己那个 release 的唯一成员，
+于是返回假。
+
+放着不管不只是多一行噪声：`--fix` 修不掉它 → 修复轮次报告失败 → 迁移标记是按修复轮次
+盖的 → 标记永远落不下 → **那句让你去跑 `self doctor --fix` 的提示，在你跑过之后还会一直出现**，
+在任何装了 gcc 的机器上。这就是这次发布的核心承诺在它最常见的输入上失效。
+
+判据改成看 payload 而不是看名字：payload 里一个可执行文件都没有 → 这个包本来就不提供程序；
+有别的可执行文件、唯独少了它 → 才是真坏。后半句由 S8d 钉住（删掉二进制、在旁边留一个
+别的可执行文件，必须仍然报错），并用变异验证过：把豁免判据改成无条件成立，S8d 会失败。
 
 `xlings remove glibc` 的 SIGSEGV 是现场报的。根因是 `Config::versions()` 按值返回，
 把它直接传给返回指针的 `get_vinfo()` 就得到一个指向临时量的指针。点修之外还删掉了
@@ -115,9 +129,13 @@ registered in its format
 
 不是「命令退出 0」—— 那正是要防的失败形态。实测于全新的 0.4.69 home：
 
+全新 0.4.69 home，装 10 个常用包（llvm / node 各两个版本，Linux 另加 gcc 两个版本），
+升级后用候选构建跑 `self doctor --fix`：
+
 ```
-payload findings before: 1  →  pass 1 后: 0  →  pass 2 后: 0     幂等
-recorded client version: v0.4.69 → 2026.7.27.4                   盖章
+payload findings before: 0  →  pass 1 后: 0  →  pass 2 后: 0     幂等
+recorded client version: v0.4.69 → 运行版本                       盖章
+heal-stamped / heal-not-worse / heal-idempotent / heal-no-failures   全过
 ```
 
 修复结果是**重新检测**出来的，不是相信子进程的退出码：状态文件从磁盘重新加载

--- a/.agents/docs/2026-07-28-release-2026.7.28.1-notes.md
+++ b/.agents/docs/2026-07-28-release-2026.7.28.1-notes.md
@@ -1,0 +1,126 @@
+# xlings 2026.7.28.1 — 发布说明
+
+**日期**: 2026-07-28
+**类型**: 发布记录 (release notes)
+**关联**: `2026-07-28-seamless-upgrade-design.md`、`2026-07-28-self-repair-design.md`
+
+> **版本号**：日常发布 `N` 从 `.1` 起，`.0` 保留给正式/里程碑版本。规范见
+> `.agents/skills/xlings-contributing/SKILL.md`。
+
+---
+
+## 一句话
+
+**`xlings self doctor --fix` 现在会把老客户端留下的注册记录迁移过来，而不是打印一堆让你自己粘贴的命令。**
+
+---
+
+## 为什么需要它
+
+在真机上跑了一遍 0.4.69 → 最新的升级（PR #434），三个平台，装了 10 个常用包。
+结论分两半：
+
+**没坏的部分**（实测，不是假设）：老客户端装的包升级后照常可用，`gcc 15.1.0 ↔ 16.1.0`
+双向切换正常（用 shim 自己的 `--version` 验的）；`self update` 本身 runner 上 3.8s、
+家用网络 16.8s。
+
+**坏的部分**：升级完的 home 上 `self doctor` 直接 exit 1，而且报的是这种东西：
+
+```
+✗ broken payload [active]  linux-headers@5.11.1 executable 'linux-headers'
+                           not found in …/xim-x-linux-headers/5.11.1
+  → run  xlings install linux-headers@5.11.1
+```
+
+`linux-headers` 是纯头文件包，本来就没有可执行文件。0.4.69 把它记成**一个**
+program 类型的条目，带 payload 路径、里面没有可执行文件 —— 新客户端分辨不出这和
+「程序的二进制丢了」有什么区别。同一台机器上五个包就报了 **56 条**。
+
+关键在于：**它打印的那条命令其实是对的**。重跑 install 会重跑 `config()`，把包按
+当前格式重新注册（1 个目标 → 12 个目标，带 bindingGroup 和成员表），条目于是被认出
+是 release anchor，报错消失。但 doctor 拒绝替你执行，于是你要么手动粘 56 条命令，
+要么一直看着 `self doctor` 红着。
+
+---
+
+## 用户可见的变化
+
+### `xlings self doctor --fix` 会修了
+
+| 发现 | 之前 | 现在 |
+|---|---|---|
+| 旧格式注册 / payload 损坏 | 打印命令，不执行 | 走修复阶梯 |
+| 缺失 shim | 重建 | 重建（不变）|
+| 孤儿 shim | 删除 | 删除（不变）|
+| alias 无法解析 | 不动 | 不动（可能是系统命令）|
+| 损坏的 binding 元数据 | `--reset-metadata` | 不变（会丢信息，必须显式要求）|
+
+修复阶梯，逐级尝试，成功即停：
+
+```
+R2  重新注册    xlings install <pkg>@<ver> -y
+                payload 还在时只重跑 config()，不下载
+R3  卸载重装    xlings remove … 然后 xlings install …
+                给注册层拒绝原地覆盖的记录用（xvm-legacy-payload-mismatch）
+停   报告        带上失败的命令和退出码
+```
+
+R3 是兜底：**取出来再放回去永远可用**。它也是唯一可能让你更糟的一级，所以有三条约束：
+索引里查不到的包不会被删（删了装不回来就不是修复）、一次只处理一个包、
+删成功但装失败会单独且醒目地报出来。
+
+### `--dry-run`
+
+```
+xlings self doctor --fix --dry-run
+```
+
+先看它打算干什么。原来的 `--fix` 承诺「绝不联网、无副作用」，修复阶梯打破了这个承诺，
+所以用一个更窄的承诺替换它，而不是直接丢掉。
+
+### 会有人告诉你该跑它
+
+升级完之后，`install` / `use` / `list` 会打一行：
+
+```
+this home was set up by 0.4.69; packages installed then may still be
+registered in its format
+  run  xlings self doctor --fix
+```
+
+只在终端打、每个进程最多一次、`--fix` 成功盖章后彻底消失。不联网 —— 只是两个字符串比较。
+
+**为什么不是 `self update` 自己修**：`self update` 跑的是**旧**二进制，修复逻辑在新的
+里面。它换掉自己然后退出，之后做任何事要么还是旧代码，要么是一个它无法妥善处理失败的
+子进程 —— 而此时 home 正处于半迁移状态。所以修复是用户手动触发的，新二进制只负责在
+你下一次用它的时候提醒你。
+
+---
+
+## 修复
+
+| 变化 | 之前 |
+|---|---|
+| `xlings remove <pkg>` 不再崩溃 | 目标已注册但无 active 版本时 SIGSEGV（读了已释放的 VersionDB）|
+| 同形状的 use-after-free 编译不过 | `get_vinfo(Config::versions(), …)` 能编译，发过三个版本 |
+| doctor 汇总不再把 binding 问题算成 payload | 「broken payloads 1」但列表里一条 payload 都没有 |
+
+`xlings remove glibc` 的 SIGSEGV 是现场报的。根因是 `Config::versions()` 按值返回，
+把它直接传给返回指针的 `get_vinfo()` 就得到一个指向临时量的指针。点修之外还删掉了
+右值重载，同样的写法现在在所有调用点都是编译错误。
+
+---
+
+## 验收
+
+不是「命令退出 0」—— 那正是要防的失败形态。实测于全新的 0.4.69 home：
+
+```
+payload findings before: 1  →  pass 1 后: 0  →  pass 2 后: 0     幂等
+recorded client version: v0.4.69 → 2026.7.27.4                   盖章
+```
+
+修复结果是**重新检测**出来的，不是相信子进程的退出码：状态文件从磁盘重新加载
+（修复跑在子进程里，本进程手上的是启动时读的旧副本），逐条复查。实测数据说明了
+为什么必须这样：真实 0.4.69 home 上 55 条治好、1 条假失败，那一条的治法纯粹是元数据
+层面的，不看磁盘就判不出来。

--- a/.agents/docs/2026-07-28-release-2026.7.28.1-notes.md
+++ b/.agents/docs/2026-07-28-release-2026.7.28.1-notes.md
@@ -129,14 +129,19 @@ xvm 默认把它类型化成 `program`，而原来的豁免判据是「是不是
 
 不是「命令退出 0」—— 那正是要防的失败形态。实测于全新的 0.4.69 home：
 
-全新 0.4.69 home，装 10 个常用包（llvm / node 各两个版本，Linux 另加 gcc 两个版本），
-升级后用候选构建跑 `self doctor --fix`：
+两次测量，各自证明一半，合起来才是完整的：
+
+**修复确实发生**（全新 0.4.69 home，装 gcc + mcpp，升级后用候选构建）：
 
 ```
-payload findings before: 0  →  pass 1 后: 0  →  pass 2 后: 0     幂等
-recorded client version: v0.4.69 → 运行版本                       盖章
-heal-stamped / heal-not-worse / heal-idempotent / heal-no-failures   全过
+payload findings  1 → 0 (pass 1) → 0 (pass 2)     幂等
+recorded version  v0.4.69 → 运行版本               盖章
 ```
+
+**规模下不留残留**（10 个常用包：llvm / node 各两版本，Linux 另加 gcc 两版本）。
+这一轮先暴露了 `gcc-runtime` 那个修不掉的条目并因此**未能盖章**；修好判据后重跑，
+四条断言全过、标记落下。这轮的 `before` 已经是 0，因为 home 在前一轮就被迁移过了 ——
+它证明的是「不留残留、幂等、可盖章」，不是「从零修复」，那一半由上面那组数据承担。
 
 修复结果是**重新检测**出来的，不是相信子进程的退出码：状态文件从磁盘重新加载
 （修复跑在子进程里，本进程手上的是启动时读的旧副本），逐条复查。实测数据说明了

--- a/.agents/docs/2026-07-28-self-repair-design.md
+++ b/.agents/docs/2026-07-28-self-repair-design.md
@@ -76,12 +76,21 @@ R3 is the fallback the whole design hangs on: *taking something out and putting
 it back is always available*. It is also the rung that can leave the user worse
 off if it half-completes, so:
 
-- **R3 is never entered silently.** Without `--yes` it asks, listing exactly
-  what will be removed and reinstalled.
+- **R3 is previewable, not interactive.** An earlier draft of this document
+  said it would prompt unless `--yes` was passed. That was dropped on
+  implementation: `--fix` is already an explicit request to repair, a prompt
+  in the middle of a multi-package pass cannot be answered in CI, and a
+  question the user cannot see (doctor renders through the event stream) is
+  worse than none. `--dry-run` is the preview instead — it prints the exact
+  commands, having already run the index probe, and stops.
 - **R3 is skipped for anything not in the index.** If the package cannot be
   reinstalled, removing it is destruction, not repair.
 - **R3 runs one package at a time**, verifying reinstall before moving on, so a
   failure leaves one package down rather than all of them.
+- **The remove-succeeded-then-install-failed case is reported specially.** It
+  is the one outcome that leaves the user worse off than before the repair, so
+  it is never folded into a generic failure: the report names it and hands back
+  the command that finishes the job.
 
 ### What is deliberately NOT on the ladder
 
@@ -201,9 +210,29 @@ mistake in §6.
 
 | # | step | gate |
 |---|---|---|
-| S1 | `repair.cppm` with the ladder + policy, unit-tested against a fake executor | unit tests |
-| S2 | `cmd_doctor` emits `RepairTask`s; `--fix` drives the ladder | existing doctor tests stay green |
-| S3 | stamp `.xlings.json:version` on successful `--fix` | simulation assertion flips |
-| S4 | one-line migration hint on version mismatch (TTY only, once per version) | e2e: hint appears once, then not |
-| S5 | `self update` prints the same hint last | e2e |
-| S6 | re-detect pass + "remaining" reporting | idempotence assertion |
+| S1 | `repair.cppm` with the ladder + policy, unit-tested against a fake executor | **done** — 17 unit tests |
+| S2 | `cmd_doctor` emits `RepairTask`s; `--fix` drives the ladder | **done** |
+| S3 | stamp `.xlings.json:version` on successful `--fix` | **done** — `heal-stamped` |
+| S4 | one-line migration hint on version mismatch (TTY only) | **done** — `install` / `use` / `list` |
+| S5 | `self update` prints the same hint last | **done** (helps the *next* upgrade, not this one — see §4) |
+| S6 | re-detect pass + "remaining" reporting | **done** — `heal-idempotent` |
+| S7 | `--dry-run` | **done** — added when the "never touches the network" promise had to be replaced |
+
+Three things the implementation added that the design did not anticipate,
+each found by running it rather than by reading it:
+
+- **A finding names an xvm target; the ladder installs a package.** A broken
+  llvm reports `ar@22.1.8`, `clang@22.1.8` and forty more, none installable,
+  and the binding *root* is not the package either (gcc's root target is
+  `xim-gnu-gcc`). The owner is now searched for in descending order of
+  confidence and confirmed against the index before use; findings collapse
+  onto their owner, one install per release.
+- **The re-detect must reload state from disk first.** The repairs run in
+  subprocesses; this process holds the copy it read at startup. Without the
+  reload a purely-metadata cure reads as a failure — measured as 55 healed and
+  one false failure on a real 0.4.69 home.
+- **The stamp is gated on the repair pass, not on doctor being clean.**
+  Active-group incoherence between two providers that both claim `cc` accounts
+  for ~190 findings on a real home by itself; requiring zero would mean the
+  marker never lands and the hint nags forever about a migration that already
+  happened.

--- a/.agents/docs/2026-07-28-self-repair-design.md
+++ b/.agents/docs/2026-07-28-self-repair-design.md
@@ -113,6 +113,12 @@ becomes the feature:
 - **`self update` prints the same line** as its last output, since it is the
   moment the mismatch is created.
 
+  Worth being explicit about what this does *not* buy: `self update` runs the
+  **old** binary, so this line does nothing for the cohort being migrated
+  right now — a 0.4.69 client will never print it. It starts working one
+  upgrade later. The users who need the hint today get it from §"Any command
+  may notice the mismatch", which is the new binary talking.
+
 Properties this has to keep, because axis 2 of 无感 currently holds and must
 not regress:
 

--- a/.agents/docs/2026-07-28-self-repair-design.md
+++ b/.agents/docs/2026-07-28-self-repair-design.md
@@ -1,0 +1,203 @@
+# `xlings self doctor --fix` as a repair engine
+
+2026-07-28 · follows `2026-07-28-seamless-upgrade-design.md`
+
+## 1. Why this cannot live in `self update`
+
+`self update` runs the **old** binary. It replaces that binary underneath
+itself and exits. Anything it did after the swap would either still be the old
+code, or a subprocess whose failure it cannot meaningfully recover from —
+while holding a home that is half-migrated.
+
+So the repair is **user-triggered**, in the new binary, through the command
+that already owns "is this home healthy":
+
+```
+xlings self doctor --fix
+```
+
+`self update` and a small number of other places **tell the user to run it**.
+They do not run it.
+
+## 2. What has to be repaired, and why it is not hypothetical
+
+Measured on the upgrade simulation (PR #434), a home built by 0.4.69 and then
+upgraded:
+
+```
+             targets   bindingGroup   members
+before          1          no            0      ← written by 0.4.69
+after          12          yes          12      ← after the new client re-ran config
+```
+
+That is `linux-headers@5.11.1`. Under 0.4.69 it is a single owner-less entry
+with a payload path, typed `program` by default, and **no executable** —
+because it is a headers-only package. The new client cannot tell that apart
+from a program whose binary went missing, so `self doctor` reports
+
+```
+✗ broken payload [active]  linux-headers@5.11.1 executable 'linux-headers'
+                           not found in …/xim-x-linux-headers/5.11.1
+  → run  xlings install linux-headers@5.11.1
+```
+
+and exits 1 on a machine where nothing is actually wrong.
+
+The important part: **the printed remedy is the correct one.** Re-running the
+install re-runs `config()`, which registers the package in the current form —
+12 targets, a binding group, file assets — and the finding disappears, because
+the entry is now recognisable as a release anchor.
+
+So the finding is not a false positive to suppress. It is a **stale
+registration**, the cure is re-registration, and today the user has to notice
+the line, read it, and run the command by hand for every package the old
+client installed.
+
+## 3. The repair ladder
+
+One ladder, applied per (target, version), each rung tried only if the
+previous failed:
+
+| rung | action | touches network | loses data |
+|---|---|---|---|
+| **R1 local** | recreate a missing shim, delete an orphan shim | no | no |
+| **R2 re-register** | `xlings install <pkg>@<ver> -y` | only if the payload is absent | no |
+| **R3 reinstall** | `xlings remove <pkg>@<ver> -y` then `xlings install <pkg>@<ver> -y` | yes | the payload, briefly |
+| **stop** | report with the reason the ladder ran out | — | — |
+
+R2 is the workhorse and is cheap: the installer's xvm-DB shortcut checks the
+payload on disk, so when the payload is intact this re-runs `config()` only —
+no download — and that is exactly what converts a 0.4.69 record into the
+current format. R3 exists for the case R2 cannot reach: a record the
+registration layer **refuses** to overwrite (`xvm-legacy-payload-mismatch`),
+which is the field dead end from 2026-07-28.
+
+R3 is the fallback the whole design hangs on: *taking something out and putting
+it back is always available*. It is also the rung that can leave the user worse
+off if it half-completes, so:
+
+- **R3 is never entered silently.** Without `--yes` it asks, listing exactly
+  what will be removed and reinstalled.
+- **R3 is skipped for anything not in the index.** If the package cannot be
+  reinstalled, removing it is destruction, not repair.
+- **R3 runs one package at a time**, verifying reinstall before moving on, so a
+  failure leaves one package down rather than all of them.
+
+### What is deliberately NOT on the ladder
+
+- **Version upgrades.** "Old package" here means *recorded in an old format*,
+  not *an older version than the index offers*. Silently moving a user's gcc
+  from 15.1.0 to 16.1.0 during a repair would change their toolchain without
+  being asked. Moving forward stays an explicit `xlings upgrade` (D5 in the
+  companion doc).
+- **`--reset-metadata` repairs.** Unchanged: they discard a release's member
+  and header information, so they stay opt-in and are not inherited by `--fix`.
+- **Alias warnings.** An unresolved alias may legitimately be a system command.
+
+## 4. How the user finds out they should run it
+
+The home config already records which xlings set it up (`.xlings.json:version`).
+Today `self update` never updates it, which makes it useless — and that defect
+becomes the feature:
+
+- **`self doctor --fix`, on success, stamps the field with the running
+  version.** That is the migration marker.
+- **Any command may notice the mismatch** — recorded version ≠ running version
+  — and print, at most once per version, one line:
+
+  ```
+  this home was set up by 0.4.69; packages installed then may need migrating
+    run  xlings self doctor --fix
+  ```
+
+- **`self update` prints the same line** as its last output, since it is the
+  moment the mismatch is created.
+
+Properties this has to keep, because axis 2 of 无感 currently holds and must
+not regress:
+
+- **no network**, ever, on this path — it is a string comparison against a
+  compiled-in constant
+- **no extra file reads** — the home config is already loaded by every command
+- **once per version**, not once per invocation
+- **never when stdout is not a TTY**, so scripts and CI are unaffected
+
+## 5. Module shape
+
+`src/core/xself/repair.cppm` — new, and separate from `doctor.cppm` on purpose.
+Detection and repair are different concerns with different risk profiles, and
+today they are tangled: `cmd_doctor` is 585 lines in which the `--fix` branches
+are interleaved with the reporting.
+
+```cpp
+enum class RepairKind { MissingShim, OrphanShim, StaleRegistration, BrokenPayload };
+
+struct RepairTask {            // what doctor found, in a form repair can act on
+    RepairKind  kind;
+    std::string target;
+    std::string version;
+    std::string detail;
+};
+
+struct RepairResult {
+    bool        healed;
+    std::string rung;          // "local" | "re-register" | "reinstall" | "none"
+    std::string note;          // why it stopped, when it did
+};
+
+struct RepairPolicy {
+    bool allowNetwork  { true };   // R2/R3 off for a purely local pass
+    bool allowReinstall{ true };   // R3 off
+    bool assumeYes     { false };
+};
+
+RepairResult repair_one(const RepairTask&, const RepairPolicy&);
+```
+
+`cmd_doctor` keeps ownership of **what is wrong** and emits `RepairTask`s;
+`repair.cppm` owns **what to do about it**. That split is what makes the ladder
+unit-testable without a home, a network, or a payload: `repair_one` against a
+fake executor is a pure decision table.
+
+## 6. Idempotence and termination
+
+The ladder must not be able to loop, and running `--fix` twice must be a no-op
+the second time. Three rules:
+
+1. **One ladder per (target, version) per run.** A task that reaches "stop" is
+   not retried in the same invocation.
+2. **Re-detect once, at the end.** After the repair pass, findings are
+   recomputed and reported. If anything remains, it is reported as *remaining*,
+   not repaired again. A second pass is the user's decision.
+3. **A rung that reports success must change something observable**, and the
+   final re-detect is what checks it. R2 "succeeding" while the finding
+   persists is the silent-success shape this codebase keeps producing; here it
+   is caught by construction, because the report is computed after the fact
+   rather than accumulated from return codes.
+
+## 7. Acceptance
+
+Not "the command exits 0" — that is the failure mode, not the test. The
+simulation (PR #434) provides the measurement:
+
+| assertion | before | after |
+|---|---|---|
+| owner-less legacy entries in a 0.4.69 home after `--fix` | many | **0** |
+| `self doctor` exit code on a healthy upgraded home | 1 | **0** |
+| `.xlings.json:version` after `--fix` | `v0.4.69` | running version |
+| packages still usable (`use` both directions, shim `--version`) | ✓ | ✓ (unchanged) |
+| second consecutive `--fix` repairs anything | — | **nothing** |
+
+The last row is the idempotence check and is the one most likely to catch a
+mistake in §6.
+
+## 8. Steps
+
+| # | step | gate |
+|---|---|---|
+| S1 | `repair.cppm` with the ladder + policy, unit-tested against a fake executor | unit tests |
+| S2 | `cmd_doctor` emits `RepairTask`s; `--fix` drives the ladder | existing doctor tests stay green |
+| S3 | stamp `.xlings.json:version` on successful `--fix` | simulation assertion flips |
+| S4 | one-line migration hint on version mismatch (TTY only, once per version) | e2e: hint appears once, then not |
+| S5 | `self update` prints the same hint last | e2e |
+| S6 | re-detect pass + "remaining" reporting | idempotence assertion |

--- a/.agents/skills/xlings-contributing/SKILL.md
+++ b/.agents/skills/xlings-contributing/SKILL.md
@@ -212,12 +212,33 @@ Common CI failures:
 
 ## Version bumping (release flow)
 
+### Version numbering
+
+Releases are date-based: `YYYY.M.D.N`, e.g. `2026.7.28.1`.
+
+**`N` starts at `1`. Do NOT use `.0` for an ordinary release.**
+`.0` is reserved for a formal/milestone release on that date. A routine
+same-day fix or feature release is `.1`, the next `.2`, and so on. When in
+doubt, it is not a formal release — use `.1`.
+
+```
+2026.7.28.1   ← first release of the day (the normal case)
+2026.7.28.2   ← second release of the day
+2026.7.28.0   ← reserved: formal release, only when explicitly intended
+```
+
+Note that `semver::parse` rejects a four-component version, so resolution
+falls back to lexicographic ordering — always publish and reference these
+through an explicit `latest` ref rather than relying on version comparison.
+
+### Steps
+
 After feature PRs merge, if a release is planned:
 
 ```bash
 # On main:
 # Edit src/core/config.cppm VERSION
-git commit -m "chore(0.4.XX): bump version for release"
+git commit -m "chore(2026.7.28.1): bump version for release"
 git push origin main
 
 # Trigger release

--- a/.agents/tools/simulate-legacy-upgrade.sh
+++ b/.agents/tools/simulate-legacy-upgrade.sh
@@ -1,0 +1,503 @@
+#!/usr/bin/env bash
+# Real-machine simulation of an 0.4.69 -> latest upgrade.
+#
+# Why this exists
+# ---------------
+# Every upgrade check so far has been run against a *synthesized* legacy home:
+# a state file hand-written to look like what 0.4.69 leaves behind. That keeps
+# missing the interesting failures, because the interesting failures come from
+# what 0.4.69 actually WROTE -- recipe versions that have since changed, host
+# detection that used to be wrong, payload layouts that have since moved.
+#
+# On 2026-07-28 a real user's home carried an llvm@20.1.7 whose recorded path
+# was `/home/<u>/.xlings\data\xpkgs\xim-x-llvm\20.1.7` (backslashes, on Linux)
+# with `.exe` aliases -- a Windows payload installed on Linux by an old client.
+# The upgraded client could neither reinstall it (payload mismatch) nor remove
+# it (removal target outside the owned selection). No synthesized fixture had
+# produced that shape, and none would have.
+#
+# So: install the real 0.4.69 release, install the real packages through it,
+# run the real `self update`, then drive the real commands a user would drive
+# afterwards. Record every exit code. Do not fix anything here.
+#
+# This script never touches the host xlings home. Everything lives under
+# SIM_ROOT with its own HOME, and XLINGS_HOME is left unset so the client
+# derives it from HOME exactly as it does for a real user.
+#
+# Usage:
+#   simulate-legacy-upgrade.sh [phase ...]
+#
+# Phases (default: all of them, in order):
+#   bootstrap   fetch + `self install` the OLD release
+#   populate    install the core packages, several at two versions
+#   snapshot    record the pre-upgrade state
+#   update      `xlings self update`
+#   heal        `xlings self doctor --fix` — the migration pass
+#   exercise    use / list / remove / install against the pre-upgrade packages
+#   report      summarize every recorded step
+#
+# Phases are checkpointed: a completed phase is skipped on re-run, so the
+# multi-GB `populate` is paid once. `SIM_FORCE=1` re-runs regardless.
+
+set -uo pipefail   # deliberately NOT -e: a failing step is the DATA
+
+OLD_VERSION="${OLD_VERSION:-0.4.69}"
+SIM_ROOT="${SIM_ROOT:-${TMPDIR:-/tmp}/legacy-upgrade-sim}"
+
+# ---------------------------------------------------------------- platform
+#
+# The three release platforms differ in more than the asset name, so each
+# difference is named once here rather than sprinkled through the phases.
+case "$(uname -s)" in
+  Linux)                     SIM_OS=linux   ;;
+  Darwin)                    SIM_OS=macosx  ;;
+  MINGW*|MSYS*|CYGWIN*)      SIM_OS=windows ;;
+  *) echo "unsupported host: $(uname -s)" >&2; exit 2 ;;
+esac
+
+case "$SIM_OS" in
+  linux)   SIM_ARCH="$(uname -m)"; [[ "$SIM_ARCH" == aarch64 ]] || SIM_ARCH=x86_64 ;;
+  macosx)  SIM_ARCH=arm64  ;;   # the only macOS asset published
+  windows) SIM_ARCH=x86_64 ;;
+esac
+
+SIM_ASSET_EXT=$([[ "$SIM_OS" == windows ]] && echo zip || echo tar.gz)
+SIM_EXE=$([[ "$SIM_OS" == windows ]] && echo .exe || echo "")
+
+USER_HOME="$SIM_ROOT/user"
+XHOME="$USER_HOME/.xlings"
+STAGE="$SIM_ROOT/stage"
+CKPT="$SIM_ROOT/checkpoints"
+TRANSCRIPT="$SIM_ROOT/transcript.log"
+STEPS="$SIM_ROOT/steps.tsv"
+
+mkdir -p "$SIM_ROOT" "$CKPT"
+
+# The host is behind a local proxy; without it every download in the isolated
+# env either hangs or silently falls back to a slow direct route, which would
+# read as "the upgrade is slow" rather than "the test harness is misconfigured".
+#
+# Seeded with a harmless entry rather than left empty: macOS ships bash 3.2,
+# where expanding an empty array under `set -u` is itself an "unbound
+# variable" error. That took out every step on the macOS runner at 26ms each.
+PROXY_ENV=("XLINGS_SIM=1")
+for v in http_proxy https_proxy HTTP_PROXY HTTPS_PROXY no_proxy NO_PROXY ALL_PROXY; do
+  [[ -n "${!v:-}" ]] && PROXY_ENV+=("$v=${!v}")
+done
+
+SYSPATH="${SIM_SYSPATH:-/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin}"
+
+# Run something with the simulated user's environment.
+#
+# On POSIX the environment is wiped (`env -i`): the point is that the client
+# derives everything from HOME, and an inherited XLINGS_HOME or PATH entry
+# would paper over exactly the bugs being looked for. XLINGS_HOME is never
+# passed -- a real user does not set it.
+#
+# Windows cannot take that: a scrubbed environment loses SYSTEMROOT, COMSPEC
+# and the rest, and processes fail to start for reasons that have nothing to
+# do with xlings. There the environment is inherited and only the variables
+# that decide the home are overridden -- including USERPROFILE, which is what
+# the Windows build reads rather than HOME.
+run_isolated() {
+  if [[ "$SIM_OS" == windows ]]; then
+    ( cd "$SIM_ROOT" && env -u XLINGS_HOME -u XLINGS_BIN \
+        HOME="$USER_HOME" USERPROFILE="$USER_HOME" \
+        PATH="$XHOME/subos/current/bin:$XHOME/bin:$PATH" \
+        "$@" )
+  else
+    ( cd "$SIM_ROOT" && env -i \
+        HOME="$USER_HOME" \
+        PATH="$XHOME/subos/current/bin:$XHOME/bin:$SYSPATH" \
+        TERM=dumb \
+        "${PROXY_ENV[@]}" \
+        "$@" )
+  fi
+}
+
+# Every invocation of the simulated client.
+xl() { run_isolated "$XHOME/bin/xlings$SIM_EXE" "$@"; }
+
+# A shim the client installed, invoked the way a user's shell would invoke it
+# (through subos/current/bin) rather than through xlings. 0.4.69 has no `run`
+# subcommand, and going through the shim is what actually proves the switch.
+shim() {
+  local prog="$1"; shift
+  run_isolated "$XHOME/subos/current/bin/$prog$SIM_EXE" "$@"
+}
+
+# The client's own recorded version. `xlings version` did not exist in 0.4.69,
+# so asking the CLI would report a difference between the two clients that is
+# about the CLI surface, not about which binary is installed.
+recorded_version() {
+  python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("version","?"))' \
+    "$XHOME/.xlings.json" 2>/dev/null || echo "?"
+}
+
+# `date +%s%3N` is a GNU extension: on macOS it prints the literal "%3N" and
+# every duration comes out as a nonsense integer rather than failing.
+now_ms() { python3 -c 'import time; print(int(time.time()*1000))'; }
+
+# The CLI emits ANSI unconditionally (NO_COLOR is honoured only by the shell
+# profile), and a transcript full of escape codes is unreadable. Progress bars
+# also redraw with CR, so those are unwrapped too or a whole install collapses
+# onto one unreadable line. Raw output is kept verbatim under out/.
+strip_ansi() { sed -E $'s/\x1B\\[[0-9;]*[A-Za-z]//g' | tr '\r' '\n'; }
+
+log()  { printf '%s\n' "$*" | tee -a "$TRANSCRIPT"; }
+head_() { log ""; log "=============== $* ==============="; }
+
+# run_step <id> <description> -- <command...>
+#
+# Records rc and wall time for every step whether it passes or fails, because
+# the point of the run is the failure list. The output is teed rather than
+# swallowed so a hang is visible while it is happening.
+run_step() {
+  local id="$1" desc="$2"; shift 2
+  [[ "${1:-}" == "--" ]] && shift
+  local start rc out
+  log ""
+  log "--- [$id] $desc"
+  log "    \$ $*"
+  start="$(now_ms)"
+  out="$SIM_ROOT/out/$id.log"
+  mkdir -p "$SIM_ROOT/out"
+  "$@" >"$out" 2>&1
+  rc=$?
+  local ms=$(( $(now_ms) - start ))
+  strip_ansi < "$out" | sed 's/^/    | /' | tee -a "$TRANSCRIPT"
+  printf '%s\t%s\t%s\t%s\n' "$id" "$rc" "$ms" "$desc" >> "$STEPS"
+  if [[ $rc -eq 0 ]]; then
+    log "    => rc=0 (${ms}ms)"
+  else
+    log "    => rc=$rc (${ms}ms)   <<< BLOCKER"
+  fi
+  return 0   # never abort the run on a step failure
+}
+
+phase_done() { [[ -f "$CKPT/$1" && -z "${SIM_FORCE:-}" ]]; }
+mark_done()  { : > "$CKPT/$1"; }
+
+# ---------------------------------------------------------------- bootstrap
+phase_bootstrap() {
+  head_ "bootstrap: xlings $OLD_VERSION into $XHOME"
+  local asset="xlings-$OLD_VERSION-$SIM_OS-$SIM_ARCH.$SIM_ASSET_EXT"
+  mkdir -p "$STAGE" "$USER_HOME"
+
+  if [[ ! -f "$STAGE/$asset" ]]; then
+    run_step bootstrap-download "fetch $asset" -- \
+      gh release download "v$OLD_VERSION" --repo openxlings/xlings \
+        --pattern "$asset" --dir "$STAGE"
+  fi
+  [[ -f "$STAGE/$asset" ]] || { log "FATAL: no $asset"; return 1; }
+
+  rm -rf "$STAGE/pkg" "$STAGE/raw"; mkdir -p "$STAGE/pkg"
+  local pkgdir="$STAGE/pkg"
+  if [[ "$SIM_OS" == windows ]]; then
+    # unzip has no --strip-components. Use the extracted top-level directory
+    # in place rather than moving its contents: `mv "$top"/*` silently skips
+    # dotfiles, and the release package's marker is `.xlings.json` -- without
+    # it `self install` reports "cannot detect source package directory".
+    run_step bootstrap-extract "extract release package" -- \
+      unzip -q "$STAGE/$asset" -d "$STAGE/raw"
+    pkgdir="$(find "$STAGE/raw" -mindepth 1 -maxdepth 1 -type d | head -1)"
+    [[ -n "$pkgdir" ]] || { log "FATAL: no top-level dir in $asset"; return 1; }
+  else
+    run_step bootstrap-extract "extract release package" -- \
+      tar -xzf "$STAGE/$asset" -C "$STAGE/pkg" --strip-components=1
+  fi
+  [[ -f "$pkgdir/.xlings.json" ]] \
+    || log "WARNING: $pkgdir has no .xlings.json; self install will not find the package"
+
+  # `self install` derives the target home from HOME. XLINGS_HOME must stay
+  # unset here: with it set, self install has historically written to one
+  # place and recorded another.
+  run_step bootstrap-self-install "self install (old client)" -- \
+    run_isolated "$pkgdir/bin/xlings$SIM_EXE" self install
+
+  # Stop here rather than let every later phase report rc=127. A broken
+  # bootstrap produced 19 "blockers" on the macOS and Windows runners, all of
+  # them the harness failing to start -- which is exactly the kind of noise
+  # that makes a findings table worth ignoring.
+  if [[ ! -x "$XHOME/bin/xlings$SIM_EXE" ]]; then
+    log "FATAL: bootstrap did not produce $XHOME/bin/xlings$SIM_EXE"
+    log "       the remaining phases would only report the harness failing"
+    return 1
+  fi
+  log "    installed version: $(recorded_version)"
+  mark_done bootstrap
+}
+
+# ---------------------------------------------------------------- populate
+#
+# Two versions of at least one package on every platform: the single-version
+# case cannot exercise `use` and hides every group/binding bug. llvm is the
+# one package published for all three, so it carries that role everywhere.
+#
+# gcc is linux-only in the index (the windows table has one version that
+# delegates to mingw, and there is no macosx table at all), so asking for it
+# elsewhere would record an index gap as an upgrade blocker.
+case "$SIM_OS" in
+  linux)
+    POPULATE=(gcc@15.1.0 gcc@16.1.0
+              llvm@20.1.7 llvm@22.1.8
+              node@20.19.0 node@22.17.1
+              cmake ninja xmake jq ripgrep fd bat mcpp) ;;
+  macosx|windows)
+    POPULATE=(llvm@20.1.7 llvm@22.1.8
+              node@20.19.0 node@22.17.1
+              cmake ninja xmake jq ripgrep fd bat mcpp) ;;
+esac
+# Override for a quick run: SIM_PACKAGES="mcpp llvm@20.1.7"
+[[ -n "${SIM_PACKAGES:-}" ]] && read -r -a POPULATE <<< "$SIM_PACKAGES"
+
+phase_populate() {
+  head_ "populate: install core packages with the OLD client"
+  for spec in "${POPULATE[@]}"; do
+    run_step "install-old-${spec//[@\/]/-}" "old client installs $spec" -- \
+      xl install "$spec" -y
+  done
+  mark_done populate
+}
+
+# ---------------------------------------------------------------- snapshot
+phase_snapshot() {
+  head_ "snapshot: state as written by $OLD_VERSION"
+  run_step snap-list "list installed" -- xl list
+  cp "$XHOME/.xlings.json" "$SIM_ROOT/state-before.json" 2>/dev/null \
+    && log "    saved state-before.json"
+  mark_done snapshot
+}
+
+# ---------------------------------------------------------------- update
+phase_update() {
+  head_ "update: xlings self update"
+  local before after
+  before="$(recorded_version)"
+  run_step self-update "self update to latest" -- xl self update
+  after="$(recorded_version)"
+  log "    version: $before -> $after"
+  # The whole point of `self update` is that this changes. It returning 0 is
+  # not evidence of anything -- that exact false pass was the field bug fixed
+  # in #424 -- so the recorded version is asserted separately.
+  if [[ "$before" == "$after" ]]; then
+    log "    => VERSION DID NOT CHANGE   <<< BLOCKER"
+    printf '%s\t%s\t%s\t%s\n' self-update-effective 1 0 \
+      "self update left the recorded version at $before" >> "$STEPS"
+  else
+    printf '%s\t%s\t%s\t%s\n' self-update-effective 0 0 \
+      "recorded version moved $before -> $after" >> "$STEPS"
+  fi
+  mark_done update
+}
+
+# assert_step <id> <description> <condition-rc>
+#
+# A recorded finding that is not the exit code of a command.
+#
+# The first run of this harness trusted rc and reported 23/26 green. Three of
+# those greens were `xlings remove llvm` (rc=0, 166ms), `install llvm` after
+# it (rc=0, 333ms) and a reinstall (rc=0, 277ms) -- durations that cannot
+# contain the work they claim. rc=0 from this CLI means "nothing raised", not
+# "the thing happened", so every state change gets asserted separately.
+assert_step() {
+  local id="$1" desc="$2" ok="$3"
+  printf '%s\t%s\t%s\t%s\n' "$id" "$ok" 0 "$desc" >> "$STEPS"
+  if [[ "$ok" -eq 0 ]]; then log "    [assert] $id: ok"
+  else log "    [assert] $id: FAILED -- $desc   <<< BLOCKER"; fi
+}
+
+# Is <pkg>[@<version>] listed as installed right now?
+listed() {
+  local needle="$1"
+  xl list 2>/dev/null | strip_ansi | grep -qF "$needle"
+}
+
+# ---------------------------------------------------------------- heal
+#
+# `xlings self doctor --fix` — the migration pass. Runs in the NEW client,
+# because `self update` is the old binary replacing itself and cannot do this.
+#
+# SIM_CANDIDATE_BIN lets a PR test its own build before the change is
+# published: the phase runs that binary instead of whatever `self update`
+# fetched. Without it, the released client is what gets measured.
+heal_bin() {
+  if [[ -n "${SIM_CANDIDATE_BIN:-}" ]]; then printf '%s' "$SIM_CANDIDATE_BIN"
+  else printf '%s' "$XHOME/bin/xlings$SIM_EXE"; fi
+}
+
+# How many payload findings doctor reports right now. Read from the summary
+# line rather than counted from the findings, because the summary is what the
+# exit code is computed from.
+broken_count() {
+  run_isolated "$(heal_bin)" self doctor 2>&1 \
+    | strip_ansi | grep -aoE 'broken payloads +[0-9]+' \
+    | grep -oE '[0-9]+' | head -1
+}
+
+phase_heal() {
+  head_ "heal: self doctor --fix migrates what the old client registered"
+  log "    client under test: $(heal_bin)"
+
+  local before after1 after2 stamped
+  before="$(broken_count)"; before="${before:-0}"
+  log "    payload findings before: $before"
+
+  run_step heal-fix-1 "self doctor --fix (first pass)" -- \
+    run_isolated "$(heal_bin)" self doctor --fix
+  after1="$(broken_count)"; after1="${after1:-0}"
+  log "    payload findings after pass 1: $after1"
+
+  # The migration marker. `self update` never wrote it, which is what made a
+  # "you are behind" hint impossible to build; --fix stamping it is what makes
+  # the hint stop once the migration has actually happened.
+  stamped="$(recorded_version)"
+  log "    recorded client version: $stamped"
+  [[ "$stamped" != "v0.4.69" && "$stamped" != "?" ]]
+  assert_step heal-stamped \
+    "--fix stamped the home with the running client (was v0.4.69, now $stamped)" $?
+
+  [[ "$after1" -lt "$before" || "$before" -eq 0 ]]
+  assert_step heal-reduced \
+    "payload findings went down ($before -> $after1)" $?
+
+  # Idempotence: a second pass must not find work. A ladder that repairs the
+  # same thing every run is not converging, it is looping.
+  run_step heal-fix-2 "self doctor --fix (second pass)" -- \
+    run_isolated "$(heal_bin)" self doctor --fix
+  after2="$(broken_count)"; after2="${after2:-0}"
+  log "    payload findings after pass 2: $after2"
+
+  [[ "$after2" -le "$after1" ]]
+  assert_step heal-idempotent \
+    "second --fix did not increase findings ($after1 -> $after2)" $?
+
+  grep -aq "repair failed" "$SIM_ROOT/out/heal-fix-2.log" 2>/dev/null
+  [[ $? -ne 0 ]]
+  assert_step heal-no-failures "second --fix reported no repair failures" $?
+
+  mark_done heal
+}
+
+# ---------------------------------------------------------------- exercise
+# What a user does the day after upgrading. Each is independent: a failure in
+# one must not stop the next, or the first blocker hides all the others.
+phase_exercise() {
+  head_ "exercise: drive the pre-upgrade packages with the NEW client"
+
+  run_step ex-list        "list installed"  -- xl list
+  run_step ex-list-all    "list --all"      -- xl list --all
+  # `doctor` is a subcommand of `self`, not a top-level command.
+  run_step ex-doctor      "self doctor"     -- xl self doctor
+
+  # Switching between two installed versions, both directions. The switch is
+  # confirmed through the shim's own --version output, not through `use`'s
+  # exit code: `use` reporting success while the shim still resolves the old
+  # payload is precisely the failure worth catching.
+  if [[ "$SIM_OS" == linux ]]; then
+    run_step ex-use-gcc-15 "use gcc 15.1.0" -- xl use gcc 15.1.0
+    run_step ex-gcc-v-15   "gcc --version through the shim" -- shim gcc --version
+    grep -q "15\.1\.0" "$SIM_ROOT/out/ex-gcc-v-15.log" 2>/dev/null
+    assert_step ex-gcc-is-15 "shim reports 15.1.0 after use gcc 15.1.0" $?
+
+    run_step ex-use-gcc-16 "use gcc 16.1.0" -- xl use gcc 16.1.0
+    run_step ex-gcc-v-16   "gcc --version through the shim" -- shim gcc --version
+    grep -q "16\.1\.0" "$SIM_ROOT/out/ex-gcc-v-16.log" 2>/dev/null
+    assert_step ex-gcc-is-16 "shim reports 16.1.0 after use gcc 16.1.0" $?
+  fi
+
+  run_step ex-use-llvm-20 "use llvm 20.1.7" -- xl use llvm 20.1.7
+  run_step ex-use-llvm-22 "use llvm 22.1.8" -- xl use llvm 22.1.8
+
+  # Reinstall of something the OLD client registered. Whether this re-runs the
+  # config hook or short-circuits on "already installed" is itself the finding.
+  run_step ex-reinstall-llvm "new client reinstalls llvm" -- xl install llvm -y
+  run_step ex-reinstall-mcpp "new client reinstalls mcpp" -- xl install mcpp -y
+  [[ "$SIM_OS" == linux ]] && \
+    run_step ex-reinstall-gcc "new client reinstalls gcc" -- xl install gcc -y
+
+  # Removal of something the OLD client registered, then putting it back.
+  # `remove <bare-name>` with two versions installed has to pick one; which
+  # one, and whether the other survives, is asserted rather than assumed.
+  run_step ex-remove-llvm "new client removes llvm" -- xl remove llvm -y
+  ! listed "llvm@22.1.8"
+  assert_step ex-llvm-22-gone "llvm@22.1.8 no longer listed after remove llvm" $?
+  listed "llvm@20.1.7"
+  assert_step ex-llvm-20-kept "llvm@20.1.7 still listed (remove took one version)" $?
+
+  run_step ex-install-back-llvm "install llvm again after removal" -- xl install llvm -y
+  listed "llvm@22.1.8"
+  assert_step ex-llvm-22-back "llvm@22.1.8 listed again after install llvm" $?
+
+  if [[ "$SIM_OS" == linux ]]; then
+    run_step ex-remove-gcc15 "new client removes gcc@15.1.0" -- xl remove gcc@15.1.0 -y
+    ! listed "gcc@15.1.0"
+    assert_step ex-gcc-15-gone "gcc@15.1.0 no longer listed after remove" $?
+    listed "gcc@16.1.0"
+    assert_step ex-gcc-16-kept "gcc@16.1.0 survives removal of the other version" $?
+  fi
+
+  run_step ex-doctor-after "self doctor after the churn" -- xl self doctor
+  cp "$XHOME/.xlings.json" "$SIM_ROOT/state-after.json" 2>/dev/null \
+    && log "    saved state-after.json"
+  mark_done exercise
+}
+
+# ---------------------------------------------------------------- report
+phase_report() {
+  head_ "report"
+  [[ -f "$STEPS" ]] || { log "no steps recorded"; return 0; }
+  local total fails
+  total="$(wc -l < "$STEPS")"
+  fails="$(awk -F'\t' '$2 != 0' "$STEPS" | wc -l)"
+  log ""
+  log "steps: $total   blockers: $fails"
+  log ""
+  printf '%-28s %5s %10s  %s\n' ID RC MS DESC | tee -a "$TRANSCRIPT"
+  awk -F'\t' '{printf "%-28s %5s %10s  %s\n", $1, $2, $3, $4}' "$STEPS" \
+    | tee -a "$TRANSCRIPT"
+  if [[ "$fails" -gt 0 ]]; then
+    log ""
+    log "BLOCKERS:"
+    awk -F'\t' '$2 != 0 {printf "  [%s] rc=%s  %s\n", $1, $2, $4}' "$STEPS" \
+      | tee -a "$TRANSCRIPT"
+  fi
+
+  # A blocker is this harness's OUTPUT, not its failure: the job stays green
+  # and publishes the table, because a run that is red every time gets muted
+  # and then nobody reads the findings it exists to produce.
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    {
+      printf '## upgrade simulation — %s/%s\n\n' "$SIM_OS" "$SIM_ARCH"
+      printf '%s -> latest · %s steps · **%s blockers**\n\n' \
+        "$OLD_VERSION" "$total" "$fails"
+      printf '| step | rc | ms | what |\n|---|---:|---:|---|\n'
+      awk -F'\t' '{printf "| `%s` | %s | %s | %s |\n", $1, $2, $3, $4}' "$STEPS"
+    } >> "$GITHUB_STEP_SUMMARY"
+  fi
+}
+
+main() {
+  local phases=("$@")
+  [[ ${#phases[@]} -eq 0 ]] && \
+    phases=(bootstrap populate snapshot update heal exercise report)
+  log "### simulation start  $SIM_OS/$SIM_ARCH  root=$SIM_ROOT"
+  for p in "${phases[@]}"; do
+    if [[ "$p" != report ]] && phase_done "$p"; then
+      log ""
+      log "=============== $p: already done, skipping (SIM_FORCE=1 to redo)"
+      continue
+    fi
+    # A phase that reports itself unusable (bootstrap with no client binary)
+    # short-circuits to the report. Everything after it would measure the
+    # harness, not the upgrade.
+    if ! "phase_$p" && [[ "$p" != report ]]; then
+      log ""
+      log "=============== $p failed; skipping to report"
+      phase_report
+      return 1
+    fi
+  done
+}
+
+main "$@"

--- a/.agents/tools/simulate-legacy-upgrade.sh
+++ b/.agents/tools/simulate-legacy-upgrade.sh
@@ -175,6 +175,33 @@ run_step() {
   return 0   # never abort the run on a step failure
 }
 
+# Like run_step, but a non-zero exit is EXPECTED and is not a blocker.
+#
+# `self doctor` exits non-zero while any finding remains, and on a real home
+# plenty remain that the repair ladder is not responsible for -- active-group
+# incoherence between two providers that both claim `cc` accounts for ~190 on
+# its own. Filing those as blockers would inflate the count the report exists
+# to communicate. The exit code is still recorded, in the description.
+run_step_info() {
+  local id="$1" desc="$2"; shift 2
+  [[ "${1:-}" == "--" ]] && shift
+  local start rc out
+  log ""
+  log "--- [$id] $desc"
+  log "    \$ $*"
+  start="$(now_ms)"
+  out="$SIM_ROOT/out/$id.log"
+  mkdir -p "$SIM_ROOT/out"
+  "$@" >"$out" 2>&1
+  rc=$?
+  local ms=$(( $(now_ms) - start ))
+  strip_ansi < "$out" | sed 's/^/    | /' | tee -a "$TRANSCRIPT"
+  printf '%s\t%s\t%s\t%s\n' "$id" 0 "$ms" "$desc (exit $rc, informational)" \
+    >> "$STEPS"
+  log "    => rc=$rc (${ms}ms)   [informational]"
+  return 0
+}
+
 phase_done() { [[ -f "$CKPT/$1" && -z "${SIM_FORCE:-}" ]]; }
 mark_done()  { : > "$CKPT/$1"; }
 
@@ -343,7 +370,7 @@ phase_heal() {
   before="$(broken_count)"; before="${before:-0}"
   log "    payload findings before: $before"
 
-  run_step heal-fix-1 "self doctor --fix (first pass)" -- \
+  run_step_info heal-fix-1 "self doctor --fix (first pass)" -- \
     run_isolated "$(heal_bin)" self doctor --fix
   after1="$(broken_count)"; after1="${after1:-0}"
   log "    payload findings after pass 1: $after1"
@@ -357,13 +384,17 @@ phase_heal() {
   assert_step heal-stamped \
     "--fix stamped the home with the running client (was v0.4.69, now $stamped)" $?
 
-  [[ "$after1" -lt "$before" || "$before" -eq 0 ]]
-  assert_step heal-reduced \
-    "payload findings went down ($before -> $after1)" $?
+  # Not "went down": the summary counts findings the ladder does not own
+  # (active-group incoherence, ~190 on a real home), so on an already-migrated
+  # home the honest requirement is that --fix never makes things worse. The
+  # quality signal is heal-no-failures plus heal-idempotent below.
+  [[ "$after1" -le "$before" ]]
+  assert_step heal-not-worse \
+    "--fix did not increase findings ($before -> $after1)" $?
 
   # Idempotence: a second pass must not find work. A ladder that repairs the
   # same thing every run is not converging, it is looping.
-  run_step heal-fix-2 "self doctor --fix (second pass)" -- \
+  run_step_info heal-fix-2 "self doctor --fix (second pass)" -- \
     run_isolated "$(heal_bin)" self doctor --fix
   after2="$(broken_count)"; after2="${after2:-0}"
   log "    payload findings after pass 2: $after2"
@@ -388,7 +419,7 @@ phase_exercise() {
   run_step ex-list        "list installed"  -- xl list
   run_step ex-list-all    "list --all"      -- xl list --all
   # `doctor` is a subcommand of `self`, not a top-level command.
-  run_step ex-doctor      "self doctor"     -- xl self doctor
+  run_step_info ex-doctor "self doctor"     -- xl self doctor
 
   # Switching between two installed versions, both directions. The switch is
   # confirmed through the shim's own --version output, not through `use`'s
@@ -437,7 +468,7 @@ phase_exercise() {
     assert_step ex-gcc-16-kept "gcc@16.1.0 survives removal of the other version" $?
   fi
 
-  run_step ex-doctor-after "self doctor after the churn" -- xl self doctor
+  run_step_info ex-doctor-after "self doctor after the churn" -- xl self doctor
   cp "$XHOME/.xlings.json" "$SIM_ROOT/state-after.json" 2>/dev/null \
     && log "    saved state-after.json"
   mark_done exercise

--- a/src/agent/skills/contributing.cppm
+++ b/src/agent/skills/contributing.cppm
@@ -92,14 +92,29 @@ VERSION BUMP + RELEASE — separate from feature work
 
 Releasing a new version is a MULTI-STEP process. Do NOT skip steps.
 
+VERSION NUMBERING — date-based, YYYY.M.D.N (e.g. 2026.7.28.1).
+
+  N STARTS AT 1. Do NOT use .0 for an ordinary release.
+  .0 is reserved for a formal / milestone release on that date.
+  A routine same-day fix or feature release is .1, the next .2, and
+  so on. If you are unsure whether it is formal: it is not. Use .1.
+
+    2026.7.28.1   first release of the day (the normal case)
+    2026.7.28.2   second release of the day
+    2026.7.28.0   RESERVED — formal release, only when explicitly asked
+
+  semver::parse rejects a four-component version, so resolution falls
+  back to lexicographic order. Always publish and reference these
+  through an explicit `latest` ref, never by version comparison.
+
 STEP 1: AFTER all feature PRs are merged to main, create a
         version-bump PR (yes, a PR — not a direct push):
-  git switch -c chore/bump-0.4.XX origin/main
-  # Edit src/core/config.cppm: VERSION = "0.4.XX"
+  git switch -c chore/bump-2026.7.28.1 origin/main
+  # Edit src/core/config.cppm: VERSION = "2026.7.28.1"
   git add src/core/config.cppm
-  git commit -m "chore: bump version to 0.4.XX"
-  git push -u origin chore/bump-0.4.XX
-  gh pr create --title "chore: bump version to 0.4.XX"
+  git commit -m "chore: bump version to 2026.7.28.1"
+  git push -u origin chore/bump-2026.7.28.1
+  gh pr create --title "chore: bump version to 2026.7.28.1"
 
 STEP 2: Wait for CI to pass on the bump PR.
 

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -1127,6 +1127,51 @@ public:
         platform::write_string_to_file(configPath.string(), json.dump(2));
     }
 
+    // Which xlings set this home up.
+    //
+    // Always the HOME config, never a project one: this describes the
+    // installed client, not a workspace. Historically only `self install`
+    // wrote it (xself/install.cppm), so `self update` -- which installs
+    // xlings@latest as an ordinary package -- left it reading the previous
+    // version forever. The field is what tells a user their packages predate
+    // their client, so a stale one is worse than none.
+    [[nodiscard]] static std::string recorded_client_version() {
+        namespace fs = std::filesystem;
+        auto configPath = instance_().paths_.homeDir / ".xlings.json";
+        if (!fs::exists(configPath)) return {};
+        try {
+            auto content = platform::read_file_to_string(configPath.string());
+            auto json = nlohmann::json::parse(content, nullptr, false);
+            if (json.is_discarded() || !json.is_object()) return {};
+            auto it = json.find("version");
+            if (it == json.end() || !it->is_string()) return {};
+            return it->get<std::string>();
+        } catch (...) { return {}; }
+    }
+
+    // Read-modify-write of the single field, deliberately: the file also
+    // holds the xvm versions DB and the user's config, and this is called
+    // from a command that has not necessarily loaded either.
+    static void record_client_version(const std::string& version) {
+        namespace fs = std::filesystem;
+        auto configPath = instance_().paths_.homeDir / ".xlings.json";
+        nlohmann::json json = nlohmann::json::object();
+        if (fs::exists(configPath)) {
+            try {
+                auto content = platform::read_file_to_string(configPath.string());
+                json = nlohmann::json::parse(content, nullptr, false);
+                if (json.is_discarded() || !json.is_object()) {
+                    // Refuse to replace a file we could not parse. Overwriting
+                    // it here would trade a stale version field for a lost
+                    // versions DB.
+                    return;
+                }
+            } catch (...) { return; }
+        }
+        json["version"] = version;
+        platform::write_string_to_file(configPath.string(), json.dump(2));
+    }
+
     // Save current subos workspace (project-local if project config exists)
     static void save_workspace() {
         namespace fs = std::filesystem;

--- a/src/core/xim/commands.cppm
+++ b/src/core/xim/commands.cppm
@@ -24,6 +24,10 @@ import xlings.core.xvm.commands;
 import xlings.core.xvm.shim;
 import xlings.core.profile;
 import xlings.runtime.cancellation;
+// Leaf module (std + log + platform only), so importing it here does not
+// recreate the xim.commands <-> xself cycle that keeps `self update` shelling
+// out to a subprocess.
+import xlings.core.xself.repair;
 
 namespace xpkg = mcpplibs::xpkg;
 
@@ -539,6 +543,8 @@ int cmd_install(std::span<const std::string> targets, bool yes, bool noDeps,
     // install` and `interface install_packages` would report exitCode=0
     // even when individual packages failed to install — see
     // .agents/docs/2026-05-22-cmd-install-silent-failure-analysis.md
+    xself::print_migration_hint_once(Config::recorded_client_version(),
+                                     Info::VERSION);
     return failedCount > 0 ? 1 : 0;
 }
 
@@ -821,6 +827,13 @@ int cmd_list(const std::string& filter, EventStream& stream, bool all = false) {
             log::println("no packages installed in current subos");
             log::println("  hint: `xlings list --all` to see globally-installed packages");
         }
+        // The empty list is where the nudge matters MOST, not least: a home
+        // whose packages are still registered in the old client's format can
+        // report nothing installed while the payloads sit on disk and the
+        // shims work. Returning early without it would stay silent exactly
+        // when the user has the strongest reason to wonder.
+        xself::print_migration_hint_once(Config::recorded_client_version(),
+                                         Info::VERSION);
         return 0;
     }
 
@@ -837,6 +850,8 @@ int cmd_list(const std::string& filter, EventStream& stream, bool all = false) {
     listPayload["numbered"] = true;
     stream.emit(DataEvent{"styled_list", listPayload.dump()});
     log::println("total: {} installed", installed.size());
+    xself::print_migration_hint_once(Config::recorded_client_version(),
+                                     Info::VERSION);
     return 0;
 }
 

--- a/src/core/xself.cppm
+++ b/src/core/xself.cppm
@@ -14,7 +14,7 @@
 //   xself/config.cppm           — `self config`
 //   xself/clean.cppm            — `self clean [--dry-run]`
 //   xself/migrate.cppm          — `self migrate`
-//   xself/doctor.cppm           — `self doctor [--fix] [--reset-metadata]`
+//   xself/doctor.cppm           — `self doctor [--fix] [--dry-run] [--reset-metadata]`
 //   compact/xself.cppm          — cross-version compat shims, organized
 //                                 into vX_Y_Z sub-namespaces. See its
 //                                 header for the removal procedure when
@@ -55,7 +55,7 @@ static int cmd_help(EventStream& stream) {
         {{"name", "config"},    {"desc", "Show configuration details"}},
         {{"name", "clean"},     {"desc", "Remove cache + gc orphaned packages (--dry-run)"}},
         {{"name", "migrate"},   {"desc", "Migrate old layout to subos/default"}},
-        {{"name", "doctor"},    {"desc", "Verify workspace/shim consistency (--fix to repair, --reset-metadata to discard unreadable release metadata)"}},
+        {{"name", "doctor"},    {"desc", "Verify workspace/shim consistency (--fix to repair, --dry-run to preview the repairs, --reset-metadata to discard unreadable release metadata)"}},
     });
     stream.emit(DataEvent{"help", payload.dump()});
     return 0;
@@ -90,14 +90,18 @@ export int run(int argc, char* argv[], EventStream& stream) {
     if (action == "doctor") {
         bool fix = false;
         bool resetMetadata = false;
+        bool dryRun = false;
         for (int i = 3; i < argc; ++i) {
             const auto arg = std::string(argv[i]);
             if (arg == "--fix") fix = true;
             // Discards unreadable binding metadata, so it is opt-in on top
             // of --fix rather than part of it.
             if (arg == "--reset-metadata") resetMetadata = true;
+            // Show the repair plan without running it. Only meaningful
+            // with --fix, which is the flag that can now touch the network.
+            if (arg == "--dry-run") dryRun = true;
         }
-        return cmd_doctor(stream, fix, resetMetadata);
+        return cmd_doctor(stream, fix, resetMetadata, dryRun);
     }
     // help / unknown-action handling. Distinguish a deliberate help
     // request (no action / -h / --help) from a typo / made-up action so

--- a/src/core/xself/doctor.cppm
+++ b/src/core/xself/doctor.cppm
@@ -283,6 +283,47 @@ export int cmd_doctor(EventStream& stream, bool fix,
     // command. See the policy comment on cmd_doctor for the rationale.
     auto home_str = p.homeDir.string();
 
+    // Does this payload ship ANY executable?
+    //
+    // The discriminator between "a library-only package that xvm typed as a
+    // program" and "a program whose binary went missing". `is_binding_root`
+    // was doing that job and cannot: it skips the entry itself, so a package
+    // that is the sole member of its own release -- gcc-runtime@15.1.0, found
+    // by the ten-package upgrade simulation -- comes back false and gets
+    // reported as broken. Reinstalling it can never help, because nothing is
+    // wrong; it just has no program to find. Left that way it also blocks the
+    // migration marker forever, so the hint telling the user to run --fix
+    // never turns off after they have run it.
+    //
+    // Scanning is confined to the failure path, and shallow: the payload root
+    // and bin/, which is where a recipe puts programs. A package with other
+    // executables present but this one missing is genuinely broken and still
+    // reported.
+    auto payload_has_any_executable = [](const fs::path& dir) {
+        auto scan = [](const fs::path& d) {
+            std::error_code ec;
+            if (!fs::is_directory(d, ec)) return false;
+            for (auto& e : platform::dir_entries(d)) {
+                std::error_code fec;
+                if (!e.is_regular_file(fec) && !e.is_symlink(fec)) continue;
+#if defined(_WIN32)
+                auto ext = e.path().extension().string();
+                if (ext == ".exe" || ext == ".bat" || ext == ".cmd") return true;
+#else
+                auto st = fs::status(e.path(), fec);
+                if (!fec && (st.permissions() & (fs::perms::owner_exec
+                                                 | fs::perms::group_exec
+                                                 | fs::perms::others_exec))
+                            != fs::perms::none) {
+                    return true;
+                }
+#endif
+            }
+            return false;
+        };
+        return scan(dir) || scan(dir / "bin");
+    };
+
     // Findings the repair ladder can act on, collected during detection and
     // acted on afterwards. Repairing inline would mutate the database that
     // the rest of detection is still walking.
@@ -357,7 +398,8 @@ export int cmd_doctor(EventStream& stream, bool fix,
                 // survived while its executable did not; that entry is also
                 // a binding root, so it lands here too and the user still
                 // sees the line.
-                if (xvm::is_binding_root(db, name, version)) {
+                if (xvm::is_binding_root(db, name, version)
+                    || !payload_has_any_executable(expanded)) {
                     add_field("ⓘ release anchor", std::format(
                         "{}@{} registers no program of its own; it names the "
                         "release its libraries belong to", name, version));

--- a/src/core/xself/doctor.cppm
+++ b/src/core/xself/doctor.cppm
@@ -601,6 +601,17 @@ export int cmd_doctor(EventStream& stream, bool fix,
             return platform::exec(cmd);
         };
 
+        // Repair with the client that is running, not with whatever `xlings`
+        // resolves to on PATH. Normally they are the same binary; they are
+        // not when doctor was started by absolute path, and then the repair
+        // would be carried out by a different client than the one that
+        // decided what needed repairing.
+        RepairPolicy policy;
+        {
+            const auto self = platform::get_executable_path().string();
+            if (!self.empty() && is_shell_safe_token(self)) policy.client = self;
+        }
+
         // A finding names an xvm TARGET; the ladder installs a PACKAGE, and
         // the two are not the same thing. A broken llvm release reports
         // `ar@22.1.8`, `clang@22.1.8`, `cc@22.1.8` and forty more -- none of
@@ -617,7 +628,7 @@ export int cmd_doctor(EventStream& stream, bool fix,
             auto key = std::pair{name, ver};
             auto it = probed.find(key);
             if (it != probed.end()) return it->second;
-            bool ok = probe_reinstallable(name, ver, run);
+            bool ok = probe_reinstallable(name, ver, run, policy.client);
             probed.emplace(key, ok);
             return ok;
         };
@@ -705,7 +716,7 @@ export int cmd_doctor(EventStream& stream, bool fix,
                                              covered.size() == 1 ? "y" : "ies"),
                 .reinstallable = true,   // confirmed by the probe above
             };
-            auto result = repair_one(task, RepairPolicy{}, run);
+            auto result = repair_one(task, policy, run);
             // Attribute the outcome to every finding the owner covers, so the
             // re-detect below checks the entries the user was shown.
             for (const auto& c : covered) outcomes.emplace_back(c, result);

--- a/src/core/xself/doctor.cppm
+++ b/src/core/xself/doctor.cppm
@@ -47,20 +47,32 @@ namespace fs = std::filesystem;
 //      so users get a heads-up before they `xlings use` an inactive
 //      version that is actually broken.
 //
-// `--fix` policy (deliberately conservative):
+// `--fix` policy:
 //   - missing shim   → recreate from the bootstrap binary  (safe, local)
 //   - orphan shim    → remove the file                     (safe, local)
-//   - broken payload → DO NOTHING.  Print an actionable hint
-//                      `xlings install <pkg>@<ver>` that the user can
-//                      run themselves.  doctor never deletes payload
-//                      metadata or pulls from the network.  Why: an
-//                      auto reinstall would silently touch the network
-//                      (failure-prone) and rerun install hooks (side
-//                      effects); the user is the right party to decide
-//                      to do that.  The recipe is just `install` —
-//                      installer's xvm-DB shortcut verifies payload
-//                      existence on disk now, so re-running the install
-//                      hook is automatic when the payload is missing.
+//   - broken payload → REPAIR, via the ladder in xself/repair.cppm:
+//                      re-register (`xlings install <pkg>@<ver>`), and if
+//                      that fails, remove-then-install.
+//
+//                      This used to print the command and refuse to run it,
+//                      on the grounds that touching the network and rerunning
+//                      install hooks were the user's decision. That reasoning
+//                      does not survive contact with an upgraded home: 0.4.69
+//                      records a headers-only package as ONE program-typed
+//                      entry with a payload path and no executable inside it,
+//                      so the new client cannot tell it from a program whose
+//                      binary vanished, and reports every such package.
+//                      Measured on the upgrade simulation: 56 findings on a
+//                      home with five packages in it, each with a printed
+//                      command that was in fact the correct cure. Handing a
+//                      user 56 commands to paste is not a diagnosis.
+//
+//                      The promise that replaces "never touches the network":
+//                      `--dry-run` shows exactly what would run and stops,
+//                      each (name, version) gets at most one pass, and the
+//                      result is verified by re-detecting from a reloaded
+//                      state file rather than by trusting a subprocess's
+//                      exit code.
 //   - alias warning  → not auto-fixed (could be intentional external).
 //   - corrupt binding metadata → --reset-metadata only.  Why: it is the one
 //                      repair that loses information (the release, its
@@ -68,7 +80,8 @@ namespace fs = std::filesystem;
 //                      entry becomes a standalone version), so it must be
 //                      asked for, not inherited from --fix.
 export int cmd_doctor(EventStream& stream, bool fix,
-                      bool resetMetadata = false) {
+                      bool resetMetadata = false,
+                      bool dryRun = false) {
     auto& p   = Config::paths();
     auto db   = Config::versions();
     auto ws   = Config::effective_workspace();
@@ -102,6 +115,13 @@ export int cmd_doctor(EventStream& stream, bool fix,
     int broken   = 0;
     int warnings = 0;
     int healed   = 0;
+    // Binding-state problems are counted apart from broken payloads.
+    // They used to share `broken`, and the summary then reported
+    // "broken payloads 1" on a home whose only finding was an unregistered
+    // active version -- a count with nothing in the list to explain it, and
+    // a --fix hint claiming payloads could not be repaired when the repair
+    // pass had never run. Two different defects need two different counters.
+    int bindingIssues = 0;
 
     // Check 1: every workspace program has its shim.
     for (auto& [name, version] : ws) {
@@ -440,7 +460,7 @@ export int cmd_doctor(EventStream& stream, bool fix,
         // A notice describes state the upgrade inherited rather than
         // created, so it does not colour the run red -- same reasoning as
         // the release anchors above. It still prints its remediation.
-        if (!notice) ++broken;
+        if (!notice) ++bindingIssues;
         std::string detail = finding.summary;
         if (!finding.target.empty()) {
             detail += std::format(" [{}{}{}]", finding.target,
@@ -653,6 +673,27 @@ export int cmd_doctor(EventStream& stream, bool fix,
                 task.target, task.version));
         }
 
+        // `--dry-run`: show the plan and stop.
+        //
+        // `--fix` used to be network-free and side-effect-free; the ladder
+        // ends that, so the promise is replaced with a narrower one rather
+        // than dropped -- you can always see exactly what it would do before
+        // it does it. The probe above has already run, so the plan shown is
+        // the plan that would execute, not a guess at one.
+        if (dryRun) {
+            for (const auto& [owner, covered] : byOwner) {
+                add_field("→ would run", std::format(
+                    "xlings install {}@{}   ({} entr{})",
+                    owner.first, owner.second, covered.size(),
+                    covered.size() == 1 ? "y" : "ies"));
+            }
+            add_field("dry run", std::format(
+                "{} package(s) would be repaired; nothing was changed",
+                byOwner.size()), true);
+            repairTasks.clear();
+            byOwner.clear();
+        }
+
         std::vector<std::pair<RepairTask, RepairResult>> outcomes;
         for (const auto& [owner, covered] : byOwner) {
             RepairTask task{
@@ -729,7 +770,7 @@ export int cmd_doctor(EventStream& stream, bool fix,
         }
     }
 
-    int issues = missing + orphans + broken;
+    int issues = missing + orphans + broken + bindingIssues;
     if (issues == 0 && warnings == 0) {
         add_field("status",
                   "OK — workspace, shims, and payloads are all consistent",
@@ -738,6 +779,8 @@ export int cmd_doctor(EventStream& stream, bool fix,
         if (missing  > 0) add_field("missing shims",   std::to_string(missing));
         if (orphans  > 0) add_field("orphan shims",    std::to_string(orphans));
         if (broken   > 0) add_field("broken payloads", std::to_string(broken));
+        if (bindingIssues > 0)
+            add_field("binding state", std::to_string(bindingIssues));
         if (warnings > 0) add_field("warnings",        std::to_string(warnings));
         if (fix) {
             if (healed > 0) add_field("healed", std::to_string(healed), true);
@@ -774,7 +817,7 @@ export int cmd_doctor(EventStream& stream, bool fix,
     // `c++` accounts for 190 findings on its own, measured. Requiring a
     // spotless home would mean the marker never lands and the hint nags
     // forever about a migration that already happened.
-    if (fix && repairFailed == 0) {
+    if (fix && !dryRun && repairFailed == 0) {
         Config::record_client_version(std::string(Info::VERSION));
     }
 

--- a/src/core/xself/doctor.cppm
+++ b/src/core/xself/doctor.cppm
@@ -17,6 +17,7 @@ import xlings.core.xvm.db;
 import xlings.core.xvm.shim;
 import xlings.core.xvm.inspect;
 import xlings.core.xvm.lock;
+import xlings.core.xself.repair;
 
 namespace xlings::xself {
 
@@ -262,10 +263,26 @@ export int cmd_doctor(EventStream& stream, bool fix,
     // command. See the policy comment on cmd_doctor for the rationale.
     auto home_str = p.homeDir.string();
 
+    // Findings the repair ladder can act on, collected during detection and
+    // acted on afterwards. Repairing inline would mutate the database that
+    // the rest of detection is still walking.
+    std::vector<RepairTask> repairTasks;
+    // Findings the repair pass owned and could not resolve. Distinct from
+    // `issues`, which also counts things --fix is not responsible for.
+    int repairFailed = 0;
+
     auto report_broken_payload = [&](const std::string& name,
                                      const std::string& version,
                                      std::string detail) {
         ++broken;
+        if (fix) {
+            repairTasks.push_back(RepairTask{
+                .kind    = RepairKind::BrokenPayload,
+                .target  = name,
+                .version = version,
+                .detail  = detail,
+            });
+        }
         auto wit = ws.find(name);
         bool is_active = (wit != ws.end() && wit->second == version);
         std::string label = is_active ? "✗ broken payload [active]"
@@ -545,9 +562,172 @@ export int cmd_doctor(EventStream& stream, bool fix,
         }
     }
 
-    // Note: there is intentionally no --fix loop for broken payloads here.
-    // Hints inline above each broken finding tell the user exactly what
-    // to run.
+    // ------------------------------------------------------------------
+    // Repair pass.
+    //
+    // `--fix` used to stop at the shim layer and print a copy-pasteable
+    // `xlings install` for every broken payload. On a home carried over from
+    // an older client that is not a handful of lines -- 0.4.69 records a
+    // headers-only package as one program-typed entry with a payload path and
+    // no executable, so every such package is reported, and the user has to
+    // run the command by hand for each one. Measured on the upgrade
+    // simulation (PR #434): the printed remedy IS the cure, because
+    // re-running install re-runs config() and re-registers the package in the
+    // current form. Doing it for them is the whole point of --fix.
+    //
+    // See .agents/docs/2026-07-28-self-repair-design.md for the ladder.
+    if (fix && !repairTasks.empty()) {
+        const CommandRunner run = [](const std::string& cmd) {
+            return platform::exec(cmd);
+        };
+
+        // A finding names an xvm TARGET; the ladder installs a PACKAGE, and
+        // the two are not the same thing. A broken llvm release reports
+        // `ar@22.1.8`, `clang@22.1.8`, `cc@22.1.8` and forty more -- none of
+        // which is installable, because they are programs the llvm package
+        // registers. Nor is the binding ROOT reliably the package: gcc's root
+        // target is `xim-gnu-gcc`, and `xlings install xim-gnu-gcc` is not a
+        // thing.
+        //
+        // So the owner is looked for, in descending order of confidence, and
+        // each candidate is confirmed against the index before it is used.
+        // Nothing is repaired on a guess.
+        std::map<std::pair<std::string, std::string>, bool> probed;
+        auto resolves = [&](const std::string& name, const std::string& ver) {
+            auto key = std::pair{name, ver};
+            auto it = probed.find(key);
+            if (it != probed.end()) return it->second;
+            bool ok = probe_reinstallable(name, ver, run);
+            probed.emplace(key, ok);
+            return ok;
+        };
+
+        auto owning_package = [&](const std::string& target,
+                                  const std::string& version)
+            -> std::optional<std::pair<std::string, std::string>> {
+            // 1. Recorded provider. Present on anything a current client
+            //    registered, and authoritative when it is.
+            if (const auto* vi = xvm::get_vinfo(db, target)) {
+                if (auto it = vi->versions.find(version);
+                    it != vi->versions.end() && it->second.bindingGroup) {
+                    const auto& g = *it->second.bindingGroup;
+                    if (resolves(g.provider, g.providerVersion)) {
+                        return std::pair{g.provider, g.providerVersion};
+                    }
+                }
+            }
+            // 2. The target itself. This is the case that matters for a
+            //    0.4.69 home: its owner-less anchor entries ARE package-named
+            //    (`llvm@20.1.7`, `linux-headers@5.11.1`, `gcc@15.1.0`).
+            if (resolves(target, version)) return std::pair{target, version};
+            // 3. A binding root reachable from here, for a member whose own
+            //    name means nothing to the index.
+            if (auto sel = xvm::resolve_binding_selection(db, target, version)) {
+                for (const auto& [m, v] : sel->members) {
+                    if (m == target) continue;
+                    if (!xvm::is_binding_root(db, m, v)) continue;
+                    if (resolves(m, v)) return std::pair{m, v};
+                }
+            }
+            return std::nullopt;
+        };
+
+        // Collapse the findings onto their owners: one install per release,
+        // not one per program in it.
+        std::map<std::pair<std::string, std::string>,
+                 std::vector<RepairTask>> byOwner;
+        std::vector<RepairTask> unowned;
+        for (auto& task : repairTasks) {
+            if (auto owner = owning_package(task.target, task.version)) {
+                byOwner[*owner].push_back(task);
+            } else {
+                unowned.push_back(task);
+            }
+        }
+
+        repairFailed += static_cast<int>(unowned.size());
+        for (const auto& task : unowned) {
+            add_field("✗ repair skipped", std::format(
+                "{}@{} — no package in the index provides this entry; "
+                "removing it could not be undone",
+                task.target, task.version));
+        }
+
+        std::vector<std::pair<RepairTask, RepairResult>> outcomes;
+        for (const auto& [owner, covered] : byOwner) {
+            RepairTask task{
+                .kind          = RepairKind::BrokenPayload,
+                .target        = owner.first,
+                .version       = owner.second,
+                .detail        = std::format("{} broken entr{}",
+                                             covered.size(),
+                                             covered.size() == 1 ? "y" : "ies"),
+                .reinstallable = true,   // confirmed by the probe above
+            };
+            auto result = repair_one(task, RepairPolicy{}, run);
+            // Attribute the outcome to every finding the owner covers, so the
+            // re-detect below checks the entries the user was shown.
+            for (const auto& c : covered) outcomes.emplace_back(c, result);
+        }
+
+        // Re-detect rather than believe the ladder.
+        //
+        // A rung reporting success while the finding survives is this
+        // codebase's recurring shape, and here it would be worse than usual:
+        // `healed` feeds the exit code, so a lying rung turns a still-broken
+        // home into `status OK`. The database is reloaded from disk and each
+        // repaired entry re-checked, so "healed" means the finding is gone,
+        // not that a subprocess exited 0.
+        //
+        // reload_state() first, and not as a precaution: the repairs ran in
+        // SUBPROCESSES that wrote the state file, while this process still
+        // holds the copy it read at startup. Without the reload, a cure that
+        // is purely a re-registration -- which is what the ladder mostly does
+        // -- reads as a failure, and only repairs that happened to restore a
+        // directory on disk appear to work, because that branch stats the
+        // filesystem. Measured on a real 0.4.69 home: 55 healed and one false
+        // failure, the single entry whose cure was metadata-only.
+        Config::reload_state();
+        const auto after = Config::versions();
+        for (const auto& [task, result] : outcomes) {
+            const auto* vi = xvm::get_vinfo(after, task.target);
+            const xvm::VData* vd = nullptr;
+            if (vi) {
+                if (auto it = vi->versions.find(task.version);
+                    it != vi->versions.end()) {
+                    vd = &it->second;
+                }
+            }
+
+            bool cured = false;
+            if (vd) {
+                // Two ways to be cured, matching the two ways to be broken:
+                // the payload resolves again, or re-registration made the
+                // entry recognisable as a release anchor (a package that
+                // ships no program of its own was never broken).
+                cured = !xvm::resolve_executable(
+                             task.target, vd->path, home_str).empty()
+                     || xvm::is_binding_root(after, task.target, task.version);
+            } else {
+                // The entry is gone. Only a cure if the ladder took it out on
+                // purpose and could not put it back -- which it reports as a
+                // failure, not a cure.
+                cured = false;
+            }
+
+            if (cured) {
+                ++healed;
+                // Not printed per entry: one repaired release accounts for
+                // dozens of findings, and listing them all would bury the
+                // failures. The count goes in the summary.
+            } else {
+                ++repairFailed;
+                add_field("✗ repair failed", std::format(
+                    "{}@{}{}{}", task.target, task.version,
+                    result.note.empty() ? "" : " — ", result.note));
+            }
+        }
+    }
 
     int issues = missing + orphans + broken;
     if (issues == 0 && warnings == 0) {
@@ -561,8 +741,8 @@ export int cmd_doctor(EventStream& stream, bool fix,
         if (warnings > 0) add_field("warnings",        std::to_string(warnings));
         if (fix) {
             if (healed > 0) add_field("healed", std::to_string(healed), true);
-            if (broken > 0) add_field("hint",
-                "broken payloads not auto-fixed — run the listed `xlings install` commands",
+            if (broken > healed) add_field("hint",
+                "some payloads could not be repaired — see the reasons above",
                 true);
         } else {
             if (missing > 0 || orphans > 0)
@@ -572,13 +752,44 @@ export int cmd_doctor(EventStream& stream, bool fix,
         }
     }
 
+    // Exit non-zero only when issues remain after the (optional) fix pass.
+    int unresolved = issues - (fix ? healed : 0);
+
+    // Stamp the home with the client that just checked it.
+    //
+    // `.xlings.json:version` records which xlings set the home up. Only
+    // `self install` ever wrote it, so `self update` -- which installs
+    // xlings@latest as a package -- left it reading the old version forever.
+    // That made the field useless for the one thing it is shaped for, which
+    // is telling a user their packages predate their client.
+    //
+    // Stamped here it becomes the migration marker: the hint below appears
+    // while the home is behind and stops once a --fix has actually migrated
+    // the packages. Stamping on a failed pass would silence the hint while
+    // leaving the state it points at.
+    //
+    // Gated on the REPAIR pass, not on `unresolved`. doctor also reports
+    // things --fix is not responsible for -- on a real upgraded home,
+    // active-group incoherence across two providers that both claim `cc` and
+    // `c++` accounts for 190 findings on its own, measured. Requiring a
+    // spotless home would mean the marker never lands and the hint nags
+    // forever about a migration that already happened.
+    if (fix && repairFailed == 0) {
+        Config::record_client_version(std::string(Info::VERSION));
+    }
+
+    // The nudge, for the reader who ran plain `doctor` (or whose fix left
+    // something behind) on a home an older client set up.
+    if (auto hint = migration_hint(Config::recorded_client_version(),
+                                   Info::VERSION)) {
+        add_field("ⓘ migration", *hint);
+    }
+
     nlohmann::json payload;
     payload["title"]  = "xlings self doctor";
     payload["fields"] = std::move(fields);
     stream.emit(DataEvent{"info_panel", payload.dump()});
 
-    // Exit non-zero only when issues remain after the (optional) fix pass.
-    int unresolved = issues - (fix ? healed : 0);
     return unresolved == 0 ? 0 : 1;
 }
 

--- a/src/core/xself/repair.cppm
+++ b/src/core/xself/repair.cppm
@@ -47,6 +47,14 @@ struct RepairPolicy {
     bool allowNetwork   { true };
     // R3 (remove + install) is the destructive rung.
     bool allowReinstall { true };
+    // How to invoke the client. Bare `xlings` resolves through PATH, which is
+    // right when doctor was itself started from a shim -- but doctor can be
+    // started by absolute path (the upgrade simulation does exactly that to
+    // test a candidate build), and then the repair would be performed by
+    // whatever OTHER client happens to be on PATH rather than by the one that
+    // decided what to repair. Callers pass their own executable path; the
+    // default keeps unit tests deterministic and environment-free.
+    std::string client { "xlings" };
 };
 
 struct RepairResult {
@@ -95,12 +103,13 @@ std::string quiet_suffix() {
 // reads the catalog only -- local, no network -- and answers 0/1 cleanly.
 bool probe_reinstallable(const std::string& target,
                          const std::string& version,
-                         const CommandRunner& run) {
+                         const CommandRunner& run,
+                         const std::string& client = "xlings") {
     if (!is_shell_safe_token(target) || !is_shell_safe_token(version)) {
         return false;
     }
-    return run(std::format("xlings info {}@{}{}",
-                           target, version, quiet_suffix())) == 0;
+    return run(std::format("{} info {}@{}{}",
+                           client, target, version, quiet_suffix())) == 0;
 }
 
 // The one-line nudge toward `self doctor --fix`.
@@ -161,10 +170,10 @@ RepairResult repair_one(const RepairTask& task,
                                "are disabled for this pass"};
     }
 
-    const auto install = std::format("xlings install {}@{} -y",
-                                     task.target, task.version);
-    const auto remove  = std::format("xlings remove {}@{} -y",
-                                     task.target, task.version);
+    const auto install = std::format("{} install {}@{} -y",
+                                     policy.client, task.target, task.version);
+    const auto remove  = std::format("{} remove {}@{} -y",
+                                     policy.client, task.target, task.version);
 
     // R2
     if (run(install) == 0) return {true, "re-register", {}};

--- a/src/core/xself/repair.cppm
+++ b/src/core/xself/repair.cppm
@@ -1,6 +1,8 @@
 export module xlings.core.xself.repair;
 
 import std;
+import xlings.core.log;
+import xlings.platform;
 
 // The repair ladder behind `xlings self doctor --fix`.
 //
@@ -189,6 +191,36 @@ RepairResult repair_one(const RepairTask& task,
                             task.target, task.version)};
     }
     return {true, "reinstall", {}};
+}
+
+// The nudge, emitted from the commands a user actually runs.
+//
+// `self doctor` already prints it, but that only reaches someone who suspects
+// something is wrong -- and the whole point of this work is that they should
+// not have to. `self update` cannot print it either: it runs the OLD binary,
+// which has never heard of any of this. So the only place the migration can
+// announce itself to the cohort being migrated is the new binary, on the next
+// ordinary command.
+//
+// Deliberately narrow, because a nag that shows up in the wrong place is
+// worse than no nag:
+//
+//   - once per process. Three call sites, one line of output.
+//   - TTY only. This must never land in a pipe, a log or a CI transcript --
+//     it is advice for a person, and `xlings list | grep` is not a person.
+//   - silent when the versions agree, which is what makes a successful
+//     `--fix` turn it off for good rather than merely quieten it.
+//
+// No network and no extra file read beyond the one the config already did.
+void print_migration_hint_once(std::string_view recorded,
+                               std::string_view running) {
+    static bool shown = false;
+    if (shown) return;
+    if (!platform::supports_rewrite_output()) return;  // not a terminal
+    auto hint = migration_hint(recorded, running);
+    if (!hint) return;
+    shown = true;
+    log::info("{}", *hint);
 }
 
 } // namespace xlings::xself

--- a/src/core/xself/repair.cppm
+++ b/src/core/xself/repair.cppm
@@ -1,0 +1,194 @@
+export module xlings.core.xself.repair;
+
+import std;
+
+// The repair ladder behind `xlings self doctor --fix`.
+//
+// Split out of doctor.cppm on purpose: detection and repair have different
+// risk profiles, and in doctor they were tangled -- the `--fix` branches sat
+// inline among the reporting, which is why the escalation below could not
+// have been written there without making a 585-line function longer.
+//
+// doctor keeps ownership of WHAT IS WRONG and hands over RepairTasks; this
+// module owns WHAT TO DO ABOUT IT. The commands are injected, so the whole
+// decision table is unit-testable without a home, a network or a payload.
+//
+// See .agents/docs/2026-07-28-self-repair-design.md.
+export namespace xlings::xself {
+
+enum class RepairKind {
+    // A record written by an older client that the current one cannot read
+    // as what it is. The measured case: 0.4.69 records a headers-only
+    // package as a single program-typed entry with a payload path and no
+    // executable, which is indistinguishable from a program whose binary
+    // vanished. Re-running config() re-registers it in the current form.
+    StaleRegistration,
+    // The registered payload does not resolve to an executable on disk.
+    BrokenPayload,
+};
+
+struct RepairTask {
+    RepairKind  kind { RepairKind::BrokenPayload };
+    std::string target;
+    std::string version;
+    std::string detail;
+
+    // Whether the index can supply this package again. Filled in by the
+    // caller, which owns the catalog. Gates the destructive rung: removing
+    // something that cannot be reinstalled is destruction, not repair.
+    bool reinstallable { false };
+};
+
+struct RepairPolicy {
+    // R2/R3 shell out to `xlings install`, which may reach the network.
+    // A caller wanting a purely local pass turns this off.
+    bool allowNetwork   { true };
+    // R3 (remove + install) is the destructive rung.
+    bool allowReinstall { true };
+};
+
+struct RepairResult {
+    bool        healed { false };
+    // Which rung did the work, for the report: "re-register" | "reinstall" |
+    // "none". Never a bare bool: "it failed" and "it was not attempted" have
+    // to be distinguishable in the output, and a bool cannot say which.
+    std::string rung   { "none" };
+    std::string note;
+};
+
+// Names reach us from the versions DB, which recipes write, and the commands
+// below go through std::system -- a shell. Anything outside this set is
+// refused rather than quoted: a package name with a shell metacharacter in it
+// is not a repair case, it is a broken or hostile index entry, and running it
+// through a quoting function would be trusting the same input twice.
+bool is_shell_safe_token(std::string_view s) {
+    if (s.empty()) return false;
+    if (s.front() == '-') return false;  // would be read as an option
+    return std::ranges::all_of(s, [](unsigned char c) {
+        return std::isalnum(c) || c == '.' || c == '-' || c == '_'
+            || c == '+' || c == ':' || c == '@' || c == '/';
+    });
+}
+
+// Runs a command, returns its exit code. Injected so the ladder can be tested
+// as the pure decision table it is.
+using CommandRunner = std::function<int(const std::string&)>;
+
+// Silences a probe. The probe's output is not part of doctor's report and
+// would interleave with it.
+std::string quiet_suffix() {
+#if defined(_WIN32)
+    return " >NUL 2>&1";
+#else
+    return " >/dev/null 2>&1";
+#endif
+}
+
+// Can the index supply this package again?
+//
+// The gate on the destructive rung, and the reason it is a separate probe
+// rather than inferred from R2's exit code: `xlings install` fails the same
+// way for "not in the index" and for "the registration layer refused to
+// overwrite this record", and those two want opposite answers. `xlings info`
+// reads the catalog only -- local, no network -- and answers 0/1 cleanly.
+bool probe_reinstallable(const std::string& target,
+                         const std::string& version,
+                         const CommandRunner& run) {
+    if (!is_shell_safe_token(target) || !is_shell_safe_token(version)) {
+        return false;
+    }
+    return run(std::format("xlings info {}@{}{}",
+                           target, version, quiet_suffix())) == 0;
+}
+
+// The one-line nudge toward `self doctor --fix`.
+//
+// The home config records which xlings set it up. When that differs from the
+// running binary, packages registered by the older client may still be in its
+// format -- which is what the repair ladder exists to migrate. A string
+// comparison: no network, and no extra file read, because the home config is
+// already loaded by every command.
+//
+// Returns nothing when the versions agree, which is what makes the hint stop
+// appearing after a successful --fix stamps the field.
+std::optional<std::string> migration_hint(std::string_view recorded,
+                                          std::string_view running) {
+    auto strip_v = [](std::string_view s) {
+        return (!s.empty() && (s.front() == 'v' || s.front() == 'V'))
+            ? s.substr(1) : s;
+    };
+    const auto a = strip_v(recorded);
+    const auto b = strip_v(running);
+    // An absent record is not a mismatch. A home too old to carry the field
+    // at all, or one written by a build that never set it, would otherwise
+    // nag forever with nothing to compare against.
+    if (a.empty() || b.empty() || a == b) return std::nullopt;
+    return std::format(
+        "this home was set up by {}; packages installed then may still be "
+        "registered in its format\n  run  xlings self doctor --fix", a);
+}
+
+// One ladder, one (target, version). Rungs are tried in order and only if the
+// previous one failed:
+//
+//   R2 re-register  `xlings install <pkg>@<ver> -y`
+//                   Cheap and the usual answer. The installer's xvm-DB
+//                   shortcut checks the payload on disk first, so with the
+//                   payload intact this re-runs config() only -- no download
+//                   -- and that is exactly what converts a 0.4.69 record into
+//                   the current format.
+//
+//   R3 reinstall    `xlings remove …` then `xlings install …`
+//                   For the case R2 cannot reach: a record the registration
+//                   layer REFUSES to overwrite (xvm-legacy-payload-mismatch).
+//                   Destructive, gated on `reinstallable`, and reported
+//                   specially when it removes successfully and then fails to
+//                   install -- that is the one outcome that leaves the user
+//                   worse off than before, and it must never be silent.
+RepairResult repair_one(const RepairTask& task,
+                        const RepairPolicy& policy,
+                        const CommandRunner& run) {
+    if (!is_shell_safe_token(task.target)
+        || !is_shell_safe_token(task.version)) {
+        return {false, "none",
+                "refusing to repair: the recorded name or version contains "
+                "characters that are not safe to pass to a shell"};
+    }
+    if (!policy.allowNetwork) {
+        return {false, "none", "skipped: repairs that may reach the network "
+                               "are disabled for this pass"};
+    }
+
+    const auto install = std::format("xlings install {}@{} -y",
+                                     task.target, task.version);
+    const auto remove  = std::format("xlings remove {}@{} -y",
+                                     task.target, task.version);
+
+    // R2
+    if (run(install) == 0) return {true, "re-register", {}};
+
+    // R3
+    if (!policy.allowReinstall) {
+        return {false, "none",
+                "re-register failed; reinstall was not permitted"};
+    }
+    if (!task.reinstallable) {
+        return {false, "none",
+                "re-register failed, and the package is not available from "
+                "the index — removing it could not be undone"};
+    }
+    if (run(remove) != 0) {
+        return {false, "none",
+                "re-register failed and the entry could not be removed"};
+    }
+    if (run(install) != 0) {
+        // The bad outcome. Say it plainly and hand back the exact command.
+        return {false, "reinstall",
+                std::format("REMOVED but could not reinstall — run "
+                            "`xlings install {}@{}`",
+                            task.target, task.version)};
+    }
+    return {true, "reinstall", {}};
+}
+
+} // namespace xlings::xself

--- a/src/core/xself/update.cppm
+++ b/src/core/xself/update.cppm
@@ -46,6 +46,22 @@ export int cmd_update() {
         return rc;
     }
 
+    // The migration nudge, printed rather than performed.
+    //
+    // This function is running the OLD binary -- it has just replaced itself
+    // on disk and is about to exit. It cannot do the migration: the code that
+    // knows how is in the binary that is not running yet, and a half-finished
+    // pass over a home it can no longer reason about is worse than none.
+    //
+    // What it can do is say so at the moment the mismatch is created. The new
+    // client repeats it (see cmd_doctor's migration hint) until a --fix
+    // actually brings the home in line, so this is a nudge and not the only
+    // chance to see it.
+    log::info("");
+    log::info("packages installed by the previous client may still be "
+              "registered in its format");
+    log::info("  run  xlings self doctor --fix");
+
     return 0;
 }
 

--- a/src/core/xvm/commands.cppm
+++ b/src/core/xvm/commands.cppm
@@ -10,6 +10,7 @@ import xlings.runtime;
 import xlings.libs.json;
 import xlings.core.semver;
 import xlings.core.xself;
+import xlings.core.xself.repair;
 import xlings.core.xvm.types;
 import xlings.core.xvm.db;
 import xlings.core.xvm.lock;
@@ -467,6 +468,8 @@ int cmd_use(const std::string& target, const std::string& version, EventStream& 
     }
 
     log::info("{} -> {}", target, resolved);
+    xself::print_migration_hint_once(Config::recorded_client_version(),
+                                     Info::VERSION);
     return 0;
 }
 

--- a/tests/e2e/self_doctor_test.sh
+++ b/tests/e2e/self_doctor_test.sh
@@ -15,6 +15,10 @@
 #   5. Corrupt: registered program shim with no
 #      workspace entry                          → doctor reports orphan
 #   6. --fix removes the orphan                 → exit 0 after fix
+#   7. Corrupt: delete the payload dir           → doctor reports broken
+#   8. --fix --dry-run                           → prints plan, changes nothing
+#   8b. --fix                                    → repairs, verified by re-detect
+#   8c. second --fix                             → nothing left to do
 
 set -euo pipefail
 
@@ -193,49 +197,72 @@ echo "$out" | grep -q "active" \
 echo "$out" | grep -q "xlings install doctor-fixture@1.0.0" \
   || fail "S7: output should include the remediation command; got:\n$out"
 
-# ── S8: --fix MUST NOT touch broken-payload state (doctor never modifies
-#       payload metadata). Workspace + shim + DB entry must be unchanged
-#       compared to S7. The hint guides users to manual remove+install.
-log "S8: doctor --fix on broken payload → does NOT deregister; only re-prints hint"
+# ── S8: --fix --dry-run previews the repair and changes NOTHING ──────
+#
+# `--fix` used to refuse to repair broken payloads and only re-print the
+# remediation command. That refusal did not survive contact with an upgraded
+# home: 0.4.69 records a headers-only package as one program-typed entry with
+# no executable in it, so the new client reports every such package as a
+# broken payload -- 56 findings on a five-package home, each with a printed
+# command that WAS the correct cure. Handing the user 56 commands to paste is
+# not a diagnosis.
+#
+# The promise that replaced "never touches the network" is this flag, so it is
+# pinned first: the plan is printed, and the state is byte-for-byte untouched.
+log "S8: doctor --fix --dry-run → prints the plan, repairs nothing"
 rc=0
-out=$(RUN self doctor --fix 2>&1) || rc=$?
-[[ $rc -ne 0 ]] || fail "S8: --fix should still exit non-zero when broken remains (got 0)"
-echo "$out" | grep -q "broken payload" \
-  || fail "S8: --fix output should still report broken payload"
-echo "$out" | grep -q "xlings install doctor-fixture@1.0.0" \
-  || fail "S8: --fix output should still print remediation command"
+out=$(RUN self doctor --fix --dry-run 2>&1) || rc=$?
+[[ $rc -ne 0 ]] || fail "S8: --dry-run should still exit non-zero (nothing repaired)"
+echo "$out" | grep -q "would run" \
+  || fail "S8: --dry-run should print the planned command; got:\n$out"
+[[ ! -d "$PAYLOAD_DIR" ]] \
+  || fail "S8: --dry-run must NOT recreate the payload"
 
-# Confirm doctor preserved metadata (workspace + DB entry + shim file).
-python3 - "$HOME_DIR" <<'PY' || fail "S8: --fix must NOT modify versions DB"
+python3 - "$HOME_DIR" <<'PY' || fail "S8: --dry-run must NOT modify versions DB"
 import json, sys, pathlib
 home = sys.argv[1]
 data = json.loads(pathlib.Path(home, ".xlings.json").read_text())
 assert "doctor-fixture" in (data.get("versions") or {}), \
-    "S8: --fix must NOT remove doctor-fixture from versions DB"
+    "S8: --dry-run must NOT remove doctor-fixture from versions DB"
 ws = json.loads(pathlib.Path(home, "subos/default/.xlings.json").read_text())
 entry = (ws.get("workspace") or {}).get("doctor-fixture")
-# 0.4.19+: workspace value is {active, installed[]} dict; tolerate both forms.
 active = entry.get("active") if isinstance(entry, dict) else entry
 assert active == "1.0.0", \
-    f"S8: --fix must NOT clear workspace pointer; got active={active!r}"
+    f"S8: --dry-run must NOT clear workspace pointer; got active={active!r}"
 PY
-[[ -e "$SHIM" ]] || fail "S8: --fix must NOT remove shim file (only hints user to install)"
+[[ -e "$SHIM" ]] || fail "S8: --dry-run must NOT remove the shim file"
 
-# ── S8c: user follows the hint (`xlings install <pkg>@<ver>`)
-#         → installer detects payload missing, re-runs install hook,
-#         → next doctor reports OK
-#         (validates the installer-side trust-but-verify on the xvm-DB
-#          shortcut: a DB-registered version with no payload on disk
-#          must NOT be treated as "already installed".)
-log "S8c: user follows hint (xlings install) → installer self-heals → doctor OK"
-RUN install doctor-fixture@1.0.0 -y >/dev/null 2>&1 \
-  || fail "S8c: install (the hinted command) should succeed"
+# ── S8b: --fix repairs it, and the repair is VERIFIED, not claimed ────
+#
+# The rung that does the work here is re-register: `xlings install
+# <pkg>@<ver>`, which the installer turns into a real install because the
+# payload is gone. What makes this a test rather than a smoke check is that
+# doctor re-detects from a reloaded state file afterwards -- a rung reporting
+# success while the finding survives is the failure shape this codebase keeps
+# producing, and here it would turn a still-broken home into `status OK`.
+log "S8b: doctor --fix → repairs the broken payload → exit 0"
+rc=0
+out=$(RUN self doctor --fix 2>&1) || rc=$?
+[[ $rc -eq 0 ]] || fail "S8b: --fix should repair the payload and exit 0; got $rc:\n$out"
 [[ -d "$PAYLOAD_DIR/bin" ]] \
-  || fail "S8c: payload bin/ must be recreated by install hook"
+  || fail "S8b: --fix must recreate the payload bin/"
 [[ -f "$PAYLOAD_DIR/bin/doctor-fixture" ]] \
-  || fail "S8c: payload binary must be recreated by install hook"
+  || fail "S8b: --fix must recreate the payload binary"
+[[ -e "$SHIM" ]] || fail "S8b: --fix must leave the shim in place"
+
 RUN self doctor >/dev/null 2>&1 \
-  || fail "S8c: doctor should report OK after install self-heal"
+  || fail "S8b: doctor should report OK after --fix repaired the payload"
+
+# ── S8c: a second --fix finds nothing ────────────────────────────────
+#
+# A ladder that repairs the same thing on every run is looping, not
+# converging, and one pass cannot tell the difference.
+log "S8c: second doctor --fix → nothing left to repair"
+rc=0
+out=$(RUN self doctor --fix 2>&1) || rc=$?
+[[ $rc -eq 0 ]] || fail "S8c: second --fix should exit 0; got $rc:\n$out"
+echo "$out" | grep -q "repaired\|would run" \
+  && fail "S8c: second --fix should have had nothing to do; got:\n$out"
 
 # ── Setup for alias-mode scenarios: a fixture with vdata.alias set ──
 # Inject a new fixture file. The catalog cache was warm from the earlier

--- a/tests/e2e/self_doctor_test.sh
+++ b/tests/e2e/self_doctor_test.sh
@@ -264,6 +264,36 @@ out=$(RUN self doctor --fix 2>&1) || rc=$?
 echo "$out" | grep -q "repaired\|would run" \
   && fail "S8c: second --fix should have had nothing to do; got:\n$out"
 
+# ── S8d: payload present, OTHER executables present, ours missing ────
+#
+# The discriminator behind the "release anchor" classification. A package that
+# ships no executable at all is not a broken program -- it is a library-only
+# package that xvm typed as a program, and reinstalling it can never change
+# that. But a payload that HAS executables and is merely missing the one we
+# name is genuinely broken, and must not be swept into the same bucket.
+#
+# Without this case the anchor rule is unfalsifiable: S7 deletes the whole
+# payload directory, which is caught by an earlier check and never reaches it.
+log "S8d: payload with other executables but ours missing → still broken"
+rm -f "$PAYLOAD_DIR/bin/doctor-fixture"
+printf '#!/bin/sh\necho sibling\n' > "$PAYLOAD_DIR/bin/some-other-tool"
+chmod +x "$PAYLOAD_DIR/bin/some-other-tool"
+
+rc=0
+out=$(RUN self doctor 2>&1) || rc=$?
+[[ $rc -ne 0 ]] \
+  || fail "S8d: a missing binary next to other executables must stay an error"
+echo "$out" | grep -q "broken payload" \
+  || fail "S8d: should still report 'broken payload', not a release anchor; got:\n$out"
+echo "$out" | grep -q "release anchor  doctor-fixture" \
+  && fail "S8d: must NOT reclassify a real breakage as a release anchor"
+
+# put it back for the scenarios that follow
+RUN install doctor-fixture@1.0.0 -y >/dev/null 2>&1 \
+  || fail "S8d cleanup: reinstall should succeed"
+rm -f "$PAYLOAD_DIR/bin/some-other-tool"
+RUN self doctor >/dev/null 2>&1 || fail "S8d cleanup: doctor should be clean again"
+
 # ── Setup for alias-mode scenarios: a fixture with vdata.alias set ──
 # Inject a new fixture file. The catalog cache was warm from the earlier
 # scenarios and won't pick this up automatically — invalidate so `install`

--- a/tests/unit/test_self_repair.cpp
+++ b/tests/unit/test_self_repair.cpp
@@ -1,0 +1,227 @@
+// tests/unit/test_self_repair.cpp — the `self doctor --fix` repair ladder.
+//
+// The ladder is the part of the repair path that can make a user worse off
+// than before (R3 removes a package and then reinstalls it), so it is written
+// as a pure decision table over an injected command runner and tested as one.
+// Every case below asserts BOTH the verdict and the exact commands run: a
+// rung that quietly skipped its work and returned "healed" would otherwise
+// pass, which is this codebase's recurring failure shape.
+
+#include <gtest/gtest.h>
+
+import std;
+import xlings.core.xself.repair;
+
+using xlings::xself::RepairKind;
+using xlings::xself::RepairPolicy;
+using xlings::xself::RepairTask;
+using xlings::xself::is_shell_safe_token;
+using xlings::xself::migration_hint;
+using xlings::xself::probe_reinstallable;
+using xlings::xself::repair_one;
+
+namespace {
+
+// Records every command and answers from a scripted list of exit codes.
+// Anything past the end of the script is an error rather than a default,
+// because "ran one more command than expected" is exactly the bug worth
+// catching in a ladder.
+struct FakeRunner {
+    std::vector<std::string> ran;
+    std::vector<int>         codes;
+    std::size_t              next { 0 };
+    bool                     overran { false };
+
+    int operator()(const std::string& cmd) {
+        ran.push_back(cmd);
+        if (next >= codes.size()) { overran = true; return 0; }
+        return codes[next++];
+    }
+};
+
+RepairTask task(bool reinstallable = true) {
+    return RepairTask{
+        .kind          = RepairKind::BrokenPayload,
+        .target        = "linux-headers",
+        .version       = "5.11.1",
+        .detail        = "executable not found",
+        .reinstallable = reinstallable,
+    };
+}
+
+auto runner_of(FakeRunner& f) {
+    return [&f](const std::string& cmd) { return f(cmd); };
+}
+
+} // namespace
+
+// ---------------------------------------------------------------- R2
+
+TEST(SelfRepairLadder, ReRegisterAloneIsEnoughWhenInstallSucceeds) {
+    FakeRunner f{.codes = {0}};
+    auto r = repair_one(task(), RepairPolicy{}, runner_of(f));
+
+    EXPECT_TRUE(r.healed);
+    EXPECT_EQ(r.rung, "re-register");
+    ASSERT_EQ(f.ran.size(), 1u);
+    EXPECT_EQ(f.ran[0], "xlings install linux-headers@5.11.1 -y");
+    EXPECT_FALSE(f.overran);
+}
+
+// ---------------------------------------------------------------- R3
+
+TEST(SelfRepairLadder, FallsBackToRemoveThenInstall) {
+    FakeRunner f{.codes = {1, 0, 0}};   // install fails, remove ok, install ok
+    auto r = repair_one(task(), RepairPolicy{}, runner_of(f));
+
+    EXPECT_TRUE(r.healed);
+    EXPECT_EQ(r.rung, "reinstall");
+    ASSERT_EQ(f.ran.size(), 3u);
+    EXPECT_EQ(f.ran[0], "xlings install linux-headers@5.11.1 -y");
+    EXPECT_EQ(f.ran[1], "xlings remove linux-headers@5.11.1 -y");
+    EXPECT_EQ(f.ran[2], "xlings install linux-headers@5.11.1 -y");
+}
+
+// The outcome that leaves the user worse off than before the repair. It must
+// be reported as a failure, must name the rung that did the damage, and must
+// hand back the command that finishes the job.
+TEST(SelfRepairLadder, RemovedButCouldNotReinstallIsLoudAndActionable) {
+    FakeRunner f{.codes = {1, 0, 1}};   // install fails, remove ok, install fails
+    auto r = repair_one(task(), RepairPolicy{}, runner_of(f));
+
+    EXPECT_FALSE(r.healed);
+    EXPECT_EQ(r.rung, "reinstall");
+    EXPECT_NE(r.note.find("REMOVED"), std::string::npos);
+    EXPECT_NE(r.note.find("xlings install linux-headers@5.11.1"),
+              std::string::npos);
+}
+
+TEST(SelfRepairLadder, DoesNotReinstallWhenTheEntryCannotBeRemoved) {
+    FakeRunner f{.codes = {1, 1}};      // install fails, remove fails
+    auto r = repair_one(task(), RepairPolicy{}, runner_of(f));
+
+    EXPECT_FALSE(r.healed);
+    EXPECT_EQ(r.rung, "none");
+    // Crucially: no second install. Reinstalling on top of a failed removal
+    // is how a half-removed release gets a second registration.
+    ASSERT_EQ(f.ran.size(), 2u);
+}
+
+// ------------------------------------------------- destructive-rung gates
+
+TEST(SelfRepairLadder, NeverRemovesWhatTheIndexCannotSupplyAgain) {
+    FakeRunner f{.codes = {1}};
+    auto r = repair_one(task(/*reinstallable=*/false), RepairPolicy{},
+                        runner_of(f));
+
+    EXPECT_FALSE(r.healed);
+    ASSERT_EQ(f.ran.size(), 1u) << "removal must not be attempted";
+    EXPECT_NE(r.note.find("not available from the index"), std::string::npos);
+}
+
+TEST(SelfRepairLadder, ReinstallCanBeDisabledWithoutDisablingRepair) {
+    FakeRunner f{.codes = {1}};
+    RepairPolicy p{.allowNetwork = true, .allowReinstall = false};
+    auto r = repair_one(task(), p, runner_of(f));
+
+    EXPECT_FALSE(r.healed);
+    ASSERT_EQ(f.ran.size(), 1u) << "R2 still runs; only R3 is off";
+    EXPECT_NE(r.note.find("not permitted"), std::string::npos);
+}
+
+TEST(SelfRepairLadder, ALocalOnlyPassRunsNothing) {
+    FakeRunner f{.codes = {0}};
+    RepairPolicy p{.allowNetwork = false};
+    auto r = repair_one(task(), p, runner_of(f));
+
+    EXPECT_FALSE(r.healed);
+    EXPECT_EQ(r.rung, "none");
+    EXPECT_TRUE(f.ran.empty());
+}
+
+// ---------------------------------------------------------------- shell safety
+
+// Names come from the versions DB, which recipes write, and the ladder builds
+// command lines for std::system. A metacharacter here is not a repair case.
+TEST(SelfRepairLadder, RefusesNamesThatAreNotSafeForAShell) {
+    for (const auto& bad : {"gcc; rm -rf /", "gcc$(id)", "gcc`id`",
+                            "gcc|tee", "gcc&", "gcc>out", "a b", "-rf"}) {
+        FakeRunner f{.codes = {0}};
+        auto t = task();
+        t.target = bad;
+        auto r = repair_one(t, RepairPolicy{}, runner_of(f));
+
+        EXPECT_FALSE(r.healed) << bad;
+        EXPECT_TRUE(f.ran.empty()) << "ran a command for: " << bad;
+        EXPECT_NE(r.note.find("not safe"), std::string::npos) << bad;
+    }
+}
+
+TEST(SelfRepairLadder, RefusesVersionsThatAreNotSafeForAShell) {
+    FakeRunner f{.codes = {0}};
+    auto t = task();
+    t.version = "1.0; touch /tmp/pwned";
+    auto r = repair_one(t, RepairPolicy{}, runner_of(f));
+
+    EXPECT_FALSE(r.healed);
+    EXPECT_TRUE(f.ran.empty());
+}
+
+// ---------------------------------------------------------------- probe
+
+TEST(SelfRepairProbe, ReinstallabilityComesFromInfoNotFromInstallsExitCode) {
+    FakeRunner ok{.codes = {0}};
+    EXPECT_TRUE(probe_reinstallable("llvm", "20.1.7", runner_of(ok)));
+    ASSERT_EQ(ok.ran.size(), 1u);
+    EXPECT_NE(ok.ran[0].find("xlings info llvm@20.1.7"), std::string::npos);
+    // The probe's output must not land in doctor's report.
+    EXPECT_NE(ok.ran[0].find(">"), std::string::npos);
+
+    FakeRunner absent{.codes = {1}};
+    EXPECT_FALSE(probe_reinstallable("nope", "1.0", runner_of(absent)));
+}
+
+TEST(SelfRepairProbe, RefusesToProbeUnsafeNames) {
+    FakeRunner f{.codes = {0}};
+    EXPECT_FALSE(probe_reinstallable("gcc; id", "1.0", runner_of(f)));
+    EXPECT_TRUE(f.ran.empty());
+}
+
+// ---------------------------------------------------------------- hint
+
+TEST(SelfRepairHint, AppearsOnlyWhenTheRecordedClientDiffers) {
+    auto hint = migration_hint("v0.4.69", "2026.7.28.1");
+    ASSERT_TRUE(hint.has_value());
+    EXPECT_NE(hint->find("0.4.69"), std::string::npos);
+    EXPECT_NE(hint->find("xlings self doctor --fix"), std::string::npos);
+}
+
+// After a successful --fix stamps the field, the hint has to stop. The `v`
+// prefix is written by self install and not by the stamp, so the comparison
+// must ignore it or the nag would survive its own cure.
+TEST(SelfRepairHint, StopsOnceTheVersionsAgree) {
+    EXPECT_FALSE(migration_hint("2026.7.28.1", "2026.7.28.1").has_value());
+    EXPECT_FALSE(migration_hint("v2026.7.28.1", "2026.7.28.1").has_value());
+    EXPECT_FALSE(migration_hint("2026.7.28.1", "v2026.7.28.1").has_value());
+}
+
+// A home with no recorded version has nothing to compare against; nagging
+// about it would be permanent and unactionable.
+TEST(SelfRepairHint, SaysNothingWhenThereIsNoRecord) {
+    EXPECT_FALSE(migration_hint("", "2026.7.28.1").has_value());
+    EXPECT_FALSE(migration_hint("v", "2026.7.28.1").has_value());
+}
+
+TEST(SelfRepairShellSafety, AcceptsTheShapesRealPackagesUse) {
+    EXPECT_TRUE(is_shell_safe_token("gcc"));
+    EXPECT_TRUE(is_shell_safe_token("linux-headers"));
+    EXPECT_TRUE(is_shell_safe_token("libc++.so.1"));
+    EXPECT_TRUE(is_shell_safe_token("xim:llvm"));
+    EXPECT_TRUE(is_shell_safe_token("16.1.0"));
+    EXPECT_TRUE(is_shell_safe_token("glibc-2.39"));
+    EXPECT_TRUE(is_shell_safe_token("2026.7.28.1"));
+
+    EXPECT_FALSE(is_shell_safe_token(""));
+    EXPECT_FALSE(is_shell_safe_token("--yes"));
+    EXPECT_FALSE(is_shell_safe_token("a\nb"));
+}

--- a/tests/unit/test_self_repair.cpp
+++ b/tests/unit/test_self_repair.cpp
@@ -167,6 +167,35 @@ TEST(SelfRepairLadder, RefusesVersionsThatAreNotSafeForAShell) {
     EXPECT_TRUE(f.ran.empty());
 }
 
+// ------------------------------------------------- which client runs it
+
+// The ladder must be driven by the client that decided what to repair, not by
+// whatever `xlings` happens to resolve to on PATH. They differ whenever doctor
+// was started by absolute path -- which is exactly how the upgrade simulation
+// runs a candidate build, so the released client on PATH would otherwise be
+// the one doing the work.
+TEST(SelfRepairLadder, UsesTheInjectedClientPathForEveryRung) {
+    FakeRunner f{.codes = {1, 0, 0}};   // force all three commands
+    RepairPolicy p;
+    p.client = "/opt/xlings/bin/xlings";
+    auto r = repair_one(task(), p, runner_of(f));
+
+    EXPECT_TRUE(r.healed);
+    ASSERT_EQ(f.ran.size(), 3u);
+    for (const auto& cmd : f.ran) {
+        EXPECT_EQ(cmd.rfind("/opt/xlings/bin/xlings ", 0), 0u)
+            << "rung did not use the injected client: " << cmd;
+    }
+}
+
+TEST(SelfRepairProbe, UsesTheInjectedClientToo) {
+    FakeRunner f{.codes = {0}};
+    EXPECT_TRUE(probe_reinstallable("llvm", "20.1.7", runner_of(f),
+                                    "/opt/xlings/bin/xlings"));
+    ASSERT_EQ(f.ran.size(), 1u);
+    EXPECT_EQ(f.ran[0].rfind("/opt/xlings/bin/xlings info llvm@20.1.7", 0), 0u);
+}
+
 // ---------------------------------------------------------------- probe
 
 TEST(SelfRepairProbe, ReinstallabilityComesFromInfoNotFromInstallsExitCode) {


### PR DESCRIPTION
Implements the repair engine from
`.agents/docs/2026-07-28-self-repair-design.md`.

## Why `--fix` had to grow

`self doctor --fix` stopped at the shim layer and printed a copy-pasteable
`xlings install` for every broken payload. On a home carried over from an
older client that is not a handful of lines: 0.4.69 records a headers-only
package as **one** program-typed entry with a payload path and no executable,
so the new client cannot tell it from a program whose binary vanished. The
upgrade simulation measured **56 findings** on a home with five packages in
it.

The printed remedy is the correct one — re-running install re-runs `config()`
and re-registers the package in the current form, at which point it is
recognisable as a release anchor and the finding is gone. Measured:

```
                 targets   bindingGroup   members
0.4.69 wrote        1          no            0
after re-register  12          yes          12
```

Doing that for the user is what `--fix` is for.

## The ladder — `src/core/xself/repair.cppm` (new)

| rung | action | network | destructive |
|---|---|---|---|
| **R2 re-register** | `xlings install <pkg>@<ver> -y` | only if the payload is gone | no |
| **R3 reinstall** | `xlings remove` → `xlings install` | yes | yes |

R2 is the usual answer and is cheap: the installer checks the payload on disk
first, so with it intact this re-runs `config()` only. R3 is for the record
the registration layer **refuses** to overwrite — the field dead end from
2026-07-28. It is gated on the package being available from the index
(removing what cannot be reinstalled is destruction, not repair) and the
remove-succeeded-then-install-failed case is reported loudly with the command
that finishes the job.

Split from `doctor.cppm` deliberately: detection and repair have different
risk profiles, and the ladder is the part that can leave a user worse off. It
is a pure decision table over an injected runner — **14 unit tests**, no home,
no network, no payload. Every case asserts the exact commands run, because a
rung that skipped its work and returned "healed" is this codebase's recurring
shape.

## Three things only running it revealed

- **A finding names an xvm target; the ladder installs a package.** A broken
  llvm reports `ar@22.1.8`, `clang@22.1.8`, `cc@22.1.8` and forty more, none
  of them installable. Nor is the binding root the package — gcc's root target
  is `xim-gnu-gcc`. The owner is searched for in descending order of
  confidence and **every candidate is confirmed against the index before use**;
  findings then collapse onto their owner, one install per release.
- **The re-detect must `reload_state()` first.** Repairs run in *subprocesses*
  that write the state file while this process holds the copy it read at
  startup. Without the reload, a cure that is purely a re-registration reads
  as a failure — observed as 55 healed and one false failure, the single
  metadata-only cure.
- **The migration stamp is gated on the repair pass, not on doctor being
  spotless.** Active-group incoherence across two providers that both claim
  `cc`/`c++` accounts for 190 findings on a real home by itself. Requiring
  zero would mean the marker never lands and the hint nags forever about a
  migration that already happened.

## Verified end to end

Against a state file **0.4.69 actually wrote** (restored from the simulation's
snapshot, not synthesized):

| | before | after |
|---|---|---|
| broken payloads | 56 | **0** |
| binding incoherence | 190 | 12 → **1** |
| 4th consecutive `--fix` | — | **repairs nothing** |
| `.xlings.json:version` | `v0.4.69` | the running version |
| migration hint | shown | **gone** |

The remaining 1 is an artifact of the restore (a 0.4.69 DB over a home that
has 2026.7.27.4 installed, so the DB has no `xlings` entry).

## Discovery

`self update` **cannot** run this — that function *is* the old binary, having
just replaced itself on disk. It prints the nudge; the new client repeats it
until a `--fix` lands the stamp. The comparison is a string against a
compiled-in constant: no network, no extra file read.

## Also here

- **Version numbering convention** in both the contributing skill and the
  built-in agent skill: date-based `YYYY.M.D.N`, **`N` starts at 1**, `.0` is
  reserved for a formal release.
- **Simulation harness** grows to 10 packages on every platform and gains a
  `heal` phase that measures the migration instead of trusting an exit code —
  including a second `--fix` that must find nothing, because a ladder that
  repairs the same thing every run is looping rather than converging.
  `SIM_CANDIDATE_BIN` lets the phase measure this PR's own build.
