### PR TITLE
feat(xself): give `self doctor --fix` a subos boundary (2026.7.28.2)

### DIFF
--- a/.agents/docs/2026-07-28-multi-subos-repair-design.md
+++ b/.agents/docs/2026-07-28-multi-subos-repair-design.md
@@ -1,0 +1,268 @@
+# 多 subos 下的 `self doctor --fix` —— 修复边界设计
+
+**日期**: 2026-07-28
+**类型**: 设计 (design)
+**关联**: `2026-07-28-self-repair-design.md`、`2026-07-28-release-2026.7.28.1-notes.md`
+**涉及仓库**: `openxlings/xlings`
+
+---
+
+## 0. 摘要
+
+`self doctor --fix` 的修复阶梯是按**单空间**写的，但它检测的对象（versions DB、
+payload）是**全 home 共享**的。这个错配在单 subos 的 home 上不可见，在多 subos 的
+home 上产生四个具体后果，其中两个是谎报。
+
+本设计不扩大 `--fix` 的能力范围，而是**给它划一条边界**：修当前空间拥有的东西，
+对不拥有的东西说清楚该去哪修，并且不再把「没删成」报告成「删了」。
+
+---
+
+## 1. 状态分层：谁是共享的，谁是每空间独立的
+
+| 层 | 位置 | 作用域 |
+|---|---|---|
+| versions DB | `~/.xlings.json:versions` | **全 home 共享** |
+| payload | `~/.xlings/data/xpkgs/<pkg>/<ver>/` | **全 home 共享**（引用计数） |
+| `workspace.active` | `~/.xlings/subos/<name>/.xlings.json` | 每空间 |
+| `workspace.installed[]` | 同上 | 每空间 |
+| shim / sysroot | `subos/<name>/{bin,lib,usr/include}` | 每空间 |
+| 迁移标记 `version` | `~/.xlings.json:version` | **全 home 共享** |
+
+`doctor` 的检测跨越了这条线：check 1/2/2.5/2.6（shim 层）和 check 4 的 workspace
+部分只看**当前空间**（`Config::paths().binDir` / `effective_workspace()`），而
+check 3（broken payload）遍历的是**全局 versions DB**（`doctor.cppm:363`）。修复
+动作则一律发生在当前空间——`xlings install` 的 `config()` 一定注册进当前 subos
+（`installer.cppm:2369` "mapping to current subos"）。
+
+`grep -c subos src/core/xself/doctor.cppm` 命中的全是注释：doctor 没有任何跨空间
+概念。`tests/e2e/self_doctor_test.sh` 也只用 `subos/default` 一个空间。
+
+---
+
+## 2. 四个具体后果
+
+### D1. R3 谎报「REMOVED」（谎报，最严重）
+
+`repair.cppm:191` 的 R3 是 `remove` 然后 `install`。多空间下 `remove` 有两条路径
+会**返回 0 但什么都没删**：
+
+- 该版本被其它 subos 引用 → `installer.cppm:2469-2481` 走 detach 早返回，
+  DB 记录和 payload 都保留；
+- 该包不在当前 subos 的 `active`/`installed[]` 里 → `commands.cppm:606-631`
+  幂等 no-op，退出 0。
+
+R3 拿到 0 之后认为"删成功了"，接着 `install` 因为记录还在而再次被注册层拒绝，于是
+输出：
+
+```
+✗ repair failed  gcc@15.1.0 — REMOVED but could not reinstall — run `xlings install gcc@15.1.0`
+```
+
+「REMOVED」是假的。这是本仓库反复出现的 silent-success 形状的镜像版本：**没发生的事
+被报告成发生了**，而且报的是最吓人的那种（用户以为包被删了）。
+
+### D2. `--fix` 的作用域泄漏
+
+check 3 扫全局 DB，所以只属于 subos B 的条目也会在 A 里被修。修复动作是
+`xlings install pkg@ver -y`，它的 `config()` 会把包注册进 **A** 的
+workspace/installed[]、在 A 的 `bin/` 建 shim、往 A 的 sysroot 铺头文件。
+
+结果：在 A 里跑一次 `--fix`，B 的包被搬进了 A。用户没要求过这件事。
+
+### D3. 其它空间的问题不可见，也没人告诉你去哪修
+
+反过来，B 空间自己的 shim 缺失 / 孤儿 shim / 组不一致，在 A 里跑 doctor 完全看不到。
+用户只能自己想到「要逐个空间跑一遍」。
+
+### D4. 迁移标记按 home 盖章，按空间修复
+
+`Config::record_client_version` 写 `~/.xlings.json:version`（`config.cppm:1167`），
+是**全 home** 的。在 A 里 `--fix` 成功就盖章，B 从此不再出现
+`run xlings self doctor --fix` 的提示——尽管 B 一次都没被修过。
+
+这正是 2026.7.28.1 发布说明里被单独强调过的那类失效：**迁移承诺在它最常见的输入上
+静默失效**，只不过上次是"标记永远落不下"，这次是"标记落早了"。
+
+### D5. 引用计数按 scope 二选一，不取并集
+
+`is_version_referenced_anywhere_`（`installer.cppm:1204`）通过
+`workspace_config_paths_for_scope_`（`:1166-1201`）枚举工作区文件：Project scope
+只枚举 `<proj>/.xlings/subos/*`，否则只枚举 `~/.xlings/subos/*`。两边**不取并集**。
+
+于是一个 global scope 的包如果同时映射进了 project subos，在全局空间
+`xlings remove` 看不到项目侧的引用 → payload 被真删 → 项目空间留下
+`xvm-active-version-missing`，而项目里什么都没做过。
+
+---
+
+## 3. 设计原则
+
+1. **共享的东西共享地修，独占的东西就地修。** payload 和 DB 记录是共享的，谁修都
+   一样；workspace / shim / sysroot 是每空间的，只能在那个空间修。
+2. **不能修的，要说清楚在哪修。** 一条 finding 如果属于别的空间，报告里必须带上空间
+   名和切过去的命令，而不是沉默或越界修。
+3. **不许谎报。** 一级修复动作声称成功，必须由独立复检确认，而不是信子进程的退出码。
+   这条在 `2026-07-28-self-repair-design.md` §6.3 已经立过，R3 的 remove 是它的漏网。
+4. **单空间 home 的行为一个字节都不许变。** 绝大多数用户只有一个 subos，本次改动对
+   他们必须是完全不可见的。这条由「无人认领 → 当前空间可修」的归属判据保证（见 §4.2）。
+
+---
+
+## 4. 方案
+
+### 4.1 新增：跨空间快照与只读检查（纯函数）
+
+`profile.cppm` 增加快照加载（文件系统侧）：
+
+```cpp
+struct SubosSnapshot {
+    std::string        name;
+    xvm::SubosWorkspace workspace;   // active + installed[]
+};
+std::vector<SubosSnapshot> load_subos_snapshots(const fs::path& xlingsHome);
+```
+
+`find_subos_referencing` 改为基于它实现，消除第二份枚举逻辑。
+
+`xvm/inspect.cppm` 增加**纯函数**检查（不碰文件系统，可单测）：
+
+```cpp
+struct SubosRef { std::string subos; Workspace active; WorkspaceInstalled installed; };
+
+// 其它空间引用了本 home DB 里不存在的版本
+std::vector<BindingFinding> inspect_subos_references(
+    const VersionDB& db, const std::vector<SubosRef>& others);
+
+// (target, version) 的归属：当前空间是否拥有 / 哪些别的空间拥有
+struct OwnershipVerdict {
+    bool                     ownedHere { false };
+    std::vector<std::string> otherSubos;      // 排序后的空间名
+};
+OwnershipVerdict subos_ownership(const Workspace& here, const WorkspaceInstalled& hereInstalled,
+                                 const std::vector<SubosRef>& others,
+                                 const std::string& target, const std::string& version);
+```
+
+两个新 finding code：
+
+| code | 含义 | severity | `--fix` |
+|---|---|---|---|
+| `xvm-subos-active-missing` | 空间 X 的 active 指向未注册的版本 | Broken | ❌ 报告，给切换命令 |
+| `xvm-subos-installed-dangling` | 空间 X 的 `installed[]` 含未注册的版本 | Notice | ❌ 报告 |
+
+`installed[]` 悬挂设为 Notice：它不影响当前使用（active 才被 dispatch 读），但会
+让 `remove` 的引用计数把一个已经不存在的版本算成"还有人用"。报告即可，不进退出码。
+
+### 4.2 doctor：按归属决定修不修（D2/D3）
+
+check 3 每条 broken payload 先问归属：
+
+```
+ownedHere                    → 生成 RepairTask（今天的行为）
+!ownedHere && otherSubos 非空 → 报告 "✗ broken payload [subos: B]"，
+                               hint: `xlings subos use B` 然后 `xlings self doctor --fix`
+!ownedHere && otherSubos 为空 → 生成 RepairTask（无人认领的孤儿，谁修都行）
+```
+
+第三条是**兼容性关键**：0.4.69 的 home 是 legacy 字符串 schema，`installed[]` 是空的，
+所以升级用户的绝大多数条目都"无人认领"。判据写成"没人认领就修"，2026.7.28.1 的迁移
+能力一字不变；写成"必须当前空间认领才修"会把它整个废掉。
+
+### 4.3 R3：删完要复检（D1）
+
+`repair_one` 增加一个注入的复检回调：
+
+```cpp
+// remove 之后确认记录真的没了。注入是因为 repair.cppm 不碰状态文件，
+// 而这个函数存在的全部理由就是 remove 会在只 detach 的情况下报成功。
+using RemovalVerifier = std::function<bool(const std::string&, const std::string&)>;
+```
+
+`run(remove) == 0` 之后若 verifier 说记录还在：
+
+```
+{false, "none", "re-register failed; `remove` only detached this subos —
+                 <target>@<ver> is still referenced by another subos.
+                 Remove it there first: xlings subos use <X> && xlings remove <t>@<v>"}
+```
+
+关键是 **rung 保持 "none"**，不再是 "reinstall"，因为没有任何东西被删除。doctor 侧
+verifier 的实现：`Config::reload_state()` 后查 DB 里 `(target, version)` 是否还在。
+
+### 4.4 迁移标记：所有空间都干净才盖章（D4）
+
+`record_client_version` 的门槛从 `repairFailed == 0` 收紧为
+`repairFailed == 0 && deferredToOtherSubos == 0`，其中 `deferredToOtherSubos` 只统计
+**别的空间拥有的 broken payload**（即 §4.2 的第二条分支）。
+
+只统计这一类，不统计 `xvm-subos-active-missing`：后者 `--fix` 修不了，计入会让标记
+永远落不下，重演 gcc-runtime 那次"提示永不消失"。
+
+盖章条件与顺序无关：在 A 修完 A，再去 B 修完 B 时，A 已经干净 → 标记在 B 落下。
+
+### 4.5 引用计数取并集（D5）
+
+`workspace_config_paths_for_scope_` 改为始终返回 global subos 路径 ∪ project subos
+路径（有 project config 时），去重。
+
+方向是**保守**的：并集只会让 payload 被保留得更多，永远不会多删。代价是一个陈旧的
+project subos 文件可能长期钉住一份 payload——`xlings self clean` 的 GC 是这条路的
+出口，且它本来就用的是另一套枚举（`profile::collect_subos_references_`，已经是全 home）。
+
+---
+
+## 5. 明确不做
+
+- **doctor `--all-subos`**：一个进程内切换 subos 需要重建 Config 单例的路径解析、
+  重新加载 workspace、并对每个空间重跑 shim 层检查。收益是省几次命令，代价是给
+  doctor 引入一个它今天没有的可变全局状态。§4.2 的归属报告已经消除了"不知道去哪修"
+  这个真正的死路。
+- **自动跨空间修复**：在 A 里替 B 修，意味着替 B 决定它的 workspace 应该长什么样。
+  这是 `xlings use` 的语义，不是 `doctor` 的。
+- **`installed[]` 的自动清理**：悬挂项报告为 Notice。清理它等于替用户决定"这个空间
+  不再想要这个版本"，而它可能只是等着被重新安装。
+
+---
+
+## 6. 验收
+
+不是"命令退出 0"。逐条对应上面的缺陷：
+
+| # | 断言 | 现在 | 之后 |
+|---|---|---|---|
+| A1 | 两空间共用 gcc，B 独占 node；在 A 里 `--fix` 后 A 的 workspace 是否含 node | 含（泄漏） | **不含** |
+| A2 | 同上场景，A 的报告是否指出 node 属于 B | 否 | **是，带 `subos use B` 命令** |
+| A3 | R3 的 remove 只 detach 时的输出 | `REMOVED but could not reinstall` | **不含 REMOVED，指出被哪个空间引用** |
+| A4 | 在 A 修完（B 仍有待修）后 `~/.xlings.json:version` | 已盖章 | **未盖章** |
+| A5 | B 修完后 | — | **盖章** |
+| A6 | 单 subos home（含 legacy 空 `installed[]`）的 `--fix` 行为 | 修复 56 条 | **完全不变** |
+| A7 | global 包被 project subos 引用时的 `remove` | payload 被删 | **payload 保留** |
+| A8 | 空间 B 的 active 指向未注册版本，在 A 里跑 doctor | 无输出 | **报告 + 切换命令** |
+
+A6 是回归闸门，用 `tests/e2e/self_doctor_test.sh` 原样保证（不修改该文件）。
+
+---
+
+## 7. 实施拆分
+
+| # | 步骤 | 产出 | 门槛 |
+|---|---|---|---|
+| S1 | `profile::load_subos_snapshots` + `find_subos_referencing` 基于它重写 | `profile.cppm` | 单测：临时目录三个空间，含损坏 JSON |
+| S2 | `inspect_subos_references` + `subos_ownership`（纯函数） | `xvm/inspect.cppm` | 单测：A8、归属三分支 |
+| S3 | doctor 集成归属判据 + 新 finding 输出 | `xself/doctor.cppm` | e2e A1/A2/A8 |
+| S4 | R3 复检回调 | `xself/repair.cppm` + doctor 注入 | 单测（假 runner + 假 verifier）+ e2e A3 |
+| S5 | 迁移标记门槛收紧 | `xself/doctor.cppm` | e2e A4/A5 |
+| S6 | 引用计数取并集 | `xim/installer.cppm` | e2e A7 |
+| S7 | e2e `self_doctor_multi_subos_test.sh` + 接入 `run_all.sh` / CI | tests | 全绿 |
+| S8 | 版本号 → PR → CI → release → 生态验证 | — | 四项发布后校验（见 §8） |
+
+## 8. 发布后校验（不可省）
+
+按 `project-release-verification-traps` 的四项，逐项用能证伪的方法：
+
+1. `gh release view v<ver> --json assets` → 期望 **8** 个资产；
+2. 自己下载并 `sha256sum`，与 sidecar **和** 索引 recipe 两边比对；
+3. 读 `xim-pkgindex` main 上 `pkgs/x/xlings.lua` 的**三个**平台表 + `latest`；
+   `bump-index` 只开 PR 不合并，必须检查是否有未合并的 PR；
+4. CN 镜像用 **GET**（HEAD 返回 401）并完整下载一个资产做哈希。

