### PR TITLE
fix(xself): stop reporting a successful alias-mode repair as a failure (2026.7.28.3)

### DIFF
--- a/.agents/docs/2026-07-28-release-2026.7.28.3-notes.md
+++ b/.agents/docs/2026-07-28-release-2026.7.28.3-notes.md
@@ -1,0 +1,72 @@
+# xlings 2026.7.28.3 — 发布说明
+
+**日期**: 2026-07-28
+**类型**: 发布记录 (release notes)
+**关联**: `2026-07-28-multi-subos-repair-design.md`、`2026-07-28-release-2026.7.28.2-notes.md`
+
+---
+
+## 一句话
+
+**`self doctor --fix` 修好了一个 alias 包之后，不再把它报告成 `✗ repair failed`。**
+
+---
+
+## 这一条是怎么找出来的
+
+2026.7.28.2 的验收是拿 fixture 包跑的。发布后改用**真实索引**复跑同一套场景，
+`patchelf` 立刻把它撞了出来 —— 这个 recipe 注册两个目标：
+
+```lua
+xvm.add("patchelf", { bindir = ... })
+xvm.add("elfpatch", { bindir = ..., alias = "patchelf" })
+```
+
+删掉 payload 再 `--fix`（2026.7.28.1 和 .2 行为一致）：
+
+```
+✗ repair failed  elfpatch@0.18.0
+healed          1
+$ echo $?   → 1
+$ ls data/xpkgs/xim-x-patchelf/0.18.0/bin/patchelf   → 在
+```
+
+payload 修好了，doctor 说它失败了，退出码 1。
+
+**原因**：修复后的复检只问了 `resolve_executable(<target>)` —— 那是 check 3 的
+**非 alias** 分支。alias 模式的条目按定义就没有自己的可执行文件，于是每一个都会被
+判成没修好。
+
+从 2026.7.28.2 起这条假失败还多了一个后果：迁移标记的门槛是 `repairFailed == 0`，
+所以家目录里只要有**一个** alias 包，标记就永远落不下，那句
+`run xlings self doctor --fix` 的提示永远不会消失。
+
+## 修复
+
+"修好了"现在的定义是**检测不会再报它**，判据逐分支对齐 check 3：
+
+| 分支 | 之前 |
+|---|---|
+| type-only 存根 | ❌ 没有 |
+| alias 模式 → payload 目录回来了就是修好了 | ❌ 没有（本次的 bug）|
+| `resolve_executable` 能解析 | ✅ 唯一有的一条 |
+| binding root | ✅ |
+| payload 里一个可执行文件都没有（release anchor）| ❌ 没有 —— 同一类假失败：纯头文件包的目录恢复了就是修好了，不是坏的 |
+
+五条里原来只有一条。
+
+## 测试
+
+e2e `self_doctor_test.sh` 新增 S11：删掉 alias 条目的 payload 目录 → `--fix` →
+断言 payload 回来了、输出里没有 `repair failed`、退出码 0。
+
+**顺带修掉一个恒真的 fixture。** alias fixture 写出的 alias 目标没有可执行位，于是
+payload"一个可执行文件都没有"，doctor 走了 release-anchor 豁免 —— **把被测分支删掉，
+S11 照样通过**。给 fixture 补上可执行位之后，变异才能被抓住（两个方向都验过：有 chmod
+时删分支 S11 失败，没 chmod 时不失败）。S9/S10 之前也是靠同一个错误理由通过的。
+
+## 已知问题（本次不修，另开）
+
+`xlings remove <pkg>` 在别的 subos 还引用该版本时走 detach 路径，但 detach 只处理
+被点名的目标，不处理 release 的其它成员：`remove patchelf` 之后，当前 subos 的
+`elfpatch` 仍然 active。2026.7.28.1 上行为相同（已验证，不是本次引入）。

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlings"
-version = "2026.7.28.2"
+version = "2026.7.28.3"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "2026.7.28.2";
+    static constexpr std::string_view VERSION = "2026.7.28.3";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/xself/doctor.cppm
+++ b/src/core/xself/doctor.cppm
@@ -900,31 +900,53 @@ export int cmd_doctor(EventStream& stream, bool fix,
         // failure, the single entry whose cure was metadata-only.
         Config::reload_state();
         const auto after = Config::versions();
-        for (const auto& [task, result] : outcomes) {
-            const auto* vi = xvm::get_vinfo(after, task.target);
-            const xvm::VData* vd = nullptr;
-            if (vi) {
-                if (auto it = vi->versions.find(task.version);
-                    it != vi->versions.end()) {
-                    vd = &it->second;
-                }
-            }
+        // Cured means DETECTION WOULD NO LONGER REPORT IT. Anything narrower
+        // is a second opinion about the same entry, and the two then disagree
+        // -- which is what happened: this used to ask only
+        // `resolve_executable(target)`, the non-alias branch of check 3. An
+        // alias-mode entry has no executable of its own by construction, so
+        // every one of them came back "repair failed" after a repair that had
+        // in fact worked. Measured against the real index: `patchelf`
+        // registers `elfpatch` with `alias = "patchelf"`, so removing that
+        // payload and running `--fix` restored it, printed
+        // `✗ repair failed elfpatch@0.18.0`, and exited 1 on a home where
+        // nothing was left to fix. Same shape as the release-anchor case the
+        // previous release fixed, in the branch it did not reach.
+        const auto payload_finding_cleared = [&](const xvm::VersionDB& state,
+                                                 const std::string& name,
+                                                 const std::string& version) {
+            const auto* vi = xvm::get_vinfo(state, name);
+            if (!vi) return false;   // entry gone: never a cure, see below
+            auto it = vi->versions.find(version);
+            if (it == vi->versions.end()) return false;
+            const auto& vd = it->second;
+            if (vd.path.empty()) return true;   // type-only stub, never reported
 
-            bool cured = false;
-            if (vd) {
-                // Two ways to be cured, matching the two ways to be broken:
-                // the payload resolves again, or re-registration made the
-                // entry recognisable as a release anchor (a package that
-                // ships no program of its own was never broken).
-                cured = !xvm::resolve_executable(
-                             task.target, vd->path, home_str).empty()
-                     || xvm::is_binding_root(after, task.target, task.version);
-            } else {
-                // The entry is gone. Only a cure if the ladder took it out on
-                // purpose and could not put it back -- which it reports as a
-                // failure, not a cure.
-                cured = false;
+            const auto expanded = xvm::expand_path(vd.path, home_str);
+            std::error_code ec;
+            if (!fs::is_directory(expanded, ec)) return false;
+
+            // Alias mode: check 3 downgrades an unresolvable alias to a
+            // warning and never calls it a broken payload, so the payload
+            // directory being back is the whole of the cure.
+            if (!vd.alias.empty() && !vd.alias[0].empty()) return true;
+
+            if (!xvm::resolve_executable(name, vd.path, home_str).empty()) {
+                return true;
             }
+            // Re-registration can also make the entry recognisable as a
+            // release anchor -- a package that ships no program of its own
+            // was never broken. Both of check 3's exemptions, not one.
+            return xvm::is_binding_root(state, name, version)
+                || !payload_has_any_executable(expanded);
+        };
+
+        for (const auto& [task, result] : outcomes) {
+            // An entry that is gone is not cured: the only way the ladder
+            // takes one out is R3, which reports its own failure when it
+            // cannot put it back.
+            const bool cured =
+                payload_finding_cleared(after, task.target, task.version);
 
             if (cured) {
                 ++healed;

--- a/tests/e2e/self_doctor_test.sh
+++ b/tests/e2e/self_doctor_test.sh
@@ -323,9 +323,21 @@ function install()
     local bindir = path.join(pkginfo.install_dir(), "bin")
     os.tryrm(pkginfo.install_dir())
     os.mkdir(bindir)
-    -- Real binary that the alias points to: alias-real
+    -- Real binary that the alias points to: alias-real.
+    --
+    -- It has to be EXECUTABLE, not merely present. doctor exempts a payload
+    -- that ships no executable at all ("this package has no program of its
+    -- own"), so a fixture whose only file is unreadable as a program takes
+    -- that exemption and every alias-mode assertion below passes for the
+    -- wrong reason -- verified by mutation: without the chmod, deleting the
+    -- alias branch under test left S11 green.
     io.writefile(path.join(bindir, "alias-real"),
                  "#!/bin/sh\necho alias-real\n")
+    if os.host() == "windows" then
+        io.writefile(path.join(bindir, "alias-real.bat"), "@echo alias-real\n")
+    else
+        os.exec("chmod +x " .. path.join(bindir, "alias-real"))
+    end
     return true
 end
 
@@ -372,6 +384,33 @@ vers = (data.get("versions") or {}).get("alias-fixture", {}).get("versions", {})
 assert "1.0.0" in vers, "S10: alias-fixture@1.0.0 should remain registered (warning is non-actionable)"
 PY
 
+# ── S11: repairing an alias-mode entry is reported as repaired ─────
+#
+# The re-detect that decides whether a repair worked used to ask only
+# `resolve_executable(<target>)` -- check 3's NON-alias branch. An alias-mode
+# entry has no executable of its own by construction, so every one of them came
+# back `✗ repair failed` after a repair that had in fact worked, and doctor
+# exited 1 on a home with nothing left to fix.
+#
+# Not a fixture-only shape: measured against the real index, `patchelf`
+# registers `elfpatch` with `alias = "patchelf"`, so deleting that payload and
+# running `--fix` restored it and then reported the restore as a failure.
+log "S11: --fix on an alias-mode entry → healed, not 'repair failed'"
+ALIAS_PAYLOAD_DIR="$HOME_DIR/data/xpkgs/xim-x-alias-fixture/1.0.0"
+rm -rf "$ALIAS_PAYLOAD_DIR"
+rc=0
+out=$(RUN self doctor 2>&1) || rc=$?
+[[ $rc -ne 0 ]] || fail "S11 setup: a missing payload directory must be an error"
+
+rc=0
+out=$(RUN self doctor --fix 2>&1) || rc=$?
+[[ -f "$ALIAS_PAYLOAD_DIR/bin/alias-real" ]] \
+  || fail "S11: --fix should have restored the payload; got:\n$out"
+echo "$out" | grep -q "repair failed" \
+  && fail "S11: the repair worked — reporting it as failed is the bug:\n$out"
+[[ $rc -eq 0 ]] \
+  || fail "S11: --fix repaired everything, so doctor must exit 0; got $rc:\n$out"
+
 # ── S12: a long report prints in full ──────────────────────────────
 # Regression: the panel renderer asked ftxui for Dimension::Fit(doc), whose
 # extend_beyond_screen parameter defaults to false -- the fitted height gets
@@ -404,4 +443,4 @@ lines=$(printf '%s\n' "$out" | wc -l)
 printf '%s\n' "$out" | grep -q "broken payloads" \
   || fail "S12: the summary line must survive a long report; got $lines lines:\n$out"
 
-log "PASS: self doctor scenarios 1-10 + S12 (long report not clamped)"
+log "PASS: self doctor scenarios 1-12 (alias repair reported honestly, long report not clamped)"


### PR DESCRIPTION
## Summary

Found by verifying 2026.7.28.2 against the **real package index** instead of a fixture.

`self doctor --fix` re-detects after repairing, so that "healed" means the finding is gone rather than that a subprocess exited 0. That re-detect asked only `resolve_executable(<target>)` — which is check 3's **non-alias** branch. An alias-mode entry has no executable of its own by construction, so every one of them came back `✗ repair failed` after a repair that had in fact worked.

Reproduced against the real index — `patchelf` registers `elfpatch` with `alias = "patchelf"`:

```
$ rm -rf data/xpkgs/xim-x-patchelf/0.18.0
$ xlings self doctor --fix          # 2026.7.28.1 and .2
  ✗ repair failed  elfpatch@0.18.0
  healed          1
$ echo $?                            # 1, on a home where the payload is back
1
$ ls data/xpkgs/xim-x-patchelf/0.18.0/bin/patchelf
... exists
```

Since 2026.7.28.2 the same false failure also holds back the migration stamp, which is gated on `repairFailed == 0` — so one aliased package anywhere in the home meant the stamp never landed and the `run xlings self doctor --fix` hint never stopped.

**Fix.** "Cured" now means *detection would no longer report it*, checked by a predicate that mirrors check 3 branch for branch: type-only stub → alias mode → resolvable executable → binding root → payload that ships no executable at all. The old code had one of those five. The release-anchor exemption was missing too and is the same class of false failure: a headers-only package whose payload directory is restored is cured, not broken.

Pre-existing, not a regression from #440 — confirmed by running 2026.7.28.1 on the same isolated home and getting the identical false report.

## Test plan

- **e2e S11** in `self_doctor_test.sh`: delete an alias-mode entry's payload directory, `--fix`, assert the payload is back, the output contains no `repair failed`, and the exit code is 0.
- **Fixture fix that the assertions turned out to depend on**: the alias fixture now makes its alias target executable. Without it the payload ships nothing executable, doctor takes the "this package has no program of its own" exemption, and **S11 passed with the branch under test deleted**. Verified by mutation both ways — with the chmod, removing the alias branch fails S11; without it, it does not. S9/S10 were passing for the same wrong reason.
- Full `self_doctor_test.sh` (S1–S12) and `self_doctor_multi_subos_test.sh` pass.
- Real-index check re-run after the fix: `--fix` exits 0, `healed 2`, payload restored.

Version bumped to `2026.7.28.3`.