### PR TITLE
fix(xim,xvm): break the upgrade loop — detach vs removal, and legacy adoption (2026.7.28.4)

### DIFF
--- a/.agents/docs/2026-07-29-remove-detach-vs-removal-design.md
+++ b/.agents/docs/2026-07-29-remove-detach-vs-removal-design.md
@@ -1,0 +1,109 @@
+# `remove` said "removed" for a run that removed nothing
+
+Date: 2026-07-29
+Issue: [#443](https://github.com/openxlings/xlings/issues/443) · related:
+[#422](https://github.com/openxlings/xlings/issues/422)
+Code: `src/core/xim/installer.cppm`, `src/core/xim/commands.cppm`,
+`src/core/profile.cppm`, `src/ui/info_panel.cppm`,
+`src/agent/text_renderer.cppm`, `tests/unit/test_runtime.cpp`,
+`tests/e2e/subos_install_remove_isolation_test.sh`
+
+## The report
+
+After upgrading, `xlings remove glibc -y` printed `✓ xim:glibc@2.39 removed`,
+but `~/.xlings/.xlings.json` still carried the glibc entry and
+`~/.xlings/data/xpkgs/xim-x-glibc/` was still on disk. The reinstall that
+follows then refused with `xvm-legacy-payload-mismatch`, whose hint is
+*"uninstall it before reinstalling"* — advice the user had just taken.
+
+## What was actually happening
+
+Reproduced on 2026.7.28.3 against a real home's state, and pinned with a
+differential — same binary, same command, one variable:
+
+| other subos pinning `glibc@2.39` | version DB entry | payload | printed |
+| --- | --- | --- | --- |
+| 20 | **kept** | **kept, 112M** | `✓ … removed` |
+| 0 | deleted | deleted | `✓ … removed` |
+
+`uninstall()` returns early when any *other* subos still references the exact
+version (`installer.cppm`, the `stillReferenced` branch): it detaches the
+current subos and keeps both the registration and the payload.
+
+**That behaviour is correct.** Deleting a payload that twenty other subos are
+using would break every one of them, and the user's documented workaround —
+`rm -rf ~/.xlings/data/xpkgs/xim-x-glibc` — does exactly that damage.
+
+The defect is that the two outcomes were **indistinguishable to the user**.
+The detach path logged one line at `debug` and then fell through to the same
+success summary as a real removal. Same wording, opposite state.
+
+Not a regression: 2026.7.28.1 behaves identically. The `.2` change to
+`workspace_config_paths_for_scope_` widened the set of files that can pin a
+payload (its own comment: *"Erring toward the union can only over-retain"*),
+which makes the branch easier to hit but did not create it.
+
+## The design
+
+**Say which of the two things happened.** No new command, no new flag, no
+change to what `remove` deletes.
+
+1. `Installer::uninstall()` returns `UninstallOutcome { detachedOnly, target,
+   version }` instead of `void`. The two exits of a function that does two
+   different things now report which one ran — the caller could not previously
+   tell them apart at all.
+2. `profile::find_subos_pinning_version(home, target, version)` names who is
+   holding it. Version-exact, and not the existing name-only
+   `find_subos_referencing()`: on a multi-version home the name-only answer
+   names subos pinning a *different* version and cannot explain why *this*
+   payload was kept. Namespace stripping mirrors
+   `is_version_referenced_anywhere_`, or the list would omit a real holder.
+3. Both renderers (`ui/info_panel`, `agent/text_renderer`) distinguish
+   `detached` from `removed` and state that the payload was kept.
+
+```
+✓ xim:glibc@2.39 detached  (subos: default)
+  payload kept — 20 other subos still use it
+  remove it there too to delete it for good
+```
+
+The closing line is the remedy, and it needs no new machinery: removing the
+package from each referencing subos in turn leaves the last one with nothing
+pinning the version, and that removal deletes the registration and the payload
+for real. That is the differential's second row.
+
+### Why the count, and why names only sometimes
+
+ftxui clips at the screen edge. Naming twenty subos rendered four names and a
+half-word — which reads as a complete list. That is the same *looks-finished,
+isn't* failure this change exists to remove, so the cap is applied where the
+count is known instead of being left to the terminal. The **count** is the
+load-bearing fact (it tells the user this is not one more `remove` away) and
+always fits; names are printed only when there are at most two of them.
+
+### Not done here
+
+- **No `--purge`.** The per-subos path above already reaches "gone for good"
+  with existing commands. A flag that deletes a payload other subos are using
+  is the user's dangerous workaround with a blessing on it.
+- **`xvm-legacy-payload-mismatch` itself is untouched.** Reaching that error
+  needs a registration written by 0.4.69; on a home whose entry is current the
+  reinstall simply re-attaches. #422 tracks that half — this change removes the
+  false "removed" that sends users into it, not the refusal at the other end.
+
+## Tests
+
+`tests/unit/test_runtime.cpp` — four cases on
+`find_subos_pinning_version`: names only the matching version, counts
+`installed[]` and not just `active`, matches namespaced stored values, and is
+empty when nobody pins it.
+
+`tests/e2e/subos_install_remove_isolation_test.sh` **S2** — the regression.
+The file already covered the *real* removal (two subos, two different
+versions); S2 adds two subos on the **same** version, removes from one, and
+asserts the output says `detached` / `payload kept` while the payload, the
+version DB and the other subos are all still intact — the exact combination
+the old wording contradicted.
+
+Falsifiability checked by mutation: forcing the renderer back onto the
+`removed` branch makes S2 fail with the old output in the failure message.

--- a/.agents/docs/2026-07-29-remove-detach-vs-removal-design.md
+++ b/.agents/docs/2026-07-29-remove-detach-vs-removal-design.md
@@ -1,9 +1,11 @@
-# `remove` said "removed" for a run that removed nothing
+# The upgrade loop: `remove` that kept it, `install` that refused it
 
 Date: 2026-07-29
-Issue: [#443](https://github.com/openxlings/xlings/issues/443) · related:
-[#422](https://github.com/openxlings/xlings/issues/422)
-Code: `src/core/xim/installer.cppm`, `src/core/xim/commands.cppm`,
+Issues: [#443](https://github.com/openxlings/xlings/issues/443) ·
+[#422](https://github.com/openxlings/xlings/issues/422) — the two ends of one
+loop, fixed together because neither exit works while the other is shut
+Code: `src/core/xvm/registration.cppm`, `src/core/xim/installer.cppm`,
+`src/core/xim/commands.cppm`,
 `src/core/profile.cppm`, `src/ui/info_panel.cppm`,
 `src/agent/text_renderer.cppm`, `tests/unit/test_runtime.cpp`,
 `tests/e2e/subos_install_remove_isolation_test.sh`
@@ -107,3 +109,91 @@ the old wording contradicted.
 
 Falsifiability checked by mutation: forcing the renderer back onto the
 `removed` branch makes S2 fail with the old output in the failure message.
+
+
+---
+
+# Part 2 — `install` refused to take over an entry nobody owned (#422)
+
+## The loop
+
+The two issues are one circuit. A user upgrading from 0.4.69 who wants a
+package re-registered is told:
+
+```
+install → owner-less legacy payload field 'path' is incompatible
+          hint: uninstall it before reinstalling
+remove  → ✓ removed          (and the entry is still there — Part 1)
+```
+
+Part 1 stops `remove` from lying. That alone does not open the door: the user
+now correctly learns the entry was kept, and `install` still refuses it. The
+only remaining exit was hand-editing `~/.xlings/.xlings.json`.
+
+## What "owner-less" means, and why refusing it protected nothing
+
+Since binding groups landed, **every** registration gets an owner — a recipe
+that registers several independent targets makes each ungrouped node its own
+singleton group. So an entry with no `bindingGroup` can only have been written
+by a client that predates ownership.
+
+`apply_registration_batch` treated the two cases oppositely:
+
+| existing entry | same provider re-registers it |
+| --- | --- |
+| **owned** | allowed — overwritten, group integrity checked |
+| **owner-less** | `LegacyPayloadMismatch` unless every field matched exactly |
+
+Nothing owns an owner-less entry, so there is no claim to protect. The refusal
+was guarding *contents*, not ownership — and the contents it guarded can be
+wrong: the measured case is an `llvm@20.1.7` whose recorded path used Windows
+backslashes **on Linux**, written by an old client on the wrong platform table.
+Refusing to replace that preserves the damage.
+
+## The change
+
+Adopt the entry in place, and say so.
+
+- The refusal becomes a recorded adoption: `{target, version, field}` collected
+  during validation, applied by the write pass that already overwrites every
+  node's fields.
+- `RegisteredMember` gains `adoptedLegacy` / `adoptedLegacyField`, so the
+  installer can print
+  `[xvm] adopted a pre-ownership registration: ninja@1.12.1 ('path' changed)`.
+  Silent adoption would be its own defect — a payload changed behind a name.
+- **Adoption is a repair, not a hole.** The entry comes out owned, so the next
+  provider that tries to take the same `name@version` meets
+  `OwnershipConflict` — a protection an owner-less entry could never raise.
+- Group-integrity checks are untouched. `IncompleteLegacyComponent` still
+  rejects a batch that would rewrite part of a bound group, and
+  `OwnershipConflict` still rejects a foreign provider.
+
+`RegistrationErrorKind::LegacyPayloadMismatch` is now unreachable. It is kept
+so old logs stay decodable, with a comment not to reintroduce it as a refusal
+without an exit the user can take.
+
+## Verified against real state
+
+A slice of the real home (266 of its 517 entries are owner-less), with
+`ninja@1.12.1`'s recorded path corrupted the way #422 measured:
+
+| binary | result |
+| --- | --- |
+| 2026.7.28.3 | `owner-less legacy payload field 'path' is incompatible` → `[ninja] failed: config hook failed` |
+| 2026.7.28.4 | `[xvm] adopted a pre-ownership registration: ninja@1.12.1 ('path' changed)` → installed |
+
+Post-state on the fixed binary: the corrupt path is replaced with the correct
+one **and** the entry is now owned.
+
+## Tests
+
+`tests/unit/test_xvm_bindings.cpp` — the refusal test
+(`RejectsIncompatibleLegacyPayloadWithoutMutation`) is replaced by four:
+adoption happens in place; the adopted entry becomes owned; the batch reports
+which members it adopted and on which field; an unchanged re-registration is
+**not** reported as an adoption.
+
+No e2e: the fixture index installs through the current client, so every entry
+it produces is already owned. Manufacturing an owner-less one means writing the
+state file by hand, which is what the unit tests do — more precisely, and
+without a network.

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlings"
-version = "2026.7.28.3"
+version = "2026.7.28.4"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"

--- a/src/agent/text_renderer.cppm
+++ b/src/agent/text_renderer.cppm
@@ -83,8 +83,24 @@ export void render_data_event(const DataEvent& e) {
     }
     else if (e.kind == "remove_summary") {
         auto name = json.value("name", json.value("target", ""));
-        std::println("Removed: {} {} (subos: {})",
-            name, json.value("version", ""), json.value("subos", ""));
+        // Same distinction the TUI makes: a detach is not a removal, and an
+        // agent reading this must not conclude the payload is gone (#443).
+        if (json.value("detached", false)) {
+            std::string others;
+            if (json.contains("pinned_by") && json["pinned_by"].is_array()) {
+                for (auto& n : json["pinned_by"]) {
+                    if (!n.is_string()) continue;
+                    if (!others.empty()) others += ", ";
+                    others += n.get<std::string>();
+                }
+            }
+            std::println("Detached: {} {} (subos: {}); payload kept, still used by {}",
+                name, json.value("version", ""), json.value("subos", ""),
+                others.empty() ? std::string("another subos") : others);
+        } else {
+            std::println("Removed: {} {} (subos: {})",
+                name, json.value("version", ""), json.value("subos", ""));
+        }
     }
     else if (e.kind == "styled_list") {
         auto title = json.value("title", "");

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -131,10 +131,18 @@ static void dispatch_data_event(const DataEvent& e) {
         // Tolerate the legacy "target" key (older interface clients) by
         // falling back when name/version were not provided.
         auto name = json.value("name", json.value("target", ""));
+        std::vector<std::string> pinnedBy;
+        if (json.contains("pinned_by") && json["pinned_by"].is_array()) {
+            for (auto& n : json["pinned_by"]) {
+                if (n.is_string()) pinnedBy.push_back(n.get<std::string>());
+            }
+        }
         ui::print_remove_summary(
             json.value("subos", ""),
             name,
-            json.value("version", ""));
+            json.value("version", ""),
+            json.value("detached", false),
+            pinnedBy);
     }
     else if (e.kind == "subos_list") {
         std::vector<std::tuple<std::string, std::string, int, bool>> entries;

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "2026.7.28.3";
+    static constexpr std::string_view VERSION = "2026.7.28.4";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/profile.cppm
+++ b/src/core/profile.cppm
@@ -307,6 +307,52 @@ export std::vector<std::string> find_subos_referencing(
     return result;
 }
 
+// Which subos still pin an EXACT version of a target.
+//
+// The version-exact counterpart to find_subos_referencing(). `remove` keeps a
+// payload alive when any OTHER subos still references the exact version being
+// removed (installer.cppm's stillReferenced branch); naming those subos is
+// what turns "✓ removed" from a claim the state contradicts into a next step.
+//
+// Version-exact and not name-only, because on a multi-version home the
+// name-only answer names subos that pin a different version and therefore
+// cannot explain why this payload was kept.
+//
+// Namespace handling mirrors is_version_referenced_anywhere_: stored values
+// are namespaced for non-primary index repos (`local:0.0.1`), and the two must
+// agree or this would omit a subos that really is holding the payload down.
+export std::vector<std::string> find_subos_pinning_version(
+        const fs::path& xlingsHome,
+        const std::string& target,
+        const std::string& version) {
+    auto matches = [&](std::string_view stored) {
+        return stored == version
+            || xvm::strip_namespace(std::string(stored)) == version;
+    };
+
+    std::vector<std::string> result;
+    for (auto& snapshot : load_subos_snapshots(xlingsHome)) {
+        const auto& ws = snapshot.workspace;
+        bool pinned = false;
+        if (auto it = ws.active.find(target);
+            it != ws.active.end() && matches(it->second)) {
+            pinned = true;
+        }
+        if (!pinned) {
+            // installed[] pins the payload just as hard as active does — a
+            // subos that opted into the version but is not currently using it
+            // still breaks if the payload goes.
+            if (auto it = ws.installed.find(target); it != ws.installed.end()) {
+                for (auto& v : it->second) {
+                    if (matches(v)) { pinned = true; break; }
+                }
+            }
+        }
+        if (pinned) result.push_back(snapshot.name);
+    }
+    return result;
+}
+
 export int gc(const fs::path& xlingsHome, bool dryRun = false) {
     auto referenced = collect_subos_references_(xlingsHome);
 

--- a/src/core/xim/commands.cppm
+++ b/src/core/xim/commands.cppm
@@ -759,10 +759,34 @@ int cmd_remove(const std::string& target, bool yes, EventStream& stream) {
         return 1;
     }
 
+    // Say which of the two things actually happened.
+    //
+    // When another subos still pins this exact version, `remove` detaches the
+    // current subos and deliberately keeps the registration and the payload —
+    // deleting them would break every other subos that is using them. That is
+    // right. Printing "✓ removed" for it was not: the user is told the package
+    // is gone while ~/.xlings/.xlings.json and data/xpkgs/ still hold it in
+    // full, and the reinstall they try next tells them to uninstall first
+    // (#443, and the closed loop in #422).
+    //
+    // The subos are named rather than merely counted because that is the whole
+    // remedy: removing it from each of them in turn lets the last one delete
+    // the payload for real.
+    std::vector<std::string> pinnedBy;
+    if (result->detachedOnly) {
+        pinnedBy = xlings::profile::find_subos_pinning_version(
+            Config::paths().homeDir,
+            result->target.empty() ? displayName : result->target,
+            result->version.empty() ? displayVersion : result->version);
+        std::erase(pinnedBy, subos);
+    }
+
     nlohmann::json summaryPayload;
     summaryPayload["subos"] = subos;
     summaryPayload["name"] = displayName;
     summaryPayload["version"] = displayVersion;
+    summaryPayload["detached"] = result->detachedOnly;
+    summaryPayload["pinned_by"] = pinnedBy;
     stream.emit(DataEvent{"remove_summary", summaryPayload.dump()});
     return 0;
 }

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -1709,6 +1709,19 @@ bool process_xvm_operations_(const PlanNode& node,
         scopedInstalled,
         metadata->removal);
 
+    // Announce any owner-less entry this install took over.
+    //
+    // Adoption replaces the contents recorded for a name@version that an
+    // older client wrote without ownership (xvm/registration.cppm). It is the
+    // right thing to do — the refusal it replaced left the user with no exit
+    // (#422) — but it is still a payload changing behind a name, so it is
+    // said out loud rather than applied silently.
+    for (const auto& member : metadata->registered) {
+        if (!member.adoptedLegacy) continue;
+        log::warn("[xvm] adopted a pre-ownership registration: {}@{} ('{}' changed)",
+                  member.target, member.version, member.adoptedLegacyField);
+    }
+
     if (!metadata->removal.removed.empty()
         || !metadata->registered.empty()) {
         Config::save_versions();

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -2396,8 +2396,24 @@ public:
         return {};
     }
 
+    // What `uninstall` actually did.
+    //
+    // Two very different things share this entry point, and they used to be
+    // indistinguishable to the caller — which is how `xlings remove glibc`
+    // came to print the same "✓ removed" whether the payload and its
+    // registration were deleted or left fully intact (#443). A removal that
+    // only detaches the current subos is the CORRECT behaviour when another
+    // subos still uses the version; reporting it as a full removal is not.
+    struct UninstallOutcome {
+        // True when the version survived because another subos still pins it:
+        // the current subos was detached, the registration and payload stayed.
+        bool        detachedOnly { false };
+        std::string target;   // resolved name, as stored in the version DB
+        std::string version;  // resolved version, as stored (may be namespaced)
+    };
+
     // Uninstall a package
-    std::expected<void, std::string>
+    std::expected<UninstallOutcome, std::string>
     uninstall(const std::string& name) {
         auto platform = detect_platform_();
         auto currentWorkspacePath = detail_::current_workspace_config_path_();
@@ -2497,7 +2513,13 @@ public:
             detail_::detach_current_subos_(detachTarget, detachVersion);
             log::debug("{}@{} detached from current subos; payload retained",
                       detachTarget, detachVersion);
-            return {};
+            // Reported, not just logged at debug: this is the branch whose
+            // silence made a no-op look like a removal (#443).
+            return UninstallOutcome{
+                .detachedOnly = true,
+                .target       = detachTarget,
+                .version      = detachVersion,
+            };
         }
 
         auto executorPkgFile = detail_::uninstall_xpkg_file_(pkgFile, installDir);
@@ -2669,7 +2691,11 @@ public:
         }
 
         log::debug("{} uninstalled", resolvedTarget);
-        return {};
+        return UninstallOutcome{
+            .detachedOnly = false,
+            .target       = detachTarget,
+            .version      = detachVersion,
+        };
     }
 
 private:

--- a/src/core/xvm/registration.cppm
+++ b/src/core/xvm/registration.cppm
@@ -52,6 +52,12 @@ struct RegisteredMember {
     std::string target;
     std::string version;
     std::string kind;
+    // Set when this member took over an OWNER-LESS entry whose contents
+    // differed -- a registration written by a client that predates ownership.
+    // Reported rather than applied silently: the payload behind a name just
+    // changed, and the user is entitled to know which field moved.
+    bool        adoptedLegacy { false };
+    std::string adoptedLegacyField;
 };
 
 enum class RegistrationErrorKind {
@@ -65,6 +71,10 @@ enum class RegistrationErrorKind {
     GroupConflict,
     TargetVersionConflict,
     OwnershipConflict,
+    // Unreachable since the owner-less adoption change: an entry nobody owns
+    // is now taken over in place rather than refused (#422). Kept so the code
+    // and its message stay decodable in older logs -- do not reintroduce it as
+    // a refusal without an exit the user can actually take.
     LegacyPayloadMismatch,
     IncompleteLegacyComponent,
     IncompleteOwnedGroup,
@@ -657,6 +667,11 @@ apply_registration_batch(
             group.headers.end());
     }
 
+    // Owner-less entries this batch takes over, and the field that differed.
+    // Collected during validation and reported with the result; see the
+    // adoption comment below.
+    std::map<detail_::RegistrationExactKey, std::string> adoptedLegacy;
+
     for (std::size_t index = 0; index < batch.nodes.size(); ++index) {
         const auto& node = batch.nodes[index];
         const auto infoIt = db.find(node.target);
@@ -717,15 +732,31 @@ apply_registration_batch(
             continue;
         }
 
+        // Owner-less entry with different contents: ADOPT it, do not refuse.
+        //
+        // This used to be RegistrationErrorKind::LegacyPayloadMismatch, whose
+        // hint told the user to uninstall the package first. Nothing owns an
+        // owner-less entry, so there is no claim to protect -- and `remove`
+        // keeps exactly these entries when another subos still references the
+        // version (#443), so the hint pointed at a door that does not open.
+        // The two ends met and the only remaining exit was hand-editing the
+        // state file (#422).
+        //
+        // Adoption is also a repair, not just an escape: the entry comes out
+        // of it OWNED (the group pass below assigns bindingGroup), so the next
+        // provider that tries to take the same name@version meets
+        // OwnershipConflict -- a protection the owner-less entry could never
+        // raise. The refusal preserved damage it could not fix; the measured
+        // case is an llvm@20.1.7 whose recorded path used Windows backslashes
+        // on Linux.
+        //
+        // The group-integrity checks below are NOT relaxed: a batch that would
+        // rewrite part of a bound group is still rejected.
         if (auto field = detail_::legacy_payload_mismatch_(
                 node, infoIt->second, data)) {
-            return std::unexpected(detail_::registration_error_(
-                RegistrationErrorKind::LegacyPayloadMismatch,
-                nodePath + "/" + *field,
-                node.target, node.version,
-                std::format(
-                    "owner-less legacy payload field '{}' is incompatible",
-                    *field)));
+            adoptedLegacy.insert_or_assign(
+                detail_::RegistrationExactKey{node.target, node.version},
+                *field);
         }
         auto selection = resolve_binding_selection(
             db, node.target, node.version);
@@ -818,10 +849,15 @@ apply_registration_batch(
             data.bindingMembersDeclared = false;
             data.bindingHeaders.clear();
             data.bindingHeadersDeclared = false;
+            const auto adoptedIt = adoptedLegacy.find(
+                detail_::RegistrationExactKey{target, version});
             registered.push_back({
                 .target = target,
                 .version = version,
                 .kind = data.kind,
+                .adoptedLegacy = adoptedIt != adoptedLegacy.end(),
+                .adoptedLegacyField = adoptedIt != adoptedLegacy.end()
+                    ? adoptedIt->second : std::string{},
             });
             auto& versions = candidateInstalled[target];
             bool foundVersion = false;

--- a/src/ui/info_panel.cppm
+++ b/src/ui/info_panel.cppm
@@ -341,22 +341,69 @@ void print_remove_plan(const std::string& subos,
 }
 
 // Print uninstall summary
+// `detached` distinguishes the two outcomes `remove` can have. They used to
+// render identically, so a run that kept the registration and the payload in
+// full looked exactly like one that deleted both (#443). `pinnedBy` names the
+// other subos still holding this version — that list is the remedy, not
+// decoration: removing it from each in turn lets the last one delete for real.
 void print_remove_summary(const std::string& subos,
                           const std::string& name,
-                          const std::string& version) {
+                          const std::string& version,
+                          bool detached,
+                          const std::vector<std::string>& pinnedBy) {
     using namespace ftxui;
 
     auto label = remove_target_label_(name, version);
 
     Elements rows;
     rows.push_back(text(""));
-    rows.push_back(hbox({
-        text("  " + std::string(theme::icon::done) + " ") | color(theme::green()),
-        text(label + " removed") | color(theme::green()) | bold,
-        subos.empty()
-            ? text("")
-            : (text("  (subos: " + subos + ")") | color(theme::dim_color())),
-    }));
+    if (detached) {
+        rows.push_back(hbox({
+            text("  " + std::string(theme::icon::done) + " ") | color(theme::green()),
+            text(label + " detached") | color(theme::green()) | bold,
+            subos.empty()
+                ? text("")
+                : (text("  (subos: " + subos + ")") | color(theme::dim_color())),
+        }));
+        // Say how many, and name them only while the line still fits.
+        //
+        // ftxui clips at the screen edge, and on a pipe that is 80 columns:
+        // a home with 20 referencing subos rendered four names and a
+        // half-word, which reads as a complete list and is not. That is the
+        // same "looks finished, isn't" failure this whole change removes, so
+        // the cap is applied here where the count is known rather than left
+        // to the terminal. The COUNT is the load-bearing fact — it tells the
+        // user this is not one more `remove` away — and it always fits.
+        constexpr std::size_t kMaxNamed = 2;
+        if (pinnedBy.empty()) {
+            // Pinned by something the subos scan cannot name (a project-local
+            // subos, say). Still say the payload stayed.
+            rows.push_back(text("    payload kept — another subos still uses it")
+                           | color(theme::dim_color()));
+        } else {
+            std::string line = std::format("    payload kept — {} other subos still use it",
+                                           pinnedBy.size());
+            if (pinnedBy.size() <= kMaxNamed) {
+                std::string names;
+                for (const auto& n : pinnedBy) {
+                    if (!names.empty()) names += ", ";
+                    names += n;
+                }
+                line = std::format("    payload kept — still used by {}", names);
+            }
+            rows.push_back(text(line) | color(theme::dim_color()));
+            rows.push_back(text("    remove it there too to delete it for good")
+                           | color(theme::dim_color()));
+        }
+    } else {
+        rows.push_back(hbox({
+            text("  " + std::string(theme::icon::done) + " ") | color(theme::green()),
+            text(label + " removed") | color(theme::green()) | bold,
+            subos.empty()
+                ? text("")
+                : (text("  (subos: " + subos + ")") | color(theme::dim_color())),
+        }));
+    }
     rows.push_back(text(""));
 
     auto doc = vbox(std::move(rows));

--- a/tests/e2e/subos_install_remove_isolation_test.sh
+++ b/tests/e2e/subos_install_remove_isolation_test.sh
@@ -161,4 +161,55 @@ print(','.join(sorted(v.keys())))
   || fail "global versions DB should only have 1.0.0, got: '$DB_VERS'"
 log "  ✓ global versions DB: only 1.0.0 remains"
 
+# ── S2: removing a version ANOTHER subos still uses is a detach, and says so
+#
+# The case above has each subos on a different version, so the removal is a
+# real removal. When two subos share the SAME version, `remove` deliberately
+# keeps the registration and the payload -- deleting them would break the
+# other subos. That is correct. Reporting it as "removed" was not: the user
+# was told the package was gone while the version DB and data/xpkgs/ still
+# held it in full, and the reinstall they tried next told them to uninstall
+# first -- a loop with no exit (openxlings/xlings#443, #422).
+#
+# Falsifiable by construction: before the fix this printed the same
+# "✓ rm-fixture@1.0.0 removed" as the real removal above, so the grep below
+# is what fails on a regression.
+log "S2: remove a version another subos still uses"
+RUN_IN tmp install rm-fixture@1.0.0 -y >/dev/null 2>&1 \
+  || fail "S2 setup: tmp install of the shared version failed"
+
+S2_OUT="$(RUN_IN tmp remove rm-fixture -y 2>&1)" || fail "S2: remove failed"
+# ftxui colours and pads; drop the escapes before matching.
+S2_TEXT="$(printf '%s' "$S2_OUT" | sed 's/\x1b\[[0-9;]*m//g')"
+
+grep -q "detached" <<<"$S2_TEXT" \
+  || fail "S2: remove reported no detach; output was: $S2_TEXT"
+log "  ✓ reported as a detach, not a removal"
+
+grep -q "payload kept" <<<"$S2_TEXT" \
+  || fail "S2: the retained payload was not mentioned; output was: $S2_TEXT"
+log "  ✓ said the payload was kept"
+
+# The state the message now matches. These held BEFORE the fix too -- they are
+# what made the old "removed" wording false, so they belong in the assertion.
+[[ -d "$HOME_DIR/data/xpkgs/xim-x-rm-fixture/1.0.0" ]] \
+  || fail "S2: payload should be retained (default still uses 1.0.0)"
+S2_DB="$(python3 -c "
+import json
+d = json.load(open('$HOME_DIR/.xlings.json'))
+v = d.get('versions',{}).get('rm-fixture',{}).get('versions',{})
+print(','.join(sorted(v.keys())))
+")"
+[[ "$S2_DB" == "1.0.0" ]] \
+  || fail "S2: version DB should still carry 1.0.0, got: '$S2_DB'"
+[[ "$(read_active "$HOME_DIR/subos/default/.xlings.json" rm-fixture)" == "1.0.0" ]] \
+  || fail "S2: default should still be on 1.0.0"
+log "  ✓ payload, version DB and the other subos are intact"
+
+# And the current subos really was detached -- otherwise "detached" would be
+# just as false as "removed" was.
+[[ "$(read_active "$HOME_DIR/subos/tmp/.xlings.json" rm-fixture)" == "<none>" ]] \
+  || fail "S2: tmp should have been detached from rm-fixture"
+log "  ✓ tmp detached"
+
 log "PASS: subos_install_remove_isolation"

--- a/tests/e2e/subos_install_remove_isolation_test.sh
+++ b/tests/e2e/subos_install_remove_isolation_test.sh
@@ -178,9 +178,13 @@ log "S2: remove a version another subos still uses"
 RUN_IN tmp install rm-fixture@1.0.0 -y >/dev/null 2>&1 \
   || fail "S2 setup: tmp install of the shared version failed"
 
-S2_OUT="$(RUN_IN tmp remove rm-fixture -y 2>&1)" || fail "S2: remove failed"
-# ftxui colours and pads; drop the escapes before matching.
-S2_TEXT="$(printf '%s' "$S2_OUT" | sed 's/\x1b\[[0-9;]*m//g')"
+# Through a file rather than a command substitution: ftxui pads with NUL
+# bytes, and `$(...)` drops them with a bash warning on every run. The file
+# also survives the assertions below, so a failure can be read back in full.
+S2_LOG="$RUNTIME_DIR/s2-remove.log"
+RUN_IN tmp remove rm-fixture -y >"$S2_LOG" 2>&1 || fail "S2: remove failed"
+# ftxui colours and pads; drop the escapes and the padding before matching.
+S2_TEXT="$(tr -d '\000' < "$S2_LOG" | sed 's/\x1b\[[0-9;]*m//g')"
 
 grep -q "detached" <<<"$S2_TEXT" \
   || fail "S2: remove reported no detach; output was: $S2_TEXT"

--- a/tests/unit/test_runtime.cpp
+++ b/tests/unit/test_runtime.cpp
@@ -239,6 +239,75 @@ TEST_F(ProfileTest, FindSubosReferencingEmpty) {
     EXPECT_TRUE(refs.empty());
 }
 
+// ── who still pins a specific version ───────────────────────────────
+//
+// `remove` keeps a payload alive when ANY other subos still references the
+// exact version being removed (installer.cppm's stillReferenced branch), and
+// then reports the same "removed" as a real removal. Naming those subos is
+// what turns that message from a lie into a next step — but only if the
+// answer is version-exact: find_subos_referencing() matches the target name
+// alone, so on a multi-version home it names subos that pin a DIFFERENT
+// version and cannot explain why this one was kept.
+namespace {
+
+void write_subos_ws_(const std::filesystem::path& home,
+                     const std::string& name,
+                     const std::string& json) {
+    auto dir = home / "subos" / name;
+    std::filesystem::create_directories(dir);
+    std::ofstream(dir / ".xlings.json") << json;
+}
+
+} // namespace
+
+TEST_F(ProfileTest, FindSubosPinningVersionNamesOnlyTheMatchingVersion) {
+    write_subos_ws_(testDir_, "dev",
+        R"({"workspace":{"glibc":{"active":"2.39","installed":["2.39"]}}})");
+    write_subos_ws_(testDir_, "old",
+        R"({"workspace":{"glibc":{"active":"2.35","installed":["2.35"]}}})");
+
+    auto refs = xlings::profile::find_subos_pinning_version(
+        testDir_, "glibc", "2.39");
+
+    ASSERT_EQ(refs.size(), 1u);
+    EXPECT_EQ(refs[0], "dev");
+}
+
+// A subos that merely has the version in installed[] (opted in, not active)
+// pins the payload just as hard — the removal path counts both.
+TEST_F(ProfileTest, FindSubosPinningVersionCountsInstalledNotJustActive) {
+    write_subos_ws_(testDir_, "dev",
+        R"({"workspace":{"glibc":{"active":"2.35","installed":["2.35","2.39"]}}})");
+
+    auto refs = xlings::profile::find_subos_pinning_version(
+        testDir_, "glibc", "2.39");
+
+    ASSERT_EQ(refs.size(), 1u);
+    EXPECT_EQ(refs[0], "dev");
+}
+
+// Stored values are namespaced for non-primary index repos; the removal path
+// strips the namespace before comparing, so this must agree with it or the
+// message would omit a subos that really is holding the payload.
+TEST_F(ProfileTest, FindSubosPinningVersionMatchesNamespacedStoredValues) {
+    write_subos_ws_(testDir_, "dev",
+        R"({"workspace":{"mcpp":{"active":"local:0.0.1","installed":["local:0.0.1"]}}})");
+
+    auto refs = xlings::profile::find_subos_pinning_version(
+        testDir_, "mcpp", "0.0.1");
+
+    ASSERT_EQ(refs.size(), 1u);
+    EXPECT_EQ(refs[0], "dev");
+}
+
+TEST_F(ProfileTest, FindSubosPinningVersionIsEmptyWhenNobodyPinsIt) {
+    write_subos_ws_(testDir_, "dev",
+        R"({"workspace":{"glibc":{"active":"2.35","installed":["2.35"]}}})");
+
+    EXPECT_TRUE(xlings::profile::find_subos_pinning_version(
+        testDir_, "glibc", "2.39").empty());
+}
+
 // ============================================================
 // Log system extended tests
 // ============================================================

--- a/tests/unit/test_xvm_bindings.cpp
+++ b/tests/unit/test_xvm_bindings.cpp
@@ -2442,8 +2442,18 @@ TEST(XvmRegistrationOwnershipTest,
     EXPECT_EQ(adopted.bindingGroup->group, "virtual");
 }
 
-TEST(XvmRegistrationOwnershipTest,
-     RejectsIncompatibleLegacyPayloadWithoutMutation) {
+// An owner-less entry is one an OLD client wrote, before registrations
+// recorded who owns them. Refusing to overwrite it protected a claim that
+// does not exist: nobody owns it, so nobody can be asked to release it. The
+// refusal's own hint said "uninstall it before reinstalling", and for exactly
+// these entries `remove` keeps them (#443) -- so the two ends met and the
+// user's only exit was hand-editing the state file (#422).
+//
+// Adopting the entry in place is that exit. Measured shape from a real home:
+// an llvm@20.1.7 whose recorded path used Windows backslashes ON LINUX, i.e.
+// a registration that is not merely different but wrong. Refusing to replace
+// it preserves the damage.
+TEST(XvmRegistrationOwnershipTest, AdoptsIncompatibleLegacyPayloadInPlace) {
     xlings::xvm::VersionDB db;
     seed_complete_legacy_registration_group(db);
     xlings::xvm::Workspace workspace{{"tool", "repo:tool-1.0.0"}};
@@ -2452,19 +2462,74 @@ TEST(XvmRegistrationOwnershipTest,
     };
     auto batch = complete_legacy_adoption_batch();
     batch.nodes[0].path = "/different/payload";
-    const auto dbBefore = xlings::xvm::versions_to_json(db);
-    const auto workspaceBefore = workspace;
-    const auto installedBefore = installed;
 
     auto result = xlings::xvm::apply_registration_batch(
         db, workspace, installed, batch);
 
-    expect_registration_error(
-        result, xlings::xvm::RegistrationErrorKind::LegacyPayloadMismatch,
-        "/nodes/0/path", "tool", "repo:tool-1.0.0");
-    expect_registration_state_unchanged(
-        db, workspace, installed,
-        dbBefore, workspaceBefore, installedBefore);
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    const auto& adopted = db.at("tool").versions.at("repo:tool-1.0.0");
+    EXPECT_EQ(adopted.path, "/different/payload");
+}
+
+// Adoption must leave the entry OWNED. That is what makes this a repair
+// rather than a hole: the next provider that tries to take the same
+// name@version now meets OwnershipConflict, which the owner-less entry could
+// never raise.
+TEST(XvmRegistrationOwnershipTest, AdoptedLegacyEntryBecomesOwned) {
+    xlings::xvm::VersionDB db;
+    seed_complete_legacy_registration_group(db);
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+    auto batch = complete_legacy_adoption_batch();
+    batch.nodes[0].path = "/different/payload";
+
+    ASSERT_TRUE(xlings::xvm::apply_registration_batch(
+        db, workspace, installed, batch).has_value());
+
+    const auto& adopted = db.at("tool").versions.at("repo:tool-1.0.0");
+    ASSERT_TRUE(adopted.bindingGroup.has_value());
+    EXPECT_EQ(adopted.bindingGroup->provider, "repo:provider");
+    EXPECT_EQ(adopted.bindingGroup->providerVersion, "1.0.0");
+}
+
+// Silent adoption would be its own defect -- the payload behind a name
+// changed and nothing said so. The batch reports which members it took over
+// and on which field they differed, so the installer can print it.
+TEST(XvmRegistrationOwnershipTest, ReportsWhichLegacyEntriesWereAdopted) {
+    xlings::xvm::VersionDB db;
+    seed_complete_legacy_registration_group(db);
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+    auto batch = complete_legacy_adoption_batch();
+    batch.nodes[0].path = "/different/payload";
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, batch);
+
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    auto adopted = std::ranges::find_if(*result, [](const auto& member) {
+        return member.target == "tool";
+    });
+    ASSERT_NE(adopted, result->end());
+    EXPECT_TRUE(adopted->adoptedLegacy);
+    EXPECT_EQ(adopted->adoptedLegacyField, "path");
+}
+
+// A re-registration that changes nothing is not an adoption, and must not be
+// announced as one.
+TEST(XvmRegistrationOwnershipTest, UnchangedLegacyEntryIsNotReportedAdopted) {
+    xlings::xvm::VersionDB db;
+    seed_complete_legacy_registration_group(db);
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, complete_legacy_adoption_batch());
+
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    for (const auto& member : *result) {
+        EXPECT_FALSE(member.adoptedLegacy) << member.target;
+    }
 }
 
 TEST(XvmRegistrationOwnershipTest,


### PR DESCRIPTION
## The report

`xlings remove glibc -y` printed `✓ xim:glibc@2.39 removed`, while
`~/.xlings/.xlings.json` still carried the glibc entry and
`~/.xlings/data/xpkgs/xim-x-glibc/` was still 112M on disk. The reinstall that
follows then refused with `xvm-legacy-payload-mismatch`, whose hint is
*"uninstall it before reinstalling"* — advice the user had just taken.

## Confirmed, and pinned with a differential

Reproduced on **2026.7.28.3** against a real home's state (isolated copy). Same
binary, same command, one variable:

| other subos pinning `glibc@2.39` | version DB entry | payload | printed |
|---|---|---|---|
| 20 | **kept** | **kept, 112M** | `✓ … removed` |
| 0 | deleted | deleted | `✓ … removed` |

`uninstall()` returns early when any *other* subos still references the exact
version: it detaches the current subos and keeps the registration and payload.

**That behaviour is correct.** Deleting a payload twenty subos are using breaks
every one of them — which is exactly what the reported workaround
(`rm -rf ~/.xlings/data/xpkgs/xim-x-glibc`) does. The defect is that the two
outcomes were **indistinguishable to the user**: the detach path logged one
line at `debug` and fell through to the same success summary as a real removal.

**Not a regression.** 2026.7.28.1 behaves identically. `.2`'s widening of
`workspace_config_paths_for_scope_` (*"Erring toward the union can only
over-retain"*) makes the branch easier to hit but did not create it.

## The change

Say which of the two things happened. No new command, no new flag, and no
change to what `remove` deletes.

- **`Installer::uninstall()` returns `UninstallOutcome{detachedOnly, …}`**
  instead of `void`. A function with two very different exits now reports which
  one ran; the caller previously could not tell them apart at all.
- **`profile::find_subos_pinning_version()`** names who is holding it.
  Version-exact rather than the existing name-only `find_subos_referencing()`:
  on a multi-version home the name-only answer names subos pinning a *different*
  version and cannot explain why *this* payload was kept. Namespace stripping
  mirrors `is_version_referenced_anywhere_`, or the list would omit a real
  holder.
- **Both renderers** (`ui/info_panel`, `agent/text_renderer`) separate
  `detached` from `removed` and state that the payload stayed.

```
✓ xim:glibc@2.39 detached  (subos: default)
  payload kept — 20 other subos still use it
  remove it there too to delete it for good
```

The closing line is the remedy and needs no new machinery: removing the package
from each referencing subos in turn leaves the last one with nothing pinning the
version, and *that* removal deletes registration and payload for real — the
differential's second row.

**Hence no `--purge`.** A flag that deletes a payload other subos are using is
the dangerous workaround with a blessing on it.

**The subos list is capped where the count is known**, not at the screen edge.
ftxui clipped twenty names to four and a half-word, which reads as a complete
list — the same *looks-finished-isn't* failure this change exists to remove. The
count always fits and is the load-bearing fact; names print only when there are
at most two.

## Not in scope

`xvm-legacy-payload-mismatch` itself is untouched. Reaching it needs a
registration written by 0.4.69; on a home whose entry is current, the reinstall
simply re-attaches (verified). #422 tracks that half — this PR removes the false
"removed" that sends users into it, not the refusal at the other end.

## Test plan

**`tests/unit/test_runtime.cpp`** — four cases on `find_subos_pinning_version`:
names only the matching version; counts `installed[]` and not just `active`;
matches namespaced stored values; empty when nobody pins it.

**`tests/e2e/subos_install_remove_isolation_test.sh` S2** — the regression. The
file already covered the *real* removal (two subos, two different versions); S2
adds two subos on the **same** version, removes from one, and asserts the output
says `detached` / `payload kept` while the payload, the version DB and the other
subos are all intact — the exact combination the old wording contradicted.

Falsifiability checked by mutation: forcing the renderer back onto the `removed`
branch makes S2 fail, with the old output quoted in the failure message.

Also run locally: full unit suite (23/23), plus `remove_multi_version_test.sh`,
`xpkg_snapshot_remove_test.sh`, `remove_self_guard_test.sh` — all pass.

Design notes: `.agents/docs/2026-07-29-remove-detach-vs-removal-design.md`

---

# Part 2 — `install` refused to take over an entry nobody owned (#422)

The two issues are one circuit. Fixing `remove` alone does not open the door:
the user now correctly learns the entry was kept, and `install` still refuses
it. The only remaining exit was hand-editing `~/.xlings/.xlings.json`.

```
install → owner-less legacy payload field 'path' is incompatible
          hint: uninstall it before reinstalling
remove  → ✓ removed          (and the entry is still there — Part 1)
```

Since binding groups landed **every** registration gets an owner (an ungrouped
node becomes its own singleton group), so an entry with no `bindingGroup` can
only have been written by a client that predates ownership. Nothing owns it —
the refusal protected no claim. It guarded *contents*, and the contents it
guarded can be **wrong**: the measured case is an `llvm@20.1.7` whose recorded
path used Windows backslashes **on Linux**. Refusing to replace that preserves
the damage.

### The change

- The refusal becomes a recorded **adoption**, applied by the write pass that
  already overwrites every node's fields.
- `RegisteredMember` gains `adoptedLegacy` / `adoptedLegacyField`; the
  installer prints
  `[xvm] adopted a pre-ownership registration: ninja@1.12.1 ('path' changed)`.
  Silent adoption would be its own defect.
- **Repair, not a hole:** the entry comes out *owned*, so the next provider
  taking the same `name@version` meets `OwnershipConflict` — a protection an
  owner-less entry could never raise.
- Group integrity untouched: `IncompleteLegacyComponent` still rejects a
  partial rewrite of a bound group; `OwnershipConflict` still rejects a foreign
  provider. `LegacyPayloadMismatch` is now unreachable, kept only so old logs
  decode.

### Verified against real state

A slice of a real home (**266 of its 517 entries are owner-less**), with
`ninja@1.12.1`'s recorded path corrupted the way #422 measured:

| binary | result |
|---|---|
| 2026.7.28.3 | `owner-less legacy payload field 'path' is incompatible` → `[ninja] failed: config hook failed` |
| 2026.7.28.4 | `[xvm] adopted a pre-ownership registration: ninja@1.12.1 ('path' changed)` → installed |

Post-state on the fixed binary: corrupt path replaced **and** the entry is now
owned.

### Tests

`tests/unit/test_xvm_bindings.cpp` — the refusal test is replaced by four:
adoption in place; adopted entry becomes owned; the batch reports which members
it adopted and on which field; an unchanged re-registration is *not* reported
as an adoption.

No e2e for this half: the fixture index installs through the current client, so
every entry it produces is already owned. Manufacturing an owner-less one means
writing the state file by hand — which is what the unit tests do, more
precisely and without a network.

Closes #443
Closes #422