--- a/.agents/docs/2026-07-28-release-2026.7.28.2-notes.md
+++ b/.agents/docs/2026-07-28-release-2026.7.28.2-notes.md
@@ -1,0 +1,124 @@
+# xlings 2026.7.28.2 — 发布说明
+
+**日期**: 2026-07-28
+**类型**: 发布记录 (release notes)
+**关联**: `2026-07-28-multi-subos-repair-design.md`、`2026-07-28-self-repair-design.md`
+
+> **版本号**：日常发布 `N` 从 `.1` 起，`.0` 保留给正式/里程碑版本。规范见
+> `.agents/skills/xlings-contributing/SKILL.md`。
+
+---
+
+## 一句话
+
+**`self doctor --fix` 现在知道自己站在哪个 subos 里：只修这个空间的东西，说清楚别的
+空间该去哪修，并且不再把「没删成」报告成「删了」。**
+
+---
+
+## 为什么需要它
+
+2026.7.28.1 把 `--fix` 从「打印命令」变成了「执行修复」。那次的修复阶梯是按**单空间**
+写的，而它检测的对象——versions DB 和 payload——是**全 home 共享**的。单 subos 的机器
+上看不出区别；多 subos 的机器上，这个错配有四个后果，其中两个是谎报。
+
+```
+共享：  ~/.xlings.json:versions        data/xpkgs/<pkg>/<ver>/     :version 迁移标记
+独占：  subos/<name>/.xlings.json      subos/<name>/{bin,lib,usr}
+```
+
+---
+
+## 用户可见的变化
+
+### 1. 属于别的空间的问题，不再在这里修
+
+之前：`default` 里跑 `--fix`，一个只有 `other` 用的包 payload 坏了，也会被
+`xlings install` 修好——而 `install` 的 `config()` 会把这个包注册进**当前**空间。
+用户想修自己的环境，结果多了一个别人的包、一个 shim、一份 sysroot 条目。
+
+现在：
+
+```
+✗ broken payload [subos: other]  ms-only-b@1.0.0 path …/xim-x-ms-only-b/1.0.0 missing
+  → run                          xlings subos use other && xlings self doctor --fix
+```
+
+报告、归属、给出命令，不越界修，也**不计入本空间的退出码**——这个空间没引用它，
+把它算成红色会让 `default` 永远失败而没有任何命令能从这里清掉。
+
+归属判据有一条重要的例外：**没有任何空间认领的条目仍然在这里修**。0.4.69 的 home 是
+旧 schema，没有 `installed[]`，所以升级用户的大多数条目都"无人认领"——写成"必须认领
+才修"会把 2026.7.28.1 的迁移能力整个关掉。
+
+### 2. 别的空间指向了不存在的版本，现在看得见
+
+```
+⚠ other subos  subos 'other' has 'ms-only-b' active at 9.9.9, which is not
+               registered — xvm-subos-active-missing — run `xlings subos use other`
+               then `xlings install ms-only-b@9.9.9` to restore it
+```
+
+之前这种状态只有站在那个空间里才看得到，而没有任何地方会告诉你该站过去。同样只报告
+不计入退出码：修它意味着替那个空间决定该指向什么，那是 `xlings use` 的语义。
+
+`installed[]` 里的悬挂项报为 `ⓘ`（Notice）——它不影响使用，但会让 `remove` 的引用计数
+把一个已经不存在的版本算成"还有人用"。
+
+### 3. 迁移标记不再按第一个修完的空间盖章
+
+标记写在 home 配置里，修复发生在一个 subos 里。之前在 `default` 修完就盖章，`other`
+从此再也收不到那句 `run xlings self doctor --fix` 的提示——尽管它一次都没被修过。
+
+现在只有当**没有任何一个别的空间还有待修的 payload** 时才盖章。只算这一类，不算
+`xvm-subos-active-missing`：后者 `--fix` 修不了，计进去会让标记永远落不下，重演
+gcc-runtime 那次"提示永不消失"。
+
+### 4. R3 不再报告没发生的删除
+
+修复阶梯的 R3 是 `remove` 然后 `install`。`xlings remove` 退出 0 有四种含义，其中三种
+**记录还在**：
+
+- 版本被别的 subos 引用 → 只 detach 当前空间；
+- 包不在当前空间 → 幂等 no-op；
+- payload 已经不在了 → 拒绝"删除"一个装都没装的东西（而这正是 broken payload 修复的
+  起点）；
+- 真的删掉了。
+
+R3 把 0 一律当成第四种，于是输出 `REMOVED but could not reinstall` —— 一句关于用户磁盘
+的、不成立的断言，出现在他们最可能照做的那条消息里。
+
+现在删完会**回读状态文件复核**这次修复涉及的条目是否真的消失，没消失就说实话：
+
+```
+✗ repair failed  ms-shared@1.0.0 — re-register failed, and `remove` exited 0 without
+                 dropping ms-shared@1.0.0 — it is still registered. …
+                 Take it out where it lives (`xlings subos use <name>` then
+                 `xlings remove ms-shared@1.0.0`) and rerun
+```
+
+复核问的是**这次修复覆盖的发现**，不是它执行命令时用的包名：一条发现叫 `ms-shared`
+（xvm 目标），阶梯装的是 `xim:ms-shared`（包），而包名不是 versions DB 的键。拿包名去
+查什么都查不到，会被读成"删掉了"——第一版复核就是这么写的，它自己重现了它要防的 bug。
+
+## 修复
+
+| 变化 | 之前 |
+|---|---|
+| payload 引用计数取 project ∪ home 的并集 | 按 scope 二选一，两边不相交：两个 project subos 共用的全局包，从其中一个删会**真删掉** payload，另一个空间随即拿到一个未注册的 active 版本 |
+| `~/.xlings/subos/*/.xlings.json` 只有一处遍历 | 三处，各有各的"什么算可读"，所以一个空间可以同时被 GC 算作引用、被引用计数漏掉 |
+
+---
+
+## 验证
+
+- 单元 13 例：归属三分支（含"无人认领"的兼容路径）、跨空间引用的两个 code、快照读取
+  （跳过损坏 JSON / `current` 符号链接）、R3 复核的三种走向。
+- e2e `self_doctor_multi_subos_test.sh`（E2E-42）：7 个场景，覆盖上述四条变化 + 引用
+  计数并集。
+- **变异验证**：逐条把实现改回旧行为，确认对应断言失败——归属判据 → S2、迁移标记门槛
+  → S3、R3 复核 → S6、引用计数并集 → S7。四个变异，四条不同的断言，没有一条是恒真的。
+- 回归：`self_doctor_test.sh`（单空间行为的闸门，一个字节没改）、
+  `subos_payload_refcount_test.sh`、`subos_install_remove_isolation_test.sh`、
+  `remove_multi_version_test.sh`、`subos_workspace_c2_schema_test.sh`、
+  project 三件套，全绿；`mcpp test` 23/23。

