### PR TITLE
chore: bump version to 2026.7.28.1

### DIFF
--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlings"
-version = "2026.7.27.3"
+version = "2026.7.28.1"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "2026.7.27.4";
+    static constexpr std::string_view VERSION = "2026.7.28.1";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 


### PR DESCRIPTION
Version bump for the release that carries the `self doctor --fix` repair
ladder (#435) and the `xlings remove` use-after-free fix (#432).

`.1` rather than `.0` — `.0` is reserved for a formal/milestone release, and
this is a routine feature release. The convention is now written down in
`.agents/skills/xlings-contributing/SKILL.md` and in the built-in agent skill,
this being the first release since it was decided.

`mcpp.toml` is bumped alongside `src/core/config.cppm`. It had drifted to
`2026.7.27.3` while the release went out as `.4`; the release workflow reads
`config.cppm` so the drift was invisible, but two files disagreeing about the
version of the same binary is the kind of thing that gets trusted later.

Release notes: `.agents/docs/2026-07-28-release-2026.7.28.1-notes.md`.