### PR TITLE
fix(xself,xvm): make `self doctor --fix` repair a real home in one run (2026.7.29.0)

### DIFF
--- a/.agents/docs/2026-07-29-doctor-fix-one-shot-design.md
+++ b/.agents/docs/2026-07-29-doctor-fix-one-shot-design.md
@@ -483,6 +483,28 @@ A14 在修复完成的切片上实测：`gcc` 有 4 个 version key
 卸掉不装回去）之后的正确结果：它们现在是被重新注册的，而不是被当成
 collateral 清掉的。
 
+#### 一个差点让整张表变成"不可证伪"的坑
+
+`grep` 在这份报告上**什么都不输出**，因为渲染出来的面板里有一个 NUL 字节，
+GNU grep 于是把整个流当二进制，`-c` 连计数都不打印。后果是每一条断言都读成
+空/0 —— **无论真实值是多少都会"通过"**。
+
+发现方式是给每个"应该为 0"的断言配一个**必须非 0 的对照**：
+把 A9 的 grep 拿去跑旧二进制的报告，预期 19，结果也是空 —— 说明坏的是 grep，
+不是 bug 修好了。加 `grep -a` 之后：
+
+| 断言 | 对照（必须非 0） | 断言值（必须 0） |
+|---|---|---|
+| A4/A5 on `fix.txt` | `· dropped` = 19、`other subos repaired` = 18 | `repair failed` = 0、`repair skipped` = 0 |
+| A6 on `after.txt` | `nothing to do` = 1 | `broken payload` = 0 |
+| A9 | 旧二进制 = 19 | 新二进制 = 0 |
+
+规矩沿用 [[reference-isolated-home-test-traps]]：**先证明这条检查能报出非 0，
+再相信它报出的 0。**
+
+（面板里那个 NUL 字节本身是个小瑕疵 —— e2e 里 `command substitution: ignored
+null byte in input` 的警告也是它。不影响正确性，另开。）
+
 #### A10 的两次修正 —— 都是真问题
 
 1. 第一次跑 A10 时三条命令全失败，原因是 TUI 面板行尾带 `\r`，被当成一个空

--- a/.agents/docs/2026-07-29-doctor-fix-one-shot-design.md
+++ b/.agents/docs/2026-07-29-doctor-fix-one-shot-design.md
@@ -272,9 +272,14 @@ coordinate_from_payload_path(std::string_view path, std::string_view xpkgsRoot);
 
 - `ⓘ release anchor` / `BindingSeverity::Notice` 不再逐条打印，
   合并为汇总行 `ⓘ 正常但值得知道  release anchor 30 · sysroot 未跟踪 2`，
-  明细放到 `--verbose`（新增 flag）。
+  明细放到 `--all`（新增 flag）。
 
 - `⚠ alias unresolved` 同一 target 的多个版本合并为一行（`claude` 5 条 → 1 条）。
+
+> **flag 名不能叫 `--verbose`。** 那是个**全局** flag：`cli.cppm` 用它抬日志级别，
+> 并且在派发前把它从 argv 里**删掉**，所以 `self doctor --verbose` 里的解析永远
+> 收不到。第一版就是这么写的，help 里写了、实测输出一字不差 —— 一个被文档化
+> 的空操作。改名 `--all`：9 行 → 40 行，实测。
 
 ### F5 阶梯补第四级：R4 prune
 

--- a/.agents/docs/2026-07-29-doctor-fix-one-shot-design.md
+++ b/.agents/docs/2026-07-29-doctor-fix-one-shot-design.md
@@ -474,8 +474,14 @@ deactivation 之前（未注册的 active 会让后者误判）。
 | A13 | 报告行数 | 239 | **46（修复前）→ 9（修复后）** | ✅ |
 | A15 | 真实 `~/.xlings/data/xpkgs` 未被改写 | — | **`find -newer` 为空** | ✅ |
 
-A14（`xlings use gcc` 双向可切）未回归：gcc 系列不在本次修复触及的条目里，
-`--fix` 只对它做了 dangling-edge 清理；这一点是**未验证**的，如实记录。
+| A14 | 修复后 `xlings use gcc` 双向可切 | — | **15.1.0 ⇄ 16.1.0 均成功，shim 报告切换后的版本，doctor 仍退出 0** | ✅ |
+
+A14 在修复完成的切片上实测：`gcc` 有 4 个 version key
+（`15.1.0` / `15.1.0-musl` / `15.1.0-aarch64-musl` / `16.1.0`），来回切换后
+`gcc --version` 分别报 15.1.0 与 16.1.0，`self doctor` 退出码保持 0。
+两个 musl flavor 也回到了 versions 列表 —— 这是 §5.5 第 2 条（R3 不再把好包
+卸掉不装回去）之后的正确结果：它们现在是被重新注册的，而不是被当成
+collateral 清掉的。
 
 #### A10 的两次修正 —— 都是真问题
 

--- a/.agents/docs/2026-07-29-doctor-fix-one-shot-design.md
+++ b/.agents/docs/2026-07-29-doctor-fix-one-shot-design.md
@@ -1,0 +1,593 @@
+# `xlings self doctor --fix` 一次修完 — 设计方案
+
+2026-07-29 · 承接 `2026-07-28-self-repair-design.md`、`2026-07-28-multi-subos-repair-design.md`
+
+目标只有一句：**在真实的 `~/.xlings` 副本上，`xlings self doctor --fix` 跑一次，
+之后 `xlings self doctor` 退出码为 0，且第二次 `--fix` 什么都不做。**
+
+前两轮"无感升级 / doctor --fix"优化没有实际效果，原因不是设计不对，而是
+**没有在真实累积状态上验证过**：单元测试与 upgrade-sim 造出来的 home 太干净，
+真实 home 里同时存在 Windows 记录、命名空间版本、跨 subos 引用、遗留 pairwise
+绑定四种形态，它们互相咬死。所以本方案把"真机切片验证"写进验收，而不是写进
+"后续可以做"。
+
+---
+
+## 1. 现场取证（2026-07-29，真实 `~/.xlings`，v2026.7.27.2）
+
+`.xlings.json`：379 个 target，9 个 subos 快照，91G payload。
+下面每一条都是从状态文件和 payload 里读出来的，不是推测。
+
+### 1.1 `llvm@20.1.7` 是一条 **Linux home 里的 Windows 注册**
+
+```json
+"llvm":  { "versions": { "20.1.7": { "path": "/home/speak/.xlings\\data\\xpkgs\\xim-x-llvm\\20.1.7" } } }
+"ar":    { "versions": { "20.1.7": { "alias": ["llvm-ar.exe"],
+                                     "path": "/home/speak/.xlings\\data\\xpkgs\\xim-x-llvm\\20.1.7/bin" } } }
+```
+
+9 条 entry（`llvm ar cl lib link nm ranlib rc strip`）路径全是反斜杠，别名全带
+`.exe`。payload 目录真实存在，里面是 29 个 `.exe` / `.dll`：
+
+```
+clang++.exe  clang-cl.exe  lld-link.exe  llvm-ar.exe  libomp.dll …
+```
+
+这 9 条是 **owner-less legacy**（没有 `bindingGroup`，只有 pairwise `bindings`）。
+
+**两扇门同时锁死**，这就是用户看到的死循环：
+
+| 方向 | 发生了什么 | 代码位置 |
+|---|---|---|
+| `install llvm@20.1.7` | Linux 配方走 `alias_apps`（`llvm-ar` 无后缀），`os.isfile` 全部失败 → 6 条 `skip xvm add alias`。batch 里没有 `ar@20.1.7`；而 persisted legacy component 有 → `IncompleteLegacyComponent`，**nothing was changed** | `registration.cppm:761-779` |
+| `remove llvm@20.1.7` | 配方 `uninstall()` 对 `collect_bin_apps()` 结果逐个 `xvm.remove` → `clang++.exe`（DB 里根本没有这个 target）→ `recipe removal target is outside the owned selection` | `removal.cppm:208-218` |
+
+装不进去、卸不掉、doctor 只会再叫你去装 —— 三方互指。
+
+### 1.2 命名空间写在 **version key** 里，所有渲染和探针都读反了
+
+```json
+"VBoxHeadless": { "versions": { "config:7.2.8": {…}, "local:7.2.8": {…} } }
+"mcpp":         { "versions": { "0.0.27": {…}, … } }        ← 另有 local-x-mcpp payload
+"freetype":     { "versions": { "2.13.2": {…}, "fromsource:2.13.2": {…} } }
+"claude":       { "versions": { …, "local:2.1.142": {…} } }
+```
+
+- doctor 一律 `std::format("{}@{}", name, version)`（`doctor.cppm:429` 等 6 处），
+  于是打印出 `mcpp@local:0.0.27`、`freetype@fromsource:2.13.2` —— **语法是错的**，
+  命名空间必须在最前面：`local:mcpp@0.0.27`。
+- `probe_reinstallable` 执行 `xlings info VBoxHeadless@config:7.2.8`
+  （`repair.cppm:128`）。`catalog::parse_target_`（`catalog.cppm:94-104`）把
+  `config:7.2.8` 当版本号，永远解析不出来 → 探针恒 false → 全部落进
+  `✗ repair skipped … no package in the index provides this entry`。
+  **所有命名空间条目从来没有被真正尝试修复过。**
+
+### 1.3 finding 认的是 xvm **target**，修复要的是可安装的 **package**
+
+`xlings install nm@20.1.7` —— `nm` 是 llvm 注册出来的程序名，索引里没有这个包。
+同类：`ar/cl/lib/link/ranlib/rc/strip`、`xim-musl-gnu-gcc`（包名是 `musl-gcc`）、
+`xim-aarch64-musl-gnu-gcc`（包名是 `aarch64-linux-musl-gcc`）、`VBoxHeadless`
+（包名是 `virtualbox`）。
+
+`owning_package()` 已经存在（`doctor.cppm:791-819`），但有两个致命限制：
+
+1. 它**只在 `if (fix)` 分支里**（`doctor.cppm:732`）。plain `doctor` 的
+   `→ run` 行完全没走它，所以裸跑 doctor 打印的命令 **100% 是错的**。
+2. 三个候选（recorded provider / target 自身 / binding root）对上面这批全部
+   落空，因为它们都不是包名。
+
+**缺的是第四个候选，而且它最可靠**：payload 路径本身就编码了包名。
+`package_store_name(ns, name) == ns + "-x-" + name`（`catalog.cppm:56-59`），
+于是：
+
+| payload 路径 | ⇒ 可安装坐标 |
+|---|---|
+| `data/xpkgs/xim-x-llvm/20.1.7` | `llvm@20.1.7` |
+| `data/xpkgs/config-x-virtualbox/7.2.8` | `config:virtualbox@7.2.8` |
+| `data/xpkgs/local-x-mcpp/0.0.27/bin` | `local:mcpp@0.0.27` |
+| `data/xpkgs/fromsource-x-freetype/2.13.2` | `fromsource:freetype@2.13.2` |
+| `data/xpkgs/xim-x-musl-gcc/15.1.0` | `musl-gcc@15.1.0` |
+| `data/xpkgs/xim-x-aarch64-linux-musl-gcc/15.1.0` | `aarch64-linux-musl-gcc@15.1.0` |
+
+一条规则覆盖了报告里几乎全部"命令是错的"的行。
+
+### 1.4 报告是**修复前**的状态，尾巴上再贴修复结果
+
+`add_field` 全部发生在检测循环里（`doctor.cppm:160-609`），repair pass 在
+`doctor.cppm:660-963` 才跑。于是同一次运行里：
+
+```
+✗ binding state  'zlib' is active at 1.3.1 but 'libz.so' … is not active   ← 检测时
+· deactivated  zlib (was part of xim:zlib@1.3.1)                            ← 修复后
+binding state   8                                                           ← 仍按修复前计数
+```
+
+用户读到的是"报了 8 个问题，又说修好了" —— 这就是"重复提示"的主因，
+`2026-07-28-self-repair-design.md` §6.2 写了"re-detect once, at the end"，
+**只对 repair 结果做了，没有对整份报告做**。
+
+### 1.5 同一个 release / 同一份 payload 被拆成 N 行
+
+```
+✗ broken payload  VBoxHeadless@config:7.2.8 path …/config-x-virtualbox/7.2.8 missing
+✗ broken payload  VBoxManage@config:7.2.8   path …/config-x-virtualbox/7.2.8 missing
+✗ broken payload  vbox@config:7.2.8         path …/config-x-virtualbox/7.2.8 missing
+```
+
+一个丢失的 payload 目录 ⇒ 3 行；llvm ⇒ 9 行。加上 30 行
+`ⓘ release anchor`（意思是"这里没问题"），报告里 60% 是噪音。
+
+### 1.6 `claude` 别名告警是真 bug：引号吃掉了绝对路径判断
+
+```json
+"alias": ["\"/home/speak/.xlings/data/xpkgs/xim-x-claude/2.1.142/…/claude.exe\""]
+```
+
+`doctor.cppm:512` 的 `fs::path(alias_prog).is_absolute()` 拿到的字符串首字符是
+`"`，判定为**相对路径**，于是走 `resolve_executable` 失败 → 告警。
+9 条 warning 里有 5 条是这个原因，纯误报。
+
+### 1.7 其他 subos 的 18 条 finding：步骤已经写死了，却要用户手动做
+
+`inspect_subos_references`（`inspect.cppm:361-411`）给出的 hint 已经是确定动作：
+
+- `xvm-subos-installed-dangling` → 从那个 subos 的 `installed[]` 里删掉一项
+- `xvm-subos-active-missing` → 那个 subos 的 `active` 指向未注册版本
+
+两者都是**纯元数据编辑**，不需要网络、不需要 payload、不会把包拉进当前 subos。
+今天却一律 report-only（`doctor.cppm:602-609`）。
+
+### 1.8 本 subos 的 INV-1 也没人修
+
+```
+✗ binding state  the active version is not registered [xim-aarch64-musl-gnu-gcc@15.1.0-aarch64-musl]
+```
+
+`--fix` 里有 dangling-edge pruning、incoherent deactivation、metadata reset，
+唯独没有 INV-1（active 指向未注册版本）的处理，而它和 1.7 的
+`subos-active-missing` 是同一种病，只是发生在当前 subos。
+
+---
+
+## 2. 缺陷清单 → 修复项
+
+| # | 缺陷 | 用户可见症状 | 修复项 |
+|---|---|---|---|
+| D1 | 报告是修复前状态 | 报了又说修好了，计数对不上 | **F1** detect → repair → re-detect → render |
+| D2 | 坐标渲染把 ns 放在版本里 | `mcpp@local:0.0.27` | **F2** `display_coordinate()` 统一渲染 |
+| D3 | remedy 从 target 生成 | `xlings install nm@20.1.7` | **F3** payload 路径反解包名 + remedy 只从可安装坐标生成 |
+| D4 | owner 解析只在 `--fix` 里 | 裸跑 doctor 的命令全错 | **F3**（同一函数提到检测阶段） |
+| D5 | 探针不认命名空间 | 所有 ns 条目 "repair skipped" | **F3**（探针用 `ns:pkg@ver`） |
+| D6 | 一 payload N 行 | 报告噪音 | **F4** 按 (payload, version) 折叠 + notice 归并计数 |
+| D7 | 阶梯没有"修不好就清掉"的出口 | 死循环 | **F5** R4 prune |
+| D8 | removal 对未注册 target 报错 | `remove` 也走不通 | **F6** 未注册即 no-op |
+| D9 | registration 拒绝缺员的 legacy 组件 | `install` 走不通 | **F7** 同 payload 的 owner-less 缺员允许丢弃 |
+| D10 | 引号绝对路径别名 | 5 条误报 warning | **F8** 去引号后再判断 |
+| D11 | 其他 subos 只报不修 | 18 条要手动做 | **F9** 直接改它们的状态文件 |
+| D12 | 本 subos INV-1 不修 | 1 条常驻 | **F10** 反激活 |
+
+---
+
+## 3. 设计
+
+### F1 报告 = 修复之后的状态
+
+`cmd_doctor` 拆成三段，`add_field` 只在最后一段调用：
+
+```cpp
+struct Findings { … };                       // 纯数据，不含渲染
+Findings detect(const DoctorState&);         // 只读，无副作用
+RepairOutcome repair(const Findings&, ...);  // 只改状态，不渲染
+void render(const Findings& remaining, const RepairOutcome&, EventStream&);
+```
+
+`--fix` 的流程固定为：
+
+```
+detect()  →  repair()  →  Config::reload_state()  →  detect() 再来一遍  →  render(第二次结果)
+```
+
+渲染的**永远是第二次 detect 的结果**。修好的问题不再出现在列表里，只出现在
+`healed N` 的汇总；没修好的问题原样列出，并附上"为什么没修好"。
+
+这条同时消掉 §1.4 的自相矛盾和大部分"重复提示"，也让计数天然一致：
+`broken payloads` 就是第二次 detect 数出来的数字。
+
+不加 `--fix` 时只跑第一次 detect，行为不变。
+
+**幂等性由构造保证**：第二次 `--fix` 的第一次 detect 就是空的，repair 无事可做。
+
+### F2 坐标渲染：命名空间永远在最前面
+
+新增单一入口（放 `xvm/db.cppm`，紧挨 `parse_ns_version`）：
+
+```cpp
+// versions DB 的 key 形如 "ns:ver"；对外展示与命令行接受的形式是 "ns:target@ver"。
+// 两者顺序相反，doctor 过去直接 "{}@{}" 拼接，产出的是不能粘贴执行的字符串。
+std::string display_coordinate(std::string_view target, std::string_view versionKey);
+//   ("mcpp", "local:0.0.27")   -> "local:mcpp@0.0.27"
+//   ("llvm", "20.1.7")         -> "llvm@20.1.7"
+```
+
+**替换 doctor 里全部 6 处 `"{}@{}"`**，以及 `inspect.cppm` 里所有把
+`target`/`version` 拼进 `summary`/`hint` 的地方（`inspect.cppm:110-118`、
+`180-190`、`262-274`、`375-406`）。
+
+配套单测：`display_coordinate` 的往返性质 —— 对任意 `(t, ns:v)`，
+`catalog::parse_target_(display_coordinate(t, v))` 解析出的 namespace/name/version
+必须等于 `(ns, t, v)`。
+
+### F3 remedy 只能从"可安装坐标"生成
+
+新增 `xvm/owner.cppm`（纯函数，可单测）：
+
+```cpp
+struct InstallCoordinate {                  // 一定可以拼成命令行
+    std::string ns;        // "" | "local" | "config" | "fromsource" | "xim"
+    std::string package;   // 包名，不是 xvm target
+    std::string version;   // 裸版本号，不带 ns
+    std::string command() const;            // "xlings install ns:pkg@ver"
+};
+
+// 从 payload 路径反解。data/xpkgs/<ns>-x-<pkg>/<ver>[/...] 是安装器写死的布局
+// （installer.cppm:2463 + catalog.cppm:56），所以这是**记录自带的**包身份，
+// 不是猜测。反斜杠先归一化，Windows 记录也能解。
+std::optional<InstallCoordinate>
+coordinate_from_payload_path(std::string_view path, std::string_view xpkgsRoot);
+```
+
+`owning_package()` 从 `if (fix)` 里提出来，候选顺序改为：
+
+| 序 | 候选 | 说明 |
+|---|---|---|
+| 1 | `bindingGroup.provider@providerVersion` | 当前格式记录，权威 |
+| 2 | **payload 路径反解**（新增） | 覆盖 §1.3 全部案例，含 Windows 记录 |
+| 3 | target 自身 | 0.4.69 anchor 条目本身就是包名 |
+| 4 | 可达的 binding root | 成员名对索引无意义时 |
+
+每个候选仍然要过 `probe_reinstallable`，但探针改成
+`xlings info <ns:pkg@ver>`（用 `InstallCoordinate::command` 同源拼装），
+于是 §1.2 的命名空间条目第一次真正被探测。
+
+**渲染规则**：
+- 解析出坐标 → 打印 `→ run  <coord.command()>`
+- 解析不出坐标 → **不打印任何命令**，改为
+  `→ 无索引提供此条目；--fix 会直接清除该注册`（对应 F5）
+
+绝不再出现"照着做也没用"的命令。
+
+### F4 折叠与降噪
+
+- **broken payload 按 `(expandedPayloadPath, versionKey)` 分组**，
+  一组一行，其余成员放进同一行的尾巴：
+
+  ```
+  ✗ broken payload  config:virtualbox@7.2.8  路径缺失 @xlings/data/xpkgs/config-x-virtualbox/7.2.8
+                    受影响程序 3 个: VBoxHeadless, VBoxManage, vbox
+    → run  xlings install config:virtualbox@7.2.8
+  ```
+
+  组标题用 §F3 解析出的**包坐标**；解析不出时退回组内字典序第一个 target 的
+  `display_coordinate`。
+
+- `ⓘ release anchor` / `BindingSeverity::Notice` 不再逐条打印，
+  合并为汇总行 `ⓘ 正常但值得知道  release anchor 30 · sysroot 未跟踪 2`，
+  明细放到 `--verbose`（新增 flag）。
+
+- `⚠ alias unresolved` 同一 target 的多个版本合并为一行（`claude` 5 条 → 1 条）。
+
+### F5 阶梯补第四级：R4 prune
+
+现有阶梯 R2 re-register → R3 remove+install → stop。新增：
+
+```
+R4 prune   —— 删除 versions DB 里这条注册（以及指向它的 workspace/installed 引用）
+```
+
+**只有同时满足下列全部条件才允许**：
+
+1. detect 已证明 payload 目录**不存在**，或存在但既无可执行文件也不是 release anchor；
+2. R2、R3 都失败（或 R3 因不可重装而未尝试）；
+3. §F3 解析不出可安装坐标，**或**坐标探针失败（索引里没有）；
+4. 该 (target, version) 不被任何 subos 的 `active` 引用为"正在使用且可用"。
+
+删的是**已经死掉的记录**：payload 已经没了，任何索引都拿不回来，留着只会
+每次 doctor 变红、并且挡住迁移标记。这不是丢数据，是丢一条指向虚空的指针。
+
+- `--dry-run` 逐条列出将被 prune 的记录（`→ would drop`），且**不做任何改动**。
+- 报告里 prune 单独成类：`· 已清除  local:mcpp@0.0.27（payload 缺失且索引不提供）`，
+  绝不混进 `healed`。
+- prune 走 `acquire_state_lock` + `reload_state` + `save_versions`，与现有
+  dangling-edge pruning 同一模式（`doctor.cppm:665-691`）。
+
+### F6 removal：未注册的目标是 no-op，不是错误
+
+`removal.cppm:208-218`，`op == "remove"` 且 `context.hasSelection` 时：
+
+```cpp
+auto memberIt = context.members.find(operation.name);
+if (memberIt == context.members.end()) {
+    // 该 target 在 DB 里根本不存在 —— 配方列的名字在本平台没有注册过
+    // （llvm 的 uninstall() 会对 collect_bin_apps() 的结果逐个 remove，
+    //  Windows payload 在 Linux 上就是 clang++.exe 这种名字）。
+    // 删一个不存在的东西已经完成了。只有"存在但不属于本次 selection"才是冲突。
+    if (!db.contains(operation.name)) continue;          // ← 新增
+    return std::unexpected(RemovalError{ … SelectionInvalid … });
+}
+```
+
+判据是 **DB 里有没有这个 target**，不是"在不在 selection 里"。存在但越界仍然
+硬失败 —— 那是真正的越权删除。
+
+单测：三个用例（不存在→跳过、存在且在 selection→删、存在但不在 selection→报错）。
+
+### F7 registration：owner-less legacy 组件允许缺员
+
+`registration.cppm:770-779` 今天要求 legacy component 的每个成员都在 batch 里，
+否则 `IncompleteLegacyComponent`。这在"同一个包在另一个平台注册了更多名字"时
+永久锁死（§1.1）。
+
+放宽条件——缺席成员满足**全部**下列条件时，从组件里丢弃而不是拒绝：
+
+1. 该成员 **owner-less**（无 `bindingGroup`）—— 没有任何 provider 在保护它；
+2. 它的 `path` 归一化后与本 batch 的 payload 根**同源**（同一个
+   `data/xpkgs/<store>/<ver>` 前缀）—— 证明它就是本包注册的；
+3. 它当前不是任何 subos 的 active。
+
+丢弃的成员写进返回的 `RegisteredMember` 列表（新增 `droppedLegacy` 标记），
+由调用方打印一行 `[xvm] 丢弃本平台不再注册的遗留条目: ar@20.1.7`。
+
+不满足 2 或 3 的仍然拒绝：那种情况下 batch 确实在改别人的东西。
+
+> 这一条是 `#422` "owner-less 直接 adopt" 的自然延伸：既然 owner-less 条目
+> 可以被就地接管，那么**同一份 payload 下、本平台不再产生的 owner-less 条目
+> 就应该被就地清理**，而不是让它把接管本身挡回去。
+
+### F8 别名去引号
+
+`doctor.cppm:507-514`，取出 `alias_prog` 后先剥掉成对的 `"` / `'`，再判断
+`is_absolute()`。同时对 `${XLINGS_HOME}` 做一次 `expand_path`
+（`doctor.cppm:493` 的 TODO 顺手结掉）。
+
+### F9 其他 subos：直接修状态文件
+
+新增 `profile::save_subos_workspace(dir, SubosWorkspace)`（与
+`load_subos_snapshots` 对称，`profile.cppm:202`），以及
+`xvm::subos_workspace_to_json`。写入走 home 级 `acquire_state_lock`
+（锁是 per-home 的，`lock.cppm:132`，覆盖所有 subos 状态文件）。
+
+`--fix` 对其他 subos 做且仅做两件事：
+
+| finding | 动作 | 为什么安全 |
+|---|---|---|
+| `xvm-subos-installed-dangling` | 从该 subos `installed[<target>]` 删掉该版本 | 没有任何东西通过 installed[] 分发；留着只会把 payload 钉在一个不存在的版本上 |
+| `xvm-subos-active-missing` | 从该 subos `active` 删掉该 target（**反激活**） | 指针指向未注册版本，shim 分发必然失败。反激活是可见问题，用一条 `xlings use` 就能恢复；替它猜一个版本才是危险的 |
+
+**明确不做**：不往别的 subos 安装任何东西，不把包拉进当前 subos。
+这条边界是 `2026-07-28-multi-subos-repair-design.md` §5 定的，本方案不动它 ——
+只是把"纯删除的元数据修复"从"报告"移到"执行"，因为它不需要任何决策。
+
+报告里这类改动单列：
+`· 其他 subos 已修  dev: 反激活 node（24.4.1 未注册）`。
+
+`deferredToOtherSubos`（另一个 subos 拥有的 broken payload）**保持不修**，
+仍然只报告 —— 修它需要在那个 subos 里跑 install，会把包拉进来。
+迁移标记的门也保持包含它（`doctor.cppm:1030`）。
+
+### F10 本 subos 的 INV-1 反激活
+
+`--fix` 增加一轮：当前 workspace 里 active 指向未注册版本的 target，
+按 F9 同样的理由反激活。放在 dangling-edge pruning 之后、incoherent
+deactivation 之前（未注册的 active 会让后者误判）。
+
+---
+
+## 4. 模块与改动面
+
+| 文件 | 改动 | 规模 |
+|---|---|---|
+| `src/core/xvm/db.cppm` | + `display_coordinate` | ~15 行 |
+| `src/core/xvm/owner.cppm` | **新增**：`InstallCoordinate`、`coordinate_from_payload_path`、owner 候选链 | ~140 行 |
+| `src/core/xvm/removal.cppm` | F6 | ~6 行 |
+| `src/core/xvm/registration.cppm` | F7 | ~45 行 |
+| `src/core/xvm/inspect.cppm` | F2 渲染统一；+ `plan_subos_metadata_repair` / `apply_…`（纯函数） | ~90 行 |
+| `src/core/profile.cppm` | + `save_subos_workspace` | ~30 行 |
+| `src/core/xself/repair.cppm` | + R4 prune、探针改用 `InstallCoordinate` | ~60 行 |
+| `src/core/xself/doctor.cppm` | **拆成 detect / repair / render 三段**；F1、F4、F8、F10 | 重构主体，净增约 200 行 |
+
+`doctor.cppm` 今天 1049 行、`cmd_doctor` 单函数 964 行 —— 这次拆分本身就是必要的
+维护性修复，F1 也没法在不拆的情况下实现（检测必须能跑两遍）。
+
+---
+
+## 5. 验收：真机切片验证
+
+**不接受"退出码 0"作为通过标准**，也不接受在 upgrade-sim 上通过 —— 前两轮
+就是这么"通过"的。
+
+### 5.1 为什么必须切片而不是整份复制
+
+`~/.xlings` 91G，磁盘 `/` **已 100% 占用，仅剩 9.0G**。整份 `cp -a` 不可能。
+好消息是关键状态全是小文件：
+
+| 内容 | 大小 | 复制方式 |
+|---|---|---|
+| `.xlings.json`（379 targets） | 249K | 真实复制 |
+| `config/`、`data/xim-pkgindex`、`data/xim-index-repos`、`data/local-indexrepo` | ~3M | 真实复制 |
+| `subos/default/` | **9.7M** | 真实复制（sysroot 拆除必须忠实） |
+| `subos/<其余 8 个>/.xlings.json` | KB 级 | 只复制状态文件 —— 它们正是钉住 payload 的东西 |
+| `data/xpkgs/`（69G） | — | `cp -al` 硬链接farm + 修复目标包真实复制 |
+| `bin/xlings` | — | 放入新构建的二进制 |
+| `subos/current -> default` | — | **最后**创建（见下） |
+
+### 5.2 两条必须遵守的规则（都踩过坑）
+
+1. **`subos/current` 一定最后建**。`glob("subos/*/.xlings.json")` 即使跳过
+   `default`，也会经 `current` 符号链接再次命中 `default`，把待测的绑定悄悄改掉，
+   产出一个"看起来真实的假结果"。
+2. **硬链接 farm 的风险点是"就地改写"，不是删除。** `rm` 只是 unlink，不动
+   真实 payload；但 `io.writefile()` 会 truncate 同一个 inode ——
+   llvm 配方的 `__install_linux_cfg()` 正是往 `install_dir/bin/clang.cfg`
+   写文件。所以**凡是本次修复会重装的包，必须真实 `cp -a`**
+   （`xim-x-llvm` 627M，空间够）。
+
+   收尾用一次**证据检查**兜底，而不是靠推理：
+
+   ```
+   跑之前:  touch /tmp/marker
+   跑之后:  find ~/.xlings/data/xpkgs -newer /tmp/marker | tee changed.txt
+   要求:    changed.txt 为空
+   ```
+
+   非空即判定本次验证作废（并说明哪个包被就地改写了）。
+
+3. 全程 `env -i HOME=$HOME PATH=/usr/bin:/bin XLINGS_HOME=$SLICE`，
+   让运行完全离开宿主配置。
+
+### 5.3 脚本
+
+新增 `.agents/tools/slice-real-home.sh`（造切片）与
+`tests/e2e/self_doctor_real_slice_test.sh`（跑断言）。
+后者从环境变量取切片路径，切片不存在时 **skip 而不是 pass** ——
+它依赖真实累积状态，不能进无条件 CI，但必须能被一条命令重跑。
+
+### 5.4 断言表 — **已实测**（2026-07-29，`2026.7.29.0` vs 已发布的 `2026.7.28.4`）
+
+切片：`slice-real-home.sh --dst … --bin …`，69G 硬链接农场 + 179 个 `.xpkg.lua`
+真实副本 + `subos/default` 全量 + 239 条 sysroot 符号链接重指向。
+每次运行都 `env -i HOME=… PATH=/usr/bin:/bin XLINGS_HOME=<slice>`。
+
+| # | 断言 | 修复前（实测） | 修复后（实测） | 结果 |
+|---|---|---|---|---|
+| A1 | `self doctor --fix` 退出码 | 1 | **0** | ✅ |
+| A2 | 紧接着 `self doctor` 退出码 | 1 | **0** | ✅ |
+| A3 | 第二次 `--fix` 的 healed / pruned | — | **无（幂等）** | ✅ |
+| A4 | `✗ repair failed` 行数 | 9 | **0** | ✅ |
+| A5 | `✗ repair skipped` 行数 | 11 | **0** | ✅ |
+| A6 | `broken payloads` | 20 | **0** | ✅ |
+| A7 | `binding state` | 134 | **0** | ✅ |
+| A8 | `other subos findings` | 18 | **0** | ✅ |
+| A9 | `name@ns:ver` 形式的坐标 | 19 | **0** | ✅ |
+| A10 | 每条 `→ run` 命令粘贴执行的退出码 | 3 条中 2 条失败 | **1 条，0 失败** | ✅ |
+| A11 | `.xlings.json:version` | `v2026.7.27.2` | **2026.7.29.0** | ✅ |
+| A12 | `claude` 相关 alias 误报 | 5 | **0** | ✅ |
+| A13 | 报告行数 | 239 | **58 →（修复后）9** | ✅ |
+| A15 | 真实 `~/.xlings/data/xpkgs` 未被改写 | — | **`find -newer` 为空** | ✅ |
+
+A14（`xlings use gcc` 双向可切）未回归：gcc 系列不在本次修复触及的条目里，
+`--fix` 只对它做了 dangling-edge 清理；这一点是**未验证**的，如实记录。
+
+#### A10 的两次修正 —— 都是真问题
+
+1. 第一次跑 A10 时三条命令全失败，原因是 TUI 面板行尾带 `\r`，被当成一个空
+   参数传进去（`package '' not found`）。**harness 的 bug**，不是产品的。
+   这正是"必须机器判定"的价值：目视永远看不出这个。
+2. 修掉 harness 之后仍有 2/3 失败：`xlings install xim:musl-gcc@15.1.0`
+   会被 dangling edge 卡住（`xvm-binding-validation-failed`），而 `--fix`
+   会先剪边再装，所以只有 `--fix` 能成功。这是**产品 bug**：报告印出了
+   一条当时不可能成功的命令 —— 正是用户第 5 条反馈的循环。
+   修法见 F3 末段：只要扫描里存在 dangling edge，payload 类修复建议一律
+   改为 `xlings self doctor --fix`。
+
+### 5.5 实施中发现的、设计没有预料到的五件事
+
+都是跑出来的，不是读出来的：
+
+1. **source 侧 dangling edge 从来没被剪过，也从来没被报过。**
+   `plan_dangling_edge_pruning` 对"own version 未注册"的边直接 `continue`，
+   理由是"解析总是从真实的 (target, version) 出发，够不到它"。这个理由是错的：
+   install 一旦注册了那个 version，边立刻变得可达，然后 batch 自校验失败
+   （`legacy binding source version is missing`）。差分证明：同一份切片、同一条
+   `xlings install xim:musl-gcc@15.1.0`，**带边失败、去边成功**。
+   真实 home 上有 14 条这样的边。原来的单测断言了错误的前提，已重写。
+
+2. **R3 会把好包卸掉不装回去。** 旧代码在 `remove` 成功后先问
+   `removalDone`，答"记录还在"就直接 return —— 执行了 remove+install 的破坏
+   一半，跳过了恢复一半。实测把一个正常的 `musl-gcc` 卸掉了。
+   现在：remove 成功后**永远**尝试 install，`removalDone` 只决定**怎么报告**
+   （避免谎称 REMOVED，这是 multi-subos e2e 守的那条）。
+
+3. **修复顺序必须是"元数据 → payload → 元数据 → prune"。**
+   一次 llvm 重注册会产生 29 个孤儿 shim 和 29 条 release 不一致 —— 那些正是
+   第一阶段修的东西，只是当时还不存在。单趟修复会把它们原样报成"没修好"。
+
+4. **prune 必须避开别的 subos 还在用的条目。** 设计里写了这个条件，实现时漏了，
+   被 multi-subos e2e 抓到：它 prune 掉了 `other` 还 active 的版本，把
+   "payload 坏了"换成了"指针指向不存在"，而且退出 0。
+
+5. **修复失败必须自己走进退出码。** R3 把包从当前 subos 摘掉又装不回去之后，
+   该条目在本 subos 变成"别人的问题"，重新检测看不见它，于是 doctor 退出 0 ——
+   典型的 silent success。现在按 (target, version) 记录失败条目，只要它在最终
+   扫描里还以任何形式存在，就计入退出码。
+
+### 5.6 原始断言表（保留，作为设计时的预期）
+
+| # | 断言 | 修复前（今天实测） | 修复后要求 |
+|---|---|---|---|
+| A1 | `self doctor --fix` 退出码 | 1 | **0** |
+| A2 | 紧接着 `self doctor` 退出码 | 1 | **0** |
+| A3 | 第二次 `--fix` 的 `healed` + 清除计数 | — | **0**（幂等） |
+| A4 | `✗ repair failed` 行数 | 9 | **0** |
+| A5 | `✗ repair skipped` 行数 | 11 | **0**（要么修好，要么按 F5 清除并计入"已清除"） |
+| A6 | `broken payloads` 计数 | 20 | **0** |
+| A7 | `binding state` 计数 | 8 | **0** |
+| A8 | `other subos findings` | 18 | **0** |
+| A9 | 输出里出现 `@<ns>:` 形式的坐标 | 6 处 | **0**（grep `-E '[A-Za-z0-9_.+-]+@[a-z]+:'` 无命中） |
+| A10 | 每条 `→ run` 的命令粘贴执行后退出码 | 多数非 0 | **全部 0**（脚本逐条执行验证） |
+| A11 | `.xlings.json:version` | `v2026.7.27.2` | 运行中的版本（迁移标记落地） |
+| A12 | `alias unresolved` 中 `claude` 相关 | 5 | **0** |
+| A13 | 报告总行数 | ~120 | **≤ 40**（降噪目标，非硬门槛，超出则复核 F4） |
+| A14 | 修复后 `xlings use gcc 15.1.0` / `16.1.0` 双向可切 | 需实测 | 与修复前一致，不得回归 |
+| A15 | 真实 `~/.xlings/data/xpkgs` 未被改写 | — | `find -newer` 为空（§5.2） |
+
+**A10 是最关键的一条**：它把"命令是对的"从人工目视变成机器判定，
+正是用户第 1、3、5 条反馈的直接度量。
+
+### 5.5 每一步都要能被证伪
+
+按 `reference-repro-from-real-home-slice` 的规矩：报告结果时必须打印
+判别性计数（例如 `other-subos refs: before=18 after=0`），
+证明两次跑的确处于不同状态 —— 而不是断言"通过了"。
+
+---
+
+## 6. 实施顺序
+
+阶梯式：每一步都能独立验证，且**前一步的门没过就不进下一步**。
+
+| 步 | 内容 | 门 |
+|---|---|---|
+| S0 | `slice-real-home.sh` + 基线：在切片上跑今天的二进制，把 §5.4 "修复前"一列**实测填满** | 基线数字与用户贴的输出一致 |
+| S1 | F6 removal no-op + F7 registration 缺员容忍（单测先行） | 单测过；切片上 `xlings remove llvm@20.1.7` 与 `install llvm@20.1.7` 至少一条能走通 |
+| S2 | F2 `display_coordinate` + 全量替换 | 往返单测过；切片输出 A9 = 0 |
+| S3 | F3 `xvm/owner.cppm` + owner 解析提到检测阶段 | 单测（6 条路径反解用例）过；切片上裸跑 doctor 的 A10 通过 |
+| S4 | F1 doctor 拆 detect/repair/render + 二次 detect | 切片上"报了又说修好了"的自相矛盾消失；A3 幂等 |
+| S5 | F5 R4 prune（含 `--dry-run` 预览） | A5 = 0；`--dry-run` 后状态文件字节不变 |
+| S6 | F8 别名去引号 + F10 本 subos INV-1 | A12 = 0；A7 = 0 |
+| S7 | F9 其他 subos 元数据修复 | A8 = 0 |
+| S8 | F4 折叠降噪 + `--verbose` | A13 |
+| S9 | 全量 §5.4 复跑 + `find -newer` 证据检查 | A1–A15 全绿 |
+
+---
+
+## 7. 明确不做
+
+- **不做版本升级。** "旧格式"不等于"旧版本"，`--fix` 不会把 gcc 15 换成 16。
+- **不往别的 subos 安装东西。** F9 只删不装。
+- **`--reset-metadata` 不并入 `--fix`。** 它丢的是 release 成员与头文件信息，
+  是唯一"真的丢信息"的修复，必须显式请求。
+- **不修 `xim-pkgindex` 里的配方。** llvm 配方在 Linux 上 remove 一堆 `.exe`
+  是它自己的毛病，但**客户端不能依赖配方正确才能自愈** ——
+  F6 让客户端对任意配方都保持可卸载。配方本身另开 issue。
+
+---
+
+## 8. 风险
+
+| 风险 | 处置 |
+|---|---|
+| R4 prune 删掉用户还想要的记录 | 四个前置条件全部要求"payload 已不存在且索引拿不回来"；`--dry-run` 全量预览；报告单列不混入 healed |
+| F7 放宽后 batch 改到别人的东西 | 三个条件里两个是"同 payload 根"和"非 active"，只放行本包自己的 owner-less 残留 |
+| F9 反激活让用户以为包丢了 | 报告明写 `run xlings use <target> <version>` 恢复；`installed[]` 不动，包还在 |
+| doctor 拆分引入回归 | S4 单独一步；`tests/unit/test_xvm_doctor.cpp`、`test_self_repair.cpp`、`tests/e2e/self_doctor_test.sh`、`self_doctor_multi_subos_test.sh` 全部先跑通再进 S5 |
+| 切片验证污染真实 home | `env -i` + `XLINGS_HOME` 隔离；`find -newer` 事后证据检查；**任何破坏性命令都不对 `~/.xlings` 本体执行** |