--- a/.github/workflows/xlings-ci-linux-e2e.yml
+++ b/.github/workflows/xlings-ci-linux-e2e.yml
@@ -3,7 +3,7 @@ name: xlings-ci-linux-e2e
 # The Linux E2E suite, split out of xlings-ci-linux.yml so it runs in PARALLEL
 # with the build + unit-test job instead of after it. Shares the same cache
 # lineage, so it restores a warm sandbox; the only added wall-clock vs. the
-# inline version is one extra release build. The E2E-02..E2E-28 block runs via
+# inline version is one extra release build. The E2E-02..E2E-42 block runs via
 # tests/e2e/run_all.sh, which times each test and prints a slowest-first
 # summary (mirrors mcpp's runner). E2E-00 / E2E-01 stay discrete steps here
 # because they're interleaved with the release build.
@@ -133,7 +133,7 @@ jobs:
           [[ -z "$tarball" ]] && { echo "No release tarball found"; exit 1; }
           cp "$tarball" build/release.tar.gz
 
-      # ── E2E-02..E2E-28 via the timed runner (slowest-first summary) ─
-      - name: "E2E suite (E2E-02..E2E-28, timed)"
+      # ── E2E-02..E2E-42 via the timed runner (slowest-first summary) ─
+      - name: "E2E suite (E2E-02..E2E-42, timed)"
         run: |
           bash tests/e2e/run_all.sh build/release.tar.gz

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlings"
-version = "2026.7.28.1"
+version = "2026.7.28.2"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "2026.7.28.1";
+    static constexpr std::string_view VERSION = "2026.7.28.2";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/profile.cppm
+++ b/src/core/profile.cppm
@@ -177,6 +177,60 @@ rollback(const fs::path& envDir, int targetGen) {
     return packages;
 }
 
