### PR TITLE
test(upgrade-sim): pick node versions the index has on all three platforms

### DIFF
--- a/.agents/tools/simulate-legacy-upgrade.sh
+++ b/.agents/tools/simulate-legacy-upgrade.sh
@@ -261,6 +261,12 @@ phase_bootstrap() {
 # case cannot exercise `use` and hides every group/binding bug. llvm is the
 # one package published for all three, so it carries that role everywhere.
 #
+# The two node versions are ones the index publishes for ALL THREE platforms.
+# node@20.19.0 is linux/macOS only, and picking it recorded a Windows blocker
+# that was the harness asking for something that does not exist -- checking
+# that a package has a windows table is not the same as checking that the
+# version does.
+#
 # gcc is linux-only in the index (the windows table has one version that
 # delegates to mingw, and there is no macosx table at all), so asking for it
 # elsewhere would record an index gap as an upgrade blocker.
@@ -268,11 +274,11 @@ case "$SIM_OS" in
   linux)
     POPULATE=(gcc@15.1.0 gcc@16.1.0
               llvm@20.1.7 llvm@22.1.8
-              node@20.19.0 node@22.17.1
+              node@22.12.0 node@22.17.1
               cmake ninja xmake jq ripgrep fd bat mcpp) ;;
   macosx|windows)
     POPULATE=(llvm@20.1.7 llvm@22.1.8
-              node@20.19.0 node@22.17.1
+              node@22.12.0 node@22.17.1
               cmake ninja xmake jq ripgrep fd bat mcpp) ;;
 esac
 # Override for a quick run: SIM_PACKAGES="mcpp llvm@20.1.7"


### PR DESCRIPTION
The Windows verification run for 2026.7.28.1 recorded a blocker for `install-old-node@20.19.0` with `package 'node@20.19.0' not found`.

Not a product failure — `node@20.19.0` is published for linux and macOS only:

```
windows: 25.9.0 24.15.0 24.4.1 23.6.0 22.17.1 22.12.0
linux  : … 22.17.1 22.14.0 22.12.0 20.19.0 18.20.8
macosx : … 22.17.1 22.14.0 22.12.0 20.19.0 18.20.8
```

My mistake when choosing the package set: I checked that `node` has a windows
table, which is not the same as checking that the *version* does. `22.12.0` and
`22.17.1` are published for all three, so the two-version case still has
something to switch between on every platform.

A harness blocker sitting in the findings table is worse than no table — it is
indistinguishable from a real finding until someone opens the log.