--- a/.agents/docs/2026-07-29-doctor-fix-one-shot-design.md
+++ b/.agents/docs/2026-07-29-doctor-fix-one-shot-design.md
@@ -465,13 +465,13 @@ deactivation 之前（未注册的 active 会让后者误判）。
 | A4 | `✗ repair failed` 行数 | 9 | **0** | ✅ |
 | A5 | `✗ repair skipped` 行数 | 11 | **0** | ✅ |
 | A6 | `broken payloads` | 20 | **0** | ✅ |
-| A7 | `binding state` | 134 | **0** | ✅ |
+| A7 | `binding state` | 134 | **0**（`--fix` 前 6 行，折叠后） | ✅ |
 | A8 | `other subos findings` | 18 | **0** | ✅ |
 | A9 | `name@ns:ver` 形式的坐标 | 19 | **0** | ✅ |
 | A10 | 每条 `→ run` 命令粘贴执行的退出码 | 3 条中 2 条失败 | **1 条，0 失败** | ✅ |
 | A11 | `.xlings.json:version` | `v2026.7.27.2` | **2026.7.29.0** | ✅ |
 | A12 | `claude` 相关 alias 误报 | 5 | **0** | ✅ |
-| A13 | 报告行数 | 239 | **58 →（修复后）9** | ✅ |
+| A13 | 报告行数 | 239 | **46（修复前）→ 9（修复后）** | ✅ |
 | A15 | 真实 `~/.xlings/data/xpkgs` 未被改写 | — | **`find -newer` 为空** | ✅ |
 
 A14（`xlings use gcc` 双向可切）未回归：gcc 系列不在本次修复触及的条目里，
@@ -520,7 +520,22 @@ A14（`xlings use gcc` 双向可切）未回归：gcc 系列不在本次修复�
    典型的 silent success。现在按 (target, version) 记录失败条目，只要它在最终
    扫描里还以任何形式存在，就计入退出码。
 
-### 5.6 原始断言表（保留，作为设计时的预期）
+### 5.6 折叠规则（实现时补的，设计只写了 payload 一种）
+
+同一个问题不能占 N 行。三处：
+
+- **broken payload 按 payload 分组** —— 设计里就有。
+- **binding state 按 (code, 条目) 分组** —— 一个遗留 anchor 每绑定一个程序就有
+  一条 dangling edge，两个 gcc flavor 各五条，于是 14 行描述 5 个条目。
+  字段名仍然全部列在那一行上。
+- **alias unresolved 按 target 分组**，且 `warnings` 计数按 target 计 ——
+  计数和列表必须对得上，否则就是上个版本刚修掉的
+  "broken payloads 1 但列表里没有对应行"那个形状。
+
+`ⓘ migration` 从独立 panel 改为主 panel 的最后一个字段：独立 panel 会渲染出
+一个空标题栏，读起来像画坏了的框而不是脚注。
+
+### 5.7 原始断言表（保留，作为设计时的预期）
 
 | # | 断言 | 修复前（今天实测） | 修复后要求 |
 |---|---|---|---|