+// One subos's workspace file, as read off disk.
+//
+// The unit every cross-subos question is answered in: "who else references
+// this version", "which subos owns this finding", "is any other subos still
+// pointing at something the DB no longer has". Those used to be three
+// separate walks of ~/.xlings/subos/*/.xlings.json with three slightly
+// different notions of what counts as a readable file; this is the one walk.
+export struct SubosSnapshot {
+    std::string         name;
+    // The subos root, so a caller can tell "the subos named x under this home"
+    // from "the project subos that happens to be named x" without guessing
+    // from the name.
+    fs::path            dir;
+    xvm::SubosWorkspace workspace;
+};
+
+// Every subos under a home, in name order.
+//
+// Unreadable and malformed files are SKIPPED, not reported: this feeds
+// read-only inspection and reference counting, and a subos whose config a
+// user hand-edited into invalid JSON must not take down an unrelated
+// `remove`. `current` is a symlink to the active one and would double-count.
+export std::vector<SubosSnapshot> load_subos_snapshots(const fs::path& xlingsHome) {
+    std::vector<SubosSnapshot> snapshots;
+    auto subosDir = xlingsHome / "subos";
+    std::error_code ec;
+    if (!fs::is_directory(subosDir, ec)) return snapshots;
+
+    for (auto& entry : platform::dir_entries(subosDir)) {
+        std::error_code dec;
+        if (!entry.is_directory(dec)) continue;
+        auto name = entry.path().filename().string();
+        if (name == "current") continue;
+        auto wsPath = entry.path() / ".xlings.json";
+        std::error_code fec;
+        if (!fs::exists(wsPath, fec)) continue;
+        try {
+            auto content = platform::read_file_to_string(wsPath.string());
+            auto json = nlohmann::json::parse(content, nullptr, false);
+            if (json.is_discarded() || !json.is_object()) continue;
+            if (!json.contains("workspace") || !json["workspace"].is_object()) continue;
+            snapshots.push_back({
+                .name = name,
+                .dir = entry.path(),
+                .workspace = xvm::subos_workspace_from_json(json["workspace"]),
+            });
+        } catch (...) {}
+    }
+    std::ranges::sort(snapshots, [](const auto& a, const auto& b) {
+        return a.name < b.name;
+    });
+    return snapshots;
+}
+
 // Build a set of referenced xpkg "dirname/version" keys from all subos workspaces
 // by mapping workspace target names to xpkg directory paths via the versions DB.
 std::set<std::string> collect_subos_references_(const fs::path& xlingsHome) {
@@ -233,21 +287,8 @@ std::set<std::string> collect_subos_references_(const fs::path& xlingsHome) {
     };
 
     // Scan all subos workspace files
-    auto subosDir = xlingsHome / "subos";
-    if (fs::exists(subosDir)) {
-        for (auto& envEntry : platform::dir_entries(subosDir)) {
-            if (!envEntry.is_directory()) continue;
-            auto name = envEntry.path().filename().string();
-            if (name == "current") continue; // symlink
-            auto wsPath = envEntry.path() / ".xlings.json";
-            if (!fs::exists(wsPath)) continue;
-            try {
-                auto content = platform::read_file_to_string(wsPath.string());
-                auto json = nlohmann::json::parse(content, nullptr, false);
-                if (!json.is_discarded() && json.contains("workspace"))
-                    add_refs_from_subos_workspace(xvm::subos_workspace_from_json(json["workspace"]));
-            } catch (...) {}
-        }
+    for (auto& snapshot : load_subos_snapshots(xlingsHome)) {
+        add_refs_from_subos_workspace(snapshot.workspace);
     }
 
     return referenced;
@@ -257,23 +298,11 @@ std::set<std::string> collect_subos_references_(const fs::path& xlingsHome) {
 export std::vector<std::string> find_subos_referencing(
         const fs::path& xlingsHome, const std::string& target) {
     std::vector<std::string> result;
-    auto subosDir = xlingsHome / "subos";
-    if (!fs::exists(subosDir)) return result;
-
-    for (auto& envEntry : platform::dir_entries(subosDir)) {
-        if (!envEntry.is_directory()) continue;
-        auto name = envEntry.path().filename().string();
-        if (name == "current") continue;
-        auto wsPath = envEntry.path() / ".xlings.json";
-        if (!fs::exists(wsPath)) continue;
-        try {
-            auto content = platform::read_file_to_string(wsPath.string());
-            auto json = nlohmann::json::parse(content, nullptr, false);
-            if (json.is_discarded() || !json.contains("workspace")) continue;
-            auto sws = xvm::subos_workspace_from_json(json["workspace"]);
-            if (sws.active.contains(target) || sws.installed.contains(target))
-                result.push_back(name);
-        } catch (...) {}
+    for (auto& snapshot : load_subos_snapshots(xlingsHome)) {
+        if (snapshot.workspace.active.contains(target)
+            || snapshot.workspace.installed.contains(target)) {
+            result.push_back(snapshot.name);
+        }
     }
     return result;
 }

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -1163,27 +1163,47 @@ xvm::SubosWorkspace load_workspace_file_(const std::filesystem::path& path) {
     }
 }
 
+// Every workspace file that can pin a payload against deletion.
+//
+// The UNION of the project-side and home-side files, deliberately, and not
+// the scope's own side only. That is what it used to return, and the two sets
+// never met: a Global-scope package mapped into a project subos was invisible
+// to a `remove` run from the global subos, which then deleted a payload the
+// project was still pointing at. The project got an unregistered active
+// version out of a command it never ran.
+//
+// Erring toward the union can only over-retain -- a stale project subos file
+// keeps a payload on disk longer than needed, which `xlings self clean`'s GC
+// already sweeps (and which walks all of them too). The opposite error
+// deletes something in use, and cannot be undone from the subos it broke.
+//
+// `scope` is retained for callers that still describe what they are removing,
+// but no longer selects a side.
 std::vector<std::filesystem::path> workspace_config_paths_for_scope_(PackageScope scope) {
     namespace fs = std::filesystem;
+    (void)scope;
     std::vector<fs::path> paths;
+    auto push = [&](fs::path p) {
+        if (p.empty()) return;
+        if (std::ranges::find(paths, p) != paths.end()) return;
+        paths.push_back(std::move(p));
+    };
 
-    if (scope == PackageScope::Project && Config::has_project_config()) {
+    if (Config::has_project_config()) {
         auto projectRoot = Config::project_dir();
         if (!projectRoot.empty()) {
-            paths.push_back(Config::project_manifest_path());
-            auto projectStatePath = Config::project_state_path();
-            if (!projectStatePath.empty()) paths.push_back(projectStatePath);
+            push(Config::project_manifest_path());
+            push(Config::project_state_path());
             auto subosRoot = projectRoot / ".xlings" / "subos";
             std::error_code ec;
             if (fs::exists(subosRoot, ec) && fs::is_directory(subosRoot, ec)) {
                 for (auto& entry : platform::dir_entries(subosRoot)) {
                     if (entry.is_directory()) {
-                        paths.push_back(entry.path() / ".xlings.json");
+                        push(entry.path() / ".xlings.json");
                     }
                 }
             }
         }
-        return paths;
     }
 
     auto subosRoot = Config::paths().homeDir / "subos";
@@ -1193,7 +1213,7 @@ std::vector<std::filesystem::path> workspace_config_paths_for_scope_(PackageScop
             if (entry.is_directory()) {
                 auto name = entry.path().filename().string();
                 if (name != "current") {
-                    paths.push_back(entry.path() / ".xlings.json");
+                    push(entry.path() / ".xlings.json");
                 }
             }
         }

--- a/src/core/xself/doctor.cppm
+++ b/src/core/xself/doctor.cppm
@@ -18,6 +18,7 @@ import xlings.core.xvm.shim;
 import xlings.core.xvm.inspect;
 import xlings.core.xvm.lock;
 import xlings.core.xself.repair;
+import xlings.core.profile;
 
 namespace xlings::xself {
 
@@ -85,6 +86,35 @@ export int cmd_doctor(EventStream& stream, bool fix,
     auto& p   = Config::paths();
     auto db   = Config::versions();
     auto ws   = Config::effective_workspace();
+
+    // The other subos of this home.
+    //
+    // Everything doctor checks above the DB layer is scoped to the subos it
+    // runs in -- its binDir, its sysroot, its workspace. The versions DB and
+    // the payload store below are shared by every subos. That split is why
+    // this list is needed twice: to keep `--fix` from repairing (and thereby
+    // pulling into THIS subos) an entry that belongs to another one, and to
+    // report the state of the others rather than leave the user to guess that
+    // per-subos runs are required.
+    //
+    // Identified by directory, not by name: a project subos may be named the
+    // same as one under the home, and excluding the wrong one would make this
+    // subos audit itself as a foreigner.
+    std::vector<xvm::SubosRef> otherSubos;
+    {
+        std::error_code cec;
+        const auto here = fs::weakly_canonical(p.subosDir, cec);
+        for (auto& snapshot : profile::load_subos_snapshots(p.homeDir)) {
+            std::error_code sec;
+            if (fs::weakly_canonical(snapshot.dir, sec) == here) continue;
+            otherSubos.push_back(xvm::SubosRef{
+                .subos     = snapshot.name,
+                .active    = snapshot.workspace.active,
+                .installed = snapshot.workspace.installed,
+            });
+        }
+    }
+    const auto& wsInstalled = Config::workspace_installed();
 
 #ifdef _WIN32
     constexpr std::string_view shim_ext = ".exe";
@@ -331,12 +361,30 @@ export int cmd_doctor(EventStream& stream, bool fix,
     // Findings the repair pass owned and could not resolve. Distinct from
     // `issues`, which also counts things --fix is not responsible for.
     int repairFailed = 0;
+    // Broken payloads another subos owns and this one does not. Not repaired
+    // here (see below), and the gate on the migration stamp.
+    int deferredToOtherSubos = 0;
 
     auto report_broken_payload = [&](const std::string& name,
                                      const std::string& version,
                                      std::string detail) {
-        ++broken;
-        if (fix) {
+        // Whose entry is this?
+        //
+        // The finding is home-wide -- the loop below walks the shared DB --
+        // but the repair is not: `xlings install` re-runs config(), and
+        // config() registers into whichever subos is current. So repairing an
+        // entry that only another subos uses does two things the user did not
+        // ask for: it adds the package to THIS subos's workspace, shims and
+        // sysroot, and it does so while they were trying to fix something
+        // else.
+        //
+        // Unclaimed entries are still repaired here. On a home written before
+        // installed[] existed, every inactive version is unclaimed, and that
+        // cohort is exactly who the repair ladder was built for.
+        const auto owner = xvm::subos_ownership(ws, wsInstalled, otherSubos,
+                                                name, version);
+        const bool elsewhere = !owner.ownedHere && !owner.otherSubos.empty();
+        if (fix && !elsewhere) {
             repairTasks.push_back(RepairTask{
                 .kind    = RepairKind::BrokenPayload,
                 .target  = name,
@@ -344,6 +392,26 @@ export int cmd_doctor(EventStream& stream, bool fix,
                 .detail  = detail,
             });
         }
+        if (elsewhere) {
+            // Not counted in `broken`, and so not in the exit code: this
+            // subos does not reference the payload, cannot repair it without
+            // adopting the package, and would otherwise stay red until the
+            // user visited another subos. It is still printed, and it still
+            // holds back the migration stamp.
+            ++deferredToOtherSubos;
+            std::string list;
+            for (const auto& other : owner.otherSubos) {
+                if (!list.empty()) list += ", ";
+                list += other;
+            }
+            add_field(std::format("✗ broken payload [subos: {}]", list),
+                      std::move(detail));
+            add_field("  → run", std::format(
+                "xlings subos use {} && xlings self doctor --fix",
+                owner.otherSubos.front()));
+            return;
+        }
+        ++broken;
         auto wit = ws.find(name);
         bool is_active = (wit != ws.end() && wit->second == version);
         std::string label = is_active ? "✗ broken payload [active]"
@@ -517,6 +585,27 @@ export int cmd_doctor(EventStream& stream, bool fix,
                   std::move(detail));
     }
 
+    // Check 5: what the OTHER subos of this home point at.
+    //
+    // Reported, never counted toward the exit code. The exit code answers "is
+    // the subos I am in healthy", and it has to stay answerable: a broken
+    // pointer in another subos cannot be repaired from here (that is `xlings
+    // use` deciding what that subos should point at), so folding it in would
+    // leave every subos of the home permanently red with no command that
+    // clears it -- the shape that made the 0.4.69 migration hint nag forever.
+    //
+    // Printing it is the point. Before this, a subos whose active version was
+    // taken out from under it had no command that mentioned it: doctor finds
+    // it when run THERE, and nothing anywhere told you to go there.
+    int otherSubosFindings = 0;
+    for (const auto& finding : xvm::inspect_subos_references(db, otherSubos)) {
+        ++otherSubosFindings;
+        add_field(finding.severity == xvm::BindingSeverity::Notice
+                      ? "ⓘ other subos" : "⚠ other subos",
+                  std::format("{} — {} — {}", finding.summary,
+                              finding.code, finding.hint));
+    }
+
     // --fix for the one binding problem that can be repaired without
     // guessing: an active release whose members disagree. Deactivate the
     // whole release and let the user re-select. Choosing a survivor here
@@ -643,6 +732,28 @@ export int cmd_doctor(EventStream& stream, bool fix,
             return platform::exec(cmd);
         };
 
+        // R3's remove exited 0 — did the records actually go?
+        //
+        // Asked of the FINDINGS the repair covers, not of the package name it
+        // ran the command with. Those differ: a finding names an xvm target
+        // (`ms-shared`, `gcc`, `cc`), while the ladder installs and removes a
+        // package (`xim:ms-shared`), and a package name is not a key in the
+        // versions DB. Looking the package name up there finds nothing and
+        // reads it as "removed" — the failure this check exists to prevent,
+        // reproduced by the check itself.
+        //
+        // Read back from disk: the remove ran in a subprocess, so the copy
+        // this process is holding cannot answer.
+        const auto records_gone = [&](const std::vector<RepairTask>& covered) {
+            Config::reload_state();
+            const auto current = Config::versions();
+            for (const auto& c : covered) {
+                const auto* vi = xvm::get_vinfo(current, c.target);
+                if (vi && vi->versions.contains(c.version)) return false;
+            }
+            return true;
+        };
+
         // Repair with the client that is running, not with whatever `xlings`
         // resolves to on PATH. Normally they are the same binary; they are
         // not when doctor was started by absolute path, and then the repair
@@ -758,7 +869,11 @@ export int cmd_doctor(EventStream& stream, bool fix,
                                              covered.size() == 1 ? "y" : "ies"),
                 .reinstallable = true,   // confirmed by the probe above
             };
-            auto result = repair_one(task, policy, run);
+            const RemovalVerifier removalDone =
+                [&](const std::string&, const std::string&) {
+                    return records_gone(covered);
+                };
+            auto result = repair_one(task, policy, run, removalDone);
             // Attribute the outcome to every finding the owner covers, so the
             // re-detect below checks the entries the user was shown.
             for (const auto& c : covered) outcomes.emplace_back(c, result);
@@ -824,7 +939,8 @@ export int cmd_doctor(EventStream& stream, bool fix,
     }
 
     int issues = missing + orphans + broken + bindingIssues;
-    if (issues == 0 && warnings == 0) {
+    if (issues == 0 && warnings == 0
+        && deferredToOtherSubos == 0 && otherSubosFindings == 0) {
         add_field("status",
                   "OK — workspace, shims, and payloads are all consistent",
                   true);
@@ -835,6 +951,14 @@ export int cmd_doctor(EventStream& stream, bool fix,
         if (bindingIssues > 0)
             add_field("binding state", std::to_string(bindingIssues));
         if (warnings > 0) add_field("warnings",        std::to_string(warnings));
+        // Reported apart from the counts above because they are apart from
+        // the exit code: they belong to a subos this run is not in.
+        if (deferredToOtherSubos > 0)
+            add_field("owned by another subos",
+                      std::format("{} — repair them there", deferredToOtherSubos));
+        if (otherSubosFindings > 0)
+            add_field("other subos findings",
+                      std::to_string(otherSubosFindings));
         if (fix) {
             if (healed > 0) add_field("healed", std::to_string(healed), true);
             if (broken > healed) add_field("hint",
@@ -870,7 +994,16 @@ export int cmd_doctor(EventStream& stream, bool fix,
     // `c++` accounts for 190 findings on its own, measured. Requiring a
     // spotless home would mean the marker never lands and the hint nags
     // forever about a migration that already happened.
-    if (fix && !dryRun && repairFailed == 0) {
+    //
+    // `deferredToOtherSubos` is in the gate because the marker is written to
+    // the HOME config while the repair happens in one SUBOS. Without it,
+    // fixing the first subos stamps the whole home as migrated and the other
+    // subos never get the hint again -- the same failure as the nag-forever
+    // case, inverted: the promise is kept for one subos and silently dropped
+    // for the rest. Only payloads another subos owns count; a broken pointer
+    // over there is not something any `--fix` can clear, and gating on it
+    // would put the marker permanently out of reach.
+    if (fix && !dryRun && repairFailed == 0 && deferredToOtherSubos == 0) {
         Config::record_client_version(std::string(Info::VERSION));
     }
 

--- a/src/core/xself/doctor.cppm
+++ b/src/core/xself/doctor.cppm
@@ -114,7 +114,10 @@ export int cmd_doctor(EventStream& stream, bool fix,
             });
         }
     }
-    const auto& wsInstalled = Config::workspace_installed();
+    // A copy, not a reference into the config singleton: the repair pass
+    // below calls reload_state(), which reassigns the member this would
+    // otherwise be pointing at. `ws` and `db` are copies for the same reason.
+    const auto wsInstalled = Config::workspace_installed();
 
 #ifdef _WIN32
     constexpr std::string_view shim_ext = ".exe";
@@ -383,16 +386,7 @@ export int cmd_doctor(EventStream& stream, bool fix,
         // cohort is exactly who the repair ladder was built for.
         const auto owner = xvm::subos_ownership(ws, wsInstalled, otherSubos,
                                                 name, version);
-        const bool elsewhere = !owner.ownedHere && !owner.otherSubos.empty();
-        if (fix && !elsewhere) {
-            repairTasks.push_back(RepairTask{
-                .kind    = RepairKind::BrokenPayload,
-                .target  = name,
-                .version = version,
-                .detail  = detail,
-            });
-        }
-        if (elsewhere) {
+        if (!owner.ownedHere && !owner.otherSubos.empty()) {
             // Not counted in `broken`, and so not in the exit code: this
             // subos does not reference the payload, cannot repair it without
             // adopting the package, and would otherwise stay red until the
@@ -412,6 +406,14 @@ export int cmd_doctor(EventStream& stream, bool fix,
             return;
         }
         ++broken;
+        if (fix) {
+            repairTasks.push_back(RepairTask{
+                .kind    = RepairKind::BrokenPayload,
+                .target  = name,
+                .version = version,
+                .detail  = detail,
+            });
+        }
         auto wit = ws.find(name);
         bool is_active = (wit != ws.end() && wit->second == version);
         std::string label = is_active ? "✗ broken payload [active]"

--- a/src/core/xself/repair.cppm
+++ b/src/core/xself/repair.cppm
@@ -84,6 +84,23 @@ bool is_shell_safe_token(std::string_view s) {
 // as the pure decision table it is.
 using CommandRunner = std::function<int(const std::string&)>;
 
+// Did the removal actually drop the records this repair is about?
+//
+// R3 reads `xlings remove` exiting 0 as "the entry is gone". Zero does not
+// mean that. It is also what removal returns when it merely detaches the
+// current subos, because another subos still references the version
+// (installer.cppm's `stillReferenced` branch); when the package is not in
+// this subos at all; and when the payload is already missing, which is
+// exactly the state a broken-payload repair starts from. In every one of
+// those the record survives, the install that follows fails against the same
+// record that made R2 fail, and R3 reports the package REMOVED.
+//
+// Injected rather than read here: this module owns the decision table and has
+// no state file access by design. A caller that supplies nothing keeps the old
+// behaviour, which is what the unit tests of the other rungs rely on.
+using RemovalVerifier =
+    std::function<bool(const std::string& target, const std::string& version)>;
+
 // Silences a probe. The probe's output is not part of doctor's report and
 // would interleave with it.
 std::string quiet_suffix() {
@@ -156,9 +173,16 @@ std::optional<std::string> migration_hint(std::string_view recorded,
 //                   specially when it removes successfully and then fails to
 //                   install -- that is the one outcome that leaves the user
 //                   worse off than before, and it must never be silent.
+//
+//                   `removalDone` is what makes "removes successfully" mean
+//                   the record is gone rather than the command exited 0. See
+//                   RemovalVerifier: on a multi-subos home those are different
+//                   statements, and reporting REMOVED for a version that is
+//                   still installed is a worse lie than any failure message.
 RepairResult repair_one(const RepairTask& task,
                         const RepairPolicy& policy,
-                        const CommandRunner& run) {
+                        const CommandRunner& run,
+                        const RemovalVerifier& removalDone = nullptr) {
     if (!is_shell_safe_token(task.target)
         || !is_shell_safe_token(task.version)) {
         return {false, "none",
@@ -191,6 +215,20 @@ RepairResult repair_one(const RepairTask& task,
     if (run(remove) != 0) {
         return {false, "none",
                 "re-register failed and the entry could not be removed"};
+    }
+    // The command exited 0. Whether anything left is a separate question.
+    if (removalDone && !removalDone(task.target, task.version)) {
+        return {false, "none",
+                std::format(
+                    "re-register failed, and `remove` exited 0 without "
+                    "dropping {}@{} — it is still registered. Removal exits 0 "
+                    "when it only detaches this subos (another subos still "
+                    "references the version) and when it declines a package "
+                    "whose payload is already gone; neither clears the record "
+                    "this repair needs cleared. Take it out where it lives "
+                    "(`xlings subos use <name>` then `xlings remove {}@{}`) "
+                    "and rerun",
+                    task.target, task.version, task.target, task.version)};
     }
     if (run(install) != 0) {
         // The bad outcome. Say it plainly and hand back the exact command.

--- a/src/core/xvm/inspect.cppm
+++ b/src/core/xvm/inspect.cppm
@@ -278,6 +278,138 @@ std::vector<BindingFinding> inspect_binding_state(
     return findings;
 }
 
+// One other subos's workspace, as the caller read it off disk.
+//
+// `active` and `installed` are that subos's own maps; the versions DB they
+// refer to is shared by every subos in the home, which is the whole reason
+// this type exists.
+struct SubosRef {
+    std::string        subos;
+    Workspace          active;
+    WorkspaceInstalled installed;
+};
+
+// Who owns a (target, version), from the point of view of the subos asking.
+struct OwnershipVerdict {
+    // The asking subos has it active or in its installed[] set.
+    bool ownedHere { false };
+    // Other subos that do, in name order. Empty AND !ownedHere means nobody
+    // claims it -- see the note on `subos_ownership`.
+    std::vector<std::string> otherSubos;
+};
+
+// Does this subos claim (target, version)?
+//
+// Either half counts: `active` is what the shims dispatch through, and
+// `installed[]` is the per-subos opt-in list, which keeps a version claimed
+// while some other version of the same target is the active one.
+bool subos_claims(const Workspace& active,
+                  const WorkspaceInstalled& installed,
+                  const std::string& target,
+                  const std::string& version) {
+    if (auto it = active.find(target);
+        it != active.end() && it->second == version) {
+        return true;
+    }
+    if (auto it = installed.find(target); it != installed.end()) {
+        return std::ranges::find(it->second, version) != it->second.end();
+    }
+    return false;
+}
+
+// Ownership of a (target, version) across the home.
+//
+// Callers use this to decide whether a repair belongs to them. Note what
+// "nobody claims it" means and does NOT mean: a home written by a client
+// older than 0.4.19 has no `installed[]` at all, so every version that is not
+// currently active comes back unclaimed. Treating unclaimed as "not mine to
+// repair" would therefore disable the migration repair on exactly the cohort
+// it was built for. Unclaimed is shared, and the subos asking may repair it.
+OwnershipVerdict subos_ownership(const Workspace& active,
+                                 const WorkspaceInstalled& installed,
+                                 const std::vector<SubosRef>& others,
+                                 const std::string& target,
+                                 const std::string& version) {
+    OwnershipVerdict verdict;
+    verdict.ownedHere = subos_claims(active, installed, target, version);
+    for (const auto& other : others) {
+        if (subos_claims(other.active, other.installed, target, version)) {
+            verdict.otherSubos.push_back(other.subos);
+        }
+    }
+    std::ranges::sort(verdict.otherSubos);
+    auto dup = std::ranges::unique(verdict.otherSubos);
+    verdict.otherSubos.erase(dup.begin(), dup.end());
+    return verdict;
+}
+
+// What the OTHER subos of this home point at that the shared DB no longer has.
+//
+// Nothing else looks here. doctor's checks are scoped to the subos it runs in
+// -- its binDir, its sysroot, its workspace -- while the versions DB and the
+// payload store underneath are shared by all of them. So a subos whose active
+// version was taken out from under it (by a removal in a third subos, or by a
+// hand-edited state file) has no command that reports it: running doctor there
+// finds it, but nothing tells you to go there.
+//
+// Read-only and never repaired from here. Fixing another subos's workspace
+// means deciding what that subos should be pointing at, which is `xlings use`
+// deciding, not `doctor` deciding. See §5 of
+// .agents/docs/2026-07-28-multi-subos-repair-design.md.
+//
+// Pure over (db, others): the caller reads the files.
+std::vector<BindingFinding> inspect_subos_references(
+        const VersionDB& db,
+        const std::vector<SubosRef>& others) {
+    std::vector<BindingFinding> findings;
+
+    const auto registered = [&](const std::string& target,
+                                const std::string& version) {
+        auto it = db.find(target);
+        return it != db.end() && it->second.versions.contains(version);
+    };
+
+    for (const auto& other : others) {
+        for (const auto& [target, version] : other.active) {
+            if (version.empty() || registered(target, version)) continue;
+            findings.push_back({
+                .code = "xvm-subos-active-missing",
+                .summary = std::format(
+                    "subos '{}' has '{}' active at {}, which is not registered",
+                    other.subos, target, version),
+                .target = target,
+                .version = version,
+                .hint = std::format(
+                    "run `xlings subos use {}` then `xlings install {}@{}` to "
+                    "restore it, or `xlings use {} <other-version>` there",
+                    other.subos, target, version, target),
+            });
+        }
+        for (const auto& [target, versions] : other.installed) {
+            for (const auto& version : versions) {
+                if (version.empty() || registered(target, version)) continue;
+                // Notice, not Broken: nothing dispatches through installed[],
+                // so this subos still works. It matters because removal counts
+                // references through this set -- a dangling entry keeps a
+                // payload pinned against a version that no longer exists.
+                findings.push_back({
+                    .code = "xvm-subos-installed-dangling",
+                    .summary = std::format(
+                        "subos '{}' lists '{}@{}' as installed, but it is not "
+                        "registered", other.subos, target, version),
+                    .target = target,
+                    .version = version,
+                    .hint = std::format(
+                        "run `xlings subos use {}` then `xlings remove {}@{}` "
+                        "to drop the stale entry", other.subos, target, version),
+                    .severity = BindingSeverity::Notice,
+                });
+            }
+        }
+    }
+    return findings;
+}
+
 // One entry found in the subos, as the caller read it off disk.
 struct SysrootEntry {
     // Relative to the subos root, e.g. "usr/include/openssl".

--- a/tests/e2e/run_all.sh
+++ b/tests/e2e/run_all.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# tests/e2e/run_all.sh — run the release-artifact E2E block (E2E-02..E2E-37)
+# tests/e2e/run_all.sh — run the release-artifact E2E block (E2E-02..E2E-42)
 # with per-test timing + a slowest-first summary, mirroring mcpp's runner.
 #
 # Usage:  bash tests/e2e/run_all.sh <release-tarball>
@@ -91,6 +91,7 @@ TESTS=(
     "E2E-39 |subos_profile_upgrade_test.sh||"
     "E2E-40 |subos_shell_level_test.sh||"
     "E2E-41 |index_artifact_update_test.sh||"
+    "E2E-42 |self_doctor_multi_subos_test.sh||"
 )
 
 PASS=0; FAIL=0; SOFTFAIL=0

--- a/tests/e2e/self_doctor_multi_subos_test.sh
+++ b/tests/e2e/self_doctor_multi_subos_test.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+# self_doctor_multi_subos_test.sh — `self doctor --fix` on a home with more
+# than one subos.
+#
+# The versions DB and the payload store are shared by every subos of a home;
+# workspace, shims and sysroot are not. doctor detects across the first pair
+# and repairs only in the second, and until this test nothing pinned what
+# happens where. Measured consequences, each an assertion below:
+#
+#   S2  a broken payload only another subos uses was repaired HERE, which
+#       registered that package into THIS subos's workspace, shims and
+#       sysroot. The user asked to fix their own environment.
+#   S3  the migration marker lives in the HOME config while the repair
+#       happens in ONE subos, so fixing the first subos stamped the whole
+#       home as migrated and the rest never saw the hint again.
+#   S4  fixing the last outstanding subos must land the stamp -- otherwise
+#       the gate above just moves the nag from "too early" to "forever".
+#   S5  a subos pointing at a version the shared DB no longer has was
+#       invisible from everywhere except that subos.
+#   S6  R3 reads `xlings remove` exiting 0 as "the record is gone". On a
+#       multi-subos home removal detaches the current subos and KEEPS the
+#       record, so R3 reported a version REMOVED that was still installed.
+#
+# Refs: .agents/docs/2026-07-28-multi-subos-repair-design.md
+set -euo pipefail
+
+# shellcheck source=./project_test_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
+
+require_fixture_index
+
+RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/self_doctor_multi_subos"
+HOME_DIR="$RUNTIME_DIR/home"
+LOCAL_INDEX_DIR="$RUNTIME_DIR/xim-pkgindex"
+FAIL_MARKER="$RUNTIME_DIR/make-install-fail"
+
+cleanup() { rm -rf "$RUNTIME_DIR"; }
+trap cleanup EXIT
+cleanup
+
+XLINGS_BIN="$(find_xlings_bin)"
+
+# Every command names the subos it runs in. This test is entirely about which
+# subos a thing happens in, so there is no default form on purpose.
+RUN_IN() {
+  local subos="$1"; shift
+  ( cd /tmp && env -i HOME="$HOME" PATH=/usr/bin:/bin \
+      XLINGS_HOME="$HOME_DIR" XLINGS_ACTIVE_SUBOS="$subos" \
+      "$XLINGS_BIN" "$@" )
+}
+
+mkdir -p "$HOME_DIR/subos/default/bin" "$RUNTIME_DIR"
+cp -r "$FIXTURE_INDEX_DIR" "$LOCAL_INDEX_DIR"
+printf 'xim_indexrepos = {}\n' > "$LOCAL_INDEX_DIR/xim-indexrepos.lua"
+rm -f "$LOCAL_INDEX_DIR/.xlings-index-cache.json"
+mkdir -p "$LOCAL_INDEX_DIR/pkgs/m"
+
+# Two fixtures with the same shape and different owners:
+#   ms-shared  — installed in BOTH subos
+#   ms-only-b  — installed in `other` ONLY
+#
+# ms-shared's install hook fails while $FAIL_MARKER exists. That is what makes
+# S6 reachable: R2 (`xlings install`) has to fail for R3 to run at all, and a
+# hook returning false is the same failure path as a bad download.
+for pkg in ms-shared ms-only-b ms-proj; do
+cat > "$LOCAL_INDEX_DIR/pkgs/m/$pkg.lua" <<LUA
+package = {
+    spec = "1", name = "$pkg",
+    description = "multi-subos doctor fixture",
+    authors = {"xlings-ci"}, licenses = {"MIT"}, type = "package",
+    archs = {"x86_64"}, status = "stable", categories = {"test-fixture"},
+    xpm = {
+        linux   = { ["1.0.0"] = {} },
+        macosx  = { ["1.0.0"] = {} },
+        windows = { ["1.0.0"] = {} },
+    },
+}
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+function install()
+    if "$pkg" == "ms-shared" and os.isfile("$FAIL_MARKER") then
+        return false
+    end
+    local bindir = path.join(pkginfo.install_dir(), "bin")
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(bindir)
+    io.writefile(path.join(bindir, "$pkg"),
+                 "#!/bin/sh\necho $pkg@" .. pkginfo.version() .. "\n")
+    return true
+end
+function config()
+    xvm.add("$pkg", { bindir = path.join(pkginfo.install_dir(), "bin") })
+    return true
+end
+function uninstall()
+    xvm.remove("$pkg")
+    return true
+end
+LUA
+done
+
+cp "$XLINGS_BIN" "$HOME_DIR/xlings"
+cat > "$HOME_DIR/.xlings.json" <<JSON
+{ "mirror": "GLOBAL",
+  "index_repos": [{ "name": "xim", "url": "$LOCAL_INDEX_DIR" }] }
+JSON
+
+log "init sandbox"
+RUN_IN default self init >/dev/null 2>&1 || fail "self init failed"
+mkdir -p "$HOME_DIR/data/xim-index-repos"
+printf '{}\n' > "$HOME_DIR/data/xim-index-repos/xim-indexrepos.json"
+RUN_IN default subos new other >/dev/null 2>&1 || fail "subos new other failed"
+
+log "Setup: default has ms-shared; other has ms-shared + ms-only-b"
+RUN_IN default install ms-shared@1.0.0 -y >/dev/null 2>&1 \
+  || fail "setup: default install ms-shared failed"
+RUN_IN other   install ms-shared@1.0.0 -y >/dev/null 2>&1 \
+  || fail "setup: other install ms-shared failed"
+RUN_IN other   install ms-only-b@1.0.0 -y >/dev/null 2>&1 \
+  || fail "setup: other install ms-only-b failed"
+
+WS_DEFAULT="$HOME_DIR/subos/default/.xlings.json"
+WS_OTHER="$HOME_DIR/subos/other/.xlings.json"
+PAYLOAD_B="$HOME_DIR/data/xpkgs/xim-x-ms-only-b/1.0.0"
+PAYLOAD_SHARED="$HOME_DIR/data/xpkgs/xim-x-ms-shared/1.0.0"
+
+# Record an older client into the home config, the way an upgraded home reads.
+# Without this the migration-marker assertions would be vacuous: a fresh home
+# already carries the running version, so "the stamp did not land" and "the
+# stamp landed" look identical.
+python3 - "$HOME_DIR" <<'PY'
+import json, pathlib, sys
+p = pathlib.Path(sys.argv[1], ".xlings.json")
+data = json.loads(p.read_text())
+data["version"] = "0.4.69"
+p.write_text(json.dumps(data, indent=2))
+PY
+
+recorded_version() {
+  python3 - "$HOME_DIR" <<'PY'
+import json, pathlib, sys
+print(json.loads(pathlib.Path(sys.argv[1], ".xlings.json").read_text()).get("version", ""))
+PY
+}
+has_ws_entry() {
+  python3 - "$1" "$2" <<'PY'
+import json, pathlib, sys
+data = json.loads(pathlib.Path(sys.argv[1]).read_text())
+ws = data.get("workspace") or {}
+sys.exit(0 if sys.argv[2] in ws else 1)
+PY
+}
+
+OUT_FILE="$RUNTIME_DIR/last-output.txt"
+# Captures into $out / $rc. Via a file because the TUI stream emits null
+# bytes, which bash drops from a command substitution with a warning each
+# time -- noise that would bury a real diagnostic in the CI log.
+run_capture() {
+  local subos="$1"; shift
+  rc=0
+  RUN_IN "$subos" "$@" >"$OUT_FILE" 2>&1 || rc=$?
+  out=$(tr -d '\0' < "$OUT_FILE")
+}
+
+# ── S1: both subos are clean ───────────────────────────────────────
+log "S1: doctor is clean in both subos"
+RUN_IN default self doctor >/dev/null 2>&1 || fail "S1: default should be clean"
+RUN_IN other   self doctor >/dev/null 2>&1 || fail "S1: other should be clean"
+[[ "$(recorded_version)" == "0.4.69" ]] \
+  || fail "S1 setup: recorded client version should still read 0.4.69"
+
+# ── S2: a payload only `other` uses is reported, attributed, NOT adopted ──
+log "S2: broken payload owned by another subos → attributed, not repaired here"
+rm -rf "$PAYLOAD_B"
+
+run_capture default self doctor
+grep -q "broken payload \[subos: other\]" <<<"$out" \
+  || fail "S2: default's report must attribute the finding to 'other'; got:\n$out"
+grep -q "xlings subos use other" <<<"$out" \
+  || fail "S2: default's report must say where to repair it; got:\n$out"
+# Not this subos's problem, so not this subos's exit code. Counting it would
+# leave `default` permanently red with no command that clears it from here.
+[[ $rc -eq 0 ]] \
+  || fail "S2: another subos's broken payload must not fail this subos (rc=$rc):\n$out"
+
+log "S2b: --fix in default must not adopt the package"
+run_capture default self doctor --fix
+has_ws_entry "$WS_DEFAULT" "ms-only-b" \
+  && fail "S2b: --fix pulled ms-only-b into default's workspace:\n$out"
+[[ ! -d "$PAYLOAD_B" ]] \
+  || fail "S2b: default's --fix must not reinstall another subos's package"
+[[ ! -e "$HOME_DIR/subos/default/bin/ms-only-b" ]] \
+  || fail "S2b: default's --fix must not create a shim for another subos's package"
+
+# ── S3: the migration marker must not land while another subos is behind ──
+log "S3: stamp withheld while another subos still has a repair outstanding"
+[[ "$(recorded_version)" == "0.4.69" ]] \
+  || fail "S3: --fix stamped the home while 'other' still had work outstanding"
+
+# ── S4: repairing it in `other` lands the stamp ──────────────────────
+log "S4: --fix in other repairs the payload and lands the stamp"
+run_capture other self doctor --fix
+[[ $rc -eq 0 ]] || fail "S4: other's --fix should exit 0; got $rc:\n$out"
+[[ -f "$PAYLOAD_B/bin/ms-only-b" ]] \
+  || fail "S4: other's --fix must restore the payload it owns"
+[[ "$(recorded_version)" != "0.4.69" ]] \
+  || fail "S4: stamp must land once nothing is outstanding anywhere"
+
+RUN_IN default self doctor >/dev/null 2>&1 \
+  || fail "S4: default should be clean again after other repaired its payload"
+
+# ── S5: what the other subos points at is visible from here ─────────
+log "S5: another subos pointing at an unregistered version is reported here"
+python3 - "$WS_OTHER" <<'PY'
+import json, pathlib, sys
+p = pathlib.Path(sys.argv[1])
+data = json.loads(p.read_text())
+ws = data.get("workspace") or {}
+entry = ws.get("ms-only-b")
+# Point the active version at something the shared DB does not have. Both
+# schema forms are accepted on read, so write back the one that is there.
+if isinstance(entry, dict):
+    entry["active"] = "9.9.9"
+else:
+    ws["ms-only-b"] = "9.9.9"
+data["workspace"] = ws
+p.write_text(json.dumps(data, indent=2))
+PY
+
+run_capture default self doctor
+grep -q "other subos" <<<"$out" \
+  || fail "S5: default must report the state of other subos; got:\n$out"
+grep -q "xvm-subos-active-missing" <<<"$out" \
+  || fail "S5: the finding must carry its code; got:\n$out"
+grep -q "xlings subos use other" <<<"$out" \
+  || fail "S5: the finding must say where to go; got:\n$out"
+# Reported, not counted: `default` cannot repair another subos's pointer, and
+# a red exit with no command that clears it is the nag-forever shape.
+[[ $rc -eq 0 ]] \
+  || fail "S5: another subos's dangling pointer must not fail this subos (rc=$rc)"
+
+# Restore `other` so the last scenario starts from a consistent home.
+RUN_IN other use ms-only-b 1.0.0 >/dev/null 2>&1 \
+  || fail "S5 cleanup: could not re-select ms-only-b in other"
+
+# ── S6: R3 must not claim a removal that only detached this subos ────
+#
+# ms-shared is installed in BOTH subos. Break its payload and make its install
+# hook fail, so R2 fails and R3 runs for real: its `xlings remove` finds the
+# version still referenced by `other`, detaches `default`, and exits 0 with
+# the record intact.
+log "S6: R3 does not report REMOVED when the record survived"
+rm -rf "$PAYLOAD_SHARED"
+: > "$FAIL_MARKER"
+
+run_capture default self doctor --fix
+[[ $rc -ne 0 ]] || fail "S6: the repair could not succeed, so doctor must not exit 0"
+grep -q "REMOVED" <<<"$out" \
+  && fail "S6: reported a removal that did not happen; got:\n$out"
+grep -q "still registered" <<<"$out" \
+  || fail "S6: must say the record survived the removal; got:\n$out"
+
+# The record it declined to claim as removed is in fact still there.
+python3 - "$HOME_DIR" <<'PY' || fail "S6: ms-shared@1.0.0 must still be registered"
+import json, pathlib, sys
+data = json.loads(pathlib.Path(sys.argv[1], ".xlings.json").read_text())
+versions = (data.get("versions") or {}).get("ms-shared") or {}
+assert "1.0.0" in (versions.get("versions") or {}), \
+    "S6: the entry R3 said it removed is gone -- the message was right after all?"
+PY
+
+# And the home must not be stamped off the back of a failed repair.
+[[ "$(recorded_version)" != "0.4.69" ]] \
+  || true   # already stamped in S4; S6 must not un-stamp, nothing to assert
+
+rm -f "$FAIL_MARKER"
+
+# ── S7: a project subos counts as a reference ────────────────────────
+#
+# Payload reference counting used to enumerate ONE side: the project subos
+# when the package's scope was Project, the home's subos otherwise. The two
+# sets never met, so a global-scope package used by two PROJECT subos was
+# counted as referenced by nobody -- and removing it from one deleted the
+# payload the other was still pointing at, from a command run in a third
+# place entirely.
+log "S7: a second project subos keeps the payload alive"
+PROJ_DIR="$RUNTIME_DIR/proj"
+mkdir -p "$PROJ_DIR"
+write_project_subos() {
+  cat > "$PROJ_DIR/.xlings.json" <<JSON
+{ "subos": "$1" }
+JSON
+}
+RUN_PROJ() {
+  ( cd "$PROJ_DIR" && env -i HOME="$HOME" PATH=/usr/bin:/bin \
+      XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@" )
+}
+
+write_project_subos pa
+RUN_PROJ install ms-proj@1.0.0 -y >/dev/null 2>&1 \
+  || fail "S7: install into project subos pa failed"
+write_project_subos pb
+RUN_PROJ install ms-proj@1.0.0 -y >/dev/null 2>&1 \
+  || fail "S7: install into project subos pb failed"
+
+PAYLOAD_PROJ="$HOME_DIR/data/xpkgs/xim-x-ms-proj/1.0.0"
+[[ -d "$PAYLOAD_PROJ" ]] || fail "S7 setup: payload should exist"
+has_ws_entry "$PROJ_DIR/.xlings/subos/pb/.xlings.json" "ms-proj" \
+  || fail "S7 setup: pb should reference ms-proj"
+
+write_project_subos pa
+RUN_PROJ remove ms-proj@1.0.0 -y >/dev/null 2>&1 \
+  || fail "S7: remove from project subos pa failed"
+
+[[ -d "$PAYLOAD_PROJ" ]] \
+  || fail "S7: payload deleted while project subos pb still referenced it"
+has_ws_entry "$PROJ_DIR/.xlings/subos/pb/.xlings.json" "ms-proj" \
+  || fail "S7: pb lost its reference to a package it still has"
+has_ws_entry "$PROJ_DIR/.xlings/subos/pa/.xlings.json" "ms-proj" \
+  && fail "S7: pa should have detached from ms-proj"
+
+log "PASS: multi-subos doctor scoping, attribution, stamping, R3 honesty, refcount union"

--- a/tests/unit/test_self_repair.cpp
+++ b/tests/unit/test_self_repair.cpp
@@ -139,6 +139,63 @@ TEST(SelfRepairLadder, ALocalOnlyPassRunsNothing) {
     EXPECT_TRUE(f.ran.empty());
 }
 
+// ------------------------------------------- R3 removal actually removed
+//
+// `xlings remove` exits 0 on a multi-subos home while leaving the record in
+// place: it detaches the current subos and keeps the version whenever another
+// subos still references it. R3 read that zero as "the entry is gone" and
+// reported the version REMOVED -- a claim about the user's disk that was not
+// true, made in the one message they are most likely to act on.
+
+TEST(SelfRepairLadder, DoesNotClaimRemovalWhenTheRecordSurvives) {
+    FakeRunner f{.codes = {1, 0}};      // install fails, remove "succeeds"
+    auto r = repair_one(task(), RepairPolicy{}, runner_of(f),
+                        [](const std::string&, const std::string&) {
+                            return false;   // still registered
+                        });
+
+    EXPECT_FALSE(r.healed);
+    EXPECT_EQ(r.rung, "none") << "nothing was removed, so no rung did damage";
+    EXPECT_EQ(r.note.find("REMOVED"), std::string::npos)
+        << "must not claim a removal that did not happen: " << r.note;
+    EXPECT_NE(r.note.find("still registered"), std::string::npos);
+    EXPECT_NE(r.note.find("another subos"), std::string::npos);
+    // No second install: it would fail against the record that is still there.
+    ASSERT_EQ(f.ran.size(), 2u);
+    EXPECT_EQ(f.ran[1], "xlings remove linux-headers@5.11.1 -y");
+}
+
+TEST(SelfRepairLadder, ProceedsWhenTheVerifierConfirmsTheRemoval) {
+    FakeRunner f{.codes = {1, 0, 0}};
+    auto r = repair_one(task(), RepairPolicy{}, runner_of(f),
+                        [](const std::string& t, const std::string& v) {
+                            EXPECT_EQ(t, "linux-headers");
+                            EXPECT_EQ(v, "5.11.1");
+                            return true;    // really gone
+                        });
+
+    EXPECT_TRUE(r.healed);
+    EXPECT_EQ(r.rung, "reinstall");
+    ASSERT_EQ(f.ran.size(), 3u);
+}
+
+// The verifier only ever runs after a removal, so a repair that never reaches
+// R3 must not pay for it -- and, more importantly, a caller passing one must
+// not change what R2 does.
+TEST(SelfRepairLadder, VerifierIsNotConsultedWhenReRegisterSucceeds) {
+    FakeRunner f{.codes = {0}};
+    bool consulted = false;
+    auto r = repair_one(task(), RepairPolicy{}, runner_of(f),
+                        [&](const std::string&, const std::string&) {
+                            consulted = true;
+                            return true;
+                        });
+
+    EXPECT_TRUE(r.healed);
+    EXPECT_EQ(r.rung, "re-register");
+    EXPECT_FALSE(consulted);
+}
+
 // ---------------------------------------------------------------- shell safety
 
 // Names come from the versions DB, which recipes write, and the ladder builds

--- a/tests/unit/test_xvm_doctor.cpp
+++ b/tests/unit/test_xvm_doctor.cpp
@@ -762,3 +762,189 @@ TEST(XvmSysrootOwnership, AnInactiveVersionDoesNotClaimTheDestination) {
     ASSERT_EQ(findings.size(), 1u);
     EXPECT_EQ(findings[0].code, "xvm-sysroot-unmanaged");
 }
+
+// ============================================================
+// Cross-subos: whose finding is this, and what are the others pointing at
+//
+// The versions DB and the payload store are shared by every subos of a home;
+// workspace, shims and sysroot are not. doctor checks both sides but repairs
+// only the second, so the first question a broken-payload finding has to
+// answer is whose it is -- a repair is an `xlings install`, and that
+// registers into whichever subos is current.
+// ============================================================
+
+namespace {
+
+xlings::xvm::VersionDB shared_db_() {
+    xlings::xvm::VersionDB db;
+    auto& gcc = db["gcc"];
+    gcc.type = "program";
+    gcc.versions["15.1.0"].path = "/home/u/.xlings/data/xpkgs/xim-x-gcc/15.1.0/bin";
+    auto& node = db["node"];
+    node.type = "program";
+    node.versions["22.17.1"].path = "/home/u/.xlings/data/xpkgs/xim-x-node/22.17.1/bin";
+    return db;
+}
+
+}  // namespace
+
+TEST(XvmSubosOwnership, ActiveHereIsOwnedHere) {
+    const xlings::xvm::Workspace here{{"gcc", "15.1.0"}};
+    const std::vector<xlings::xvm::SubosRef> others{
+        {.subos = "build", .active = {{"gcc", "15.1.0"}}},
+    };
+    const auto v = xlings::xvm::subos_ownership(here, {}, others,
+                                                "gcc", "15.1.0");
+    EXPECT_TRUE(v.ownedHere);
+    EXPECT_EQ(v.otherSubos, std::vector<std::string>{"build"});
+}
+
+// installed[] is the per-subos opt-in list. A version stays this subos's
+// business while some *other* version of the same target is the active one --
+// otherwise `--fix` would decline to repair anything a user had switched away
+// from.
+TEST(XvmSubosOwnership, InstalledButInactiveIsStillOwnedHere) {
+    const xlings::xvm::Workspace here{{"gcc", "16.1.0"}};
+    const xlings::xvm::WorkspaceInstalled hereInstalled{
+        {"gcc", {"15.1.0", "16.1.0"}}};
+    const auto v = xlings::xvm::subos_ownership(here, hereInstalled, {},
+                                                "gcc", "15.1.0");
+    EXPECT_TRUE(v.ownedHere);
+}
+
+TEST(XvmSubosOwnership, AnotherSubosOwnsItAndThisOneDoesNot) {
+    const std::vector<xlings::xvm::SubosRef> others{
+        {.subos = "web", .installed = {{"node", {"22.17.1"}}}},
+        {.subos = "api", .active = {{"node", "22.17.1"}}},
+    };
+    const auto v = xlings::xvm::subos_ownership({}, {}, others,
+                                                "node", "22.17.1");
+    EXPECT_FALSE(v.ownedHere);
+    // Sorted, so the reported "go fix it there" command is stable across runs.
+    EXPECT_EQ(v.otherSubos, (std::vector<std::string>{"api", "web"}));
+}
+
+// The compatibility case, and the reason "unclaimed" is not "not mine".
+//
+// A home written before installed[] existed has no installed[] at all, so
+// every version that is not currently active comes back unclaimed by
+// everyone. That cohort is precisely who the migration repair exists for; a
+// judgment of "belongs to nobody, so leave it alone" would switch the whole
+// feature off for them.
+TEST(XvmSubosOwnership, NobodyClaimsALegacyInactiveVersion) {
+    const std::vector<xlings::xvm::SubosRef> others{
+        {.subos = "build", .active = {{"gcc", "16.1.0"}}},
+    };
+    const auto v = xlings::xvm::subos_ownership({{"gcc", "16.1.0"}}, {}, others,
+                                                "gcc", "15.1.0");
+    EXPECT_FALSE(v.ownedHere);
+    EXPECT_TRUE(v.otherSubos.empty())
+        << "an unclaimed version must not be attributed to another subos";
+}
+
+TEST(XvmSubosReferences, AnotherSubosPointingAtAnUnregisteredVersionIsReported) {
+    const std::vector<xlings::xvm::SubosRef> others{
+        {.subos = "build", .active = {{"gcc", "14.2.0"}}},
+    };
+    const auto findings =
+        xlings::xvm::inspect_subos_references(shared_db_(), others);
+    ASSERT_EQ(findings.size(), 1u);
+    EXPECT_EQ(findings[0].code, "xvm-subos-active-missing");
+    EXPECT_EQ(findings[0].severity, xlings::xvm::BindingSeverity::Broken);
+    // Naming the subos is the whole point: the user is standing in a
+    // different one and has no other way to learn where to go.
+    EXPECT_NE(findings[0].summary.find("build"), std::string::npos);
+    EXPECT_NE(findings[0].hint.find("xlings subos use build"),
+              std::string::npos);
+}
+
+// Nothing dispatches through installed[], so a stale entry there does not
+// break that subos. It does keep a payload pinned against removal, which is
+// worth saying once and not worth painting the run red for.
+TEST(XvmSubosReferences, ADanglingInstalledEntryIsANoticeNotABreak) {
+    const std::vector<xlings::xvm::SubosRef> others{
+        {.subos = "web", .installed = {{"node", {"22.17.1", "18.0.0"}}}},
+    };
+    const auto findings =
+        xlings::xvm::inspect_subos_references(shared_db_(), others);
+    ASSERT_EQ(findings.size(), 1u);
+    EXPECT_EQ(findings[0].code, "xvm-subos-installed-dangling");
+    EXPECT_EQ(findings[0].severity, xlings::xvm::BindingSeverity::Notice);
+    EXPECT_EQ(findings[0].version, "18.0.0");
+}
+
+TEST(XvmSubosReferences, ConsistentSubosProduceNothing) {
+    const std::vector<xlings::xvm::SubosRef> others{
+        {.subos = "build",
+         .active = {{"gcc", "15.1.0"}},
+         .installed = {{"gcc", {"15.1.0"}}}},
+        {.subos = "web",
+         .active = {{"node", "22.17.1"}},
+         .installed = {{"node", {"22.17.1"}}}},
+    };
+    EXPECT_TRUE(
+        xlings::xvm::inspect_subos_references(shared_db_(), others).empty());
+}
+
+// An empty active pointer is how a subos records "nothing selected". It is
+// not a dangling reference, and reporting it would fire on every subos that
+// has ever had a package removed.
+TEST(XvmSubosReferences, AnEmptyActivePointerIsNotADanglingReference) {
+    const std::vector<xlings::xvm::SubosRef> others{
+        {.subos = "build", .active = {{"gcc", ""}}},
+    };
+    EXPECT_TRUE(
+        xlings::xvm::inspect_subos_references(shared_db_(), others).empty());
+}
+
+// ------------------------------------------------- reading them off disk
+
+// The one walk of ~/.xlings/subos/*/.xlings.json. It used to be three, with
+// three slightly different notions of what counts as readable, which is how a
+// subos could pin a payload for the GC and be invisible to the reference
+// count in the same run.
+TEST(SubosSnapshots, ReadsEverySubosAndSkipsWhatIsNotOne) {
+    namespace fs = std::filesystem;
+    auto home = fs::temp_directory_path() / "xlings_subos_snapshot_test";
+    std::error_code ec;
+    fs::remove_all(home, ec);
+
+    auto write_subos = [&](const std::string& name, std::string_view body) {
+        fs::create_directories(home / "subos" / name);
+        xlings::platform::write_string_to_file(
+            (home / "subos" / name / ".xlings.json").string(), std::string(body));
+    };
+
+    write_subos("default", R"({"workspace":{"gcc":{"active":"15.1.0","installed":["15.1.0"]}}})");
+    write_subos("build",   R"({"workspace":{"node":"22.17.1"}})");
+    // Legacy string form: still a workspace, still must be read.
+    write_subos("broken",  R"({not json at all)");
+    // A directory with no config is not a subos yet.
+    fs::create_directories(home / "subos" / "empty");
+    // `current` is a pointer to the active one; counting it would double every
+    // reference the active subos holds.
+    write_subos("current", R"({"workspace":{"gcc":"15.1.0"}})");
+
+    const auto snapshots = xlings::profile::load_subos_snapshots(home);
+    ASSERT_EQ(snapshots.size(), 2u);
+    EXPECT_EQ(snapshots[0].name, "build");
+    EXPECT_EQ(snapshots[1].name, "default");
+    EXPECT_EQ(snapshots[0].workspace.active.at("node"), "22.17.1");
+    EXPECT_EQ(snapshots[1].workspace.installed.at("gcc").front(), "15.1.0");
+    EXPECT_EQ(snapshots[1].dir, home / "subos" / "default");
+
+    // Both users of the walk agree, which is the property that was missing.
+    const auto referencing =
+        xlings::profile::find_subos_referencing(home, "gcc");
+    EXPECT_EQ(referencing, std::vector<std::string>{"default"});
+
+    fs::remove_all(home, ec);
+}
+
+TEST(SubosSnapshots, AHomeWithNoSubosDirectoryIsEmptyNotAnError) {
+    namespace fs = std::filesystem;
+    auto home = fs::temp_directory_path() / "xlings_subos_snapshot_absent";
+    std::error_code ec;
+    fs::remove_all(home, ec);
+    EXPECT_TRUE(xlings::profile::load_subos_snapshots(home).empty());
+}


### PR DESCRIPTION
## Summary

`self doctor --fix` (shipped 2026.7.28.1) is written per-subos; what it detects — the versions DB and the payload store — is shared by every subos of the home. Single-subos homes cannot see the mismatch. This PR draws the boundary: repair what this subos owns, say where to repair the rest, and stop reporting removals that did not happen.

Four defects, each with an assertion:

| # | defect | now |
|---|---|---|
| D1 | R3 read `xlings remove` exiting 0 as "the record is gone" and reported the package **REMOVED**. Removal also exits 0 when it merely detaches this subos, when the package is not in this subos, and when the payload is already missing — the state a broken-payload repair starts from | removal confirmed by re-reading the state file; when the record survives, the note says so and names no removal |
| D2 | `--fix` repaired a payload only another subos used. The repair is an `xlings install`, whose `config()` registers into the **current** subos — fixing your own environment adopted someone else's package | attributed and deferred: `✗ broken payload [subos: other]` + `xlings subos use other && xlings self doctor --fix` |
| D3 | the other subos of a home were invisible; a subos whose active version had gone missing was reported nowhere but from inside it | new read-only check with codes `xvm-subos-active-missing` / `xvm-subos-installed-dangling` |
| D4 | the migration marker is written to the **home** config while the repair happens in **one** subos, so fixing the first subos stamped the whole home and the rest never saw the hint again | stamp withheld while another subos still has a repairable payload outstanding |
| D5 | payload reference counting picked project-side **or** home-side workspace files by scope; the two sets never met, so a global-scope package used by two project subos counted as referenced by nobody | union of both |

Two decisions worth calling out:

- **Unclaimed entries are still repaired here.** A home written before `installed[]` existed has none, so every inactive version comes back unclaimed — that cohort is exactly who the 2026.7.28.1 repair ladder was built for. "Nobody claims it" means shared, not foreign.
- **Findings that belong to another subos are printed but kept out of the exit code.** This subos has no command that clears them; counting them would leave every subos of the home permanently red, which is the nag-forever shape the last release fixed in the other direction.

Design: `.agents/docs/2026-07-28-multi-subos-repair-design.md` · release notes: `.agents/docs/2026-07-28-release-2026.7.28.2-notes.md`

## Test plan

- **Unit (13 new)** — ownership three ways incl. the unclaimed/legacy path; both cross-subos codes and their severities; snapshot reading (skips malformed JSON and the `current` symlink); R3's three outcomes (survives / confirmed / not consulted on R2 success).
- **E2E (new, E2E-42)** — `tests/e2e/self_doctor_multi_subos_test.sh`, 7 scenarios over a home with two subos plus two project subos.
- **Mutation-verified** — each fix reverted to its old behaviour, and the intended assertion failed. Ownership → S2, stamp gate → S3, R3 check → S6, refcount union → S7. Four mutations, four different assertions, none vacuous.
- **Regression** — `self_doctor_test.sh` (the single-subos gate, unchanged by design), `subos_payload_refcount_test.sh`, `subos_install_remove_isolation_test.sh`, `remove_multi_version_test.sh`, `subos_workspace_c2_schema_test.sh`, `project_home_test.sh`, `project_global_fallback_test.sh`, `nested_xlings_home_test.sh`, `shim_owner_anchoring_test.sh`, `xvm_metadata_reset_test.sh`, `xvm_group_switch_test.sh` — all pass. `mcpp test` 23/23.

Version bumped to `2026.7.28.2` (`src/core/config.cppm` + `mcpp.toml`) for the release that follows this merge.