--- a/.agents/tools/doctor-acceptance.sh
+++ b/.agents/tools/doctor-acceptance.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Measure `xlings self doctor [--fix]` against a slice and print the acceptance
+# table from .agents/docs/2026-07-29-doctor-fix-one-shot-design.md §5.4.
+#
+# Prints discriminating counts, not a verdict, so a "pass" cannot be asserted
+# without the numbers that justify it. A1..A15 are checked at the end.
+set -uo pipefail
+
+SLICE="${1:?usage: doctor-acceptance.sh <slice-dir> [outdir]}"
+OUT="${2:-/tmp/doctor-acceptance}"
+mkdir -p "$OUT"
+
+XL="$SLICE/bin/xlings"
+[[ -x "$XL" ]] || { echo "no binary at $XL" >&2; exit 2; }
+
+run() {  # run <logfile> <args...>
+    local log="$1"; shift
+    env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$SLICE" \
+        "$XL" "$@" >"$log" 2>&1
+    echo $?
+}
+# The TUI pads panel lines and terminates them with CR. Both have to go, or a
+# captured command carries a trailing \r that is passed as an empty argument
+# and every remedy "fails" for a reason that is entirely the harness's.
+strip() { sed -r 's/\x1B\[[0-9;]*[a-zA-Z]//g' "$1" | tr -d '\r' | sed -r 's/[[:space:]]+$//'; }
+
+echo "=== 1. plain doctor (before fix)"
+rc_before=$(run "$OUT/before.txt" self doctor)
+echo "=== 2. doctor --fix"
+rc_fix=$(run "$OUT/fix.txt" self doctor --fix)
+echo "=== 3. plain doctor (after fix)"
+rc_after=$(run "$OUT/after.txt" self doctor)
+echo "=== 4. doctor --fix again (idempotence)"
+rc_fix2=$(run "$OUT/fix2.txt" self doctor --fix)
+
+count() { strip "$1" | grep -cF "$2" || true; }
+field() { strip "$1" | sed -n -r "s/^ *$2 +([0-9]+).*/\1/p" | head -1; }
+
+echo
+echo "---------------- measurements ----------------"
+printf 'A1  doctor --fix exit code              : %s   (want 0)\n' "$rc_fix"
+printf 'A2  doctor exit code after fix          : %s   (want 0)\n' "$rc_after"
+printf 'A3  second --fix healed/pruned          : %s / %s   (want 0 / 0)\n' \
+    "$(field "$OUT/fix2.txt" 'healed')" "$(field "$OUT/fix2.txt" 'pruned')"
+printf 'A4  "repair failed" lines  before/after : %s / %s   (want ?/0)\n' \
+    "$(count "$OUT/fix.txt" '✗ repair failed')" \
+    "$(count "$OUT/fix2.txt" '✗ repair failed')"
+printf 'A5  "repair skipped" lines before/after : %s / %s   (want ?/0)\n' \
+    "$(count "$OUT/fix.txt" '✗ repair skipped')" \
+    "$(count "$OUT/fix2.txt" '✗ repair skipped')"
+printf 'A6  broken payloads   before/after      : %s / %s   (want ?/0)\n' \
+    "$(field "$OUT/before.txt" 'broken payloads')" \
+    "$(field "$OUT/after.txt" 'broken payloads')"
+printf 'A7  binding state     before/after      : %s / %s   (want ?/0)\n' \
+    "$(field "$OUT/before.txt" 'binding state')" \
+    "$(field "$OUT/after.txt" 'binding state')"
+printf 'A8  other subos       before/after      : %s / %s   (want ?/0)\n' \
+    "$(field "$OUT/before.txt" 'other subos findings')" \
+    "$(field "$OUT/after.txt" 'other subos findings')"
+
+# A9: a coordinate must never render as target@ns:version.
+bad_coord_before=$(strip "$OUT/before.txt" \
+    | grep -cE '[A-Za-z0-9_.+-]+@[a-z][a-z0-9-]*:' || true)
+bad_coord_after=$(strip "$OUT/after.txt" \
+    | grep -cE '[A-Za-z0-9_.+-]+@[a-z][a-z0-9-]*:' || true)
+printf 'A9  "name@ns:ver" occurrences bef/aft   : %s / %s   (want ?/0)\n' \
+    "$bad_coord_before" "$bad_coord_after"
+
+printf 'A12 claude alias warnings  before/after : %s / %s   (want ?/0)\n' \
+    "$(strip "$OUT/before.txt" | grep -c 'alias unresolved.*claude' || true)" \
+    "$(strip "$OUT/after.txt"  | grep -c 'alias unresolved.*claude' || true)"
+printf 'A13 report lines      before/after      : %s / %s\n' \
+    "$(wc -l < "$OUT/before.txt")" "$(wc -l < "$OUT/after.txt")"
+printf 'A11 recorded client version             : %s\n' \
+    "$(python3 -c "import json;print(json.load(open('$SLICE/.xlings.json')).get('version'))")"
+printf '    running version                     : %s\n' \
+    "$(env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$SLICE" "$XL" --version 2>&1 | head -1)"
+
+# A10: every printed remedy must actually work. This is the assertion that
+# turns "the command is correct" from eyeballing into a measurement.
+#
+# Read off the BEFORE report, not the after: a successful --fix leaves nothing
+# to print, so grading the after report would be grading an empty list and
+# calling it a pass.
+echo
+echo "---------------- A10: printed remedies (from before.txt) ----------------"
+mapfile -t cmds < <(strip "$OUT/before.txt" \
+    | sed -n -r 's/^ *→ run +(xlings .*)$/\1/p' | sort -u)
+if [[ ${#cmds[@]} -eq 0 ]]; then
+    echo "  (no remedy commands printed)"
+else
+    a10_fail=0
+    for c in "${cmds[@]}"; do
+        # shellcheck disable=SC2086
+        args=(${c#xlings })
+        env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$SLICE" \
+            "$XL" "${args[@]}" >/dev/null 2>&1
+        rc=$?
+        [[ $rc -eq 0 ]] || { a10_fail=$((a10_fail+1)); echo "  FAIL rc=$rc : $c"; }
+    done
+    echo "  ${#cmds[@]} command(s), $a10_fail failing   (want 0)"
+fi
+echo
+echo "logs in $OUT/{before,fix,after,fix2}.txt"

--- a/.agents/tools/doctor-acceptance.sh
+++ b/.agents/tools/doctor-acceptance.sh
@@ -33,7 +33,12 @@ rc_after=$(run "$OUT/after.txt" self doctor)
 echo "=== 4. doctor --fix again (idempotence)"
 rc_fix2=$(run "$OUT/fix2.txt" self doctor --fix)
 
-count() { strip "$1" | grep -cF "$2" || true; }
+# `grep -a` is load-bearing, not defensive. The rendered panel contains a NUL
+# byte, and without -a GNU grep treats the stream as binary and prints NOTHING
+# -- so every count reads as empty/0 and every assertion passes whether or not
+# it should. Caught by running the A9 grep against the OLD report, which must
+# be non-zero: it came back empty too.
+count() { strip "$1" | grep -acF "$2" || true; }
 field() { strip "$1" | sed -n -r "s/^ *$2 +([0-9]+).*/\1/p" | head -1; }
 
 echo
@@ -60,15 +65,15 @@ printf 'A8  other subos       before/after      : %s / %s   (want ?/0)\n' \
 
 # A9: a coordinate must never render as target@ns:version.
 bad_coord_before=$(strip "$OUT/before.txt" \
-    | grep -cE '[A-Za-z0-9_.+-]+@[a-z][a-z0-9-]*:' || true)
+    | grep -acE '[A-Za-z0-9_.+-]+@[a-z][a-z0-9-]*:' || true)
 bad_coord_after=$(strip "$OUT/after.txt" \
-    | grep -cE '[A-Za-z0-9_.+-]+@[a-z][a-z0-9-]*:' || true)
+    | grep -acE '[A-Za-z0-9_.+-]+@[a-z][a-z0-9-]*:' || true)
 printf 'A9  "name@ns:ver" occurrences bef/aft   : %s / %s   (want ?/0)\n' \
     "$bad_coord_before" "$bad_coord_after"
 
 printf 'A12 claude alias warnings  before/after : %s / %s   (want ?/0)\n' \
-    "$(strip "$OUT/before.txt" | grep -c 'alias unresolved.*claude' || true)" \
-    "$(strip "$OUT/after.txt"  | grep -c 'alias unresolved.*claude' || true)"
+    "$(strip "$OUT/before.txt" | grep -ac 'alias unresolved.*claude' || true)" \
+    "$(strip "$OUT/after.txt"  | grep -ac 'alias unresolved.*claude' || true)"
 printf 'A13 report lines      before/after      : %s / %s\n' \
     "$(wc -l < "$OUT/before.txt")" "$(wc -l < "$OUT/after.txt")"
 printf 'A11 recorded client version             : %s\n' \
@@ -85,7 +90,7 @@ printf '    running version                     : %s\n' \
 echo
 echo "---------------- A10: printed remedies (from before.txt) ----------------"
 mapfile -t cmds < <(strip "$OUT/before.txt" \
-    | sed -n -r 's/^ *→ run +(xlings .*)$/\1/p' | sort -u)
+    | grep -a . | sed -n -r 's/^ *→ run +(xlings .*)$/\1/p' | sort -u)
 if [[ ${#cmds[@]} -eq 0 ]]; then
     echo "  (no remedy commands printed)"
 else

--- a/.agents/tools/slice-real-home.sh
+++ b/.agents/tools/slice-real-home.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# Build a runnable slice of a real ~/.xlings into a scratch directory.
+#
+# Why a slice and not a copy: a real home is tens of gigabytes and the disk it
+# lives on is usually the one with no room left. Everything that decides what
+# `self doctor` sees is small -- the version DB, the subos state files, the
+# index -- so those are copied for real. The payload store is reproduced as a
+# HARDLINK FARM, which costs directory entries and nothing else.
+#
+# The hardlink farm is safe against deletion (unlink drops the slice's name,
+# the real file survives) but NOT against in-place rewriting: an install hook
+# that does io.writefile() over an existing path truncates the shared inode.
+# Two defences, and the second is the one to trust:
+#   1. --real <store-dir> forces a genuine copy for packages a repair is
+#      expected to reinstall.
+#   2. `verify-untouched` proves after the fact that nothing under the real
+#      store changed. Run it every time; do not reason about it instead.
+#
+# Never point --home at a home you are willing to lose. This script only reads
+# it, but what you run against the slice afterwards is up to you.
+set -euo pipefail
+
+SRC="${HOME}/.xlings"
+DST=""
+BIN=""
+REAL_STORES=()
+MODE="build"
+
+usage() {
+    cat <<'EOF'
+usage:
+  slice-real-home.sh --dst <dir> [--home <src>] [--bin <xlings>] [--real <store-name>]...
+  slice-real-home.sh verify-untouched --marker <file> [--home <src>]
+
+  --dst    where to build the slice (must not exist)
+  --home   source home (default: ~/.xlings)
+  --bin    xlings binary to install as the slice's bin/xlings
+  --real   payload store dir to copy for real instead of hardlinking,
+           repeatable. Use for any package the run will reinstall.
+           Default: xim-x-llvm
+
+  verify-untouched --marker F   fail if anything under <home>/data/xpkgs is
+                                newer than F. Create F with `touch` before the
+                                run under test.
+EOF
+}
+
+if [[ "${1:-}" == "verify-untouched" ]]; then
+    MODE="verify"; shift
+fi
+
+MARKER=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dst)    DST="$2"; shift 2 ;;
+        --home)   SRC="$2"; shift 2 ;;
+        --bin)    BIN="$2"; shift 2 ;;
+        --real)   REAL_STORES+=("$2"); shift 2 ;;
+        --marker) MARKER="$2"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "unknown option: $1" >&2; usage; exit 2 ;;
+    esac
+done
+
+if [[ "$MODE" == "verify" ]]; then
+    [[ -n "$MARKER" ]] || { echo "verify-untouched needs --marker" >&2; exit 2; }
+    changed="$(find "$SRC/data/xpkgs" -newer "$MARKER" 2>/dev/null || true)"
+    if [[ -n "$changed" ]]; then
+        echo "FAIL: the real payload store was modified:" >&2
+        printf '%s\n' "$changed" | head -40 >&2
+        exit 1
+    fi
+    echo "OK: $SRC/data/xpkgs unchanged since $MARKER"
+    exit 0
+fi
+
+[[ -n "$DST" ]] || { echo "--dst is required" >&2; usage; exit 2; }
+[[ -d "$SRC" ]] || { echo "source home not found: $SRC" >&2; exit 1; }
+[[ ! -e "$DST" ]] || { echo "destination already exists: $DST" >&2; exit 1; }
+[[ ${#REAL_STORES[@]} -gt 0 ]] || REAL_STORES=(xim-x-llvm)
+
+# Same filesystem, or `cp -al` cannot link.
+src_dev="$(stat -c %d "$SRC")"
+mkdir -p "$(dirname "$DST")"
+dst_dev="$(stat -c %d "$(dirname "$DST")")"
+if [[ "$src_dev" != "$dst_dev" ]]; then
+    echo "refusing: $DST is on a different filesystem than $SRC;" >&2
+    echo "the payload store could only be copied for real (tens of GB)." >&2
+    exit 1
+fi
+
+echo "==> slice $SRC -> $DST"
+mkdir -p "$DST/data" "$DST/subos" "$DST/bin"
+
+# The version DB. The whole point of the slice.
+cp -a "$SRC/.xlings.json" "$DST/.xlings.json"
+[[ -d "$SRC/config" ]] && cp -a "$SRC/config" "$DST/config"
+
+# Index + repo metadata: small, and doctor's remedy probe reads it.
+for d in xim-pkgindex xim-index-repos local-indexrepo scode ros2; do
+    [[ -e "$SRC/data/$d" ]] && cp -a "$SRC/data/$d" "$DST/data/$d"
+done
+[[ -f "$SRC/data/github-mirrors.json" ]] \
+    && cp -a "$SRC/data/github-mirrors.json" "$DST/data/"
+# data/runtimedir is download scratch; recreated on demand, gigabytes, skipped.
+
+# The payload store, as a hardlink farm.
+#
+# A few files cannot be hardlinked at all: setuid binaries under
+# fs.protected_hardlinks (bwrap, code's chrome-sandbox). Those get a real copy
+# -- there are single digits of them, and leaving them out would change what
+# doctor sees. cp's failure is expected here, so it must not take the run down.
+echo "==> payload store (hardlink farm)"
+link_errors="$(mktemp)"
+cp -al "$SRC/data/xpkgs" "$DST/data/xpkgs" 2>"$link_errors" || true
+# `cp: cannot create hard link 'DST/…' to 'SRC/…': …`
+sed -n "s|^cp: cannot create hard link '\\([^']*\\)' to '\\([^']*\\)'.*|\\1\\t\\2|p" \
+    "$link_errors" | while IFS=$'\t' read -r dstfile srcfile; do
+    echo "    real copy (unlinkable): ${srcfile#$SRC/}"
+    mkdir -p "$(dirname "$dstfile")"
+    cp -a "$srcfile" "$dstfile"
+done
+# Anything else cp complained about is a genuine failure.
+if grep -qv 'cannot create hard link' "$link_errors" 2>/dev/null \
+   && grep -q . "$link_errors"; then
+    if grep -v 'cannot create hard link' "$link_errors" | grep -q .; then
+        echo "FAIL: payload store copy reported errors:" >&2
+        grep -v 'cannot create hard link' "$link_errors" >&2
+        exit 1
+    fi
+fi
+rm -f "$link_errors"
+
+# Break the links the installer is KNOWN to rewrite in place.
+#
+# A payload dir carries `.xpkg.lua`, the recipe snapshot, and every install
+# rewrites it -- io.writefile() truncates in place, so through a hardlink that
+# is a write to the real home. Measured: one `--fix` pass touched seven of
+# them. The content came out byte-identical (same recipe, same bytes), so
+# nothing was damaged, but `verify-untouched` reported the real store as
+# modified and it was right to.
+#
+# These files are ~10KB each and there are a few hundred, so copying them for
+# real removes the whole class for about the price of nothing.
+echo "==> unlink rewritable metadata"
+broken=0
+while IFS= read -r meta; do
+    cp -a --remove-destination "$(readlink -f "$meta")" "$meta.slice-tmp"
+    mv -f "$meta.slice-tmp" "$meta"
+    broken=$((broken + 1))
+done < <(find "$DST/data/xpkgs" -name '.xpkg.lua' -type f)
+echo "    real copy: $broken metadata file(s)"
+
+for store in "${REAL_STORES[@]}"; do
+    if [[ -d "$DST/data/xpkgs/$store" ]]; then
+        echo "==> real copy: $store"
+        rm -rf "$DST/data/xpkgs/$store"
+        cp -a "$SRC/data/xpkgs/$store" "$DST/data/xpkgs/$store"
+    fi
+done
+
+# subos: `default` in full (sysroot teardown has to be faithful), every other
+# one as its state file only -- those are what pin payloads and what the
+# cross-subos checks read.
+echo "==> subos"
+for dir in "$SRC"/subos/*/; do
+    name="$(basename "$dir")"
+    [[ "$name" == "current" ]] && continue          # symlink, handled last
+    [[ -L "${dir%/}" ]] && continue
+    if [[ "$name" == "default" ]]; then
+        cp -a "${dir%/}" "$DST/subos/default"
+    elif [[ -f "$dir/.xlings.json" ]]; then
+        mkdir -p "$DST/subos/$name"
+        cp -a "$dir/.xlings.json" "$DST/subos/$name/.xlings.json"
+    fi
+done
+
+# Repoint every absolute path at the slice.
+#
+# The version DB stores payload paths absolutely (`/home/you/.xlings/data/…`),
+# so a slice left as-is would have its records pointing back into the REAL
+# store: doctor would grade the original, and any repair would rewrite it. This
+# rewrite is what makes the slice self-contained, and it is a plain prefix
+# substitution so pathological records survive it intact -- a Windows-style
+# `/home/you/.xlings\data\xpkgs\…` keeps its backslashes, which is exactly the
+# state under test.
+echo "==> repoint paths to the slice"
+python3 - "$SRC" "$DST" <<'PY'
+import os, pathlib, sys
+src, dst = sys.argv[1].rstrip('/'), sys.argv[2].rstrip('/')
+root = pathlib.Path(dst)
+targets = [root / '.xlings.json'] + sorted(root.glob('subos/*/.xlings.json'))
+n = 0
+for path in targets:
+    if not path.is_file() or path.is_symlink():
+        continue
+    text = path.read_text(encoding='utf-8')
+    if src not in text:
+        continue
+    path.write_text(text.replace(src, dst), encoding='utf-8')
+    n += 1
+print(f"    rewrote {n} state file(s)")
+
+# The sysroot is made of symlinks INTO the payload store, and `cp -a` copies a
+# symlink's text verbatim -- so every one of them still points at the real
+# home. Left that way the slice does not merely lose fidelity, it invents a
+# defect: `xvm-sysroot-drift` fires for every declared destination whose link
+# does not start with this home's payload root, which on the measured home is
+# 126 findings that do not exist outside the slice.
+links = 0
+for path in root.glob('subos/**/*'):
+    if not path.is_symlink():
+        continue
+    target = os.readlink(path)
+    if not target.startswith(src):
+        continue
+    path.unlink()
+    path.symlink_to(target.replace(src, dst, 1))
+    links += 1
+print(f"    repointed {links} sysroot symlink(s)")
+PY
+
+if [[ -n "$BIN" ]]; then
+    cp -a "$BIN" "$DST/bin/xlings"
+    chmod +x "$DST/bin/xlings"
+fi
+
+# LAST. A `subos/*/.xlings.json` loop that skips `default` still reaches it
+# through `current`, so anything scripted above would have silently edited the
+# subos under test.
+ln -sfn default "$DST/subos/current"
+
+echo "==> done: $DST"
+du -sh "$DST" 2>/dev/null || true

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlings"
-version = "2026.7.28.4"
+version = "2026.7.29.0"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -871,7 +871,7 @@ export int run(int argc, char* argv[]) {
                     {"config",   "Show configuration details"},
                     {"clean",    "Remove cache + gc orphaned packages (--dry-run)"},
                     {"migrate",  "Migrate old layout to subos/default"},
-                    {"doctor",   "Verify workspace/shim consistency (--fix to repair, --reset-metadata to discard unreadable release metadata)"},
+                    {"doctor",   "Verify workspace/shim consistency (--fix to repair, --dry-run to preview, --all to list non-defect findings, --reset-metadata to discard unreadable release metadata)"},
                 },
             };
             else if (match("subos")) h = SubHelp{

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "2026.7.28.4";
+    static constexpr std::string_view VERSION = "2026.7.29.0";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/profile.cppm
+++ b/src/core/profile.cppm
@@ -231,6 +231,50 @@ export std::vector<SubosSnapshot> load_subos_snapshots(const fs::path& xlingsHom
     return snapshots;
 }
 
+// Write one other subos's workspace back, preserving everything else in its
+// state file.
+//
+// The counterpart to load_subos_snapshots, and it exists for one caller:
+// `self doctor --fix` repairing a subos it is not currently in. Those repairs
+// are pure deletions from `active` / `installed[]` -- a pointer at a version
+// the shared database no longer has -- so nothing here needs to understand
+// what the subos is for.
+//
+// Read-modify-write of the whole document rather than a targeted edit: the
+// file carries fields this process does not model, and rewriting it from a
+// SubosWorkspace alone would silently drop them. Callers hold the home's state
+// lock; this does not take it, because it has no way to know whether the
+// caller is mid-transaction over several files.
+export bool save_subos_workspace(const fs::path& subosRoot,
+                                 const xvm::SubosWorkspace& workspace) {
+    const auto wsPath = subosRoot / ".xlings.json";
+    nlohmann::json json = nlohmann::json::object();
+    std::error_code ec;
+    if (fs::exists(wsPath, ec)) {
+        try {
+            auto content = platform::read_file_to_string(wsPath.string());
+            auto parsed = nlohmann::json::parse(content, nullptr, false);
+            if (!parsed.is_discarded() && parsed.is_object()) {
+                json = std::move(parsed);
+            } else {
+                // Refuse rather than replace: an unreadable file is not an
+                // empty one, and overwriting it would turn "we could not read
+                // your subos" into "your subos is now blank".
+                return false;
+            }
+        } catch (...) {
+            return false;
+        }
+    }
+    json["workspace"] = xvm::subos_workspace_to_json(workspace);
+    try {
+        platform::write_string_to_file(wsPath.string(), json.dump(2));
+    } catch (...) {
+        return false;
+    }
+    return true;
+}
+
 // Build a set of referenced xpkg "dirname/version" keys from all subos workspaces
 // by mapping workspace target names to xpkg directory paths via the versions DB.
 std::set<std::string> collect_subos_references_(const fs::path& xlingsHome) {

--- a/src/core/xim/catalog.cppm
+++ b/src/core/xim/catalog.cppm
@@ -62,6 +62,22 @@ std::string package_scope_label(PackageScope scope) {
     return scope == PackageScope::Project ? "project" : "global";
 }
 
+// The parsed shape of a command-line coordinate: `[ns:]name[@version]`.
+//
+// Exported because the coordinate is now produced in more than one place --
+// `self doctor` synthesises remedies -- and a renderer that cannot be checked
+// against the parser is a renderer that drifts from it. Round-tripping is a
+// unit test, not a hope.
+struct ParsedPackageTarget {
+    std::string raw;
+    std::string name;
+    std::string version;
+    std::string namespaceName;
+    bool explicitNamespace { false };
+};
+
+ParsedPackageTarget parse_package_target(std::string target);
+
 std::string format_ambiguous_candidates(std::string_view target,
                                         std::span<const PackageMatch> matches) {
     std::string msg = std::format("package '{}' is ambiguous, candidates:\n", target);
@@ -113,6 +129,24 @@ ParsedTarget_ parse_target_(std::string target) {
     }
     return parsed;
 }
+
+}  // namespace detail_
+
+// Definition sits here rather than beside the declaration: it delegates to
+// detail_::parse_target_, which is what every other resolution path uses, so
+// the exported form cannot drift from the internal one.
+ParsedPackageTarget parse_package_target(std::string target) {
+    const auto parsed = detail_::parse_target_(std::move(target));
+    return {
+        .raw = parsed.raw,
+        .name = parsed.name,
+        .version = parsed.version,
+        .namespaceName = parsed.namespaceName,
+        .explicitNamespace = parsed.explicitNamespace,
+    };
+}
+
+namespace detail_ {
 
 std::string select_version_(const xpkg::Package& pkg,
                             const std::string& platform,

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -194,6 +194,9 @@ using XpkgXvmMetadataError = std::variant<
 struct XpkgXvmMetadataResult {
     xvm::RemovalBatchResult removal;
     std::vector<xvm::RegisteredMember> registered;
+    // Legacy component members this batch could not re-register and detached
+    // instead of refusing over. See apply_registration_batch.
+    std::vector<xvm::DetachedLegacyMember> detachedLegacy;
     std::vector<XpkgFilesystemEffect> effects;
 };
 
@@ -640,13 +643,15 @@ apply_xpkg_xvm_metadata_batch(
     }
 
     std::vector<xvm::RegisteredMember> registered;
+    std::vector<xvm::DetachedLegacyMember> detachedLegacy;
     if (!registration.batch.nodes.empty()
         || !registration.batch.headers.empty()) {
         auto registrationResult = xvm::apply_registration_batch(
             candidateDb,
             candidateWorkspace,
             candidateInstalled,
-            registration.batch);
+            registration.batch,
+            &detachedLegacy);
         if (!registrationResult) {
             return std::unexpected(XpkgXvmMetadataError{
                 std::in_place_type<xvm::RegistrationError>,
@@ -662,6 +667,7 @@ apply_xpkg_xvm_metadata_batch(
     return XpkgXvmMetadataResult{
         .removal = std::move(*removal),
         .registered = std::move(registered),
+        .detachedLegacy = std::move(detachedLegacy),
         .effects = registration.effects,
     };
 }
@@ -1720,6 +1726,19 @@ bool process_xvm_operations_(const PlanNode& node,
         if (!member.adoptedLegacy) continue;
         log::warn("[xvm] adopted a pre-ownership registration: {}@{} ('{}' changed)",
                   member.target, member.version, member.adoptedLegacyField);
+    }
+
+    // Announce anything the batch left behind rather than refused over.
+    //
+    // These are names an older client registered for this same payload on a
+    // platform whose recipe produces them and this one's does not (a Windows
+    // llvm leaves `cl`, `lib`, `link`, `rc`). They keep their record and lose
+    // their edge to this release; `self doctor` reports them and can prune
+    // them. Silence here would make a release quietly shed members.
+    for (const auto& member : metadata->detachedLegacy) {
+        log::warn("[xvm] detached a legacy entry this platform no longer "
+                  "registers: {} (run `xlings self doctor --fix` to clear it)",
+                  xvm::display_coordinate(member.target, member.version));
     }
 
     if (!metadata->removal.removed.empty()

--- a/src/core/xself.cppm
+++ b/src/core/xself.cppm
@@ -55,7 +55,7 @@ static int cmd_help(EventStream& stream) {
         {{"name", "config"},    {"desc", "Show configuration details"}},
         {{"name", "clean"},     {"desc", "Remove cache + gc orphaned packages (--dry-run)"}},
         {{"name", "migrate"},   {"desc", "Migrate old layout to subos/default"}},
-        {{"name", "doctor"},    {"desc", "Verify workspace/shim consistency (--fix to repair, --dry-run to preview the repairs, --reset-metadata to discard unreadable release metadata)"}},
+        {{"name", "doctor"},    {"desc", "Verify workspace/shim consistency (--fix to repair, --dry-run to preview the repairs, --verbose to list non-defect findings, --reset-metadata to discard unreadable release metadata)"}},
     });
     stream.emit(DataEvent{"help", payload.dump()});
     return 0;
@@ -91,6 +91,7 @@ export int run(int argc, char* argv[], EventStream& stream) {
         bool fix = false;
         bool resetMetadata = false;
         bool dryRun = false;
+        bool verbose = false;
         for (int i = 3; i < argc; ++i) {
             const auto arg = std::string(argv[i]);
             if (arg == "--fix") fix = true;
@@ -100,8 +101,14 @@ export int run(int argc, char* argv[], EventStream& stream) {
             // Show the repair plan without running it. Only meaningful
             // with --fix, which is the flag that can now touch the network.
             if (arg == "--dry-run") dryRun = true;
+            // List the findings that are not defects -- release anchors,
+            // aliases that are probably system commands, notices about state
+            // the upgrade inherited. They are summarised to one counted line
+            // by default because there are dozens of them on a real home and
+            // they buried the handful that mattered.
+            if (arg == "--verbose" || arg == "-v") verbose = true;
         }
-        return cmd_doctor(stream, fix, resetMetadata, dryRun);
+        return cmd_doctor(stream, fix, resetMetadata, dryRun, verbose);
     }
     // help / unknown-action handling. Distinguish a deliberate help
     // request (no action / -h / --help) from a typo / made-up action so

--- a/src/core/xself.cppm
+++ b/src/core/xself.cppm
@@ -55,7 +55,7 @@ static int cmd_help(EventStream& stream) {
         {{"name", "config"},    {"desc", "Show configuration details"}},
         {{"name", "clean"},     {"desc", "Remove cache + gc orphaned packages (--dry-run)"}},
         {{"name", "migrate"},   {"desc", "Migrate old layout to subos/default"}},
-        {{"name", "doctor"},    {"desc", "Verify workspace/shim consistency (--fix to repair, --dry-run to preview the repairs, --verbose to list non-defect findings, --reset-metadata to discard unreadable release metadata)"}},
+        {{"name", "doctor"},    {"desc", "Verify workspace/shim consistency (--fix to repair, --dry-run to preview the repairs, --all to list non-defect findings, --reset-metadata to discard unreadable release metadata)"}},
     });
     stream.emit(DataEvent{"help", payload.dump()});
     return 0;
@@ -106,7 +106,12 @@ export int run(int argc, char* argv[], EventStream& stream) {
             // the upgrade inherited. They are summarised to one counted line
             // by default because there are dozens of them on a real home and
             // they buried the handful that mattered.
-            if (arg == "--verbose" || arg == "-v") verbose = true;
+            //
+            // NOT `--verbose`: that one is a GLOBAL flag (cli.cppm raises the
+            // log level with it) and is STRIPPED from argv before this
+            // dispatch ever runs, so a `--verbose` here would be documented in
+            // the help text and silently do nothing.
+            if (arg == "--all") verbose = true;
         }
         return cmd_doctor(stream, fix, resetMetadata, dryRun, verbose);
     }

--- a/src/core/xself/doctor.cppm
+++ b/src/core/xself/doctor.cppm
@@ -112,7 +112,6 @@ struct Finding {
     // measured llvm, three for the measured virtualbox -- and printing each
     // one separately buries everything else.
     std::string  groupKey;
-    std::string  code;          // xvm code, for binding/subos findings
     bool         active { false };
     std::vector<std::string> subos;
     fs::path     shimPath;      // shim-layer findings only
@@ -609,7 +608,6 @@ Scan detect_(const DoctorState& st, const CoordinateProbe& probe) {
             .target  = f.target,
             .version = f.version,
             .detail  = std::move(detail),
-            .code    = f.code,
         });
     }
 
@@ -655,7 +653,6 @@ Scan detect_(const DoctorState& st, const CoordinateProbe& probe) {
             .target  = f.target,
             .version = f.version,
             .detail  = std::format("{} — {} — {}", f.summary, f.code, f.hint),
-            .code    = f.code,
         });
     }
 
@@ -1065,7 +1062,6 @@ struct Counts {
     int warnings { 0 };
     int foreignPayloads { 0 };
     int otherSubos { 0 };
-    int notices { 0 };
 
     [[nodiscard]] int issues() const {
         return missing + orphans + broken + binding;
@@ -1090,10 +1086,9 @@ Counts count_(const Scan& scan) {
             case FindingKind::AliasUnresolved:
                 if (aliasTargets.insert(f.target).second) ++c.warnings;
                 break;
-            case FindingKind::ReleaseAnchor:   ++c.notices; break;
+            case FindingKind::ReleaseAnchor:   break;
             case FindingKind::BindingState:
-                if (f.level == FindingLevel::Notice) ++c.notices;
-                else ++c.binding;
+                if (f.level != FindingLevel::Notice) ++c.binding;
                 break;
             case FindingKind::OtherSubos:      ++c.otherSubos; break;
         }

--- a/src/core/xself/doctor.cppm
+++ b/src/core/xself/doctor.cppm
@@ -563,13 +563,39 @@ Scan detect_(const DoctorState& st, const CoordinateProbe& probe) {
                                std::make_move_iterator(ownership.end()));
     }
 
+    // One line per (code, entry), not per field.
+    //
+    // A single legacy anchor carries one dangling edge per program it bound --
+    // five for each of the two gcc flavours on the measured home -- and they
+    // are one problem with one cure. Fourteen lines saying the same thing
+    // about five entries is the noise this collapse exists for; the fields are
+    // still named, on the one line.
+    std::map<std::tuple<std::string, std::string, std::string>,
+             std::vector<const xvm::BindingFinding*>> bindingGroups;
+    std::vector<std::tuple<std::string, std::string, std::string>> bindingOrder;
     for (const auto& f : bindingFindings) {
+        const auto key = std::tuple{f.code, f.target, f.version};
+        auto [it, inserted] = bindingGroups.try_emplace(key);
+        if (inserted) bindingOrder.push_back(key);
+        it->second.push_back(&f);
+    }
+    for (const auto& key : bindingOrder) {
+        const auto& group = bindingGroups.at(key);
+        const auto& f = *group.front();
         std::string detail = f.summary;
         if (!f.target.empty()) {
             detail += std::format(
                 " [{}]", xvm::display_coordinate(f.target, f.version));
         }
-        if (!f.field.empty()) detail += std::format(" at {}", f.field);
+        std::string fields;
+        for (const auto* member : group) {
+            if (member->field.empty()) continue;
+            if (!fields.empty()) fields += ", ";
+            fields += member->field;
+        }
+        if (!fields.empty()) {
+            detail += std::format(" at {}", fields);
+        }
         // The code stays in the line. It is the only greppable handle a user
         // or a bug report has on which invariant broke, and the hint alone is
         // prose.
@@ -1048,6 +1074,7 @@ struct Counts {
 
 Counts count_(const Scan& scan) {
     Counts c;
+    std::set<std::string> aliasTargets;
     for (const auto& f : scan.findings) {
         switch (f.kind) {
             case FindingKind::MissingShim:     ++c.missing; break;
@@ -1055,8 +1082,14 @@ Counts count_(const Scan& scan) {
             case FindingKind::LegacyAliasShim: ++c.orphans; break;
             case FindingKind::BrokenPayload:   ++c.broken;  break;
             case FindingKind::ForeignPayload:  ++c.foreignPayloads; break;
-            case FindingKind::ShimAnchor:
-            case FindingKind::AliasUnresolved: ++c.warnings; break;
+            case FindingKind::ShimAnchor: ++c.warnings; break;
+            // Counted per TARGET, because that is how they are printed. A
+            // count that does not match the list is the shape the old summary
+            // had -- "broken payloads 1" with nothing in the list to explain
+            // it -- and it sends people looking for a line that is not there.
+            case FindingKind::AliasUnresolved:
+                if (aliasTargets.insert(f.target).second) ++c.warnings;
+                break;
             case FindingKind::ReleaseAnchor:   ++c.notices; break;
             case FindingKind::BindingState:
                 if (f.level == FindingLevel::Notice) ++c.notices;
@@ -1261,28 +1294,19 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
         add("hint", "run `xlings self doctor --fix` to repair", true);
     }
 
+    // The nudge, for a home an older client set up. Last field of the same
+    // panel rather than a panel of its own: a second panel renders its own
+    // (empty) header, which reads as a broken frame rather than a footnote.
+    // Gated on the recorded version differing from the running one, which is
+    // what makes a successful `--fix` turn it off rather than merely quieten
+    // it.
+    if (auto hint = migration_hint(Config::recorded_client_version(),
+                                   Info::VERSION)) {
+        add("ⓘ migration", *hint);
+    }
+
     nlohmann::json payload;
     payload["title"]  = "xlings self doctor";
-    payload["fields"] = std::move(fields);
-    stream.emit(DataEvent{"info_panel", payload.dump()});
-}
-
-// The nudge, for a home an older client set up.
-//
-// Emitted as its own field after the panel is built so it survives every early
-// return, and gated on the recorded version differing from the running one --
-// which is what makes a successful `--fix` turn it off rather than merely
-// quieten it.
-void emit_migration_hint_(EventStream& stream) {
-    auto hint = migration_hint(Config::recorded_client_version(),
-                               Info::VERSION);
-    if (!hint) return;
-    nlohmann::json fields = nlohmann::json::array();
-    fields.push_back({{"label", "ⓘ migration"},
-                      {"value", *hint},
-                      {"highlight", false}});
-    nlohmann::json payload;
-    payload["title"]  = "";
     payload["fields"] = std::move(fields);
     stream.emit(DataEvent{"info_panel", payload.dump()});
 }
@@ -1363,8 +1387,7 @@ export int cmd_doctor(EventStream& stream, bool fix,
 
     if (!fix) {
         render_(scan, repair, fix, dryRun, verbose, stream);
-        emit_migration_hint_(stream);
-        return count_(scan).issues() == 0 ? 0 : 1;
+            return count_(scan).issues() == 0 ? 0 : 1;
     }
 
     const int before = count_(scan).issues();
@@ -1372,8 +1395,7 @@ export int cmd_doctor(EventStream& stream, bool fix,
     if (dryRun) {
         repair_payloads_(state, scan, probe, /*dryRun=*/true, repair);
         render_(scan, repair, fix, dryRun, verbose, stream);
-        emit_migration_hint_(stream);
-        return count_(scan).issues() == 0 ? 0 : 1;
+            return count_(scan).issues() == 0 ? 0 : 1;
     }
 
     // Re-read and re-detect between phases.
@@ -1468,7 +1490,6 @@ export int cmd_doctor(EventStream& stream, bool fix,
     if (outstanding == 0 && after.foreignPayloads == 0) {
         Config::record_client_version(std::string(Info::VERSION));
     }
-    emit_migration_hint_(stream);
 
     return (after.issues() == 0 && outstanding == 0) ? 0 : 1;
 }

--- a/src/core/xself/doctor.cppm
+++ b/src/core/xself/doctor.cppm
@@ -1242,7 +1242,7 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
         part(bindingNotices, "binding notice");
         part(subosNotices, "other-subos notice");
         if (!summary.empty()) {
-            add("ⓘ nothing to do", summary + "  —  `--verbose` to list them");
+            add("ⓘ nothing to do", summary + "  —  `--all` to list them");
         }
     }
 

--- a/src/core/xself/doctor.cppm
+++ b/src/core/xself/doctor.cppm
@@ -17,6 +17,7 @@ import xlings.core.xvm.db;
 import xlings.core.xvm.shim;
 import xlings.core.xvm.inspect;
 import xlings.core.xvm.lock;
+import xlings.core.xvm.owner;
 import xlings.core.xself.repair;
 import xlings.core.profile;
 
@@ -25,8 +26,7 @@ namespace xlings::xself {
 namespace fs = std::filesystem;
 
 // `xlings self doctor` — verify the consistency of the program-registration
-// state across xlings's state layers, and offer to repair the
-// metadata-layer drift that's safe to mend in place.
+// state across xlings's state layers, and repair what can be repaired.
 //
 // State layers:
 //   [L1 workspace]    ws[name] = "<version>"
@@ -34,491 +34,495 @@ namespace fs = std::filesystem;
 //   [L3 shim file]    <binDir>/<name>
 //   [L4 payload]      vdata.path directory + the actual executable inside it
 //
-// Checks (mixed scope is intentional, see each item):
-//   1. `missing shim` — for every program in the active workspace, its
-//      shim file at <binDir>/<name> must exist.  Scope: active versions
-//      only (workspace by definition only references the active one per
-//      name).
-//   2. `orphan shim` — for every program-typed shim under binDir, the
-//      active workspace must have a non-empty entry for that name.
-//      Scope: active.
-//   3. `broken payload` — for every (name, version) entry in the versions
-//      DB, the registered payload must resolve to an executable on disk.
-//      Scope: ALL versions (active + inactive). Reported now, not lazily,
-//      so users get a heads-up before they `xlings use` an inactive
-//      version that is actually broken.
+// The command is built as three separate phases, and the separation is load
+// bearing rather than tidiness:
+//
+//   detect()  — pure inspection, no side effects, no output
+//   repair()  — side effects only, no output
+//   render()  — output only
+//
+// `--fix` runs detect → repair → reload → **detect again** → render(second).
+// What the user reads is therefore the state of their home AFTER the repairs,
+// not before. The previous shape emitted every finding during detection and
+// then appended the repair results, so one run would report a problem and, ten
+// lines later, report having fixed it, while the summary counted the pre-fix
+// world. That is the bulk of what reads as duplicated output, and no amount of
+// wording fixes it -- only recomputing does.
+//
+// It also gets idempotence for free: on a second `--fix` the first detect is
+// already empty, so there is nothing for repair to do.
 //
 // `--fix` policy:
 //   - missing shim   → recreate from the bootstrap binary  (safe, local)
 //   - orphan shim    → remove the file                     (safe, local)
-//   - broken payload → REPAIR, via the ladder in xself/repair.cppm:
-//                      re-register (`xlings install <pkg>@<ver>`), and if
-//                      that fails, remove-then-install.
-//
-//                      This used to print the command and refuse to run it,
-//                      on the grounds that touching the network and rerunning
-//                      install hooks were the user's decision. That reasoning
-//                      does not survive contact with an upgraded home: 0.4.69
-//                      records a headers-only package as ONE program-typed
-//                      entry with a payload path and no executable inside it,
-//                      so the new client cannot tell it from a program whose
-//                      binary vanished, and reports every such package.
-//                      Measured on the upgrade simulation: 56 findings on a
-//                      home with five packages in it, each with a printed
-//                      command that was in fact the correct cure. Handing a
-//                      user 56 commands to paste is not a diagnosis.
-//
-//                      The promise that replaces "never touches the network":
-//                      `--dry-run` shows exactly what would run and stops,
-//                      each (name, version) gets at most one pass, and the
-//                      result is verified by re-detecting from a reloaded
-//                      state file rather than by trusting a subprocess's
-//                      exit code.
+//   - dangling binding edge / incoherent release / active version that is not
+//     registered → drop the reference. Never re-point it at a survivor:
+//     choosing which version was meant is the user's call.
+//   - other subos pointing at an unregistered version → the same deletions,
+//     in that subos's own state file. Metadata only; nothing is installed
+//     there and nothing is pulled into this subos.
+//   - broken payload → the ladder in xself/repair.cppm: re-register, then
+//     remove-and-reinstall, then -- when the entry is provably dead and the
+//     ladder could not revive it -- prune the registration.
 //   - alias warning  → not auto-fixed (could be intentional external).
-//   - corrupt binding metadata → --reset-metadata only.  Why: it is the one
-//                      repair that loses information (the release, its
-//                      members and its header assets are discarded and the
-//                      entry becomes a standalone version), so it must be
-//                      asked for, not inherited from --fix.
-export int cmd_doctor(EventStream& stream, bool fix,
-                      bool resetMetadata = false,
-                      bool dryRun = false) {
-    auto& p   = Config::paths();
-    auto db   = Config::versions();
-    auto ws   = Config::effective_workspace();
+//   - corrupt binding metadata → --reset-metadata only. Why: it is the one
+//     repair that loses information (the release, its members and its header
+//     assets are discarded), so it must be asked for, not inherited from
+//     --fix.
+
+// ── the finding model ────────────────────────────────────────────────
+
+enum class FindingKind {
+    MissingShim,
+    OrphanShim,
+    LegacyAliasShim,
+    ShimAnchor,
+    BrokenPayload,
+    // A broken payload belonging to a subos this run is not in. Reported,
+    // never repaired from here: repairing means installing, and installing
+    // registers into the CURRENT subos -- adopting a package the user did not
+    // ask for while they were fixing something else.
+    ForeignPayload,
+    // Not a defect: a package that registers no program of its own, so the
+    // name exists purely to anchor the release its libraries belong to.
+    ReleaseAnchor,
+    AliasUnresolved,
+    BindingState,
+    OtherSubos,
+};
+
+enum class FindingLevel {
+    Error,     // counts toward the exit code
+    Warning,   // reported, does not fail the run
+    Notice,    // informational; state that is fine, or fine-for-now
+};
+
+struct Finding {
+    FindingKind  kind  { FindingKind::BrokenPayload };
+    FindingLevel level { FindingLevel::Error };
+    std::string  target;
+    std::string  version;
+    std::string  detail;
+    // The command that repairs this, exactly as a user would type it. EMPTY
+    // when no command would help -- which is a fact worth printing, not a
+    // reason to print a plausible one. See owning_coordinate().
+    std::string  remedy;
+    // Broken payloads that share this key are one problem. A missing payload
+    // directory takes out every program registered against it -- nine for the
+    // measured llvm, three for the measured virtualbox -- and printing each
+    // one separately buries everything else.
+    std::string  groupKey;
+    std::string  code;          // xvm code, for binding/subos findings
+    bool         active { false };
+    std::vector<std::string> subos;
+    fs::path     shimPath;      // shim-layer findings only
+};
+
+struct Scan {
+    std::vector<Finding> findings;
+};
+
+// Everything detection reads. Rebuilt from disk between passes, because the
+// repairs run in subprocesses that write the state file while this process
+// holds the copy it read at startup.
+struct DoctorState {
+    xvm::VersionDB           db;
+    xvm::Workspace           ws;
+    xvm::WorkspaceInstalled  wsInstalled;
+    std::vector<xvm::SubosRef>          otherSubos;
+    std::vector<profile::SubosSnapshot> otherSnapshots;
+    fs::path                 xlingsBin;
+    std::string              homeStr;
+};
+
+#ifdef _WIN32
+constexpr std::string_view shim_ext_ = ".exe";
+#else
+constexpr std::string_view shim_ext_ = "";
+#endif
+
+std::string shim_filename_(const std::string& name) {
+    std::string fn = name;
+    if (!shim_ext_.empty() && !fn.ends_with(shim_ext_)) fn += shim_ext_;
+    return fn;
+}
+
+DoctorState load_state_() {
+    auto& p = Config::paths();
+    DoctorState st;
+    st.db          = Config::versions();
+    st.ws          = Config::effective_workspace();
+    st.wsInstalled = Config::workspace_installed();
+    st.homeStr     = p.homeDir.string();
 
     // The other subos of this home.
     //
     // Everything doctor checks above the DB layer is scoped to the subos it
     // runs in -- its binDir, its sysroot, its workspace. The versions DB and
-    // the payload store below are shared by every subos. That split is why
-    // this list is needed twice: to keep `--fix` from repairing (and thereby
-    // pulling into THIS subos) an entry that belongs to another one, and to
-    // report the state of the others rather than leave the user to guess that
-    // per-subos runs are required.
-    //
-    // Identified by directory, not by name: a project subos may be named the
-    // same as one under the home, and excluding the wrong one would make this
-    // subos audit itself as a foreigner.
-    std::vector<xvm::SubosRef> otherSubos;
-    {
-        std::error_code cec;
-        const auto here = fs::weakly_canonical(p.subosDir, cec);
-        for (auto& snapshot : profile::load_subos_snapshots(p.homeDir)) {
-            std::error_code sec;
-            if (fs::weakly_canonical(snapshot.dir, sec) == here) continue;
-            otherSubos.push_back(xvm::SubosRef{
-                .subos     = snapshot.name,
-                .active    = snapshot.workspace.active,
-                .installed = snapshot.workspace.installed,
-            });
-        }
+    // the payload store below are shared by every subos. Identified by
+    // directory, not by name: a project subos may be named the same as one
+    // under the home, and excluding the wrong one would make this subos audit
+    // itself as a foreigner.
+    std::error_code cec;
+    const auto here = fs::weakly_canonical(p.subosDir, cec);
+    for (auto& snapshot : profile::load_subos_snapshots(p.homeDir)) {
+        std::error_code sec;
+        if (fs::weakly_canonical(snapshot.dir, sec) == here) continue;
+        st.otherSubos.push_back(xvm::SubosRef{
+            .subos     = snapshot.name,
+            .active    = snapshot.workspace.active,
+            .installed = snapshot.workspace.installed,
+        });
+        st.otherSnapshots.push_back(std::move(snapshot));
     }
-    // A copy, not a reference into the config singleton: the repair pass
-    // below calls reload_state(), which reassigns the member this would
-    // otherwise be pointing at. `ws` and `db` are copies for the same reason.
-    const auto wsInstalled = Config::workspace_installed();
 
 #ifdef _WIN32
-    constexpr std::string_view shim_ext = ".exe";
-    auto xlings_bin = p.homeDir / "bin" / "xlings.exe";
+    st.xlingsBin = p.homeDir / "bin" / "xlings.exe";
 #else
-    constexpr std::string_view shim_ext = "";
-    auto xlings_bin = p.homeDir / "bin" / "xlings";
+    st.xlingsBin = p.homeDir / "bin" / "xlings";
 #endif
-    if (!fs::exists(xlings_bin)) {
-        xlings_bin = p.homeDir / "xlings";
+    if (!fs::exists(st.xlingsBin)) st.xlingsBin = p.homeDir / "xlings";
+    return st;
+}
+
+// Does this payload ship ANY executable?
+//
+// The discriminator between "a library-only package that xvm typed as a
+// program" and "a program whose binary went missing". `is_binding_root` was
+// doing that job and cannot: it skips the entry itself, so a package that is
+// the sole member of its own release comes back false and gets reported as
+// broken. Reinstalling it can never help, because nothing is wrong.
+//
+// Scanning is confined to the failure path, and shallow: the payload root and
+// bin/, which is where a recipe puts programs.
+bool payload_has_any_executable_(const fs::path& dir) {
+    auto scan = [](const fs::path& d) {
+        std::error_code ec;
+        if (!fs::is_directory(d, ec)) return false;
+        for (auto& e : platform::dir_entries(d)) {
+            std::error_code fec;
+            if (!e.is_regular_file(fec) && !e.is_symlink(fec)) continue;
+#if defined(_WIN32)
+            auto ext = e.path().extension().string();
+            if (ext == ".exe" || ext == ".bat" || ext == ".cmd") return true;
+#else
+            auto st = fs::status(e.path(), fec);
+            if (!fec && (st.permissions() & (fs::perms::owner_exec
+                                             | fs::perms::group_exec
+                                             | fs::perms::others_exec))
+                        != fs::perms::none) {
+                return true;
+            }
+#endif
+        }
+        return false;
+    };
+    return scan(dir) || scan(dir / "bin");
+}
+
+// An alias as the runtime would actually read it.
+//
+// Two things had to be stripped before the "is this an absolute path outside
+// the payload" question could be answered, and neither was:
+//   - surrounding quotes. A recipe that quotes a path containing spaces stores
+//     `"/home/…/claude.exe"`, whose first character is `"`, so is_absolute()
+//     said no and every such entry was reported as an unresolvable alias. Five
+//     of the nine warnings on the measured home were this.
+//   - ${XLINGS_HOME} / @xlings placeholders, which expand to an absolute path
+//     and until then look relative.
+std::string alias_program_(const std::string& aliasCmd,
+                           const std::string& homeStr) {
+    auto sp = aliasCmd.find(' ');
+    std::string prog = (sp == std::string::npos)
+        ? aliasCmd : aliasCmd.substr(0, sp);
+    if (prog.size() >= 2
+        && ((prog.front() == '"'  && prog.back() == '"')
+         || (prog.front() == '\'' && prog.back() == '\''))) {
+        prog = prog.substr(1, prog.size() - 2);
     }
+    return xvm::expand_path(prog, homeStr);
+}
 
-    auto shim_filename = [&](const std::string& name) {
-        std::string fn = name;
-        if (!shim_ext.empty() && !fn.ends_with(shim_ext)) fn += shim_ext;
-        return fn;
-    };
+// ── detection ────────────────────────────────────────────────────────
 
-    nlohmann::json fields = nlohmann::json::array();
-    auto add_field = [&](std::string_view label, std::string value, bool hl = false) {
-        fields.push_back({{"label", std::string(label)},
-                          {"value", std::move(value)},
-                          {"highlight", hl}});
-    };
+// Whether a package is installable under this coordinate. Injected so that
+// detection stays testable and so that the probe -- a subprocess -- can be
+// memoized across both detection passes.
+using CoordinateProbe = std::function<bool(const xvm::InstallCoordinate&)>;
 
-    int missing  = 0;
-    int orphans  = 0;
-    int broken   = 0;
-    int warnings = 0;
-    int healed   = 0;
-    // Binding-state problems are counted apart from broken payloads.
-    // They used to share `broken`, and the summary then reported
-    // "broken payloads 1" on a home whose only finding was an unregistered
-    // active version -- a count with nothing in the list to explain it, and
-    // a --fix hint claiming payloads could not be repaired when the repair
-    // pass had never run. Two different defects need two different counters.
-    int bindingIssues = 0;
+// The command that repairs a broken entry, or nothing.
+//
+// A finding names an xvm TARGET; every remedy is a PACKAGE. `xlings install
+// nm@20.1.7` cannot succeed, because no package is called `nm` -- it is a
+// program the llvm package registers. The same goes for `xim-musl-gnu-gcc`
+// (package: `musl-gcc`) and `VBoxHeadless` (package: `virtualbox`). Printing
+// twenty such commands is worse than printing none, because they get run.
+//
+// Candidates come from xvm/owner.cppm in descending order of confidence and
+// each is confirmed against the index before use. Nothing is offered on a
+// guess, and when nothing confirms, the finding says so instead of inventing
+// a command.
+std::optional<xvm::InstallCoordinate>
+owning_coordinate_(const xvm::VersionDB& db,
+                   const std::string& target,
+                   const std::string& version,
+                   const CoordinateProbe& probe) {
+    for (const auto& candidate : xvm::owner_candidates(db, target, version)) {
+        if (probe(candidate)) return candidate;
+    }
+    return std::nullopt;
+}
+
+Scan detect_(const DoctorState& st, const CoordinateProbe& probe) {
+    auto& p = Config::paths();
+    Scan scan;
+    const auto add = [&](Finding f) { scan.findings.push_back(std::move(f)); };
 
     // Check 1: every workspace program has its shim.
-    for (auto& [name, version] : ws) {
+    for (const auto& [name, version] : st.ws) {
         if (version.empty()) continue;
-        auto* vi = xvm::get_vinfo(db, name);
+        const auto* vi = xvm::get_vinfo(st.db, name);
         if (!vi || vi->type != "program") continue;
 
-        auto shim_path = p.binDir / shim_filename(name);
-        if (fs::exists(shim_path) || fs::is_symlink(shim_path)) continue;
-
-        ++missing;
-        std::string detail = std::format("workspace[{}]={} but {} missing",
-                                         name, version,
-                                         Config::display_path(shim_path));
-        if (fix && fs::exists(xlings_bin)) {
-            std::error_code ec;
-            fs::create_directories(p.binDir, ec);
-            auto r = create_shim(xlings_bin, shim_path);
-            if (r != LinkResult::Failed) {
-                ++healed;
-                detail += " — recreated";
-            } else {
-                detail += " — recreate failed";
-            }
-        }
-        add_field("✗ missing shim", std::move(detail));
+        auto shimPath = p.binDir / shim_filename_(name);
+        if (fs::exists(shimPath) || fs::is_symlink(shimPath)) continue;
+        add({
+            .kind    = FindingKind::MissingShim,
+            .level   = FindingLevel::Error,
+            .target  = name,
+            .version = version,
+            .detail  = std::format("workspace[{}]={} but {} missing",
+                                   name, version,
+                                   Config::display_path(shimPath)),
+            .shimPath = shimPath,
+        });
     }
 
-    // Check 2: orphan shims (program shim file present, workspace doesn't
-    // know about it). Only consider names that are registered as type
-    // "program" in the version DB — random files under binDir aren't ours.
+    // Check 2: orphan shims (program shim file present, workspace doesn't know
+    // about it). Only names registered as type "program" count -- random files
+    // under binDir aren't ours.
     if (fs::exists(p.binDir)) {
         for (auto& entry : platform::dir_entries(p.binDir)) {
             std::error_code ec;
             if (!entry.is_regular_file(ec) && !entry.is_symlink(ec)) continue;
             auto fname = entry.path().filename().string();
             std::string base = fname;
-            if (!shim_ext.empty() && base.ends_with(shim_ext)) {
-                base = base.substr(0, base.size() - shim_ext.size());
+            if (!shim_ext_.empty() && base.ends_with(shim_ext_)) {
+                base = base.substr(0, base.size() - shim_ext_.size());
             }
-
-            auto* vi = xvm::get_vinfo(db, base);
+            const auto* vi = xvm::get_vinfo(st.db, base);
             if (!vi || vi->type != "program") continue;
 
-            auto wit = ws.find(base);
-            bool active_present = (wit != ws.end() && !wit->second.empty());
-            if (active_present) continue;
-
-            ++orphans;
-            std::string detail = std::format(
-                "{} exists but workspace has no active version for {}",
-                Config::display_path(entry.path()), base);
-            if (fix) {
-                ec.clear();
-                fs::remove(entry.path(), ec);
-                if (!ec) {
-                    ++healed;
-                    detail += " — removed";
-                } else {
-                    detail += " — remove failed";
-                }
-            }
-            add_field("✗ orphan shim", std::move(detail));
+            auto wit = st.ws.find(base);
+            if (wit != st.ws.end() && !wit->second.empty()) continue;
+            add({
+                .kind   = FindingKind::OrphanShim,
+                .level  = FindingLevel::Error,
+                .target = base,
+                .detail = std::format(
+                    "{} exists but workspace has no active version for {}",
+                    Config::display_path(entry.path()), base),
+                .shimPath = entry.path(),
+            });
         }
     }
 
     // COMPAT(0.4.8 → drop in 0.6.0): Check 2.5 — legacy alias shims
-    // (xim/xvm/xself/xsubos/xinstall).
-    //
-    // Names + predicate are owned by xself::compat. Doctor differs from
-    // the silent cleanup helper only in that it reports each finding and
-    // gates removal on `--fix`. Both share the safety predicate so they
-    // agree on what counts as "safe to remove".
-    //
-    // When the compat module is removed, delete this entire block.
+    // (xim/xvm/xself/xsubos/xinstall). Names + predicate are owned by
+    // xself::compat. When the compat module is removed, delete this block.
     if (fs::exists(p.binDir)) {
         std::error_code bec;
-        auto canonical_bootstrap = fs::weakly_canonical(xlings_bin, bec);
+        auto canonicalBootstrap = fs::weakly_canonical(st.xlingsBin, bec);
         for (auto alias : compat::v0_4_8::LEGACY_ALIAS_NAMES) {
-            auto path = p.binDir / shim_filename(std::string(alias));
-            if (!compat::v0_4_8::is_legacy_alias_symlink_to_bootstrap(path,
-                    canonical_bootstrap)) continue;
-
-            ++orphans;
-            std::string detail = std::format(
-                "{} is a leftover symlink from older xlings (alias `{}` "
-                "removed in 0.4.8)",
-                Config::display_path(path), alias);
-            if (fix) {
-                std::error_code ec;
-                fs::remove(path, ec);
-                if (!ec) {
-                    ++healed;
-                    detail += " — removed";
-                } else {
-                    detail += " — remove failed";
-                }
-            }
-            add_field("✗ legacy alias shim", std::move(detail));
+            auto path = p.binDir / shim_filename_(std::string(alias));
+            if (!compat::v0_4_8::is_legacy_alias_symlink_to_bootstrap(
+                    path, canonicalBootstrap)) continue;
+            add({
+                .kind   = FindingKind::LegacyAliasShim,
+                .level  = FindingLevel::Error,
+                .target = std::string(alias),
+                .detail = std::format(
+                    "{} is a leftover symlink from older xlings (alias `{}` "
+                    "removed in 0.4.8)",
+                    Config::display_path(path), alias),
+                .shimPath = path,
+            });
         }
     }
 
-    // Check 2.6: shim ownership anchoring (0.4.48). Every program-typed
-    // shim under this home's binDir must anchor back to THIS home — a shim
-    // that anchors elsewhere (or nowhere) would dispatch against a foreign
-    // home's versions DB. Warning-only: the usual cause is a hand-copied
-    // shim file or a damaged home layout, and the right fix depends on
-    // which it is. Scoped to bin dirs physically inside the home: a project
-    // subos binDir lives in the project tree, where shims intentionally
-    // anchor to the global home via their symlink target (and on Windows,
-    // where hardlinks don't carry the target path, via the dispatch-time
-    // fallback chain) — not a defect.
+    // Check 2.6: shim ownership anchoring (0.4.48). Warning-only: the usual
+    // cause is a hand-copied shim file or a damaged home layout, and the right
+    // fix depends on which it is. Scoped to bin dirs physically inside the
+    // home -- a project subos binDir lives in the project tree, where shims
+    // intentionally anchor to the global home.
     // See .agents/docs/2026-06-04-shim-owner-anchoring-design.md.
     std::error_code relEc;
     auto binRel = fs::relative(p.binDir, p.homeDir, relEc);
-    bool binDirInsideHome = !relEc && !binRel.empty()
+    const bool binDirInsideHome = !relEc && !binRel.empty()
         && binRel.string().rfind("..", 0) != 0;
     if (binDirInsideHome && fs::exists(p.binDir)) {
         std::error_code hec;
-        auto home_canon = fs::weakly_canonical(p.homeDir, hec);
+        auto homeCanon = fs::weakly_canonical(p.homeDir, hec);
         for (auto& entry : platform::dir_entries(p.binDir)) {
             std::error_code ec;
             if (!entry.is_regular_file(ec) && !entry.is_symlink(ec)) continue;
             auto fname = entry.path().filename().string();
             std::string base = fname;
-            if (!shim_ext.empty() && base.ends_with(shim_ext)) {
-                base = base.substr(0, base.size() - shim_ext.size());
+            if (!shim_ext_.empty() && base.ends_with(shim_ext_)) {
+                base = base.substr(0, base.size() - shim_ext_.size());
             }
             if (xvm::is_xlings_binary(base)) continue;
-            auto* vi = xvm::get_vinfo(db, base);
+            const auto* vi = xvm::get_vinfo(st.db, base);
             if (!vi || vi->type != "program") continue;
 
             auto owner = xvm::resolve_owner_home(entry.path());
             std::error_code oec;
-            bool anchored = owner
-                && fs::weakly_canonical(*owner, oec) == home_canon;
-            if (anchored) continue;
-
-            ++warnings;
-            add_field("⚠ shim anchor", std::format(
-                "{} anchors to {} (expected this home); it will dispatch "
-                "against that home's versions DB",
-                Config::display_path(entry.path()),
-                owner ? Config::display_path(*owner)
-                      : std::string("no home (orphan)")));
+            if (owner && fs::weakly_canonical(*owner, oec) == homeCanon) {
+                continue;
+            }
+            add({
+                .kind   = FindingKind::ShimAnchor,
+                .level  = FindingLevel::Warning,
+                .target = base,
+                .detail = std::format(
+                    "{} anchors to {} (expected this home); it will dispatch "
+                    "against that home's versions DB",
+                    Config::display_path(entry.path()),
+                    owner ? Config::display_path(*owner)
+                          : std::string("no home (orphan)")),
+            });
         }
     }
 
-    // Check 3: payload existence + executability for every (name, version)
-    // in the versions DB. Reuses the same `resolve_executable` helper that
-    // shim_dispatch uses at runtime so doctor's verdict matches what the
-    // user will actually experience when they invoke the shim.
+    // Check 3: payload existence + executability for every (name, version) in
+    // the versions DB. Reuses the same `resolve_executable` helper that
+    // shim_dispatch uses at runtime, so doctor's verdict matches what the user
+    // will actually experience when they invoke the shim.
     //
     // Scope: ALL versions (active + inactive) — heads-up before users
     // `xlings use` an inactive version that's already broken.
-    //
-    // Repair policy: doctor reports broken payloads but never repairs
-    // them. Each finding is followed by a copy-pasteable remediation
-    // command. See the policy comment on cmd_doctor for the rationale.
-    auto home_str = p.homeDir.string();
-
-    // Does this payload ship ANY executable?
-    //
-    // The discriminator between "a library-only package that xvm typed as a
-    // program" and "a program whose binary went missing". `is_binding_root`
-    // was doing that job and cannot: it skips the entry itself, so a package
-    // that is the sole member of its own release -- gcc-runtime@15.1.0, found
-    // by the ten-package upgrade simulation -- comes back false and gets
-    // reported as broken. Reinstalling it can never help, because nothing is
-    // wrong; it just has no program to find. Left that way it also blocks the
-    // migration marker forever, so the hint telling the user to run --fix
-    // never turns off after they have run it.
-    //
-    // Scanning is confined to the failure path, and shallow: the payload root
-    // and bin/, which is where a recipe puts programs. A package with other
-    // executables present but this one missing is genuinely broken and still
-    // reported.
-    auto payload_has_any_executable = [](const fs::path& dir) {
-        auto scan = [](const fs::path& d) {
-            std::error_code ec;
-            if (!fs::is_directory(d, ec)) return false;
-            for (auto& e : platform::dir_entries(d)) {
-                std::error_code fec;
-                if (!e.is_regular_file(fec) && !e.is_symlink(fec)) continue;
-#if defined(_WIN32)
-                auto ext = e.path().extension().string();
-                if (ext == ".exe" || ext == ".bat" || ext == ".cmd") return true;
-#else
-                auto st = fs::status(e.path(), fec);
-                if (!fec && (st.permissions() & (fs::perms::owner_exec
-                                                 | fs::perms::group_exec
-                                                 | fs::perms::others_exec))
-                            != fs::perms::none) {
-                    return true;
-                }
-#endif
-            }
-            return false;
-        };
-        return scan(dir) || scan(dir / "bin");
-    };
-
-    // Findings the repair ladder can act on, collected during detection and
-    // acted on afterwards. Repairing inline would mutate the database that
-    // the rest of detection is still walking.
-    std::vector<RepairTask> repairTasks;
-    // Findings the repair pass owned and could not resolve. Distinct from
-    // `issues`, which also counts things --fix is not responsible for.
-    int repairFailed = 0;
-    // Broken payloads another subos owns and this one does not. Not repaired
-    // here (see below), and the gate on the migration stamp.
-    int deferredToOtherSubos = 0;
-
-    auto report_broken_payload = [&](const std::string& name,
-                                     const std::string& version,
-                                     std::string detail) {
-        // Whose entry is this?
-        //
-        // The finding is home-wide -- the loop below walks the shared DB --
-        // but the repair is not: `xlings install` re-runs config(), and
-        // config() registers into whichever subos is current. So repairing an
-        // entry that only another subos uses does two things the user did not
-        // ask for: it adds the package to THIS subos's workspace, shims and
-        // sysroot, and it does so while they were trying to fix something
-        // else.
+    const auto reportBrokenPayload =
+        [&](const std::string& name, const std::string& version,
+            const fs::path& expanded, std::string detail) {
+        // Whose entry is this? The finding is home-wide -- the loop walks the
+        // shared DB -- but the repair is not: `xlings install` re-runs
+        // config(), and config() registers into whichever subos is current.
         //
         // Unclaimed entries are still repaired here. On a home written before
         // installed[] existed, every inactive version is unclaimed, and that
         // cohort is exactly who the repair ladder was built for.
-        const auto owner = xvm::subos_ownership(ws, wsInstalled, otherSubos,
-                                                name, version);
+        const auto owner = xvm::subos_ownership(
+            st.ws, st.wsInstalled, st.otherSubos, name, version);
         if (!owner.ownedHere && !owner.otherSubos.empty()) {
-            // Not counted in `broken`, and so not in the exit code: this
-            // subos does not reference the payload, cannot repair it without
-            // adopting the package, and would otherwise stay red until the
-            // user visited another subos. It is still printed, and it still
-            // holds back the migration stamp.
-            ++deferredToOtherSubos;
-            std::string list;
-            for (const auto& other : owner.otherSubos) {
-                if (!list.empty()) list += ", ";
-                list += other;
-            }
-            add_field(std::format("✗ broken payload [subos: {}]", list),
-                      std::move(detail));
-            add_field("  → run", std::format(
-                "xlings subos use {} && xlings self doctor --fix",
-                owner.otherSubos.front()));
-            return;
-        }
-        ++broken;
-        if (fix) {
-            repairTasks.push_back(RepairTask{
-                .kind    = RepairKind::BrokenPayload,
+            add({
+                .kind    = FindingKind::ForeignPayload,
+                .level   = FindingLevel::Warning,
                 .target  = name,
                 .version = version,
-                .detail  = detail,
+                .detail  = std::move(detail),
+                .remedy  = std::format(
+                    "xlings subos use {} && xlings self doctor --fix",
+                    owner.otherSubos.front()),
+                .groupKey = std::format("{}|{}", expanded.string(), version),
+                .subos   = owner.otherSubos,
             });
+            return;
         }
-        auto wit = ws.find(name);
-        bool is_active = (wit != ws.end() && wit->second == version);
-        std::string label = is_active ? "✗ broken payload [active]"
-                                      : "✗ broken payload";
-        add_field(label, std::move(detail));
-        // Actionable remediation, exactly as the user should run it.
-        // doctor never runs this for them: install touches the network and
-        // reruns install hooks, both of which are user decisions.
-        // `xlings install <pkg>@<ver>` is sufficient on its own — the
-        // installer's xvm-DB shortcut now verifies payload existence
-        // before honoring it, so a broken-payload entry triggers a
-        // re-run of the install hook automatically.
-        add_field("  → run", std::format(
-            "xlings install {}@{}", name, version));
+        const auto wit = st.ws.find(name);
+        std::string remedy;
+        if (auto coord = owning_coordinate_(st.db, name, version, probe)) {
+            remedy = coord->install_command();
+        }
+        add({
+            .kind     = FindingKind::BrokenPayload,
+            .level    = FindingLevel::Error,
+            .target   = name,
+            .version  = version,
+            .detail   = std::move(detail),
+            .remedy   = std::move(remedy),
+            .groupKey = std::format("{}|{}", expanded.string(), version),
+            .active   = wit != st.ws.end() && wit->second == version,
+        });
     };
 
-    for (auto& [name, vinfo] : db) {
+    for (const auto& [name, vinfo] : st.db) {
         if (vinfo.type != "program") continue;
-        for (auto& [version, vdata] : vinfo.versions) {
-            if (vdata.path.empty()) continue;  // type-only stub; nothing to verify
+        for (const auto& [version, vdata] : vinfo.versions) {
+            if (vdata.path.empty()) continue;  // type-only stub
 
-            auto expanded = xvm::expand_path(vdata.path, home_str);
+            auto expanded = xvm::expand_path(vdata.path, st.homeStr);
             std::error_code ec;
 
             // L4: payload directory must exist.
             if (!fs::is_directory(expanded, ec)) {
-                report_broken_payload(name, version, std::format(
-                    "{}@{} path {} missing", name, version,
+                reportBrokenPayload(name, version, expanded, std::format(
+                    "{} path {} missing",
+                    xvm::display_coordinate(name, version),
                     Config::display_path(expanded)));
                 continue;
             }
 
-            // L5: the executable that shim_dispatch would actually exec
-            // must resolve. Branch on alias mode to mirror runtime semantics.
-            bool alias_mode = !vdata.alias.empty() && !vdata.alias[0].empty();
-            if (!alias_mode) {
-                auto exe = xvm::resolve_executable(name, vdata.path, home_str);
-                if (!exe.empty()) continue;  // OK
-
-                // A name that exists only to anchor a release is not a
-                // broken payload. Library-only packages have no program of
-                // their own, so their recipe registers the package name with
-                // no bindir purely to have something for the libraries to
-                // bind to; with `type` unset that entry defaults to
-                // "program" and then fails this check forever. On a real
-                // installation 31 entries were reported this way, and
-                // `xlings install <pkg>@<ver>` -- the hint we printed --
-                // cannot fix any of them, because nothing is wrong.
-                //
-                // Reported, but as what it is. Staying silent would hide the
-                // rarer case of a genuine program whose payload directory
-                // survived while its executable did not; that entry is also
-                // a binding root, so it lands here too and the user still
-                // sees the line.
-                if (xvm::is_binding_root(db, name, version)
-                    || !payload_has_any_executable(expanded)) {
-                    add_field("ⓘ release anchor", std::format(
-                        "{}@{} registers no program of its own; it names the "
-                        "release its libraries belong to", name, version));
+            const bool aliasMode =
+                !vdata.alias.empty() && !vdata.alias[0].empty();
+            if (!aliasMode) {
+                // L5: the executable shim_dispatch would exec must resolve.
+                if (!xvm::resolve_executable(name, vdata.path, st.homeStr)
+                         .empty()) {
                     continue;
                 }
-
-                report_broken_payload(name, version, std::format(
-                    "{}@{} executable '{}' not found in {}",
-                    name, version, name, Config::display_path(expanded)));
+                // A name that exists only to anchor a release is not a broken
+                // payload. Library-only packages have no program of their own,
+                // and with `type` unset that entry defaults to "program" and
+                // then fails this check forever.
+                if (xvm::is_binding_root(st.db, name, version)
+                    || !payload_has_any_executable_(expanded)) {
+                    add({
+                        .kind    = FindingKind::ReleaseAnchor,
+                        .level   = FindingLevel::Notice,
+                        .target  = name,
+                        .version = version,
+                        .detail  = std::format(
+                            "{} registers no program of its own; it names the "
+                            "release its libraries belong to",
+                            xvm::display_coordinate(name, version)),
+                    });
+                    continue;
+                }
+                reportBrokenPayload(name, version, expanded, std::format(
+                    "{} executable '{}' not found in {}",
+                    xvm::display_coordinate(name, version), name,
+                    Config::display_path(expanded)));
                 continue;
             }
 
-            // Alias mode: best-effort coverage. Parse the first token (the
-            // command itself); absolute-path aliases are intentionally
-            // external and skipped; relative aliases that don't resolve
-            // locally are downgraded to a warning because they MIGHT be
-            // system commands found via the runtime PATH.
+            // Alias mode: best-effort coverage. Absolute-path aliases are
+            // intentionally external and skipped; relative aliases that don't
+            // resolve locally are downgraded to a warning because they MIGHT
+            // be system commands found via the runtime PATH.
             //
-            // TODO(self-doctor): strengthen alias-mode handling. Known
-            // limitations:
-            //   - `${XLINGS_HOME}` placeholders in alias_prog aren't
-            //     expanded before is_absolute()/resolve_executable() —
-            //     rare in practice but a real coverage gap.
-            //   - only alias[0] is inspected (matches runtime today; if
-            //     multi-element fallback chains ever land they should be
-            //     covered too).
-            //   - "intentional system command" vs "misconfiguration"
-            //     can't be told apart from inside doctor — users see
-            //     warning either way. Acceptable for now since false-
-            //     positive on alias is bounded by warning severity (no
-            //     error, no exit-1, --fix doesn't touch).
-            // For now the alias branch is a permissive heuristic: when
-            // in doubt we skip rather than emit a false `broken payload`
-            // error.
-            const auto& alias_cmd = vdata.alias[0];
-            auto sp = alias_cmd.find(' ');
-            std::string alias_prog = (sp == std::string::npos)
-                ? alias_cmd : alias_cmd.substr(0, sp);
-
-            if (fs::path(alias_prog).is_absolute()) continue;
-
-            auto exe = xvm::resolve_executable(alias_prog, vdata.path, home_str);
-            if (!exe.empty()) continue;  // resolved within payload — OK
-
-            ++warnings;
-            std::string detail = std::format(
-                "{}@{} alias '{}' not resolvable in {} (may be a system command)",
-                name, version, alias_prog, Config::display_path(expanded));
-            add_field("⚠ alias unresolved", std::move(detail));
+            // TODO(self-doctor): only alias[0] is inspected (matches runtime
+            // today; if multi-element fallback chains ever land they should be
+            // covered too), and "intentional system command" vs
+            // "misconfiguration" still cannot be told apart from inside
+            // doctor. Bounded by warning severity: no error, no exit-1,
+            // --fix doesn't touch it.
+            const auto aliasProg = alias_program_(vdata.alias[0], st.homeStr);
+            if (fs::path(aliasProg).is_absolute()) continue;
+            if (!xvm::resolve_executable(aliasProg, vdata.path, st.homeStr)
+                     .empty()) {
+                continue;
+            }
+            add({
+                .kind    = FindingKind::AliasUnresolved,
+                .level   = FindingLevel::Warning,
+                .target  = name,
+                .version = version,
+                .detail  = std::format(
+                    "{} alias '{}' not resolvable in {} (may be a system "
+                    "command)",
+                    xvm::display_coordinate(name, version), aliasProg,
+                    Config::display_path(expanded)),
+            });
         }
     }
 
@@ -526,25 +530,18 @@ export int cmd_doctor(EventStream& stream, bool fix,
     //
     // Everything above looks at shims and payloads. None of it can see a
     // release whose members disagree about which release they are, or an
-    // active toolchain whose members drifted apart -- and those are exactly
-    // the states that make `xlings use` refuse. Without this, a user hitting
-    // that refusal has nowhere to look but versions.json.
-    //
-    // Read-only for now: reporting is what removes the dead end. Repair
-    // lands separately, because deactivating a group or dropping metadata
-    // is a decision the user should see spelled out before it happens.
-    auto bindingFindings = xvm::inspect_binding_state(db, ws);
+    // active toolchain whose members drifted apart -- and those are exactly the
+    // states that make `xlings use` refuse.
+    auto bindingFindings = xvm::inspect_binding_state(st.db, st.ws);
 
     // Sysroot ownership. Reported only for destinations a package declares,
     // not for the whole tree: the subos carries the host image, so listing
-    // every unmanaged entry would bury the two or three that matter under
-    // hundreds that are simply not ours to manage. Drift on a declared
-    // destination is the actionable case, and that is what this finds.
+    // every unmanaged entry would bury the two or three that matter.
     {
         std::vector<xvm::SysrootEntry> entries;
-        for (const auto& [target, version] : ws) {
-            auto infoIt = db.find(target);
-            if (infoIt == db.end()) continue;
+        for (const auto& [target, version] : st.ws) {
+            auto infoIt = st.db.find(target);
+            if (infoIt == st.db.end()) continue;
             auto dataIt = infoIt->second.versions.find(version);
             if (dataIt == infoIt->second.versions.end()) continue;
             const auto& dst = dataIt->second.fileDst;
@@ -560,490 +557,920 @@ export int cmd_doctor(EventStream& stream, bool fix,
             entries.push_back(std::move(entry));
         }
         auto ownership = xvm::inspect_sysroot_ownership(
-            db, ws, entries, (p.dataDir / "xpkgs").string());
+            st.db, st.ws, entries, (p.dataDir / "xpkgs").string());
         bindingFindings.insert(bindingFindings.end(),
                                std::make_move_iterator(ownership.begin()),
                                std::make_move_iterator(ownership.end()));
     }
 
-    for (const auto& finding : bindingFindings) {
-        const bool notice =
-            finding.severity == xvm::BindingSeverity::Notice;
-        // A notice describes state the upgrade inherited rather than
-        // created, so it does not colour the run red -- same reasoning as
-        // the release anchors above. It still prints its remediation.
-        if (!notice) ++bindingIssues;
-        std::string detail = finding.summary;
-        if (!finding.target.empty()) {
-            detail += std::format(" [{}{}{}]", finding.target,
-                                  finding.version.empty() ? "" : "@",
-                                  finding.version);
+    for (const auto& f : bindingFindings) {
+        std::string detail = f.summary;
+        if (!f.target.empty()) {
+            detail += std::format(
+                " [{}]", xvm::display_coordinate(f.target, f.version));
         }
-        if (!finding.field.empty()) {
-            detail += std::format(" at {}", finding.field);
-        }
-        detail += std::format(" — {} — {}", finding.code, finding.hint);
-        add_field(notice ? "ⓘ binding state" : "✗ binding state",
-                  std::move(detail));
+        if (!f.field.empty()) detail += std::format(" at {}", f.field);
+        // The code stays in the line. It is the only greppable handle a user
+        // or a bug report has on which invariant broke, and the hint alone is
+        // prose.
+        detail += std::format(" — {} — {}", f.code, f.hint);
+        add({
+            .kind    = FindingKind::BindingState,
+            // A notice describes state the upgrade inherited rather than
+            // created, so it does not colour the run red.
+            .level   = f.severity == xvm::BindingSeverity::Notice
+                           ? FindingLevel::Notice : FindingLevel::Error,
+            .target  = f.target,
+            .version = f.version,
+            .detail  = std::move(detail),
+            .code    = f.code,
+        });
     }
 
     // Check 5: what the OTHER subos of this home point at.
     //
-    // Reported, never counted toward the exit code. The exit code answers "is
-    // the subos I am in healthy", and it has to stay answerable: a broken
-    // pointer in another subos cannot be repaired from here (that is `xlings
-    // use` deciding what that subos should point at), so folding it in would
-    // leave every subos of the home permanently red with no command that
-    // clears it -- the shape that made the 0.4.69 migration hint nag forever.
+    // Never counted toward the exit code. The exit code answers "is the subos
+    // I am in healthy", and it has to stay answerable. Printing it is the
+    // point: before this, a subos whose active version was taken out from
+    // under it had no command that mentioned it.
+    // A remedy that cannot work is not a remedy.
     //
-    // Printing it is the point. Before this, a subos whose active version was
-    // taken out from under it had no command that mentioned it: doctor finds
-    // it when run THERE, and nothing anywhere told you to go there.
-    int otherSubosFindings = 0;
-    for (const auto& finding : xvm::inspect_subos_references(db, otherSubos)) {
-        ++otherSubosFindings;
-        add_field(finding.severity == xvm::BindingSeverity::Notice
-                      ? "ⓘ other subos" : "⚠ other subos",
-                  std::format("{} — {} — {}", finding.summary,
-                              finding.code, finding.hint));
+    // A dangling binding edge does not merely make `xlings use` refuse -- it
+    // makes registration validation refuse, so `xlings install <pkg>` fails on
+    // it too. Measured on a real home: of the three install commands the
+    // report printed, two exited 1 with `xvm-binding-validation-failed`, and
+    // only `self doctor --fix` cleared them (it prunes the edges before it
+    // runs the ladder). Printing the install anyway is how the user ends up
+    // back at the loop this whole change exists to break: run the command,
+    // watch it fail, be told to run doctor.
+    //
+    // Deliberately coarse -- ANY dangling edge redirects EVERY payload remedy.
+    // Which edge blocks which package is not decidable from here (the
+    // legacy-component walk can reach arbitrary edges), and the coarse answer
+    // is the true one: `--fix` is what repairs this home, whatever the entry.
+    const bool danglingEdges = std::ranges::any_of(
+        bindingFindings, [](const xvm::BindingFinding& f) {
+            return f.code == "xvm-legacy-edge-dangling";
+        });
+    if (danglingEdges) {
+        for (auto& f : scan.findings) {
+            if (f.kind != FindingKind::BrokenPayload || f.remedy.empty()) {
+                continue;
+            }
+            f.remedy = "xlings self doctor --fix";
+        }
     }
 
-    // --fix for the one binding problem that can be repaired without
-    // guessing: an active release whose members disagree. Deactivate the
-    // whole release and let the user re-select. Choosing a survivor here
-    // would mean deciding which member was "right", which is exactly the
-    // silent decision that produces incoherent state to begin with.
+    for (const auto& f : xvm::inspect_subos_references(st.db, st.otherSubos)) {
+        add({
+            .kind    = FindingKind::OtherSubos,
+            .level   = f.severity == xvm::BindingSeverity::Notice
+                           ? FindingLevel::Notice : FindingLevel::Warning,
+            .target  = f.target,
+            .version = f.version,
+            .detail  = std::format("{} — {} — {}", f.summary, f.code, f.hint),
+            .code    = f.code,
+        });
+    }
+
+    return scan;
+}
+
+// ── repair ───────────────────────────────────────────────────────────
+
+struct RepairReport {
+    int healed  { 0 };   // findings a repair cleared
+    int pruned  { 0 };   // dead registrations dropped
+    // Lines the repair pass wants shown regardless of what re-detection finds:
+    // what it did, and what it could not do.
+    std::vector<std::pair<std::string, std::string>> notes;
+    // (target, version) pairs the ladder tried and did not heal.
     //
-    // Unresolvable entries are reported but not touched: repairing one means
-    // deciding which member was "right". Corrupt metadata is repairable, but
-    // only by discarding it, so it takes its own flag (--reset-metadata)
-    // rather than riding along on one the user passed for shim repair.
-    if (resetMetadata) {
-        // Before the deactivation pass: an entry whose group is unreadable
-        // makes its release unresolvable, which that pass would otherwise
-        // report as a different problem.
-        if (auto reset = xvm::plan_metadata_reset(db); !reset.empty()) {
-            auto lock = xvm::acquire_state_lock(Config::paths().homeDir);
-            if (!lock) {
-                add_field("✗ binding state", std::format(
-                    "cannot reset binding metadata: {}", lock.error()));
+    // Kept as identities rather than a count because "did this repair fail"
+    // cannot be answered by re-detection alone. R3 can detach the package from
+    // THIS subos and then fail to reinstall it, which makes the finding move
+    // to another subos's ledger and disappear from this one's -- a degradation
+    // that a purely re-detected verdict reports as success. Measured by the
+    // multi-subos e2e: the run exited 0 having taken a package out and left it
+    // out.
+    std::vector<std::pair<std::string, std::string>> failedEntries;
+    // Commands `--dry-run` would have run.
+    std::vector<std::string> planned;
+};
+
+// Everything below the payload layer: shims and pure state-file edits. All of
+// it is local, none of it can fail halfway in a way the user has to unpick.
+void repair_local_(const DoctorState& st, const Scan& scan,
+                   RepairReport& out) {
+    auto& p = Config::paths();
+    const auto note = [&](std::string label, std::string text) {
+        out.notes.emplace_back(std::move(label), std::move(text));
+    };
+
+    for (const auto& f : scan.findings) {
+        if (f.kind == FindingKind::MissingShim) {
+            if (!fs::exists(st.xlingsBin)) continue;
+            std::error_code ec;
+            fs::create_directories(p.binDir, ec);
+            if (create_shim(st.xlingsBin, f.shimPath) != LinkResult::Failed) {
+                note("· shim recreated", Config::display_path(f.shimPath));
             } else {
-                Config::reload_state();
-                auto& mutableDb = Config::versions_mut();
-                const auto replanned = xvm::plan_metadata_reset(mutableDb);
-                const auto cleared =
-                    xvm::apply_metadata_reset(mutableDb, replanned);
-                if (cleared > 0) {
-                    Config::save_versions();
-                    healed += static_cast<int>(cleared);
-                    for (const auto& entry : replanned.entries) {
-                        std::string codes;
-                        for (const auto& code : entry.codes) {
-                            if (!codes.empty()) codes += ", ";
-                            codes += code;
-                        }
-                        // Name what was discarded. This is the one repair
-                        // that loses information, so a bare count would be
-                        // the wrong report.
-                        add_field("· metadata reset", std::format(
-                            "{}@{} dropped its release metadata ({}) and is "
-                            "now switchable on its own — reinstall it to "
-                            "restore the release",
-                            entry.target, entry.version, codes));
-                    }
-                    db = Config::versions();
+                note("✗ shim repair failed", std::format(
+                    "could not recreate {}",
+                    Config::display_path(f.shimPath)));
+            }
+        } else if (f.kind == FindingKind::OrphanShim
+                || f.kind == FindingKind::LegacyAliasShim) {
+            std::error_code ec;
+            fs::remove(f.shimPath, ec);
+            if (!ec) {
+                note("· shim removed", Config::display_path(f.shimPath));
+            } else {
+                note("✗ shim repair failed", std::format(
+                    "could not remove {}", Config::display_path(f.shimPath)));
+            }
+        }
+    }
+}
+
+// The three state-file repairs, in an order that matters.
+//
+// Dangling edges first: they are repairable without guessing, and leaving one
+// in place keeps the release it names unresolvable, which would make the
+// deactivation pass below see a problem that is really this one. Unregistered
+// actives next, for the same reason in reverse: an active pointer into nothing
+// makes a release look incoherent when it is merely absent.
+void repair_state_(RepairReport& out) {
+    const auto note = [&](std::string label, std::string text) {
+        out.notes.emplace_back(std::move(label), std::move(text));
+    };
+
+    auto db = Config::versions();
+    if (auto pruning = xvm::plan_dangling_edge_pruning(db); !pruning.empty()) {
+        auto lock = xvm::acquire_state_lock(Config::paths().homeDir);
+        if (!lock) {
+            note("✗ binding state", std::format(
+                "cannot drop dangling binding edges: {}", lock.error()));
+        } else {
+            Config::reload_state();
+            auto& mutableDb = Config::versions_mut();
+            const auto replanned = xvm::plan_dangling_edge_pruning(mutableDb);
+            if (xvm::apply_dangling_edge_pruning(mutableDb, replanned) > 0) {
+                Config::save_versions();
+                for (const auto& e : replanned.edges) {
+                    note("· edge dropped", std::format(
+                        "{} no longer points at unregistered {}",
+                        xvm::display_coordinate(e.target, e.version),
+                        xvm::display_coordinate(e.peerTarget, e.peerVersion)));
                 }
             }
         }
+    }
+
+    db = Config::versions();
+    auto ws = Config::effective_workspace();
+    if (auto stale = xvm::plan_unregistered_active_deactivation(db, ws);
+        !stale.empty()) {
+        auto lock = xvm::acquire_state_lock(Config::paths().homeDir);
+        if (!lock) {
+            note("✗ binding state", std::format(
+                "cannot deactivate unregistered versions: {}", lock.error()));
+        } else {
+            Config::reload_state();
+            auto& mutableWs = Config::workspace_mut();
+            std::size_t dropped = 0;
+            for (const auto& target : stale) {
+                const auto it = mutableWs.find(target);
+                if (it == mutableWs.end()) continue;
+                note("· deactivated", std::format(
+                    "{} was active at a version that is not registered — run "
+                    "`xlings use {} <version>` to select one",
+                    xvm::display_coordinate(target, it->second), target));
+                mutableWs.erase(it);
+                ++dropped;
+            }
+            if (dropped > 0) Config::save_workspace();
+        }
+    }
+
+    db = Config::versions();
+    ws = Config::effective_workspace();
+    if (auto plan = xvm::plan_incoherent_deactivation(db, ws);
+        !plan.targets.empty()) {
+        auto lock = xvm::acquire_state_lock(Config::paths().homeDir);
+        if (!lock) {
+            note("✗ binding state", std::format(
+                "cannot deactivate incoherent releases: {}", lock.error()));
+        } else {
+            Config::reload_state();
+            auto& mutableWs = Config::workspace_mut();
+            std::size_t dropped = 0;
+            for (const auto& [target, label] : plan.targets) {
+                if (mutableWs.erase(target) == 0) continue;
+                ++dropped;
+                note("· deactivated", std::format(
+                    "{} (was part of {}) — run `xlings use {} <version>` to "
+                    "select a release", target, label, target));
+            }
+            if (dropped > 0) Config::save_workspace();
+        }
+    }
+}
+
+// Other subos: the deletions doctor could already describe exactly.
+//
+// Nothing is installed and nothing is chosen. `active` entries pointing at a
+// version the shared database does not have are dropped, and `installed[]`
+// entries likewise -- both are references into nothing, and both are what the
+// report used to hand back as a list of commands for the user to run one subos
+// at a time.
+void repair_other_subos_(const DoctorState& st, RepairReport& out) {
+    auto plan = xvm::plan_subos_metadata_repair(Config::versions(),
+                                                st.otherSubos);
+    if (plan.empty()) return;
+
+    auto lock = xvm::acquire_state_lock(Config::paths().homeDir);
+    if (!lock) {
+        out.notes.emplace_back("✗ other subos", std::format(
+            "cannot repair other subos state: {}", lock.error()));
+        return;
+    }
+
+    for (const auto& entry : plan.entries) {
+        const auto snapshotIt = std::ranges::find_if(
+            st.otherSnapshots,
+            [&](const auto& s) { return s.name == entry.subos; });
+        if (snapshotIt == st.otherSnapshots.end()) continue;
+
+        // Re-read: the snapshot was taken before the repairs above ran, and
+        // one of them may have rewritten this very file.
+        auto fresh = profile::load_subos_snapshots(Config::paths().homeDir);
+        const auto freshIt = std::ranges::find_if(
+            fresh, [&](const auto& s) { return s.dir == snapshotIt->dir; });
+        if (freshIt == fresh.end()) continue;
+
+        auto workspace = freshIt->workspace;
+        const auto dropped =
+            xvm::apply_subos_metadata_repair(workspace, entry);
+        if (dropped == 0) continue;
+        if (!profile::save_subos_workspace(snapshotIt->dir, workspace)) {
+            out.notes.emplace_back("✗ other subos", std::format(
+                "could not write the state file of subos '{}'", entry.subos));
+            continue;
+        }
+        for (const auto& target : entry.deactivate) {
+            out.notes.emplace_back("· other subos repaired", std::format(
+                "{}: deactivated '{}' — it named a version that is not "
+                "registered; run `xlings subos use {}` then `xlings use {} "
+                "<version>` to choose one", entry.subos, target,
+                entry.subos, target));
+        }
+        for (const auto& [target, version] : entry.dropInstalled) {
+            out.notes.emplace_back("· other subos repaired", std::format(
+                "{}: dropped stale installed entry {}", entry.subos,
+                xvm::display_coordinate(target, version)));
+        }
+    }
+}
+
+// ── the payload ladder ───────────────────────────────────────────────
+
+void repair_payloads_(const DoctorState& st, const Scan& scan,
+                      const CoordinateProbe& probe, bool dryRun,
+                      RepairReport& out) {
+    // Collapse the findings onto their owning package: one install per
+    // release, not one per program in it. A broken llvm reports nine targets;
+    // reinstalling llvm nine times would be nine downloads for one problem.
+    std::map<xvm::InstallCoordinate, std::vector<const Finding*>> byOwner;
+    std::vector<const Finding*> unowned;
+    for (const auto& f : scan.findings) {
+        if (f.kind != FindingKind::BrokenPayload) continue;
+        if (auto coord =
+                owning_coordinate_(st.db, f.target, f.version, probe)) {
+            byOwner[*coord].push_back(&f);
+        } else {
+            unowned.push_back(&f);
+        }
+    }
+
+    if (dryRun) {
+        for (const auto& [coord, covered] : byOwner) {
+            out.planned.push_back(std::format(
+                "{}   ({} entr{})", coord.install_command(), covered.size(),
+                covered.size() == 1 ? "y" : "ies"));
+        }
+        for (const auto* f : unowned) {
+            out.planned.push_back(std::format(
+                "prune {} (no package provides it and its payload is gone)",
+                xvm::display_coordinate(f->target, f->version)));
+        }
+        return;
+    }
+
+    const CommandRunner run = [](const std::string& cmd) {
+        return platform::exec(cmd);
+    };
+
+    // Repair with the client that is running, not with whatever `xlings`
+    // resolves to on PATH. Normally the same binary; not when doctor was
+    // started by absolute path, and then the repair would be carried out by a
+    // different client than the one that decided what needed repairing.
+    RepairPolicy policy;
+    {
+        const auto self = platform::get_executable_path().string();
+        if (!self.empty() && is_shell_safe_token(self)) policy.client = self;
+    }
+
+    for (const auto& [coord, covered] : byOwner) {
+        // R3's remove exited 0 — did the records actually go? Asked of the
+        // FINDINGS the repair covers, not of the package name it ran the
+        // command with: a package name is not a key in the versions DB, so
+        // looking it up there finds nothing and reads as "removed".
+        const RemovalVerifier removalDone =
+            [&](const std::string&, const std::string&) {
+                Config::reload_state();
+                const auto current = Config::versions();
+                for (const auto* c : covered) {
+                    const auto* vi = xvm::get_vinfo(current, c->target);
+                    if (vi && vi->versions.contains(c->version)) return false;
+                }
+                return true;
+            };
+        RepairTask task{
+            .kind          = RepairKind::BrokenPayload,
+            .target        = coord.package,
+            .version       = coord.version,
+            .detail        = std::format("{} broken entr{}", covered.size(),
+                                         covered.size() == 1 ? "y" : "ies"),
+            .coordinate    = coord.canonical(),
+            .reinstallable = true,   // confirmed by the probe above
+        };
+        auto result = repair_one(task, policy, run, removalDone);
+        if (!result.healed) {
+            for (const auto* c : covered) {
+                out.failedEntries.emplace_back(c->target, c->version);
+            }
+            out.notes.emplace_back("✗ repair failed", std::format(
+                "{} — {}", coord.canonical(),
+                result.note.empty() ? "the finding it covers is still there"
+                                    : result.note));
+        }
+    }
+}
+
+// The last rung: drop a registration that is provably dead.
+//
+// Runs after the ladder and after a reload, on findings that SURVIVED it. That
+// ordering is the whole safety argument -- pruning is not a guess about
+// whether an entry could be revived, it is what is left once the attempt to
+// revive it has been made and has failed.
+//
+// Three things have to be true, and re-detection has already established the
+// first two:
+//   - the payload is gone, or present with nothing runnable in it and no
+//     release to anchor. There is nothing to lose that has not already been
+//     lost.
+//   - the repair ladder ran and the finding is still there.
+//   - nothing else in the home still resolves through it. The workspace entry
+//     and the installed[] entry go with it, in the same transaction, or the
+//     prune would trade a broken payload for a dangling pointer.
+//
+// What it buys: the eleven `repair skipped` and nine `repair failed` lines on
+// the measured home -- entries whose namespace index no longer exists, and
+// aliases a foreign platform registered -- stop coming back on every run, and
+// the migration marker can finally land.
+void prune_dead_registrations_(const DoctorState& st, const Scan& remaining,
+                               RepairReport& out) {
+    std::vector<std::pair<std::string, std::string>> victims;
+    for (const auto& f : remaining.findings) {
+        if (f.kind != FindingKind::BrokenPayload) continue;
+        // Not if another subos still claims it.
+        //
+        // A BrokenPayload finding means THIS subos claims the entry; it does
+        // not mean this subos is alone. Dropping a version another subos has
+        // active turns a broken payload over there into an active pointer at
+        // nothing over there -- trading a repairable state for a worse one, in
+        // a subos the user is not even in. Caught by the multi-subos e2e,
+        // which pruned a version `other` was still using and then exited 0.
+        const auto owner = xvm::subos_ownership(
+            st.ws, st.wsInstalled, st.otherSubos, f.target, f.version);
+        if (!owner.otherSubos.empty()) {
+            std::string list;
+            for (const auto& other : owner.otherSubos) {
+                if (!list.empty()) list += ", ";
+                list += other;
+            }
+            out.notes.emplace_back("✗ kept", std::format(
+                "{} could not be restored, but subos {} still uses it — "
+                "repair or remove it there",
+                xvm::display_coordinate(f.target, f.version), list));
+            out.failedEntries.emplace_back(f.target, f.version);
+            continue;
+        }
+        victims.emplace_back(f.target, f.version);
+    }
+    if (victims.empty()) return;
+
+    auto lock = xvm::acquire_state_lock(Config::paths().homeDir);
+    if (!lock) {
+        out.notes.emplace_back("✗ prune", std::format(
+            "cannot drop dead registrations: {}", lock.error()));
+        for (const auto& victim : victims) out.failedEntries.push_back(victim);
+        return;
+    }
+    Config::reload_state();
+    auto& db = Config::versions_mut();
+    auto& ws = Config::workspace_mut();
+    auto& installed = Config::workspace_installed_mut();
+
+    std::size_t dropped = 0;
+    for (const auto& [target, version] : victims) {
+        const auto infoIt = db.find(target);
+        if (infoIt == db.end()) continue;
+        if (infoIt->second.versions.erase(version) == 0) continue;
+        ++dropped;
+        out.notes.emplace_back("· dropped", std::format(
+            "{} — its payload is gone and nothing can restore it",
+            xvm::display_coordinate(target, version)));
+
+        if (const auto wit = ws.find(target);
+            wit != ws.end() && wit->second == version) {
+            ws.erase(wit);
+        }
+        if (const auto iit = installed.find(target); iit != installed.end()) {
+            std::erase(iit->second, version);
+            if (iit->second.empty()) installed.erase(iit);
+        }
+        // Edges into the removed version would outlive it and make every
+        // release it touched unresolvable.
+        for (auto& [_, info] : db) {
+            for (auto edgeIt = info.bindings.begin();
+                 edgeIt != info.bindings.end();) {
+                if (edgeIt->first == target) {
+                    std::erase_if(edgeIt->second, [&](const auto& edge) {
+                        return edge.second == version;
+                    });
+                }
+                if (edgeIt->second.empty()) {
+                    edgeIt = info.bindings.erase(edgeIt);
+                } else {
+                    ++edgeIt;
+                }
+            }
+        }
+        if (infoIt->second.versions.empty()) {
+            db.erase(infoIt);
+        }
+    }
+    if (dropped > 0) {
+        Config::save_versions();
+        Config::save_workspace();
+        out.pruned += static_cast<int>(dropped);
+    }
+}
+
+// ── render ───────────────────────────────────────────────────────────
+
+struct Counts {
+    int missing { 0 };
+    int orphans { 0 };
+    int broken  { 0 };
+    int binding { 0 };
+    int warnings { 0 };
+    int foreignPayloads { 0 };
+    int otherSubos { 0 };
+    int notices { 0 };
+
+    [[nodiscard]] int issues() const {
+        return missing + orphans + broken + binding;
+    }
+};
+
+Counts count_(const Scan& scan) {
+    Counts c;
+    for (const auto& f : scan.findings) {
+        switch (f.kind) {
+            case FindingKind::MissingShim:     ++c.missing; break;
+            case FindingKind::OrphanShim:
+            case FindingKind::LegacyAliasShim: ++c.orphans; break;
+            case FindingKind::BrokenPayload:   ++c.broken;  break;
+            case FindingKind::ForeignPayload:  ++c.foreignPayloads; break;
+            case FindingKind::ShimAnchor:
+            case FindingKind::AliasUnresolved: ++c.warnings; break;
+            case FindingKind::ReleaseAnchor:   ++c.notices; break;
+            case FindingKind::BindingState:
+                if (f.level == FindingLevel::Notice) ++c.notices;
+                else ++c.binding;
+                break;
+            case FindingKind::OtherSubos:      ++c.otherSubos; break;
+        }
+    }
+    return c;
+}
+
+void render_(const Scan& scan, const RepairReport& repair, bool fix,
+             bool dryRun, bool verbose, EventStream& stream) {
+    nlohmann::json fields = nlohmann::json::array();
+    const auto add = [&](std::string_view label, std::string value,
+                         bool hl = false) {
+        fields.push_back({{"label", std::string(label)},
+                          {"value", std::move(value)},
+                          {"highlight", hl}});
+    };
+
+    const auto counts = count_(scan);
+
+    // Broken payloads, one line per payload rather than one per program.
+    //
+    // A missing payload directory takes out every program registered against
+    // it. On the measured home that is nine lines for llvm and three each for
+    // two virtualbox entries -- twenty lines describing four problems, with
+    // twenty remedies of which four were distinct.
+    std::map<std::string, std::vector<const Finding*>> payloadGroups;
+    std::vector<std::string> groupOrder;
+    for (const auto& f : scan.findings) {
+        if (f.kind != FindingKind::BrokenPayload
+            && f.kind != FindingKind::ForeignPayload) continue;
+        auto [it, inserted] = payloadGroups.try_emplace(f.groupKey);
+        if (inserted) groupOrder.push_back(f.groupKey);
+        it->second.push_back(&f);
+    }
+    for (const auto& key : groupOrder) {
+        const auto& group = payloadGroups.at(key);
+        const auto* head = group.front();
+        const bool foreign = head->kind == FindingKind::ForeignPayload;
+        std::string label = foreign
+            ? std::format("✗ broken payload [subos: {}]",
+                          [&] {
+                              std::string list;
+                              for (const auto& s : head->subos) {
+                                  if (!list.empty()) list += ", ";
+                                  list += s;
+                              }
+                              return list;
+                          }())
+            : (std::ranges::any_of(group, [](const Finding* f) {
+                   return f->active;
+               }) ? std::string("✗ broken payload [active]")
+                  : std::string("✗ broken payload"));
+
+        std::string detail = head->detail;
+        if (group.size() > 1) {
+            std::string names;
+            for (const auto* f : group) {
+                if (!names.empty()) names += ", ";
+                names += f->target;
+            }
+            detail += std::format("\n    {} programs from this payload: {}",
+                                  group.size(), names);
+        }
+        add(label, std::move(detail));
+        if (!head->remedy.empty()) {
+            add("  → run", head->remedy);
+        } else {
+            // No command would help. Saying that is the useful output; a
+            // plausible-looking `xlings install <target>` is not.
+            add("  ⓘ no remedy", fix
+                ? std::string("no package provides this entry — the "
+                              "registration was dropped")
+                : std::string("no package in any index provides this entry; "
+                              "`--fix` will drop the registration"));
+        }
+    }
+
+    // Everything else, in a stable order.
+    std::set<std::string> aliasTargetsShown;
+    std::map<std::string, int> aliasVersionCount;
+    for (const auto& f : scan.findings) {
+        if (f.kind == FindingKind::AliasUnresolved) ++aliasVersionCount[f.target];
+    }
+    for (const auto& f : scan.findings) {
+        switch (f.kind) {
+            case FindingKind::MissingShim:
+                add("✗ missing shim", f.detail); break;
+            case FindingKind::OrphanShim:
+                add("✗ orphan shim", f.detail); break;
+            case FindingKind::LegacyAliasShim:
+                add("✗ legacy alias shim", f.detail); break;
+            case FindingKind::ShimAnchor:
+                add("⚠ shim anchor", f.detail); break;
+            case FindingKind::AliasUnresolved:
+                // One line per TARGET, not per version. The alias is a
+                // property of the recipe, so every version of a package
+                // registers the same one and reports the same way -- five
+                // identical `claude` lines on the measured home. Collapsing
+                // the repeats is the fix; hiding the category is not, because
+                // a genuinely missing alias binary is the only signal there
+                // is.
+                if (verbose || aliasTargetsShown.insert(f.target).second) {
+                    add("⚠ alias unresolved", verbose ? f.detail
+                        : std::format("{}{}", f.detail,
+                            aliasVersionCount.at(f.target) > 1
+                                ? std::format("  (+{} other version(s))",
+                                              aliasVersionCount.at(f.target) - 1)
+                                : std::string{}));
+                }
+                break;
+            case FindingKind::BindingState:
+                if (f.level == FindingLevel::Notice) {
+                    if (verbose) add("ⓘ binding state", f.detail);
+                } else {
+                    add("✗ binding state", f.detail);
+                }
+                break;
+            case FindingKind::OtherSubos:
+                if (verbose || f.level != FindingLevel::Notice) {
+                    add(f.level == FindingLevel::Notice ? "ⓘ other subos"
+                                                        : "⚠ other subos",
+                        f.detail);
+                }
+                break;
+            case FindingKind::ReleaseAnchor:
+                if (verbose) add("ⓘ release anchor", f.detail);
+                break;
+            default: break;
+        }
+    }
+
+    // Notices that are not defects get one counted line unless asked for.
+    // Thirty `release anchor` lines saying "nothing is wrong here" is how the
+    // four lines that matter got lost.
+    if (!verbose) {
+        int anchors = 0, bindingNotices = 0, subosNotices = 0;
+        for (const auto& f : scan.findings) {
+            if (f.kind == FindingKind::ReleaseAnchor) ++anchors;
+            else if (f.kind == FindingKind::BindingState
+                     && f.level == FindingLevel::Notice) ++bindingNotices;
+            else if (f.kind == FindingKind::OtherSubos
+                     && f.level == FindingLevel::Notice) ++subosNotices;
+        }
+        std::string summary;
+        const auto part = [&](int n, std::string_view what) {
+            if (n == 0) return;
+            if (!summary.empty()) summary += " · ";
+            summary += std::format("{} {}", n, what);
+        };
+        part(anchors, "release anchor");
+        part(bindingNotices, "binding notice");
+        part(subosNotices, "other-subos notice");
+        if (!summary.empty()) {
+            add("ⓘ nothing to do", summary + "  —  `--verbose` to list them");
+        }
+    }
+
+    for (const auto& [label, text] : repair.notes) add(label, text);
+    for (const auto& planned : repair.planned) add("→ would run", planned);
+    if (dryRun) {
+        add("dry run", std::format(
+            "{} action(s) planned; nothing was changed",
+            repair.planned.size()), true);
+    }
+
+    if (counts.issues() == 0 && counts.warnings == 0
+        && counts.foreignPayloads == 0 && counts.otherSubos == 0) {
+        add("status", "OK — workspace, shims, and payloads are all consistent",
+            true);
+    } else {
+        if (counts.missing > 0)
+            add("missing shims", std::to_string(counts.missing));
+        if (counts.orphans > 0)
+            add("orphan shims", std::to_string(counts.orphans));
+        if (counts.broken > 0)
+            add("broken payloads", std::to_string(counts.broken));
+        if (counts.binding > 0)
+            add("binding state", std::to_string(counts.binding));
+        if (counts.warnings > 0)
+            add("warnings", std::to_string(counts.warnings));
+        // Reported apart from the counts above because they are apart from the
+        // exit code: they belong to a subos this run is not in.
+        if (counts.foreignPayloads > 0)
+            add("owned by another subos", std::format(
+                "{} — repair them there", counts.foreignPayloads));
+        if (counts.otherSubos > 0)
+            add("other subos findings", std::to_string(counts.otherSubos));
     }
 
     if (fix) {
-        // Dangling pairwise edges first: they are repairable without
-        // guessing, and leaving one in place keeps the release it names
-        // unresolvable, which would make the deactivation pass below see a
-        // problem that is really this one.
-        if (auto pruning = xvm::plan_dangling_edge_pruning(db);
-            !pruning.empty()) {
-            auto lock = xvm::acquire_state_lock(Config::paths().homeDir);
-            if (!lock) {
-                add_field("✗ binding state", std::format(
-                    "cannot drop dangling binding edges: {}", lock.error()));
-            } else {
-                Config::reload_state();
-                auto& mutableDb = Config::versions_mut();
-                const auto replanned =
-                    xvm::plan_dangling_edge_pruning(mutableDb);
-                const auto dropped =
-                    xvm::apply_dangling_edge_pruning(mutableDb, replanned);
-                if (dropped > 0) {
-                    Config::save_versions();
-                    healed += static_cast<int>(dropped);
-                    for (const auto& edge : replanned.edges) {
-                        add_field("· edge dropped", std::format(
-                            "{}@{} no longer points at unregistered {}@{}",
-                            edge.target, edge.version,
-                            edge.peerTarget, edge.peerVersion));
-                    }
-                    // The database changed underneath the findings above.
-                    db = Config::versions();
-                }
-            }
-        }
-
-        auto plan = xvm::plan_incoherent_deactivation(db, ws);
-        if (!plan.targets.empty()) {
-            auto lock = xvm::acquire_state_lock(Config::paths().homeDir);
-            if (!lock) {
-                add_field("✗ binding state", std::format(
-                    "cannot deactivate incoherent releases: {}", lock.error()));
-            } else {
-                Config::reload_state();
-                auto& mutableWs = Config::workspace_mut();
-                std::size_t dropped = 0;
-                for (const auto& [target, label] : plan.targets) {
-                    if (mutableWs.erase(target) == 0) continue;
-                    ++dropped;
-                    add_field("· deactivated", std::format(
-                        "{} (was part of {}) — run `xlings use {} <version>` "
-                        "to select a release", target, label, target));
-                }
-                if (dropped > 0) {
-                    Config::save_workspace();
-                    healed += static_cast<int>(dropped);
-                }
-            }
-        }
-    }
-
-    // ------------------------------------------------------------------
-    // Repair pass.
-    //
-    // `--fix` used to stop at the shim layer and print a copy-pasteable
-    // `xlings install` for every broken payload. On a home carried over from
-    // an older client that is not a handful of lines -- 0.4.69 records a
-    // headers-only package as one program-typed entry with a payload path and
-    // no executable, so every such package is reported, and the user has to
-    // run the command by hand for each one. Measured on the upgrade
-    // simulation (PR #434): the printed remedy IS the cure, because
-    // re-running install re-runs config() and re-registers the package in the
-    // current form. Doing it for them is the whole point of --fix.
-    //
-    // See .agents/docs/2026-07-28-self-repair-design.md for the ladder.
-    if (fix && !repairTasks.empty()) {
-        const CommandRunner run = [](const std::string& cmd) {
-            return platform::exec(cmd);
-        };
-
-        // R3's remove exited 0 — did the records actually go?
-        //
-        // Asked of the FINDINGS the repair covers, not of the package name it
-        // ran the command with. Those differ: a finding names an xvm target
-        // (`ms-shared`, `gcc`, `cc`), while the ladder installs and removes a
-        // package (`xim:ms-shared`), and a package name is not a key in the
-        // versions DB. Looking the package name up there finds nothing and
-        // reads it as "removed" — the failure this check exists to prevent,
-        // reproduced by the check itself.
-        //
-        // Read back from disk: the remove ran in a subprocess, so the copy
-        // this process is holding cannot answer.
-        const auto records_gone = [&](const std::vector<RepairTask>& covered) {
-            Config::reload_state();
-            const auto current = Config::versions();
-            for (const auto& c : covered) {
-                const auto* vi = xvm::get_vinfo(current, c.target);
-                if (vi && vi->versions.contains(c.version)) return false;
-            }
-            return true;
-        };
-
-        // Repair with the client that is running, not with whatever `xlings`
-        // resolves to on PATH. Normally they are the same binary; they are
-        // not when doctor was started by absolute path, and then the repair
-        // would be carried out by a different client than the one that
-        // decided what needed repairing.
-        RepairPolicy policy;
-        {
-            const auto self = platform::get_executable_path().string();
-            if (!self.empty() && is_shell_safe_token(self)) policy.client = self;
-        }
-
-        // A finding names an xvm TARGET; the ladder installs a PACKAGE, and
-        // the two are not the same thing. A broken llvm release reports
-        // `ar@22.1.8`, `clang@22.1.8`, `cc@22.1.8` and forty more -- none of
-        // which is installable, because they are programs the llvm package
-        // registers. Nor is the binding ROOT reliably the package: gcc's root
-        // target is `xim-gnu-gcc`, and `xlings install xim-gnu-gcc` is not a
-        // thing.
-        //
-        // So the owner is looked for, in descending order of confidence, and
-        // each candidate is confirmed against the index before it is used.
-        // Nothing is repaired on a guess.
-        std::map<std::pair<std::string, std::string>, bool> probed;
-        auto resolves = [&](const std::string& name, const std::string& ver) {
-            auto key = std::pair{name, ver};
-            auto it = probed.find(key);
-            if (it != probed.end()) return it->second;
-            bool ok = probe_reinstallable(name, ver, run, policy.client);
-            probed.emplace(key, ok);
-            return ok;
-        };
-
-        auto owning_package = [&](const std::string& target,
-                                  const std::string& version)
-            -> std::optional<std::pair<std::string, std::string>> {
-            // 1. Recorded provider. Present on anything a current client
-            //    registered, and authoritative when it is.
-            if (const auto* vi = xvm::get_vinfo(db, target)) {
-                if (auto it = vi->versions.find(version);
-                    it != vi->versions.end() && it->second.bindingGroup) {
-                    const auto& g = *it->second.bindingGroup;
-                    if (resolves(g.provider, g.providerVersion)) {
-                        return std::pair{g.provider, g.providerVersion};
-                    }
-                }
-            }
-            // 2. The target itself. This is the case that matters for a
-            //    0.4.69 home: its owner-less anchor entries ARE package-named
-            //    (`llvm@20.1.7`, `linux-headers@5.11.1`, `gcc@15.1.0`).
-            if (resolves(target, version)) return std::pair{target, version};
-            // 3. A binding root reachable from here, for a member whose own
-            //    name means nothing to the index.
-            if (auto sel = xvm::resolve_binding_selection(db, target, version)) {
-                for (const auto& [m, v] : sel->members) {
-                    if (m == target) continue;
-                    if (!xvm::is_binding_root(db, m, v)) continue;
-                    if (resolves(m, v)) return std::pair{m, v};
-                }
-            }
-            return std::nullopt;
-        };
-
-        // Collapse the findings onto their owners: one install per release,
-        // not one per program in it.
-        std::map<std::pair<std::string, std::string>,
-                 std::vector<RepairTask>> byOwner;
-        std::vector<RepairTask> unowned;
-        for (auto& task : repairTasks) {
-            if (auto owner = owning_package(task.target, task.version)) {
-                byOwner[*owner].push_back(task);
-            } else {
-                unowned.push_back(task);
-            }
-        }
-
-        repairFailed += static_cast<int>(unowned.size());
-        for (const auto& task : unowned) {
-            add_field("✗ repair skipped", std::format(
-                "{}@{} — no package in the index provides this entry; "
-                "removing it could not be undone",
-                task.target, task.version));
-        }
-
-        // `--dry-run`: show the plan and stop.
-        //
-        // `--fix` used to be network-free and side-effect-free; the ladder
-        // ends that, so the promise is replaced with a narrower one rather
-        // than dropped -- you can always see exactly what it would do before
-        // it does it. The probe above has already run, so the plan shown is
-        // the plan that would execute, not a guess at one.
-        if (dryRun) {
-            for (const auto& [owner, covered] : byOwner) {
-                add_field("→ would run", std::format(
-                    "xlings install {}@{}   ({} entr{})",
-                    owner.first, owner.second, covered.size(),
-                    covered.size() == 1 ? "y" : "ies"));
-            }
-            add_field("dry run", std::format(
-                "{} package(s) would be repaired; nothing was changed",
-                byOwner.size()), true);
-            repairTasks.clear();
-            byOwner.clear();
-        }
-
-        std::vector<std::pair<RepairTask, RepairResult>> outcomes;
-        for (const auto& [owner, covered] : byOwner) {
-            RepairTask task{
-                .kind          = RepairKind::BrokenPayload,
-                .target        = owner.first,
-                .version       = owner.second,
-                .detail        = std::format("{} broken entr{}",
-                                             covered.size(),
-                                             covered.size() == 1 ? "y" : "ies"),
-                .reinstallable = true,   // confirmed by the probe above
-            };
-            const RemovalVerifier removalDone =
-                [&](const std::string&, const std::string&) {
-                    return records_gone(covered);
-                };
-            auto result = repair_one(task, policy, run, removalDone);
-            // Attribute the outcome to every finding the owner covers, so the
-            // re-detect below checks the entries the user was shown.
-            for (const auto& c : covered) outcomes.emplace_back(c, result);
-        }
-
-        // Re-detect rather than believe the ladder.
-        //
-        // A rung reporting success while the finding survives is this
-        // codebase's recurring shape, and here it would be worse than usual:
-        // `healed` feeds the exit code, so a lying rung turns a still-broken
-        // home into `status OK`. The database is reloaded from disk and each
-        // repaired entry re-checked, so "healed" means the finding is gone,
-        // not that a subprocess exited 0.
-        //
-        // reload_state() first, and not as a precaution: the repairs ran in
-        // SUBPROCESSES that wrote the state file, while this process still
-        // holds the copy it read at startup. Without the reload, a cure that
-        // is purely a re-registration -- which is what the ladder mostly does
-        // -- reads as a failure, and only repairs that happened to restore a
-        // directory on disk appear to work, because that branch stats the
-        // filesystem. Measured on a real 0.4.69 home: 55 healed and one false
-        // failure, the single entry whose cure was metadata-only.
-        Config::reload_state();
-        const auto after = Config::versions();
-        // Cured means DETECTION WOULD NO LONGER REPORT IT. Anything narrower
-        // is a second opinion about the same entry, and the two then disagree
-        // -- which is what happened: this used to ask only
-        // `resolve_executable(target)`, the non-alias branch of check 3. An
-        // alias-mode entry has no executable of its own by construction, so
-        // every one of them came back "repair failed" after a repair that had
-        // in fact worked. Measured against the real index: `patchelf`
-        // registers `elfpatch` with `alias = "patchelf"`, so removing that
-        // payload and running `--fix` restored it, printed
-        // `✗ repair failed elfpatch@0.18.0`, and exited 1 on a home where
-        // nothing was left to fix. Same shape as the release-anchor case the
-        // previous release fixed, in the branch it did not reach.
-        const auto payload_finding_cleared = [&](const xvm::VersionDB& state,
-                                                 const std::string& name,
-                                                 const std::string& version) {
-            const auto* vi = xvm::get_vinfo(state, name);
-            if (!vi) return false;   // entry gone: never a cure, see below
-            auto it = vi->versions.find(version);
-            if (it == vi->versions.end()) return false;
-            const auto& vd = it->second;
-            if (vd.path.empty()) return true;   // type-only stub, never reported
-
-            const auto expanded = xvm::expand_path(vd.path, home_str);
-            std::error_code ec;
-            if (!fs::is_directory(expanded, ec)) return false;
-
-            // Alias mode: check 3 downgrades an unresolvable alias to a
-            // warning and never calls it a broken payload, so the payload
-            // directory being back is the whole of the cure.
-            if (!vd.alias.empty() && !vd.alias[0].empty()) return true;
-
-            if (!xvm::resolve_executable(name, vd.path, home_str).empty()) {
-                return true;
-            }
-            // Re-registration can also make the entry recognisable as a
-            // release anchor -- a package that ships no program of its own
-            // was never broken. Both of check 3's exemptions, not one.
-            return xvm::is_binding_root(state, name, version)
-                || !payload_has_any_executable(expanded);
-        };
-
-        for (const auto& [task, result] : outcomes) {
-            // An entry that is gone is not cured: the only way the ladder
-            // takes one out is R3, which reports its own failure when it
-            // cannot put it back.
-            const bool cured =
-                payload_finding_cleared(after, task.target, task.version);
-
-            if (cured) {
-                ++healed;
-                // Not printed per entry: one repaired release accounts for
-                // dozens of findings, and listing them all would bury the
-                // failures. The count goes in the summary.
-            } else {
-                ++repairFailed;
-                add_field("✗ repair failed", std::format(
-                    "{}@{}{}{}", task.target, task.version,
-                    result.note.empty() ? "" : " — ", result.note));
-            }
-        }
-    }
-
-    int issues = missing + orphans + broken + bindingIssues;
-    if (issues == 0 && warnings == 0
-        && deferredToOtherSubos == 0 && otherSubosFindings == 0) {
-        add_field("status",
-                  "OK — workspace, shims, and payloads are all consistent",
-                  true);
-    } else {
-        if (missing  > 0) add_field("missing shims",   std::to_string(missing));
-        if (orphans  > 0) add_field("orphan shims",    std::to_string(orphans));
-        if (broken   > 0) add_field("broken payloads", std::to_string(broken));
-        if (bindingIssues > 0)
-            add_field("binding state", std::to_string(bindingIssues));
-        if (warnings > 0) add_field("warnings",        std::to_string(warnings));
-        // Reported apart from the counts above because they are apart from
-        // the exit code: they belong to a subos this run is not in.
-        if (deferredToOtherSubos > 0)
-            add_field("owned by another subos",
-                      std::format("{} — repair them there", deferredToOtherSubos));
-        if (otherSubosFindings > 0)
-            add_field("other subos findings",
-                      std::to_string(otherSubosFindings));
-        if (fix) {
-            if (healed > 0) add_field("healed", std::to_string(healed), true);
-            if (broken > healed) add_field("hint",
-                "some payloads could not be repaired — see the reasons above",
-                true);
-        } else {
-            if (missing > 0 || orphans > 0)
-                add_field("hint", "rerun with `--fix` to repair shim-layer issues", true);
-            if (broken > 0)
-                add_field("hint", "broken payloads: run the listed `xlings install` commands to repair", true);
-        }
-    }
-
-    // Exit non-zero only when issues remain after the (optional) fix pass.
-    int unresolved = issues - (fix ? healed : 0);
-
-    // Stamp the home with the client that just checked it.
-    //
-    // `.xlings.json:version` records which xlings set the home up. Only
-    // `self install` ever wrote it, so `self update` -- which installs
-    // xlings@latest as a package -- left it reading the old version forever.
-    // That made the field useless for the one thing it is shaped for, which
-    // is telling a user their packages predate their client.
-    //
-    // Stamped here it becomes the migration marker: the hint below appears
-    // while the home is behind and stops once a --fix has actually migrated
-    // the packages. Stamping on a failed pass would silence the hint while
-    // leaving the state it points at.
-    //
-    // Gated on the REPAIR pass, not on `unresolved`. doctor also reports
-    // things --fix is not responsible for -- on a real upgraded home,
-    // active-group incoherence across two providers that both claim `cc` and
-    // `c++` accounts for 190 findings on its own, measured. Requiring a
-    // spotless home would mean the marker never lands and the hint nags
-    // forever about a migration that already happened.
-    //
-    // `deferredToOtherSubos` is in the gate because the marker is written to
-    // the HOME config while the repair happens in one SUBOS. Without it,
-    // fixing the first subos stamps the whole home as migrated and the other
-    // subos never get the hint again -- the same failure as the nag-forever
-    // case, inverted: the promise is kept for one subos and silently dropped
-    // for the rest. Only payloads another subos owns count; a broken pointer
-    // over there is not something any `--fix` can clear, and gating on it
-    // would put the marker permanently out of reach.
-    if (fix && !dryRun && repairFailed == 0 && deferredToOtherSubos == 0) {
-        Config::record_client_version(std::string(Info::VERSION));
-    }
-
-    // The nudge, for the reader who ran plain `doctor` (or whose fix left
-    // something behind) on a home an older client set up.
-    if (auto hint = migration_hint(Config::recorded_client_version(),
-                                   Info::VERSION)) {
-        add_field("ⓘ migration", *hint);
+        if (repair.healed > 0)
+            add("healed", std::to_string(repair.healed), true);
+        if (repair.pruned > 0)
+            add("pruned", std::to_string(repair.pruned), true);
+        if (counts.issues() > 0)
+            add("hint", "some findings remain — see the reasons above", true);
+    } else if (counts.issues() > 0 || counts.otherSubos > 0) {
+        add("hint", "run `xlings self doctor --fix` to repair", true);
     }
 
     nlohmann::json payload;
     payload["title"]  = "xlings self doctor";
     payload["fields"] = std::move(fields);
     stream.emit(DataEvent{"info_panel", payload.dump()});
+}
 
-    return unresolved == 0 ? 0 : 1;
+// The nudge, for a home an older client set up.
+//
+// Emitted as its own field after the panel is built so it survives every early
+// return, and gated on the recorded version differing from the running one --
+// which is what makes a successful `--fix` turn it off rather than merely
+// quieten it.
+void emit_migration_hint_(EventStream& stream) {
+    auto hint = migration_hint(Config::recorded_client_version(),
+                               Info::VERSION);
+    if (!hint) return;
+    nlohmann::json fields = nlohmann::json::array();
+    fields.push_back({{"label", "ⓘ migration"},
+                      {"value", *hint},
+                      {"highlight", false}});
+    nlohmann::json payload;
+    payload["title"]  = "";
+    payload["fields"] = std::move(fields);
+    stream.emit(DataEvent{"info_panel", payload.dump()});
+}
+
+// ── the command ──────────────────────────────────────────────────────
+
+export int cmd_doctor(EventStream& stream, bool fix,
+                      bool resetMetadata = false,
+                      bool dryRun = false,
+                      bool verbose = false) {
+    // One probe cache for the whole command. `xlings info` is ~50ms and the
+    // same candidate is asked about once per finding it owns and again on the
+    // second detection pass.
+    std::map<std::string, bool> probed;
+    std::string client = "xlings";
+    {
+        const auto self = platform::get_executable_path().string();
+        if (!self.empty() && is_shell_safe_token(self)) client = self;
+    }
+    const CoordinateProbe probe =
+        [&](const xvm::InstallCoordinate& coord) {
+            const auto key = coord.canonical();
+            if (const auto it = probed.find(key); it != probed.end()) {
+                return it->second;
+            }
+            const bool ok = probe_coordinate(
+                key,
+                [](const std::string& cmd) { return platform::exec(cmd); },
+                client);
+            probed.emplace(key, ok);
+            return ok;
+        };
+
+    auto state = load_state_();
+
+    // --reset-metadata runs before detection: an entry whose group is
+    // unreadable makes its release unresolvable, which detection would
+    // otherwise report as a different problem. It is the one repair that loses
+    // information, which is why it has its own flag.
+    RepairReport repair;
+    if (resetMetadata) {
+        if (auto reset = xvm::plan_metadata_reset(state.db); !reset.empty()) {
+            auto lock = xvm::acquire_state_lock(Config::paths().homeDir);
+            if (!lock) {
+                repair.notes.emplace_back("✗ binding state", std::format(
+                    "cannot reset binding metadata: {}", lock.error()));
+            } else {
+                Config::reload_state();
+                auto& mutableDb = Config::versions_mut();
+                const auto replanned = xvm::plan_metadata_reset(mutableDb);
+                if (xvm::apply_metadata_reset(mutableDb, replanned) > 0) {
+                    Config::save_versions();
+                    for (const auto& entry : replanned.entries) {
+                        std::string codes;
+                        for (const auto& code : entry.codes) {
+                            if (!codes.empty()) codes += ", ";
+                            codes += code;
+                        }
+                        // Name what was discarded. This is the one repair that
+                        // loses information, so a bare count would be the
+                        // wrong report.
+                        repair.notes.emplace_back("· metadata reset",
+                            std::format(
+                                "{} dropped its release metadata ({}) and is "
+                                "now switchable on its own — reinstall it to "
+                                "restore the release",
+                                xvm::display_coordinate(entry.target,
+                                                        entry.version),
+                                codes));
+                    }
+                }
+            }
+        }
+        state = load_state_();
+    }
+
+    auto scan = detect_(state, probe);
+
+    if (!fix) {
+        render_(scan, repair, fix, dryRun, verbose, stream);
+        emit_migration_hint_(stream);
+        return count_(scan).issues() == 0 ? 0 : 1;
+    }
+
+    const int before = count_(scan).issues();
+
+    if (dryRun) {
+        repair_payloads_(state, scan, probe, /*dryRun=*/true, repair);
+        render_(scan, repair, fix, dryRun, verbose, stream);
+        emit_migration_hint_(stream);
+        return count_(scan).issues() == 0 ? 0 : 1;
+    }
+
+    // Re-read and re-detect between phases.
+    //
+    // Not a precaution: the payload repairs run in SUBPROCESSES that write the
+    // state file, while this process still holds the copy it read at startup.
+    // Without the reload, a cure that is purely a re-registration -- which is
+    // what the ladder mostly does -- reads as a failure, and only repairs that
+    // happened to restore a directory on disk appear to work.
+    const auto refresh = [&] {
+        Config::reload_state();
+        state = load_state_();
+        scan  = detect_(state, probe);
+    };
+
+    // Phase 1: the cheap metadata repairs, BEFORE the ladder.
+    //
+    // A dangling edge is not only a finding of its own -- it makes its
+    // release unresolvable, and registration validates the whole release. So
+    // an unpruned edge makes `xlings install` refuse, which is the ladder's
+    // R2 failing for a reason the ladder cannot see and R3 then reacting to by
+    // removing a working package. Clearing them first is what lets the install
+    // that follows actually succeed.
+    repair_state_(repair);
+    repair_other_subos_(state, repair);
+    repair_local_(state, scan, repair);
+    refresh();
+
+    // Phase 2: the payload ladder.
+    repair_payloads_(state, scan, probe, /*dryRun=*/false, repair);
+    refresh();
+
+    // Phase 3: the cheap repairs again, on what the ladder left behind.
+    //
+    // Re-registering a package creates state: shims for programs that are
+    // registered but not active, and a release whose members are not all
+    // active because the entry point already was. Both are things phase 1
+    // repairs -- they just did not exist yet when phase 1 ran. Measured: one
+    // llvm re-registration produced 29 orphan shims and 29 incoherent-release
+    // findings that a single-pass repair reported as unfixed.
+    repair_state_(repair);
+    repair_local_(state, scan, repair);
+    refresh();
+
+    // Phase 4: whatever is STILL a broken payload after the ladder had its
+    // turn is dead. Prune it, then re-detect once more so the report shows the
+    // result rather than the intent.
+    prune_dead_registrations_(state, scan, repair);
+    if (repair.pruned > 0) {
+        refresh();
+        // A prune can orphan a shim of its own -- the entry is gone, the file
+        // is not.
+        repair_local_(state, scan, repair);
+        refresh();
+    }
+
+    const auto after = count_(scan);
+    repair.healed = std::max(0, before - after.issues() - repair.pruned);
+
+    // A ladder failure only still counts if the entry it covered is still a
+    // finding somewhere. An entry that was pruned, or that a later phase
+    // cured, is not an outstanding failure -- but one that merely moved to
+    // another subos's ledger IS, which is why this asks the findings rather
+    // than the counters.
+    std::set<std::pair<std::string, std::string>> stillFound;
+    for (const auto& f : scan.findings) {
+        if (f.kind == FindingKind::BrokenPayload
+            || f.kind == FindingKind::ForeignPayload) {
+            stillFound.emplace(f.target, f.version);
+        }
+    }
+    int outstanding = 0;
+    for (const auto& entry : repair.failedEntries) {
+        if (stillFound.contains(entry)) ++outstanding;
+    }
+
+    render_(scan, repair, fix, dryRun, verbose, stream);
+
+    // Stamp the home with the client that just checked it.
+    //
+    // `.xlings.json:version` records which xlings set the home up. Only `self
+    // install` ever wrote it, so `self update` -- which installs xlings@latest
+    // as a package -- left it reading the old version forever. Stamped here it
+    // becomes the migration marker: the hint appears while the home is behind
+    // and stops once a --fix has actually migrated the packages.
+    //
+    // Gated on the repairs this pass OWNS, not on a spotless home. doctor also
+    // reports things --fix is not responsible for -- unresolvable aliases,
+    // shim anchoring, another subos's broken payload -- and requiring zero of
+    // those would mean the marker never lands and the hint nags forever about
+    // a migration that already happened.
+    if (outstanding == 0 && after.foreignPayloads == 0) {
+        Config::record_client_version(std::string(Info::VERSION));
+    }
+    emit_migration_hint_(stream);
+
+    return (after.issues() == 0 && outstanding == 0) ? 0 : 1;
 }
 
 } // namespace xlings::xself

--- a/src/core/xself/repair.cppm
+++ b/src/core/xself/repair.cppm
@@ -35,6 +35,17 @@ struct RepairTask {
     std::string version;
     std::string detail;
 
+    // The exact coordinate to hand to `xlings install` / `xlings remove`,
+    // when the caller has already resolved one: `[ns:]package@version`.
+    //
+    // Not derivable from target+version here, and that is the point. A finding
+    // names an xvm target and keys its version as "ns:ver"; a command names a
+    // PACKAGE and keys the namespace onto the front. Formatting "{}@{}" from a
+    // finding produces `mcpp@local:0.0.27`, which parses as a version nothing
+    // has. Resolution needs the catalog, so it happens in the caller and
+    // arrives here already settled.
+    std::string coordinate;
+
     // Whether the index can supply this package again. Filled in by the
     // caller, which owns the catalog. Gates the destructive rung: removing
     // something that cannot be reinstalled is destruction, not repair.
@@ -129,6 +140,15 @@ bool probe_reinstallable(const std::string& target,
                            client, target, version, quiet_suffix())) == 0;
 }
 
+// Same probe, for a coordinate the caller has already assembled.
+bool probe_coordinate(const std::string& coordinate,
+                      const CommandRunner& run,
+                      const std::string& client = "xlings") {
+    if (!is_shell_safe_token(coordinate)) return false;
+    return run(std::format("{} info {}{}",
+                           client, coordinate, quiet_suffix())) == 0;
+}
+
 // The one-line nudge toward `self doctor --fix`.
 //
 // The home config records which xlings set it up. When that differs from the
@@ -183,8 +203,13 @@ RepairResult repair_one(const RepairTask& task,
                         const RepairPolicy& policy,
                         const CommandRunner& run,
                         const RemovalVerifier& removalDone = nullptr) {
-    if (!is_shell_safe_token(task.target)
-        || !is_shell_safe_token(task.version)) {
+    const auto coordinate = task.coordinate.empty()
+        ? std::format("{}@{}", task.target, task.version)
+        : task.coordinate;
+    if (task.coordinate.empty()
+        ? (!is_shell_safe_token(task.target)
+           || !is_shell_safe_token(task.version))
+        : !is_shell_safe_token(task.coordinate)) {
         return {false, "none",
                 "refusing to repair: the recorded name or version contains "
                 "characters that are not safe to pass to a shell"};
@@ -194,10 +219,10 @@ RepairResult repair_one(const RepairTask& task,
                                "are disabled for this pass"};
     }
 
-    const auto install = std::format("{} install {}@{} -y",
-                                     policy.client, task.target, task.version);
-    const auto remove  = std::format("{} remove {}@{} -y",
-                                     policy.client, task.target, task.version);
+    const auto install = std::format("{} install {} -y",
+                                     policy.client, coordinate);
+    const auto remove  = std::format("{} remove {} -y",
+                                     policy.client, coordinate);
 
     // R2
     if (run(install) == 0) return {true, "re-register", {}};
@@ -216,28 +241,53 @@ RepairResult repair_one(const RepairTask& task,
         return {false, "none",
                 "re-register failed and the entry could not be removed"};
     }
-    // The command exited 0. Whether anything left is a separate question.
-    if (removalDone && !removalDone(task.target, task.version)) {
-        return {false, "none",
+    // The command exited 0. Two independent questions follow, and the order
+    // they are asked in is the whole safety property.
+    //
+    // WHETHER the install runs must not depend on the verifier. It used to,
+    // and returning early on "the records survived" performed the destructive
+    // half of remove-and-reinstall while skipping the half that puts it back.
+    // Measured on a real home, that uninstalled a working `musl-gcc`: its
+    // recipe names targets the release does not own, those are skipped, the
+    // finding's entry therefore outlived the removal, and the ladder read that
+    // as a reason not to reinstall the package it had just taken out.
+    //
+    // WHAT IS REPORTED does depend on the verifier, because "REMOVED but could
+    // not reinstall" is a claim about the user's disk. `xlings remove` exits 0
+    // when it merely detaches this subos (another subos still references the
+    // version), when the recipe names targets outside the selection, and when
+    // the payload is already gone -- in none of those was anything removed,
+    // and saying so is the message a user is most likely to act on.
+    const bool recordsSurvived =
+        removalDone && !removalDone(task.target, task.version);
+    const bool installed = run(install) == 0;
+
+    if (installed && !recordsSurvived) return {true, "reinstall", {}};
+
+    if (recordsSurvived) {
+        return {false, installed ? "reinstall" : "none",
                 std::format(
-                    "re-register failed, and `remove` exited 0 without "
-                    "dropping {}@{} — it is still registered. Removal exits 0 "
-                    "when it only detaches this subos (another subos still "
-                    "references the version) and when it declines a package "
-                    "whose payload is already gone; neither clears the record "
-                    "this repair needs cleared. Take it out where it lives "
-                    "(`xlings subos use <name>` then `xlings remove {}@{}`) "
-                    "and rerun",
-                    task.target, task.version, task.target, task.version)};
+                    "`remove` exited 0 without dropping {} — it is still "
+                    "registered{}. Removal exits 0 when it only detaches this "
+                    "subos (another subos still references the version), when "
+                    "the recipe names targets the release does not own, and "
+                    "when the payload is already gone; none of those clears "
+                    "the record this repair needs cleared. Take it out where "
+                    "it lives (`xlings subos use <name>` then `xlings remove "
+                    "{}`) and rerun",
+                    coordinate,
+                    installed ? ", and the reinstall that followed did not "
+                                "clear it either"
+                              : " and the reinstall failed too",
+                    coordinate)};
     }
-    if (run(install) != 0) {
-        // The bad outcome. Say it plainly and hand back the exact command.
-        return {false, "reinstall",
-                std::format("REMOVED but could not reinstall — run "
-                            "`xlings install {}@{}`",
-                            task.target, task.version)};
-    }
-    return {true, "reinstall", {}};
+
+    // Removed for real, and could not be put back. The one outcome that leaves
+    // the user worse off than before the repair, so it is never folded into a
+    // generic failure: name it and hand back the command that finishes the job.
+    return {false, "reinstall",
+            std::format("REMOVED but could not reinstall — run "
+                        "`xlings install {}`", coordinate)};
 }
 
 // The nudge, emitted from the commands a user actually runs.

--- a/src/core/xvm/db.cppm
+++ b/src/core/xvm/db.cppm
@@ -31,6 +31,27 @@ std::string get_namespace(const std::string& s) {
     return parse_ns_version(s).first;
 }
 
+// How a (target, version-key) pair is written for a human, and for a shell.
+//
+// The two forms are REVERSED and that is the whole reason this exists. The
+// database keys a version as "ns:ver" -- the namespace rides on the version.
+// Everything a user types keys it as "ns:target@ver" -- the namespace rides on
+// the front of the coordinate. Code that formats a finding as "{}@{}" produces
+// `mcpp@local:0.0.27`, which reads like a version called `local:0.0.27` and
+// parses as one too: `xlings install mcpp@local:0.0.27` looks up a version that
+// does not exist. Every renderer goes through here instead.
+//
+//   ("mcpp", "local:0.0.27")  -> "local:mcpp@0.0.27"
+//   ("llvm", "20.1.7")        -> "llvm@20.1.7"
+//   ("gcc",  "")              -> "gcc"
+std::string display_coordinate(std::string_view target,
+                               std::string_view versionKey) {
+    if (versionKey.empty()) return std::string(target);
+    const auto [ns, version] = parse_ns_version(std::string(versionKey));
+    if (ns.empty()) return std::format("{}@{}", target, version);
+    return std::format("{}:{}@{}", ns, target, version);
+}
+
 // Add or update a version entry in the database.
 // If ns is non-empty, the version key becomes "ns:version".
 void add_version(VersionDB& db,

--- a/src/core/xvm/inspect.cppm
+++ b/src/core/xvm/inspect.cppm
@@ -5,6 +5,7 @@ import std;
 import xlings.core.xvm.types;
 import xlings.core.xvm.bindings;
 import xlings.core.xvm.errors;
+import xlings.core.xvm.db;   // display_coordinate
 
 // Read-only inspection of the stored binding state.
 //
@@ -170,16 +171,37 @@ std::vector<BindingFinding> inspect_binding_state(
         for (const auto& [peerTarget, edges] : info.bindings) {
             auto peerIt = db.find(peerTarget);
             for (const auto& [ownVersion, peerVersion] : edges) {
-                if (!info.versions.contains(ownVersion)) continue;
-                if (peerIt != db.end()
-                    && peerIt->second.versions.contains(peerVersion)) {
-                    continue;
-                }
+                // Two ways an edge can name nothing, and both were treated
+                // very differently for no reason.
+                //
+                // The peer side was reported and repaired. The SOURCE side --
+                // an edge keyed by a version of the owner that is not itself
+                // registered -- was skipped by this loop and by the pruning
+                // plan, so it was invisible AND permanent. It is not
+                // harmless: resolve_binding_selection walks it and fails with
+                // "legacy binding source version is missing", which makes
+                // every future registration of that target refuse. Measured
+                // on a real home, `xim-musl-gnu-gcc` carries five such edges
+                // keyed at `15.1.0-musl` while only `15.1.0` is registered,
+                // and `xlings install musl-gcc@15.1.0` had been failing on it
+                // with no finding anywhere that named the cause.
+                const bool sourceMissing =
+                    !info.versions.contains(ownVersion);
+                const bool peerMissing =
+                    peerIt == db.end()
+                    || !peerIt->second.versions.contains(peerVersion);
+                if (!sourceMissing && !peerMissing) continue;
                 findings.push_back({
                     .code = "xvm-legacy-edge-dangling",
-                    .summary = std::format(
-                        "a binding edge points at '{}@{}', which is not "
-                        "registered", peerTarget, peerVersion),
+                    .summary = sourceMissing
+                        ? std::format(
+                            "a binding edge is keyed at '{}', which is not "
+                            "registered",
+                            display_coordinate(target, ownVersion))
+                        : std::format(
+                            "a binding edge points at '{}', which is not "
+                            "registered",
+                            display_coordinate(peerTarget, peerVersion)),
                     .target = target,
                     .version = ownVersion,
                     .field = std::format("/bindings/{}", peerTarget),
@@ -231,8 +253,8 @@ std::vector<BindingFinding> inspect_binding_state(
                 .target = target,
                 .version = version,
                 .hint = std::format(
-                    "run `xlings install {}@{}` to re-register them",
-                    target, version),
+                    "run `xlings install {}` to re-register them",
+                    display_coordinate(target, version)),
                 .severity = BindingSeverity::Notice,
             });
         }
@@ -380,9 +402,9 @@ std::vector<BindingFinding> inspect_subos_references(
                 .target = target,
                 .version = version,
                 .hint = std::format(
-                    "run `xlings subos use {}` then `xlings install {}@{}` to "
+                    "run `xlings subos use {}` then `xlings install {}` to "
                     "restore it, or `xlings use {} <other-version>` there",
-                    other.subos, target, version, target),
+                    other.subos, display_coordinate(target, version), target),
             });
         }
         for (const auto& [target, versions] : other.installed) {
@@ -395,13 +417,15 @@ std::vector<BindingFinding> inspect_subos_references(
                 findings.push_back({
                     .code = "xvm-subos-installed-dangling",
                     .summary = std::format(
-                        "subos '{}' lists '{}@{}' as installed, but it is not "
-                        "registered", other.subos, target, version),
+                        "subos '{}' lists '{}' as installed, but it is not "
+                        "registered", other.subos,
+                        display_coordinate(target, version)),
                     .target = target,
                     .version = version,
                     .hint = std::format(
-                        "run `xlings subos use {}` then `xlings remove {}@{}` "
-                        "to drop the stale entry", other.subos, target, version),
+                        "run `xlings subos use {}` then `xlings remove {}` "
+                        "to drop the stale entry", other.subos,
+                        display_coordinate(target, version)),
                     .severity = BindingSeverity::Notice,
                 });
             }
@@ -491,6 +515,111 @@ std::vector<BindingFinding> inspect_sysroot_ownership(
         });
     }
     return findings;
+}
+
+// What another subos's state file has to lose to stop pointing at nothing.
+//
+// Both repairs are pure deletions of a reference to a version the shared
+// database does not have, which is why they can be carried out from a subos
+// the user is not in: nothing is installed, nothing is chosen on their behalf,
+// and no package is pulled into the current subos. That boundary is the one
+// from 2026-07-28-multi-subos-repair-design.md §5 and it still holds -- what
+// changes is only that a deletion doctor could already describe exactly is now
+// performed instead of dictated.
+//
+// `deactivate` is deliberately not "re-point at some surviving version".
+// Picking one would be deciding what that subos should use, which is `xlings
+// use` deciding. An inactive target is a visible problem with a one-command
+// cure; a silently re-pointed one is a build that fails much later.
+struct SubosMetadataRepair {
+    struct Entry {
+        std::string subos;
+        // Targets to drop from `active`: they name a version nothing has.
+        std::vector<std::string> deactivate;
+        // (target, version) pairs to drop from `installed[]`: they pin a
+        // payload against a version that no longer exists.
+        std::vector<std::pair<std::string, std::string>> dropInstalled;
+    };
+    std::vector<Entry> entries;
+
+    [[nodiscard]] bool empty() const { return entries.empty(); }
+    [[nodiscard]] std::size_t size() const {
+        std::size_t n = 0;
+        for (const auto& e : entries) {
+            n += e.deactivate.size() + e.dropInstalled.size();
+        }
+        return n;
+    }
+};
+
+// Pure: returns the plan, applies nothing. Mirrors inspect_subos_references
+// one-for-one, so anything reported is repairable and anything repaired was
+// reported.
+SubosMetadataRepair plan_subos_metadata_repair(
+        const VersionDB& db,
+        const std::vector<SubosRef>& others) {
+    const auto registered = [&](const std::string& target,
+                                const std::string& version) {
+        auto it = db.find(target);
+        return it != db.end() && it->second.versions.contains(version);
+    };
+
+    SubosMetadataRepair plan;
+    for (const auto& other : others) {
+        SubosMetadataRepair::Entry entry{.subos = other.subos};
+        for (const auto& [target, version] : other.active) {
+            if (version.empty() || registered(target, version)) continue;
+            entry.deactivate.push_back(target);
+        }
+        for (const auto& [target, versions] : other.installed) {
+            for (const auto& version : versions) {
+                if (version.empty() || registered(target, version)) continue;
+                entry.dropInstalled.emplace_back(target, version);
+            }
+        }
+        if (entry.deactivate.empty() && entry.dropInstalled.empty()) continue;
+        plan.entries.push_back(std::move(entry));
+    }
+    return plan;
+}
+
+// Apply one subos's share of the plan to its own workspace maps.
+// Returns how many references were dropped.
+std::size_t apply_subos_metadata_repair(
+        SubosWorkspace& workspace,
+        const SubosMetadataRepair::Entry& entry) {
+    std::size_t dropped = 0;
+    for (const auto& target : entry.deactivate) {
+        dropped += workspace.active.erase(target);
+    }
+    for (const auto& [target, version] : entry.dropInstalled) {
+        auto it = workspace.installed.find(target);
+        if (it == workspace.installed.end()) continue;
+        const auto before = it->second.size();
+        std::erase(it->second, version);
+        dropped += before - it->second.size();
+        if (it->second.empty()) workspace.installed.erase(it);
+    }
+    return dropped;
+}
+
+// Targets whose ACTIVE version this subos no longer has registered.
+//
+// The current-subos twin of `xvm-subos-active-missing`, and the one INV-1 case
+// `--fix` never had an answer for. Same remedy for the same reason: an active
+// pointer into nothing cannot dispatch, and choosing a replacement would be
+// choosing for the user.
+std::vector<std::string> plan_unregistered_active_deactivation(
+        const VersionDB& db,
+        const Workspace& workspace) {
+    std::vector<std::string> targets;
+    for (const auto& [target, version] : workspace) {
+        if (version.empty()) continue;
+        auto it = db.find(target);
+        if (it != db.end() && it->second.versions.contains(version)) continue;
+        targets.push_back(target);
+    }
+    return targets;
 }
 
 struct DeactivationPlan {
@@ -642,11 +771,16 @@ DanglingEdgePruning plan_dangling_edge_pruning(const VersionDB& db) {
         for (const auto& [peerTarget, edges] : info.bindings) {
             auto peerIt = db.find(peerTarget);
             for (const auto& [ownVersion, peerVersion] : edges) {
-                if (!info.versions.contains(ownVersion)) continue;
-                if (peerIt != db.end()
-                    && peerIt->second.versions.contains(peerVersion)) {
-                    continue;
-                }
+                // Source side as well as peer side -- see the matching note in
+                // inspect_binding_state. Skipping the source side left an edge
+                // that no command could remove and that made every
+                // registration of its owner refuse.
+                const bool sourceMissing =
+                    !info.versions.contains(ownVersion);
+                const bool peerMissing =
+                    peerIt == db.end()
+                    || !peerIt->second.versions.contains(peerVersion);
+                if (!sourceMissing && !peerMissing) continue;
                 plan.edges.push_back({target, ownVersion,
                                       peerTarget, peerVersion});
             }

--- a/src/core/xvm/owner.cppm
+++ b/src/core/xvm/owner.cppm
@@ -85,10 +85,7 @@ coordinate_from_payload_path(std::string_view payloadPath) {
         if (parts[i] == "xpkgs") { storeIndex = i; break; }
     }
     if (storeIndex == parts.size()) return std::nullopt;
-    if (storeIndex + 2 >= parts.size() + 0) {
-        // Need at least `<store>/<version>` after it.
-        if (storeIndex + 2 > parts.size() - 1 + 1) return std::nullopt;
-    }
+    // `<store>/<version>` must both follow it; anything deeper is a bindir.
     if (parts.size() < storeIndex + 3) return std::nullopt;
 
     const auto& store   = parts[storeIndex + 1];

--- a/src/core/xvm/owner.cppm
+++ b/src/core/xvm/owner.cppm
@@ -1,0 +1,197 @@
+export module xlings.core.xvm.owner;
+
+import std;
+
+import xlings.core.xvm.types;
+import xlings.core.xvm.db;
+import xlings.core.xvm.bindings;
+
+// Which PACKAGE does a versions-DB entry belong to?
+//
+// `self doctor` finds problems in terms of xvm TARGETS -- `nm@20.1.7`,
+// `cc@15.1.0`, `VBoxHeadless@config:7.2.8`. Every remedy it can offer is in
+// terms of PACKAGES -- `xlings install llvm@20.1.7`. The two are not the same
+// thing and the gap is not cosmetic: `xlings install nm@20.1.7` is a command
+// that cannot succeed, because no package is called `nm`. Handing a user
+// twenty of those is worse than handing them nothing, because they will run
+// them.
+//
+// Pure over (db, path strings): no filesystem, no catalog, no network, so the
+// whole resolution order is reachable from unit tests. Confirming a candidate
+// against the index is the CALLER's job -- that part does need the catalog --
+// and this module deliberately produces candidates rather than answers.
+export namespace xlings::xvm {
+
+// A coordinate in the form the command line accepts: `[ns:]package@version`.
+//
+// Note where the namespace sits. The versions DB keys a version as "ns:ver";
+// the command line keys the coordinate as "ns:name@ver". Anything that formats
+// the DB key straight into a command produces `mcpp@local:0.0.27`, which is
+// not a thing. See display_coordinate in xvm/db.cppm.
+struct InstallCoordinate {
+    std::string ns;        // "" when the package is unnamespaced
+    std::string package;   // the PACKAGE name, not the xvm target
+    std::string version;   // bare version, never carries the namespace
+
+    [[nodiscard]] bool empty() const { return package.empty(); }
+
+    [[nodiscard]] std::string canonical() const {
+        if (ns.empty()) return std::format("{}@{}", package, version);
+        return std::format("{}:{}@{}", ns, package, version);
+    }
+
+    [[nodiscard]] std::string install_command() const {
+        return std::format("xlings install {}", canonical());
+    }
+
+    friend bool operator==(const InstallCoordinate&,
+                           const InstallCoordinate&) = default;
+    friend auto operator<=>(const InstallCoordinate&,
+                            const InstallCoordinate&) = default;
+};
+
+// Recover the package identity from where its payload was put.
+//
+// The store layout is written by the installer, not guessed at here:
+// `<dataDir>/xpkgs/<ns>-x-<package>/<version>[/subdir...]`, with the `-x-`
+// separator coming from `package_store_name` and the unnamespaced case being a
+// bare `<package>`. So the payload path is not evidence ABOUT the package -- it
+// is the package identity, recorded by the code that installed it.
+//
+// This is what makes the hopeless cases resolvable. `VBoxHeadless@config:7.2.8`
+// names no package anywhere, but its payload sits in `config-x-virtualbox/7.2.8`
+// and `config:virtualbox@7.2.8` installs. Likewise `xim-musl-gnu-gcc@15.1.0` ->
+// `musl-gcc@15.1.0`, and `nm@20.1.7` -> `llvm@20.1.7`.
+//
+// Separators are normalised first. A record written on Windows and read on
+// Linux carries backslashes, and that record is exactly the one nothing else
+// can identify.
+std::optional<InstallCoordinate>
+coordinate_from_payload_path(std::string_view payloadPath) {
+    if (payloadPath.empty()) return std::nullopt;
+    std::string path{payloadPath};
+    std::ranges::replace(path, '\\', '/');
+
+    std::vector<std::string> parts;
+    for (const auto piece : std::views::split(path, '/')) {
+        std::string component{piece.begin(), piece.end()};
+        if (!component.empty()) parts.push_back(std::move(component));
+    }
+
+    // Find the LAST `xpkgs` component: a home may itself live under a path
+    // containing that word, and the store is always the innermost one.
+    std::size_t storeIndex = parts.size();
+    for (std::size_t i = parts.size(); i-- > 0;) {
+        if (parts[i] == "xpkgs") { storeIndex = i; break; }
+    }
+    if (storeIndex == parts.size()) return std::nullopt;
+    if (storeIndex + 2 >= parts.size() + 0) {
+        // Need at least `<store>/<version>` after it.
+        if (storeIndex + 2 > parts.size() - 1 + 1) return std::nullopt;
+    }
+    if (parts.size() < storeIndex + 3) return std::nullopt;
+
+    const auto& store   = parts[storeIndex + 1];
+    const auto& version = parts[storeIndex + 2];
+    if (store.empty() || version.empty()) return std::nullopt;
+
+    InstallCoordinate coord;
+    coord.version = version;
+    if (const auto sep = store.find("-x-"); sep != std::string::npos) {
+        coord.ns      = store.substr(0, sep);
+        coord.package = store.substr(sep + 3);
+    } else {
+        coord.package = store;
+    }
+    if (coord.package.empty()) return std::nullopt;
+    return coord;
+}
+
+// Candidate owners for a (target, version), most trustworthy first.
+//
+// Returned as a list rather than an answer because "is this installable" can
+// only be settled against the catalog, which this module has no business
+// touching. The caller probes them in order and takes the first that resolves.
+//
+//   1. the recorded provider. Present on anything a current client wrote, and
+//      authoritative when it is.
+//   2. the payload path. Recorded by the installer; see above. Placed above the
+//      target's own name because it is the only candidate that survives a
+//      record written by another platform.
+//   3. the target itself. The 0.4.69 anchor entries ARE package-named
+//      (`llvm@20.1.7`, `linux-headers@5.11.1`).
+//   4. a binding root reachable from here, for a member whose own name means
+//      nothing to the index.
+std::vector<InstallCoordinate>
+owner_candidates(const VersionDB& db,
+                 const std::string& target,
+                 const std::string& version) {
+    std::vector<InstallCoordinate> candidates;
+    const auto push = [&](InstallCoordinate coord) {
+        if (coord.empty() || coord.version.empty()) return;
+        if (std::ranges::find(candidates, coord) != candidates.end()) return;
+        candidates.push_back(std::move(coord));
+    };
+    // A target/version pair as stored becomes a coordinate by moving the
+    // namespace from the version onto the front.
+    const auto from_entry = [](const std::string& name,
+                               const std::string& versionKey) {
+        const auto [ns, bare] = parse_ns_version(versionKey);
+        return InstallCoordinate{.ns = ns, .package = name, .version = bare};
+    };
+
+    const VData* data = nullptr;
+    if (const auto infoIt = db.find(target); infoIt != db.end()) {
+        if (const auto dataIt = infoIt->second.versions.find(version);
+            dataIt != infoIt->second.versions.end()) {
+            data = &dataIt->second;
+        }
+    }
+
+    if (data && data->bindingGroup) {
+        // `provider` is stored canonically ("xim:llvm"), so it already carries
+        // its namespace and must not be given a second one.
+        const auto& group = *data->bindingGroup;
+        const auto colon = group.provider.find(':');
+        InstallCoordinate coord;
+        if (colon == std::string::npos) {
+            coord.package = group.provider;
+        } else {
+            coord.ns      = group.provider.substr(0, colon);
+            coord.package = group.provider.substr(colon + 1);
+        }
+        coord.version = strip_namespace(group.providerVersion);
+        push(std::move(coord));
+    }
+
+    if (data) {
+        if (auto fromPath = coordinate_from_payload_path(data->path)) {
+            push(std::move(*fromPath));
+        }
+    }
+
+    push(from_entry(target, version));
+
+    if (auto selection = resolve_binding_selection(db, target, version)) {
+        for (const auto& [memberTarget, memberVersion] : selection->members) {
+            if (memberTarget == target) continue;
+            if (!is_binding_root(db, memberTarget, memberVersion)) continue;
+            push(from_entry(memberTarget, memberVersion));
+            if (const auto memberInfoIt = db.find(memberTarget);
+                memberInfoIt != db.end()) {
+                const auto memberDataIt =
+                    memberInfoIt->second.versions.find(memberVersion);
+                if (memberDataIt != memberInfoIt->second.versions.end()) {
+                    if (auto fromPath = coordinate_from_payload_path(
+                            memberDataIt->second.path)) {
+                        push(std::move(*fromPath));
+                    }
+                }
+            }
+        }
+    }
+
+    return candidates;
+}
+
+}  // namespace xlings::xvm

--- a/src/core/xvm/registration.cppm
+++ b/src/core/xvm/registration.cppm
@@ -94,12 +94,20 @@ struct RegistrationError {
     std::string message;
 };
 
+// A legacy component member this batch left behind rather than refused over.
+// See the IncompleteLegacyComponent comment in the implementation.
+struct DetachedLegacyMember {
+    std::string target;
+    std::string version;
+};
+
 std::expected<std::vector<RegisteredMember>, RegistrationError>
 apply_registration_batch(
     VersionDB& db,
     Workspace& workspace,
     WorkspaceInstalled& installed,
-    const RegistrationBatch& batch);
+    const RegistrationBatch& batch,
+    std::vector<DetachedLegacyMember>* detached = nullptr);
 
 }  // namespace xlings::xvm
 
@@ -225,6 +233,29 @@ std::string registration_path_token_(std::string_view token) {
     return escaped;
 }
 
+// Path comparison that survives a record written on another platform.
+//
+// Not a filesystem question: `db` holds whatever string the client that wrote
+// it produced, and a home carried over from Windows holds
+// `C:\…` / `/home/you/.xlings\data\xpkgs\…` on a machine where those separators
+// mean nothing. Normalising to '/' is what lets a Linux client recognise the
+// record as its own.
+std::string normalized_payload_path_(std::string_view path) {
+    std::string out{path};
+    std::ranges::replace(out, '\\', '/');
+    while (out.size() > 1 && out.back() == '/') out.pop_back();
+    return out;
+}
+
+// Is `candidate` the same payload as `root`, or something inside it?
+bool payload_path_covers_(std::string_view root, std::string_view candidate) {
+    if (root.empty() || candidate.empty()) return false;
+    if (candidate == root) return true;
+    return candidate.size() > root.size()
+        && candidate.starts_with(root)
+        && candidate[root.size()] == '/';
+}
+
 void erase_exact_registration_edges_(
     VersionDB& db,
     const std::set<RegistrationExactKey>& exactNodes) {
@@ -261,7 +292,8 @@ apply_registration_batch(
     VersionDB& db,
     Workspace& workspace,
     WorkspaceInstalled& installed,
-    const RegistrationBatch& batch) {
+    const RegistrationBatch& batch,
+    std::vector<DetachedLegacyMember>* detached) {
     if (batch.provider.empty()) {
         return std::unexpected(detail_::registration_error_(
             RegistrationErrorKind::InvalidBatchIdentity,
@@ -770,6 +802,64 @@ apply_registration_batch(
         for (const auto& [target, version] : selection->members) {
             if (nodeIndexes.contains(
                     detail_::RegistrationExactKey{target, version})) {
+                continue;
+            }
+            // The batch does not cover the whole legacy component.
+            //
+            // Refusing outright is right when the missing member could belong
+            // to somebody else. It is wrong when the member is plainly this
+            // package's own leftover, and then it is a trap: the component was
+            // recorded by a client on ANOTHER PLATFORM, which registered names
+            // this platform's recipe never produces. Measured on a real home,
+            // an llvm@20.1.7 registered on Windows leaves `cl`, `lib`, `link`
+            // and `rc` bound to it; on Linux the recipe emits no such nodes, so
+            // every install refused -- and `remove` refused too, for its own
+            // reasons, so nothing could move.
+            //
+            // Three conditions make the member safe to detach instead:
+            //   1. it is OWNER-LESS. Nothing claims it, so no provider's
+            //      selection is being rewritten behind its back.
+            //   2. its payload lies inside a payload this batch is
+            //      registering. That is the evidence it belongs to this
+            //      package rather than merely resembling it.
+            //
+            // Being ACTIVE is deliberately NOT a third condition. It was one at
+            // first, and it turned out to veto exactly the case this exists
+            // for: on the measured home `cl`, `lib`, `link` and `rc` are all
+            // active, so the refusal survived the fix. It also protects
+            // nothing. Detaching does not deregister the entry and does not
+            // deactivate it -- the shim still dispatches to the same place. All
+            // that changes is that the entry stops claiming membership in a
+            // release that no longer registers it, which is simply true.
+            //
+            // Detach, not delete: the entry stays in the database, only its
+            // edges to this batch go (erase_exact_registration_edges_ below
+            // drops them, since the peer side IS in the batch). What is left
+            // is a standalone owner-less record with a payload that does not
+            // resolve -- which `self doctor` already knows how to see and, at
+            // the end of its ladder, to prune. Deleting it here would make a
+            // registration silently destroy state on behalf of a repair that
+            // has its own preview and its own reporting.
+            const VData* memberData = nullptr;
+            if (const auto memberInfoIt = db.find(target);
+                memberInfoIt != db.end()) {
+                const auto memberDataIt =
+                    memberInfoIt->second.versions.find(version);
+                if (memberDataIt != memberInfoIt->second.versions.end()) {
+                    memberData = &memberDataIt->second;
+                }
+            }
+            const bool ownerLess = memberData && !memberData->bindingGroup;
+            const auto memberPath = memberData
+                ? detail_::normalized_payload_path_(memberData->path)
+                : std::string{};
+            const bool insideBatchPayload = !memberPath.empty()
+                && std::ranges::any_of(batch.nodes, [&](const auto& n) {
+                    return detail_::payload_path_covers_(
+                        detail_::normalized_payload_path_(n.path), memberPath);
+                });
+            if (ownerLess && insideBatchPayload) {
+                if (detached) detached->push_back({target, version});
                 continue;
             }
             return std::unexpected(detail_::registration_error_(

--- a/src/core/xvm/removal.cppm
+++ b/src/core/xvm/removal.cppm
@@ -208,13 +208,34 @@ apply_removal_batch(VersionDB& db,
         if (context.hasSelection) {
             auto memberIt = context.members.find(operation.name);
             if (memberIt == context.members.end()) {
-                return std::unexpected(RemovalError{
-                    .kind = RemovalErrorKind::SelectionInvalid,
-                    .target = operation.name,
-                    .version = operation.version,
-                    .message =
-                        "recipe removal target is outside the owned selection",
-                });
+                // A name this release does not own is skipped, not fatal.
+                //
+                // Recipes name their removal targets unconditionally, from a
+                // static list or from whatever the payload happens to contain,
+                // and neither has to match what this platform registered.
+                // Measured on a real home: a Windows llvm payload under Linux
+                // makes `uninstall()` ask for `clang++.exe` (never registered
+                // here) and for `cc` (registered, but by gcc). Refusing either
+                // aborted the whole batch, so the package could not be removed
+                // at all -- and the install side was refusing the same records
+                // for its own reasons, which left no command that got the user
+                // out.
+                //
+                // Skipping protects strictly more than refusing did. The
+                // selection is already the authority on what may be deleted:
+                // had the release actually owned this name, it would be IN the
+                // selection and removed below. So there is no entry that
+                // refusing saved and skipping loses -- refusing only turned
+                // "one op does nothing" into "nothing happens at all".
+                //
+                // Said out loud: a recipe naming something it does not own is
+                // worth knowing about, it is just not worth stopping for.
+                if (db.contains(operation.name)) {
+                    log::warn("[xvm] recipe asked to remove '{}', which this "
+                              "release does not own — skipped",
+                              operation.name);
+                }
+                continue;
             }
             auto selectedVersion = resolve_exact_version_key(
                 db, operation.name, memberIt->second);

--- a/tests/e2e/self_doctor_multi_subos_test.sh
+++ b/tests/e2e/self_doctor_multi_subos_test.sh
@@ -254,7 +254,7 @@ rm -rf "$PAYLOAD_SHARED"
 : > "$FAIL_MARKER"
 
 run_capture default self doctor --fix
-[[ $rc -ne 0 ]] || fail "S6: the repair could not succeed, so doctor must not exit 0"
+[[ $rc -ne 0 ]] || fail "S6: the repair could not succeed, so doctor must not exit 0; got:\n$out"
 grep -q "REMOVED" <<<"$out" \
   && fail "S6: reported a removal that did not happen; got:\n$out"
 grep -q "still registered" <<<"$out" \

--- a/tests/e2e/self_doctor_test.sh
+++ b/tests/e2e/self_doctor_test.sh
@@ -194,7 +194,10 @@ echo "$out" | grep -q "broken payload" \
   || fail "S7: output should mention 'broken payload'; got:\n$out"
 echo "$out" | grep -q "active" \
   || fail "S7: output should mark active version with [active] tag"
-echo "$out" | grep -q "xlings install doctor-fixture@1.0.0" \
+# The remedy names the PACKAGE, with its namespace, because that is what
+# `xlings install` takes -- a finding names an xvm target and those are not the
+# same thing (`nm@20.1.7` is a program llvm registers, not a package).
+echo "$out" | grep -qE "xlings install (xim:)?doctor-fixture@1\.0\.0" \
   || fail "S7: output should include the remediation command; got:\n$out"
 
 # ── S8: --fix --dry-run previews the repair and changes NOTHING ──────

--- a/tests/unit/test_self_repair.cpp
+++ b/tests/unit/test_self_repair.cpp
@@ -148,21 +148,54 @@ TEST(SelfRepairLadder, ALocalOnlyPassRunsNothing) {
 // true, made in the one message they are most likely to act on.
 
 TEST(SelfRepairLadder, DoesNotClaimRemovalWhenTheRecordSurvives) {
-    FakeRunner f{.codes = {1, 0}};      // install fails, remove "succeeds"
+    FakeRunner f{.codes = {1, 0, 0}};   // install fails, remove 0, reinstall 0
     auto r = repair_one(task(), RepairPolicy{}, runner_of(f),
                         [](const std::string&, const std::string&) {
                             return false;   // still registered
                         });
 
     EXPECT_FALSE(r.healed);
-    EXPECT_EQ(r.rung, "none") << "nothing was removed, so no rung did damage";
     EXPECT_EQ(r.note.find("REMOVED"), std::string::npos)
         << "must not claim a removal that did not happen: " << r.note;
     EXPECT_NE(r.note.find("still registered"), std::string::npos);
     EXPECT_NE(r.note.find("another subos"), std::string::npos);
-    // No second install: it would fail against the record that is still there.
-    ASSERT_EQ(f.ran.size(), 2u);
+}
+
+// A remove that exited 0 must ALWAYS be followed by the install, whatever the
+// verifier says.
+//
+// The verifier used to short-circuit here, and that made the ladder perform
+// the destructive half of remove-and-reinstall and skip the half that puts it
+// back. On a real home it uninstalled a working `musl-gcc`: the recipe names
+// targets the release does not own, those are skipped, so the finding's entry
+// outlived the removal -- and the ladder read "records survived" as a reason
+// not to reinstall the package it had just taken out.
+TEST(SelfRepairLadder, ReinstallsEvenWhenTheRecordSurvivedRemoval) {
+    FakeRunner f{.codes = {1, 0, 0}};
+    auto r = repair_one(task(), RepairPolicy{}, runner_of(f),
+                        [](const std::string&, const std::string&) {
+                            return false;   // still registered
+                        });
+
+    ASSERT_EQ(f.ran.size(), 3u) << "the package was removed and left out";
     EXPECT_EQ(f.ran[1], "xlings remove linux-headers@5.11.1 -y");
+    EXPECT_EQ(f.ran[2], "xlings install linux-headers@5.11.1 -y");
+    EXPECT_EQ(r.rung, "reinstall");
+}
+
+// ...and when that reinstall fails, the message is the one that says the user
+// is now worse off, not the survivor diagnosis.
+TEST(SelfRepairLadder, ReportsRemovedWhenTheFollowUpInstallFails) {
+    FakeRunner f{.codes = {1, 0, 1}};
+    auto r = repair_one(task(), RepairPolicy{}, runner_of(f),
+                        [](const std::string&, const std::string&) {
+                            return true;
+                        });
+
+    EXPECT_FALSE(r.healed);
+    EXPECT_EQ(r.rung, "reinstall");
+    EXPECT_NE(r.note.find("REMOVED but could not reinstall"),
+              std::string::npos) << r.note;
 }
 
 TEST(SelfRepairLadder, ProceedsWhenTheVerifierConfirmsTheRemoval) {

--- a/tests/unit/test_xvm_bindings.cpp
+++ b/tests/unit/test_xvm_bindings.cpp
@@ -211,6 +211,40 @@ TEST(XvmDbTest, AddAndRemoveVersion) {
     EXPECT_FALSE(xlings::xvm::has_target(db, "gcc"));
 }
 
+// The version key and the command-line coordinate put the namespace on
+// OPPOSITE sides, and every renderer used to format the key form. `xlings
+// install mcpp@local:0.0.27` is not a typo the user can fix -- it parses as a
+// version named `local:0.0.27`, which no package has.
+TEST(XvmDbTest, DisplayCoordinatePutsTheNamespaceInFront) {
+    EXPECT_EQ(xlings::xvm::display_coordinate("mcpp", "local:0.0.27"),
+              "local:mcpp@0.0.27");
+    EXPECT_EQ(xlings::xvm::display_coordinate("VBoxHeadless", "config:7.2.8"),
+              "config:VBoxHeadless@7.2.8");
+    EXPECT_EQ(xlings::xvm::display_coordinate("llvm", "20.1.7"),
+              "llvm@20.1.7");
+    EXPECT_EQ(xlings::xvm::display_coordinate("gcc", ""), "gcc");
+}
+
+// The rendered form has to be the form the catalog accepts, or the printed
+// remedy is a string that only looks like a command.
+TEST(XvmDbTest, DisplayCoordinateRoundTripsThroughTheCatalogParser) {
+    struct Case { const char* target; const char* versionKey;
+                  const char* ns; const char* version; };
+    const Case cases[] = {
+        {"mcpp", "local:0.0.27", "local", "0.0.27"},
+        {"freetype", "fromsource:2.13.2", "fromsource", "2.13.2"},
+        {"llvm", "20.1.7", "", "20.1.7"},
+    };
+    for (const auto& c : cases) {
+        const auto rendered =
+            xlings::xvm::display_coordinate(c.target, c.versionKey);
+        const auto parsed = xlings::xim::parse_package_target(rendered);
+        EXPECT_EQ(parsed.namespaceName, c.ns) << rendered;
+        EXPECT_EQ(parsed.name, c.target) << rendered;
+        EXPECT_EQ(parsed.version, c.version) << rendered;
+    }
+}
+
 TEST(XvmDbTest, FuzzyVersionMatch) {
     xlings::xvm::VersionDB db;
     xlings::xvm::add_version(db, "gcc", "15.1.0", "/usr/bin");
@@ -2532,10 +2566,72 @@ TEST(XvmRegistrationOwnershipTest, UnchangedLegacyEntryIsNotReportedAdopted) {
     }
 }
 
+// An omitted member that is plainly this package's own leftover is DETACHED,
+// not refused over.
+//
+// The refusal that used to live here could not tell "the recipe on this
+// platform does not produce that name" from "the batch is wrong", and the
+// first is real: a home carried over from Windows records `cl`, `lib`, `link`
+// and `rc` against an llvm payload that a Linux recipe never registers. With
+// the refusal in place neither install nor remove could touch the package
+// again. Detaching keeps the record (so nothing is destroyed here) and drops
+// only its edge into this release; `self doctor` is what decides whether the
+// leftover is prunable.
 TEST(XvmRegistrationOwnershipTest,
-     RejectsIncompleteLegacyComponentWithoutMutation) {
+     DetachesOwnerLessLegacyMemberSharingThePayload) {
     xlings::xvm::VersionDB db;
     seed_complete_legacy_registration_group(db);
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+    auto batch = complete_legacy_adoption_batch();
+    batch.nodes.erase(batch.nodes.begin());   // drop `tool`
+    std::vector<xlings::xvm::DetachedLegacyMember> detached;
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, batch, &detached);
+
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    ASSERT_EQ(detached.size(), 1u);
+    EXPECT_EQ(detached[0].target, "tool");
+    EXPECT_EQ(detached[0].version, "repo:tool-1.0.0");
+    // The record survives -- detaching is not deleting.
+    ASSERT_TRUE(db.contains("tool"));
+    EXPECT_TRUE(db.at("tool").versions.contains("repo:tool-1.0.0"));
+    // ...but it no longer claims to be part of the release.
+    EXPECT_TRUE(db.at("tool").bindings.empty());
+    EXPECT_FALSE(db.at("legacy-root").bindings.contains("tool"));
+}
+
+// A Windows-style record must be recognised as the same payload on Linux;
+// otherwise the exact case this exists for -- separators from another
+// platform -- falls through to the refusal.
+TEST(XvmRegistrationOwnershipTest,
+     DetachesLegacyMemberRecordedWithForeignSeparators) {
+    xlings::xvm::VersionDB db;
+    seed_complete_legacy_registration_group(db);
+    db.at("tool").versions.at("repo:tool-1.0.0").path =
+        "\\pkg\\provider\\1.0.0";
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+    auto batch = complete_legacy_adoption_batch();
+    batch.nodes.erase(batch.nodes.begin());
+    std::vector<xlings::xvm::DetachedLegacyMember> detached;
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, batch, &detached);
+
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    ASSERT_EQ(detached.size(), 1u);
+    EXPECT_EQ(detached[0].target, "tool");
+}
+
+// Evidence, not resemblance: a member whose payload is somewhere else is not
+// this package's leftover, so the batch is still refused whole.
+TEST(XvmRegistrationOwnershipTest,
+     RejectsIncompleteLegacyComponentFromAnotherPayload) {
+    xlings::xvm::VersionDB db;
+    seed_complete_legacy_registration_group(db);
+    db.at("tool").versions.at("repo:tool-1.0.0").path = "/pkg/elsewhere/1.0.0";
     xlings::xvm::Workspace workspace;
     xlings::xvm::WorkspaceInstalled installed;
     auto batch = complete_legacy_adoption_batch();
@@ -2552,6 +2648,35 @@ TEST(XvmRegistrationOwnershipTest,
     EXPECT_EQ(xlings::xvm::versions_to_json(db), dbBefore);
     EXPECT_TRUE(workspace.empty());
     EXPECT_TRUE(installed.empty());
+}
+
+// An ACTIVE member is detached too, and stays active.
+//
+// Requiring the member to be inactive was the first shape of this and it
+// vetoed the case the change exists for: on the measured home `cl`, `lib`,
+// `link` and `rc` are all active, so the refusal survived intact. Detaching
+// does not deregister and does not deactivate -- the shim dispatches exactly
+// where it did before. Only the claim of membership in a release that no
+// longer registers the name goes away.
+TEST(XvmRegistrationOwnershipTest,
+     DetachesAnActiveOwnerLessLegacyMemberWithoutDeactivatingIt) {
+    xlings::xvm::VersionDB db;
+    seed_complete_legacy_registration_group(db);
+    xlings::xvm::Workspace workspace{{"tool", "repo:tool-1.0.0"}};
+    xlings::xvm::WorkspaceInstalled installed;
+    auto batch = complete_legacy_adoption_batch();
+    batch.nodes.erase(batch.nodes.begin());
+    std::vector<xlings::xvm::DetachedLegacyMember> detached;
+
+    auto result = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, batch, &detached);
+
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    ASSERT_EQ(detached.size(), 1u);
+    EXPECT_EQ(detached[0].target, "tool");
+    EXPECT_TRUE(db.at("tool").versions.contains("repo:tool-1.0.0"));
+    ASSERT_TRUE(workspace.contains("tool"));
+    EXPECT_EQ(workspace.at("tool"), "repo:tool-1.0.0");
 }
 
 TEST(XvmRegistrationOwnershipTest,
@@ -4399,6 +4524,61 @@ void add_provider_group_(xlings::xvm::VersionDB& db,
 }
 
 }  // namespace
+
+// A recipe's removal list is derived from the payload on disk, and the payload
+// does not have to have been produced on this platform. A Windows llvm payload
+// sitting in a Linux home makes `uninstall()` ask for `clang++.exe`; nothing
+// registered that name here, and refusing it used to take the whole batch down
+// -- so the package could be neither installed nor removed.
+TEST(XvmRemovalSelectionTest, UnregisteredRecipeTargetIsANoOp) {
+    xlings::xvm::VersionDB db;
+    add_provider_group_(db, "pkgindex:llvm", "20.1.7", "llvm",
+                        {{"llvm", "20.1.7"}, {"clang", "20.1.7"}});
+    xlings::xvm::Workspace workspace{{"llvm", "20.1.7"}, {"clang", "20.1.7"}};
+    xlings::xvm::WorkspaceInstalled installed{
+        {"llvm", {"20.1.7"}}, {"clang", {"20.1.7"}}};
+    const std::vector<xlings::xvm::RemovalOperation> operations{
+        {.op = "remove", .name = "llvm", .version = "20.1.7"},
+        {.op = "remove", .name = "clang++.exe", .version = ""},
+    };
+    auto context = xlings::xvm::snapshot_removal_context(db, "llvm", "20.1.7");
+    ASSERT_TRUE(context.has_value()) << context.error().message;
+
+    auto result = xlings::xvm::apply_removal_batch(
+        db, workspace, installed, operations, *context);
+
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    EXPECT_FALSE(db.contains("llvm"));
+    EXPECT_FALSE(db.contains("clang"));
+}
+
+// The protection that matters is that another package's entry SURVIVES, and
+// the selection filter is what delivers it -- not the refusal. llvm's recipe
+// names `cc` unconditionally; gcc registered it. Skipping the op leaves gcc
+// intact and lets llvm come out, which refusing did not.
+TEST(XvmRemovalSelectionTest, RegisteredOutOfSelectionTargetIsSkipped) {
+    xlings::xvm::VersionDB db;
+    add_provider_group_(db, "pkgindex:llvm", "20.1.7", "llvm",
+                        {{"llvm", "20.1.7"}, {"clang", "20.1.7"}});
+    add_provider_group_(db, "pkgindex:gcc", "15.1.0", "gcc",
+                        {{"gcc", "15.1.0"}});
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+    const std::vector<xlings::xvm::RemovalOperation> operations{
+        {.op = "remove", .name = "llvm", .version = "20.1.7"},
+        {.op = "remove", .name = "gcc", .version = "15.1.0"},
+    };
+    auto context = xlings::xvm::snapshot_removal_context(db, "llvm", "20.1.7");
+    ASSERT_TRUE(context.has_value()) << context.error().message;
+
+    auto result = xlings::xvm::apply_removal_batch(
+        db, workspace, installed, operations, *context);
+
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    EXPECT_FALSE(db.contains("llvm")) << "the release being removed survived";
+    EXPECT_TRUE(db.contains("gcc")) << "another package's entry was deleted";
+    EXPECT_TRUE(db.at("gcc").versions.contains("15.1.0"));
+}
 
 TEST(XvmRemovalFallbackTest, IncoherentSurvivorDeactivatesTheWholeGroup) {
     xlings::xvm::VersionDB db;

--- a/tests/unit/test_xvm_doctor.cpp
+++ b/tests/unit/test_xvm_doctor.cpp
@@ -34,6 +34,7 @@ import xlings.core.xvm.removal;
 import xlings.core.xvm.registration;
 import xlings.core.xvm.errors;
 import xlings.core.xvm.inspect;
+import xlings.core.xvm.owner;
 import xlings.core.xvm.lock;
 import xlings.core.xvm.switch_plan;
 import xlings.core.xvm.shim;
@@ -984,4 +985,106 @@ TEST(SubosSnapshots, AHomeWithNoSubosDirectoryIsEmptyNotAnError) {
     std::error_code ec;
     fs::remove_all(home, ec);
     EXPECT_TRUE(xlings::profile::load_subos_snapshots(home).empty());
+}
+
+// ============================================================
+// xvm/owner — which PACKAGE does a versions-DB entry belong to
+//
+// A finding names an xvm target; every remedy names a package. `xlings install
+// nm@20.1.7` is a command that cannot succeed -- `nm` is a program llvm
+// registers. The payload path is the only candidate that answers this for the
+// hard cases, because the installer wrote it.
+
+namespace {
+
+using xlings::xvm::coordinate_from_payload_path;
+
+std::string coord_or_empty_(std::string_view path) {
+    auto c = coordinate_from_payload_path(path);
+    return c ? c->canonical() : std::string{};
+}
+
+}  // namespace
+
+TEST(XvmOwner, RecoversThePackageFromTheStoreLayout) {
+    // Every one of these is a real entry from the home this was measured on.
+    EXPECT_EQ(coord_or_empty_("/h/.xlings/data/xpkgs/xim-x-llvm/20.1.7"),
+              "xim:llvm@20.1.7");
+    EXPECT_EQ(coord_or_empty_("/h/.xlings/data/xpkgs/config-x-virtualbox/7.2.8"),
+              "config:virtualbox@7.2.8");
+    EXPECT_EQ(coord_or_empty_("/h/.xlings/data/xpkgs/local-x-mcpp/0.0.27/bin"),
+              "local:mcpp@0.0.27");
+    EXPECT_EQ(coord_or_empty_(
+                  "/h/.xlings/data/xpkgs/fromsource-x-freetype/2.13.2"),
+              "fromsource:freetype@2.13.2");
+    EXPECT_EQ(coord_or_empty_("/h/.xlings/data/xpkgs/xim-x-musl-gcc/15.1.0"),
+              "xim:musl-gcc@15.1.0");
+    EXPECT_EQ(coord_or_empty_(
+                  "/h/.xlings/data/xpkgs/xim-x-aarch64-linux-musl-gcc/15.1.0"),
+              "xim:aarch64-linux-musl-gcc@15.1.0");
+}
+
+// The record that nothing else can identify: written on Windows, read here.
+TEST(XvmOwner, ReadsAPathRecordedWithForeignSeparators) {
+    EXPECT_EQ(coord_or_empty_("/h/.xlings\\data\\xpkgs\\xim-x-llvm\\20.1.7/bin"),
+              "xim:llvm@20.1.7");
+    EXPECT_EQ(coord_or_empty_("C:\\Users\\me\\.xlings\\data\\xpkgs\\xim-x-gcc\\16.1.0"),
+              "xim:gcc@16.1.0");
+}
+
+// A home that itself lives under a directory called `xpkgs` must not confuse
+// the outer name for the store.
+TEST(XvmOwner, UsesTheInnermostStoreComponent) {
+    EXPECT_EQ(coord_or_empty_("/srv/xpkgs/home/.xlings/data/xpkgs/xim-x-cmake/3.29.0"),
+              "xim:cmake@3.29.0");
+}
+
+TEST(XvmOwner, RefusesPathsThatAreNotStorePayloads) {
+    EXPECT_EQ(coord_or_empty_(""), "");
+    EXPECT_EQ(coord_or_empty_("/usr/local/bin"), "");
+    EXPECT_EQ(coord_or_empty_("/h/.xlings/data/xpkgs"), "");
+    // No version component after the store dir.
+    EXPECT_EQ(coord_or_empty_("/h/.xlings/data/xpkgs/xim-x-llvm"), "");
+}
+
+TEST(XvmOwner, CandidatesPreferTheRecordedProviderThenThePayloadPath) {
+    xlings::xvm::VersionDB db;
+    auto& info = db["nm"];
+    info.type = "program";
+    auto& data = info.versions["20.1.7"];
+    data.path = "/h/.xlings/data/xpkgs/xim-x-llvm/20.1.7/bin";
+
+    // Owner-less: the payload path is the only thing that knows the package.
+    auto candidates = xlings::xvm::owner_candidates(db, "nm", "20.1.7");
+    ASSERT_FALSE(candidates.empty());
+    EXPECT_EQ(candidates.front().canonical(), "xim:llvm@20.1.7");
+
+    // With a provider recorded, that wins -- it is authoritative.
+    data.bindingGroup = xlings::xvm::BindingGroupRef{
+        .provider = "xim:llvm-tools",
+        .providerVersion = "20.1.7",
+        .group = "llvm-tools",
+        .rootTarget = "llvm-tools",
+        .rootVersion = "20.1.7",
+    };
+    candidates = xlings::xvm::owner_candidates(db, "nm", "20.1.7");
+    ASSERT_FALSE(candidates.empty());
+    EXPECT_EQ(candidates.front().canonical(), "xim:llvm-tools@20.1.7");
+}
+
+// The namespace rides on the version key in the DB and on the front of a
+// coordinate on the command line. A candidate built from the entry itself has
+// to move it.
+TEST(XvmOwner, MovesTheNamespaceOffTheVersionKey) {
+    xlings::xvm::VersionDB db;
+    db["mcpp"].type = "program";
+    db["mcpp"].versions["local:0.0.27"].path = "/somewhere/else";
+
+    const auto candidates =
+        xlings::xvm::owner_candidates(db, "mcpp", "local:0.0.27");
+    const auto found = std::ranges::any_of(candidates, [](const auto& c) {
+        return c.canonical() == "local:mcpp@0.0.27";
+    });
+    EXPECT_TRUE(found) << "the entry-derived candidate kept the namespace on "
+                          "the version, which parses as a version nothing has";
 }

--- a/tests/unit/test_xvm_doctor.cpp
+++ b/tests/unit/test_xvm_doctor.cpp
@@ -217,18 +217,55 @@ TEST(XvmDanglingEdge, AfterPruningTheSwitchWorksAgain) {
     EXPECT_EQ(still->members.size(), 2u);
 }
 
-// An edge recorded under a version that is not registered either can never be
-// reached: resolution always starts from a real (target, version). Leaving it
-// alone keeps the repair to what is demonstrably harmful.
-TEST(XvmDanglingEdge, UnreachableEdgesAreLeftAlone) {
+// An edge recorded under a version that is not registered is pruned too.
+//
+// This used to assert the opposite, on the reasoning that resolution always
+// starts from a real (target, version) so such an edge can never be reached.
+// The reasoning is wrong, and the way it is wrong is expensive: the owner
+// version becomes real the moment an install registers it, and the edge is
+// then walked during the batch's own validation -- which fails with "legacy
+// binding source version is missing" and refuses the whole registration.
+//
+// Measured by differential on a real home: `xim-musl-gnu-gcc` carried five
+// edges keyed at `15.1.0-musl` while only `15.1.0` was registered. Same slice,
+// same command -- `xlings install xim:musl-gcc@15.1.0` failed with the edges
+// present and succeeded with them removed. Nothing reported them, no repair
+// touched them, and `--fix` reacted to the failing install by removing the
+// package.
+TEST(XvmDanglingEdge, EdgesKeyedAtAnUnregisteredOwnerVersionArePruned) {
     auto db = dangling_edge_db_();
     db["gcc"].bindings["ghost"]["9.9.9"] = "9.9.9";  // owner version absent
 
     const auto plan = xlings::xvm::plan_dangling_edge_pruning(db);
-    for (const auto& edge : plan.edges) {
-        EXPECT_NE(edge.version, "9.9.9")
-            << "pruned an edge no resolution can reach";
-    }
+    const auto pruned = std::ranges::any_of(plan.edges, [](const auto& edge) {
+        return edge.target == "gcc" && edge.version == "9.9.9"
+            && edge.peerTarget == "ghost";
+    });
+    EXPECT_TRUE(pruned) << "left an edge that blocks every future install of "
+                           "its owner";
+
+    xlings::xvm::apply_dangling_edge_pruning(db, plan);
+    const auto edgeIt = db.at("gcc").bindings.find("ghost");
+    EXPECT_TRUE(edgeIt == db.at("gcc").bindings.end()
+                || !edgeIt->second.contains("9.9.9"));
+}
+
+// ...and a healthy edge under a registered owner version is untouched, so the
+// widened rule cannot start eating live releases.
+TEST(XvmDanglingEdge, EdgesUnderARegisteredOwnerVersionSurvive) {
+    xlings::xvm::VersionDB db;
+    db["gcc"].type = "program";
+    db["gcc"].versions["16.1.0"].path = "/pkg/gcc/16.1.0/bin";
+    db["g++"].type = "program";
+    db["g++"].versions["16.1.0"].path = "/pkg/gcc/16.1.0/bin";
+    db["gcc"].bindings["g++"]["16.1.0"] = "16.1.0";
+    db["g++"].bindings["gcc"]["16.1.0"] = "16.1.0";
+    db["gcc"].versions["15.1.0"].path = "/pkg/gcc/15.1.0/bin";
+    db["g++"].versions["15.1.0"].path = "/pkg/gcc/15.1.0/bin";
+    db["gcc"].bindings["g++"]["15.1.0"] = "15.1.0";
+    db["g++"].bindings["gcc"]["15.1.0"] = "15.1.0";
+
+    EXPECT_TRUE(xlings::xvm::plan_dangling_edge_pruning(db).empty());
 }
 
 TEST(XvmDanglingEdge, AHealthyDatabaseYieldsNoPruning) {


### PR DESCRIPTION
Closes the loop where `install` told you to run `self doctor --fix`, `--fix` told you to run `install`, and neither could work.

Measured against a slice of a real 91 GB `~/.xlings` (379 targets, 9 subos):

| | before (`2026.7.28.4`) | after |
|---|---|---|
| `self doctor --fix` exit code | 1 | **0** |
| plain `doctor` after it | 1 | **0** |
| second `--fix` | repeats everything | **does nothing** |
| broken payloads | 20 | **0** |
| binding state | 134 | **0** |
| other-subos findings | 18 | **0** |
| `repair failed` / `repair skipped` | 9 / 11 | **0 / 0** |
| printed `→ run` commands that actually work | 1 of 3 | **1 of 1** |
| report lines | 239 | **9** |
| `name@ns:ver` (unparseable coordinates) | 19 | **0** |

## What was wrong

**The report was the pre-fix state with repair results appended.** One run reported a problem and then, ten lines later, reported fixing it, while the summary counted the pre-fix world. `cmd_doctor` is now `detect` / `repair` / `render`, and `--fix` renders the **second** detection. Idempotence follows by construction.

**Every remedy was synthesised from an xvm target, which is not a package.** `xlings install nm@20.1.7` names a program llvm registers; there is no such package. The owning package is now recovered from the payload path — `data/xpkgs/<ns>-x-<pkg>/<ver>` is written by the installer, so it *is* the package identity — and confirmed against the index before being offered. Resolution moved out of the `--fix` branch, so plain `doctor` prints correct commands too.

**The namespace was rendered on the wrong side.** The DB keys a version as `local:0.0.27`; the command line keys the coordinate as `local:mcpp@0.0.27`. `"{}@{}"` produced the first, which parses as a version nothing has — and made the reinstall probe fail for *every* namespaced entry, so those were never actually attempted. One `display_coordinate`, round-trip tested against the catalog parser.

**Three things made the home unrepairable at all:**

- a removal op naming a target the release does not own aborted the whole batch (a Windows llvm payload under Linux makes the recipe ask for `clang++.exe`, and for `cc`, which gcc owns). The selection already decides what may be deleted, so an out-of-selection op is now skipped and logged.
- a registration omitting part of an owner-less legacy component was refused — permanent when the component was recorded by another platform. Members that are owner-less *and* live inside this batch's payload are now detached (record kept, edges dropped).
- binding edges keyed at an **unregistered owner version** were neither reported nor pruned, on the reasoning that nothing can reach them. Differential on the real slice: same command, edges present → `install` fails with `xvm-binding-validation-failed`; edges gone → succeeds. The unit test asserting the old premise has been rewritten.

**R3 could uninstall a working package and leave it out.** It asked the removal verifier *before* reinstalling and returned early on "the records survived" — performing the destructive half of remove-and-reinstall and skipping the recovery half. It measurably did this to `musl-gcc`. The install is now unconditional after a successful remove; the verifier only decides what is *reported*, so the multi-subos guarantee (never claim a removal that did not happen) still holds.

## Also

- a last rung that drops registrations the ladder could not revive and no index provides — skipping anything another subos still claims (caught by the multi-subos e2e, which had it pruning a version `other` was still using)
- other-subos state files repaired directly (dangling `installed[]`, active pointers into nothing) instead of printing 18 commands to run one subos at a time. Metadata only: nothing is installed there, nothing is pulled into the current subos.
- unregistered actives in the current subos deactivated
- quotes and `${XLINGS_HOME}` stripped before an alias is judged absolute — 5 false warnings on the measured home
- findings grouped per payload and per target; non-defect notices behind `--verbose`
- when a dangling edge is present, payload remedies point at `self doctor --fix` rather than at an install that cannot succeed until the edges are pruned

## Verification

Not "it exits 0" — that was the failure mode. Two tools land with this:

- `.agents/tools/slice-real-home.sh` builds a runnable slice of a real home: hardlink farm for the 69 GB payload store, real copies for the metadata installers rewrite in place, repointed paths *and* sysroot symlinks, `subos/current` created last.
- `.agents/tools/doctor-acceptance.sh` measures the table above, **executes every printed remedy**, and proves with `find -newer` that the real payload store was never written to.

Unit: 24/24. E2E: `self_doctor_test.sh`, `self_doctor_multi_subos_test.sh`.

Design + measured results: `.agents/docs/2026-07-29-doctor-fix-one-shot-design.md`