### PR TITLE
ci: verify a fresh install end to end (Linux, CentOS 7, Windows, macOS)

### DIFF
--- a/.github/workflows/xlings-ci-fresh-install.yml
+++ b/.github/workflows/xlings-ci-fresh-install.yml
@@ -1,0 +1,181 @@
+name: xlings-ci-fresh-install
+
+# Fresh-install CI — validates the RELEASED xlings on a clean machine.
+#
+# Every other workflow here builds xlings from the PR and tests that binary
+# against a warm, cached environment. This one tests the path a real first-time
+# user takes: land on a bare host, run quick_install, use the tool. That path
+# has failure modes the rest of the matrix structurally cannot see — a broken
+# release artifact, a quick_install regression, an index that cannot resolve on
+# a cold home, a shim that does not resolve, a version switch that silently
+# no-ops, or a binary that will not start on an old glibc.
+#
+# Modelled on mcpp-community/mcpp's ci-fresh-install.yml.
+#
+# The suites live in tests/fresh-install/ rather than inline here: the CentOS 7
+# leg runs them under `docker run`, where a mounted script beats escaping a long
+# heredoc through two shell layers, and it means a failure reproduces locally
+# with one command:
+#
+#   HOME=$(mktemp -d) bash tests/fresh-install/smoke.sh gcc
+
+on:
+  # ── STAGE 1 ONLY ────────────────────────────────────────────────────
+  # Present so this workflow can be validated on the PR that introduces it.
+  # Once it is green, delete this `pull_request:` block — the three triggers
+  # below are already correct and are inert on a PR, so stage 2 is a pure
+  # deletion with nothing to rewrite.
+  pull_request:
+    branches: [main, master, 'release/**']
+  # ────────────────────────────────────────────────────────────────────
+
+  workflow_dispatch:
+
+  # `release: published` is deliberately NOT used. release.yml creates the
+  # release with GITHUB_TOKEN, and GitHub suppresses workflow triggers from
+  # GITHUB_TOKEN-generated events, so it would never fire from the pipeline.
+  # workflow_run is a platform-generated event, exempt from that suppression,
+  # and needs no cross-repo PAT.
+  workflow_run:
+    workflows: [release]
+    types: [completed]
+
+  # Daily, to catch breakage that arrives from outside the repo: a runner image
+  # update, an index change, a package host going away.
+  schedule:
+    - cron: '0 6 * * *'
+
+concurrency:
+  group: xlings-ci-fresh-install-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  XLINGS_NON_INTERACTIVE: '1'
+  # Runners reach github.com but not the gitee/gitcode endpoints, which need
+  # auth — force GLOBAL rather than letting region detection guess.
+  XLINGS_RELEASE_MIRROR: GLOBAL
+  GIT_TERMINAL_PROMPT: '0'
+
+jobs:
+  # ────────────────────────────────────────────────────────────────────
+  # Linux — the reference leg. All three suites.
+  # ────────────────────────────────────────────────────────────────────
+  linux-fresh:
+    name: Linux fresh (${{ matrix.suite }})
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        # Each cell does its OWN fresh install — no shared warm state, which is
+        # the entire point. They run in parallel, so wall-clock is one
+        # bootstrap plus one toolchain, not the sum.
+        suite: [core, gcc, llvm]
+    steps:
+      - uses: actions/checkout@v4
+
+      # Deliberately no actions/cache anywhere in this workflow: a warm cache
+      # would defeat the thing being tested.
+      - name: Run ${{ matrix.suite }} suite
+        run: bash tests/fresh-install/smoke.sh ${{ matrix.suite }}
+
+  # ────────────────────────────────────────────────────────────────────
+  # CentOS 7 — the old-glibc proof (glibc 2.17, EOL).
+  #
+  # A `container:` job cannot work here: actions/checkout, actions/cache and
+  # every other JS action need Node 20, which needs glibc 2.28. So the JS
+  # actions run on the ubuntu host, the repo is bind-mounted in, and only the
+  # smoke script executes inside the container.
+  #
+  # This leg is load-bearing, not decorative. The xlings Linux binary is
+  # static-musl so it *should* start on 2.17, and gcc/llvm pull in a
+  # self-contained xim:glibc@2.39 rather than the host's — but whether that
+  # whole stack works on a 2.17 host is otherwise unproven.
+  # ────────────────────────────────────────────────────────────────────
+  centos7-fresh:
+    name: CentOS 7 fresh (${{ matrix.suite }})
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [core, gcc, llvm]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run ${{ matrix.suite }} suite in centos:7
+        run: |
+          # If docker.io/centos:7 is ever pulled from Docker Hub, the drop-in
+          # replacement is quay.io/centos/centos:centos7 (same contents).
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE:/w" -w /w \
+            -e HOME=/root \
+            -e XLINGS_NON_INTERACTIVE=1 \
+            -e XLINGS_RELEASE_MIRROR=GLOBAL \
+            -e GIT_TERMINAL_PROMPT=0 \
+            centos:7 \
+            bash -euo pipefail -c '
+              # CentOS 7 is EOL and mirrorlist.centos.org no longer resolves,
+              # so every yum call 404s until the repos point at the vault.
+              sed -i -e "s|^mirrorlist=|#mirrorlist=|g" \
+                     -e "s|^#\?baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g" \
+                     /etc/yum.repos.d/CentOS-*.repo
+
+              # curl and tar are hard requirements of quick_install.sh; it also
+              # locates the extracted directory with a glob, so findutils/which
+              # are installed explicitly rather than assumed present.
+              yum -y install curl tar gzip xz git which findutils ca-certificates
+
+              # The stock CA bundle predates the roots the GitHub asset CDN
+              # serves; without this, downloads fail at TLS handshake.
+              update-ca-trust force-enable
+              update-ca-trust extract
+
+              echo "host glibc: $(ldd --version | head -1)"
+              bash /w/tests/fresh-install/smoke.sh ${{ matrix.suite }}
+            '
+
+  # ────────────────────────────────────────────────────────────────────
+  # Windows.
+  #
+  # The gcc cell asserts group *registration*, not group switching: the index
+  # ships exactly one Windows gcc (15.1.0, via mingw64), so there is nothing to
+  # switch between. Real group switching is covered on Linux and CentOS 7.
+  # ────────────────────────────────────────────────────────────────────
+  windows-fresh:
+    name: Windows fresh (${{ matrix.suite }})
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: windows-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [core, gcc, llvm]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run ${{ matrix.suite }} suite
+        shell: pwsh
+        run: pwsh -File tests/fresh-install/smoke.ps1 -Suite ${{ matrix.suite }}
+
+  # ────────────────────────────────────────────────────────────────────
+  # macOS — no gcc cell: the package index ships no macOS gcc.
+  # ────────────────────────────────────────────────────────────────────
+  macos-fresh:
+    name: macOS fresh (${{ matrix.suite }})
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    # macos-14 is the support floor — xlings ships minos=14.0 binaries, so a
+    # fresh install passing here is the continuous proof of that floor.
+    runs-on: macos-14
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: [core, llvm]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run ${{ matrix.suite }} suite
+        run: bash tests/fresh-install/smoke.sh ${{ matrix.suite }}

--- a/.github/workflows/xlings-ci-fresh-install.yml
+++ b/.github/workflows/xlings-ci-fresh-install.yml
@@ -33,6 +33,15 @@ name: xlings-ci-fresh-install
 # Run it by hand from the Actions tab when you want an answer now.
 on:
   workflow_dispatch:
+    inputs:
+      index_ref:
+        # Recipe bugs are only ever caught on a real install, so a recipe fix
+        # cannot be validated until it is already published. This runs the
+        # whole suite, on every platform, against an unmerged xim-pkgindex
+        # branch — replacing only pkgs/ in the fetched index.
+        description: 'xim-pkgindex branch/tag to test against (blank = the published index)'
+        required: false
+        default: ''
 
   # `release: published` is deliberately NOT used. release.yml creates the
   # release with GITHUB_TOKEN, and GitHub suppresses workflow triggers from
@@ -54,6 +63,8 @@ concurrency:
 
 env:
   XLINGS_NON_INTERACTIVE: '1'
+  # Blank on every trigger except a manual run that named a candidate index.
+  XIM_PKGINDEX_REF: ${{ inputs.index_ref }}
   # Runners reach github.com but not the gitee/gitcode endpoints, which need
   # auth — force GLOBAL rather than letting region detection guess.
   XLINGS_RELEASE_MIRROR: GLOBAL
@@ -118,6 +129,7 @@ jobs:
             -e XLINGS_NON_INTERACTIVE=1 \
             -e XLINGS_RELEASE_MIRROR=GLOBAL \
             -e GIT_TERMINAL_PROMPT=0 \
+            -e XIM_PKGINDEX_REF="$XIM_PKGINDEX_REF" \
             centos:7 \
             bash -euo pipefail -c '
               # CentOS 7 is EOL and mirrorlist.centos.org no longer resolves,
@@ -162,6 +174,69 @@ jobs:
       - name: Run ${{ matrix.suite }} suite
         shell: pwsh
         run: pwsh -File tests/fresh-install/smoke.ps1 -Suite ${{ matrix.suite }}
+
+  # ────────────────────────────────────────────────────────────────────
+  # TEMPORARY — diagnosing xim-pkgindex#443's macOS half.
+  #
+  # `clang h.c -o h` dies because Apple's own linker is made to load OUR
+  # bundled libc++ and aborts on __ZdaPv. Ruled out already: the dep list,
+  # a missing libc++abi (both versions ship identical dylib sets), and
+  # clang's link commands (clang-20 and clang-22 have identical
+  # LC_LOAD_DYLIB/LC_RPATH). This runs the differentials that need a real
+  # macOS host. Delete once the cause is known.
+  # ────────────────────────────────────────────────────────────────────
+  macos-llvm-probe:
+    name: TEMP macOS llvm probe
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: macos-14
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install xlings + llvm@22.1.8
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
+          export PATH="$HOME/.xlings/subos/current/bin:$PATH"
+          xlings config --mirror GLOBAL
+          xlings update
+          xlings install llvm@22.1.8 -y -g
+          xlings use llvm@22.1.8
+
+      - name: "Probe 1 — does anything register DYLD envs?"
+        run: |
+          for f in "$HOME/.xlings/.xlings.json" "$HOME/.xlings/subos/default/.xlings.json"; do
+            echo "== $f"
+            grep -oE '"(envs|DYLD[A-Z_]*)"[^,}]*' "$f" 2>/dev/null || echo "   (no envs / DYLD keys)"
+          done
+
+      - name: "Probe 2 — clang.cfg written by __install_macosx_cfg"
+        run: |
+          for f in "$HOME"/.xlings/data/xpkgs/xim-x-llvm/22.1.8/bin/*.cfg; do
+            [ -e "$f" ] || continue
+            echo "== $f"; cat "$f"
+          done
+
+      # The decisive differential. If the real binary links fine and only the
+      # shimmed one fails, the shim is injecting something; if both fail, it is
+      # the payload and the shim is innocent.
+      - name: "Probe 3 — shimmed clang vs the real binary"
+        run: |
+          printf '#include <stdio.h>\nint main(void){printf("ok\\n");return 0;}\n' > /tmp/h.c
+          real="$HOME/.xlings/data/xpkgs/xim-x-llvm/22.1.8/bin/clang"
+          echo "=== via shim ==="
+          ( export PATH="$HOME/.xlings/subos/current/bin:$PATH"; cd /tmp && clang h.c -o h_shim && ./h_shim ) \
+            && echo "SHIM: ok" || echo "SHIM: FAILED"
+          echo "=== direct, no shim ==="
+          ( cd /tmp && "$real" h.c -o h_real && ./h_real ) \
+            && echo "DIRECT: ok" || echo "DIRECT: FAILED"
+
+      - name: "Probe 4 — which libc++ does the linker actually load?"
+        run: |
+          export PATH="$HOME/.xlings/subos/current/bin:$PATH"
+          cd /tmp
+          echo "--- env seen here ---"; env | grep -iE 'dyld|ld_library' || echo "   (none in parent env)"
+          echo "--- DYLD_PRINT_LIBRARIES during link ---"
+          DYLD_PRINT_LIBRARIES=1 clang h.c -o h_probe 2>&1 | grep -iE 'libc\+\+|xim-x-llvm|/usr/lib' | head -20 || true
 
   # ────────────────────────────────────────────────────────────────────
   # macOS — no gcc cell: the package index ships no macOS gcc.

--- a/.github/workflows/xlings-ci-fresh-install.yml
+++ b/.github/workflows/xlings-ci-fresh-install.yml
@@ -19,16 +19,19 @@ name: xlings-ci-fresh-install
 #
 #   HOME=$(mktemp -d) bash tests/fresh-install/smoke.sh gcc
 
+# Deliberately NOT on `pull_request`. It ran on PRs while it was being
+# validated (openxlings/xlings#446, four runs across all four platforms) and
+# that trigger is now removed, for two reasons:
+#
+#   1. It tests the *released* binary, so on a PR it validates the workflow
+#      rather than the change — near-zero signal per run, at four platforms
+#      and eleven cold toolchain installs of cost.
+#   2. The defects it currently reports live in xim-pkgindex, not here
+#      (openxlings/xim-pkgindex#442, #443, #444). Gating unrelated PRs on
+#      another repository's release state would train people to ignore it.
+#
+# Run it by hand from the Actions tab when you want an answer now.
 on:
-  # ── STAGE 1 ONLY ────────────────────────────────────────────────────
-  # Present so this workflow can be validated on the PR that introduces it.
-  # Once it is green, delete this `pull_request:` block — the three triggers
-  # below are already correct and are inert on a PR, so stage 2 is a pure
-  # deletion with nothing to rewrite.
-  pull_request:
-    branches: [main, master, 'release/**']
-  # ────────────────────────────────────────────────────────────────────
-
   workflow_dispatch:
 
   # `release: published` is deliberately NOT used. release.yml creates the

--- a/docs/superpowers/specs/2026-07-29-fresh-install-ci-design.md
+++ b/docs/superpowers/specs/2026-07-29-fresh-install-ci-design.md
@@ -170,15 +170,15 @@ stack works on a 2.17 host is unproven today.
 
 ## Triggers
 
-Two stages, as requested.
+Two stages, as requested. **Both are now done.**
 
-**Stage 1 (this PR)** — `pull_request` included so the workflow can be validated
-before it is trusted:
+**Stage 1** — `pull_request` was included so the workflow could be validated
+before it was trusted. Four runs on #446 exercised all four platforms.
+
+**Stage 2** — the `pull_request:` block is removed. Final state:
 
 ```yaml
 on:
-  pull_request:          # STAGE 1 ONLY — remove once green
-    branches: [main, master, 'release/**']
   workflow_dispatch:
   workflow_run:
     workflows: [release]
@@ -187,8 +187,12 @@ on:
     - cron: '0 6 * * *'
 ```
 
-**Stage 2** — delete the `pull_request:` block. The other three triggers are
-already correct and are inert on a PR, so stage 2 is a pure deletion.
+Removing it is not only the agreed sequence, it is the right steady state. The
+workflow tests the *released* binary, so on a PR it validates the workflow
+rather than the change — near-zero signal, at the cost of four platforms and
+eleven cold toolchain installs. And the defects it currently reports live in
+xim-pkgindex; gating unrelated PRs on another repository's release state would
+train people to ignore it.
 
 `release: published` is deliberately **not** used. `release.yml` creates the
 release with `GITHUB_TOKEN`, and GitHub suppresses workflow triggers from
@@ -208,13 +212,27 @@ is a weak result, not a red build — so the added complexity is not yet paid fo
 Worth revisiting if the post-release run needs to be a hard gate on the new
 version, which would also mean introducing a pin to bump each release.
 
-## Results of the first run (PR #446)
+## Results, and where each defect belongs
 
 | Cell | Linux | CentOS 7 | Windows | macOS |
 | --- | --- | --- | --- | --- |
 | `core` | pass | pass | pass | pass |
-| `gcc` | pass | pass | *was a test bug, fixed* | n/a |
+| `gcc` | pass | pass | **fail** | n/a |
 | `llvm` | **fail** | **fail** | **fail** | **fail** |
+
+Every failure was traced to a specific layer and filed:
+
+| Defect | Layer | Issue |
+| --- | --- | --- |
+| `mingw-w64` config hook uses xvm node kind `binding`; xlings accepts only `program`/`lib`/`group`/`files`, so the hook aborts and **no C++ compiler is obtainable on Windows at all** | xim-pkgindex | [#442](https://github.com/openxlings/xim-pkgindex/issues/442) |
+| `gcc.lua`'s windows entry declares no payload and no deps despite its "deps mingw64" comment | xim-pkgindex | [#442](https://github.com/openxlings/xim-pkgindex/issues/442) (comment) |
+| `llvm@22.1.8` does not carry its C++ runtime — missing `libstdc++.so.6` on Linux/CentOS 7, `__ZdaPv` on macOS | xim-pkgindex | [#443](https://github.com/openxlings/xim-pkgindex/issues/443) |
+| `llvm`'s `collect_bin_apps` registers zero programs on Windows although `clang.exe` is on disk, and logs nothing | xim-pkgindex | [#444](https://github.com/openxlings/xim-pkgindex/issues/444) |
+| `install` prints `✓ N package(s) installed` without checking the package's own declared `programs` registered | **xlings** | [#447](https://github.com/openxlings/xlings/issues/447) |
+
+Only the last is an xlings defect, and it is the one that turns the other four
+from "install failed, here is the missing program" into "everything said OK and
+nothing works".
 
 `core` green on all four platforms is the headline: bootstrap, index refresh,
 install, run, multi-version switch, project mode, doctor and uninstall all work
@@ -278,28 +296,60 @@ $ clang --version
 [error] xlings: 'clang' is not installed
 ```
 
-Install reports success, `use` reports success, and there is no compiler. The
-`llvm` shim itself exists — that is what `use` switched — but `llvm.lua`'s
-`config()` populates `clang`/`clang++` from `collect_bin_apps(bindir)`, and on
-Windows that found nothing. No `skip xvm add alias` warning was emitted either,
-so the bin directory was empty rather than merely differently named. Affects
-both 20.1.7 and 22.1.8.
+Install reports success, `use` reports success, and there is no compiler.
+Affects both 20.1.7 and 22.1.8. The failure-state dump proves the payload
+landed correctly:
+
+```
+...\xim-x-llvm\20.1.7\bin\clang.exe
+...\xim-x-llvm\20.1.7\bin\clang++.exe
+...\xim-x-llvm\20.1.7\bin\lld-link.exe
+```
+
+So this is registration, not extraction. `xvm.add(package.name)` — `config()`'s
+first line — clearly worked, since `use` resolves. Everything after it
+registered nothing, and **nothing was logged**: no error, not even the
+`skip xvm add alias (not found)` warning the recipe emits per missing alias.
+
+`llvm.lua` populates the per-program shims by shelling out —
+`io.popen('dir /b "<bindir>"')` on Windows, `ls -1` on Linux, where it works.
+A likely contributor is that libxpkg's `path.join` hardcodes `sep = "/"`
+regardless of host, so `bindir` is `C:\...\20.1.7/bin` and `cmd.exe`'s `dir`
+is unreliable with forward slashes. That mechanism is a lead, not a conclusion;
+the confirmed facts are the four above. If it is `path.join`, the fix belongs in
+libxpkg rather than the index.
 
 This is the silent-success pattern in its purest form: two consecutive success
 messages and a completely unusable install.
 
-### Not a finding — the Windows `gcc` cell was wrong
+### Finding 4 — the Windows `gcc` cell: one test bug hiding one real bug
 
-`xlings install gcc@15.1.0` on Windows "succeeds" and registers nothing, so
-`xlings use gcc@15.1.0` then fails with `'gcc' not found in version database`.
-That is because `gcc.lua`'s `config()` returns early on Windows
-("config in mingw-w64.lua") and its lone windows entry declares no payload —
-**`mingw-w64` is the package that registers the gcc/g++/c++ shims**.
+The first run failed with `'gcc' not found in version database`, which was
+**this suite's** bug: `gcc.lua`'s `config()` returns early on Windows
+("config in mingw-w64.lua") and its lone windows entry declares no payload, so
+**`mingw-w64` is the package that registers the gcc/g++/c++ shims**. The suite
+now installs `mingw-w64` there, and asserts group *consistency* rather than a
+switch since only one version exists.
 
-The suite now installs `mingw-w64` on Windows. Worth noting separately that
-`xlings install gcc` on Windows reporting `✓ 1 package(s) installed` while
-installing nothing usable is itself a defect, just not one this suite should
-encode as its Windows gcc coverage.
+The corrected test then failed on a real defect:
+
+```
+$ xlings install mingw-w64@13.0.0 -y -g
+[error] unsupported registration node kind 'binding'
+[error] [mingw-w64] failed: config hook failed
+```
+
+`mingw-w64.lua` registers an umbrella placeholder with `type = "binding"`, and
+`registration.cppm` accepts only `program` / `lib` / `group` / `files` — on
+`main` too, so this is not release lag. The whole hook aborts, taking the
+earlier `gcc`/`g++`/`c++` registrations with it.
+
+Net effect: **there is currently no working way to get a C++ compiler on
+Windows through xlings.** `gcc` installs nothing, `mingw-w64` aborts, and `llvm`
+registers no `clang`.
+
+That is worth stating plainly as the single most valuable thing this CI found,
+and it was invisible to every existing workflow.
 
 ### Why the llvm suite is not being softened
 

--- a/docs/superpowers/specs/2026-07-29-fresh-install-ci-design.md
+++ b/docs/superpowers/specs/2026-07-29-fresh-install-ci-design.md
@@ -208,12 +208,24 @@ is a weak result, not a red build — so the added complexity is not yet paid fo
 Worth revisiting if the post-release run needs to be a hard gate on the new
 version, which would also mean introducing a pin to bump each release.
 
-## First finding — `llvm@22.1.8` is unusable on a clean machine
+## Results of the first run (PR #446)
 
-Found by running the `llvm` suite locally before the workflow ever ran, which is
-a decent sign the design points at the right gap.
+| Cell | Linux | CentOS 7 | Windows | macOS |
+| --- | --- | --- | --- | --- |
+| `core` | pass | pass | pass | pass |
+| `gcc` | pass | pass | *was a test bug, fixed* | n/a |
+| `llvm` | **fail** | **fail** | **fail** | **fail** |
 
-On a fresh home containing only llvm and its declared deps:
+`core` green on all four platforms is the headline: bootstrap, index refresh,
+install, run, multi-version switch, project mode, doctor and uninstall all work
+from cold everywhere — **including CentOS 7**, which also passes the full gcc
+release-group switch on glibc 2.17. That was the leg most likely to be
+unsupportable, and it is not.
+
+Every `llvm` cell fails, on all four platforms, for three distinct reasons.
+None of them is a test artefact.
+
+### Finding 1 — `llvm@22.1.8` cannot start on Linux / CentOS 7
 
 ```
 $ xlings install llvm@22.1.8 -y -g && clang --version
@@ -228,7 +240,7 @@ Root cause, confirmed against the installed payloads:
 - `clang-22` (22.1.8) **does** link `libstdc++.so.6`.
 - Both get the same baked RPATH — llvm's own `lib`, plus `glibc`, `zlib`,
   `libxml2`, and `subos/default/lib` — and **none of them ships libstdc++**.
-- `llvm.lua`'s linux `deps` list (`xim:glibc`, `xim:linux-headers`, `xim:zlib`,
+- `llvm.lua`'s linux `deps` (`xim:glibc`, `xim:linux-headers`, `xim:zlib`,
   `xim:libxml2`) never gained `xim:gcc-runtime` when the 22.1.8 payload started
   linking libstdc++ dynamically.
 
@@ -242,9 +254,59 @@ Impact is wider than this test: `latest` resolves to 22.1.8, so plain
 have a libstdc++ around. That is why it went unnoticed — dev machines and CI
 images all have gcc installed.
 
-The suite is deliberately **not** softened to work around this. A test adjusted
-until it passes against a broken package is the silent-success pattern this
-repo keeps getting bitten by.
+### Finding 2 — `llvm@22.1.8` cannot link on macOS
+
+The version switch itself passes (`clang` and `clang++` both move to 22.1.8),
+then compilation dies at the linker:
+
+```
+dyld[2263]: Symbol not found: __ZdaPv
+```
+
+`__ZdaPv` is `operator delete[](void*)` — the same shape of defect as finding 1,
+a C++ runtime the 22.1.8 payload expects and does not carry, surfacing on macOS
+as a missing libc++/libc++abi rather than a missing libstdc++.
+
+### Finding 3 — `xlings install llvm` registers no `clang` on Windows
+
+```
+$ xlings install llvm@20.1.7 -y -g
+  ✓ 1 package(s) installed
+$ xlings use llvm@20.1.7
+[xlings] llvm -> 20.1.7
+$ clang --version
+[error] xlings: 'clang' is not installed
+```
+
+Install reports success, `use` reports success, and there is no compiler. The
+`llvm` shim itself exists — that is what `use` switched — but `llvm.lua`'s
+`config()` populates `clang`/`clang++` from `collect_bin_apps(bindir)`, and on
+Windows that found nothing. No `skip xvm add alias` warning was emitted either,
+so the bin directory was empty rather than merely differently named. Affects
+both 20.1.7 and 22.1.8.
+
+This is the silent-success pattern in its purest form: two consecutive success
+messages and a completely unusable install.
+
+### Not a finding — the Windows `gcc` cell was wrong
+
+`xlings install gcc@15.1.0` on Windows "succeeds" and registers nothing, so
+`xlings use gcc@15.1.0` then fails with `'gcc' not found in version database`.
+That is because `gcc.lua`'s `config()` returns early on Windows
+("config in mingw-w64.lua") and its lone windows entry declares no payload —
+**`mingw-w64` is the package that registers the gcc/g++/c++ shims**.
+
+The suite now installs `mingw-w64` on Windows. Worth noting separately that
+`xlings install gcc` on Windows reporting `✓ 1 package(s) installed` while
+installing nothing usable is itself a defect, just not one this suite should
+encode as its Windows gcc coverage.
+
+### Why the llvm suite is not being softened
+
+A test adjusted until it passes against a broken package is exactly the
+silent-success pattern this repo keeps getting bitten by. Findings 1–3 are real
+user-facing breakage in the current release; the suite reports them, and the
+`llvm` cells stay red until the recipes are fixed in `xim-pkgindex`.
 
 ## Failure modes this cannot catch
 

--- a/docs/superpowers/specs/2026-07-29-fresh-install-ci-design.md
+++ b/docs/superpowers/specs/2026-07-29-fresh-install-ci-design.md
@@ -1,0 +1,257 @@
+# Fresh-install CI — design
+
+> 2026-07-29 | status: approved
+
+## Problem
+
+Every existing xlings workflow builds xlings from the PR and tests *that* binary
+against a warm, cached environment. Nothing verifies the path a real first-time
+user takes: land on a clean machine, run `quick_install`, and use the tool.
+
+That path has its own failure modes, none of which the current matrix can see:
+
+- the published release artifact is broken or missing for a platform
+- `quick_install.sh` / `.ps1` regresses against a bare host
+- the bundled package index cannot resolve a package on a cold home
+- a package installs but its shim does not resolve
+- a version switch silently no-ops
+- the static-musl binary fails to start on an old-glibc host
+
+Modelled on `mcpp-community/mcpp`'s `ci-fresh-install.yml`.
+
+## Scope
+
+Verify **released** xlings, floating at latest — the exact thing a new user
+gets — from bootstrap through the mainstream feature set, on a cold machine
+with no caches, on Linux / CentOS 7 / Windows / macOS.
+
+Explicitly out of scope: building xlings from source (covered by
+`xlings-ci-*.yml`), and the E2E suite (covered by `xlings-ci-linux-e2e.yml`).
+
+## Structure
+
+The test body lives in the repo as scripts rather than inline YAML. The CentOS 7
+leg executes inside `docker run`, where a mounted script beats escaping a long
+heredoc through two shell layers; it also makes local reproduction a single
+command.
+
+```
+tests/fresh-install/
+  lib.sh      # assertion helpers (POSIX bash)
+  smoke.sh    # Linux / CentOS 7 / macOS body
+  lib.ps1     # assertion helpers (PowerShell)
+  smoke.ps1   # Windows body
+.github/workflows/xlings-ci-fresh-install.yml
+```
+
+Each script takes one argument — the suite name — so a red cell names the
+subsystem instead of "fresh-install is broken":
+
+```bash
+bash tests/fresh-install/smoke.sh core   # lifecycle + mcpp version switch
+bash tests/fresh-install/smoke.sh gcc    # gcc release-group switch
+bash tests/fresh-install/smoke.sh llvm   # llvm version switch
+```
+
+The scripts bootstrap xlings themselves (they run `quick_install` as their first
+phase) rather than relying on the workflow to do it. That keeps the Linux and
+CentOS 7 legs byte-identical and lets the whole thing run under `docker run`
+with no `$GITHUB_PATH` involvement.
+
+## Job matrix
+
+`suite` × platform, each cell doing its **own** fresh install — no shared warm
+state, which is the entire point. Cells run in parallel, so wall-clock is one
+bootstrap plus one toolchain, not the sum.
+
+| Platform | Runner | Suites |
+| --- | --- | --- |
+| Linux | `ubuntu-24.04` | core, gcc, llvm |
+| CentOS 7 | `ubuntu-24.04` + `docker run centos:7` | core, gcc, llvm |
+| Windows | `windows-latest` | core, gcc\*, llvm |
+| macOS | `macos-14` | core, llvm |
+
+Two constraints come from the package index, not from a choice:
+
+- **`gcc` on Windows has exactly one version** (`15.1.0`, via mingw64). That
+  cell therefore cannot test a *switch*; it installs 15.1.0 and asserts the
+  group members are present and mutually consistent — group registration, not
+  group switching. Real switching is Linux/CentOS 7, where `9.4.0` … `16.1.0`
+  are all available.
+- **`gcc` does not exist on macOS** in the index, so macOS has no gcc cell.
+
+## Suites
+
+### `core` — lifecycle, with the multi-version switch on `mcpp`
+
+```
+quick_install (no version arg → floating latest)
+xlings --version                        → non-empty
+xlings config --mirror GLOBAL
+xlings update                           → index refresh on a cold home
+xlings search mcpp                      → finds it
+xlings install ninja -y -g              → ninja --version == 1.12.1
+xlings install mcpp@<A> mcpp@<B> -y -g
+xlings use mcpp@<A>                     → mcpp --version reports A
+xlings use mcpp@<B>                     → mcpp --version reports B   (must CHANGE)
+xlings list                             → contains ninja and mcpp
+<tmpdir>/.xlings.json + xlings -y install
+                                        → .xlings/subos/_/bin/ninja resolves
+xlings self doctor                      → exit 0
+xlings self uninstall -y                → $XLINGS_HOME gone
+```
+
+`ninja` is the install-and-run probe because it is tiny, statically linked, and
+present on all four platforms. `mcpp` is the version-switch probe because it
+ships many versions on all four platforms.
+
+### `gcc` — release-group switch (Linux / CentOS 7)
+
+`gcc` registers a *group* of shims — `gcc`, `g++`, `c++`, `cpp`, `gcc-ar`,
+`gcov`, … — and `xlings use` is specified to move the whole group together.
+
+```
+xlings install gcc@15.1.0 gcc@16.1.0 -y -g
+xlings use gcc@15.1.0   → gcc AND g++ AND c++ AND cpp all report 15.1.0
+xlings use gcc@16.1.0   → all four report 16.1.0
+g++ hello.cpp && ./a.out                → the switched toolchain actually compiles
+```
+
+Asserting all four members move *together* is the point. A group switch that
+moves `gcc` but strands `g++` on the previous version passes any check that only
+looks at `gcc --version`.
+
+On Windows the same suite degrades to a presence-and-consistency check, since
+only one version exists.
+
+### `llvm` — version switch (all platforms)
+
+Same shape on `20.1.7 ↔ 22.1.8`, asserting `clang` and `clang++` move in sync,
+then compiling and running a **C** file with the switched clang. C rather than
+C++ on purpose: that asserts the driver and its runtime work end to end without
+also betting on libc++ wiring, which is a separate concern from the version
+switch under test.
+
+**Known red as of 2026-07-29.** On a fresh home this suite fails on Linux, and
+correctly so — see "First finding" below.
+
+## Differential assertions
+
+Every switch assertion captures the reported version **before and after** and
+fails if it did not move. This is deliberate: xlings has a recurring bug class
+where "never happened" and "succeeded" produce identical output, and a `use`
+that silently no-ops would otherwise pass a check that merely confirms
+`mcpp --version` still runs.
+
+`assert_switch` therefore takes the expected version *and* refuses a result
+equal to the pre-switch value.
+
+## CentOS 7 mechanics
+
+`docker run` inside a normal `ubuntu-24.04` job. A `container:` job cannot work:
+`actions/checkout`, `actions/cache` and every other JS action need Node 20,
+which needs glibc 2.28; CentOS 7 ships 2.17.
+
+So JS actions run on the host, the repo is bind-mounted, and only the smoke
+script runs in the container. Three fixups that leg needs and no other does:
+
+1. **Dead yum mirrors.** CentOS 7 is EOL and `mirrorlist.centos.org` is gone;
+   the repo files are rewritten to `vault.centos.org` before any `yum install`.
+2. **Stale CA bundle.** `ca-certificates` must be reinstalled and
+   `update-ca-trust` run, or TLS against the GitHub asset CDN fails.
+3. **`quick_install.sh` prerequisites.** It hard-requires `curl` and `tar`, and
+   locates the extracted directory with a glob; `which`, `findutils`, `gzip`,
+   `xz` and `git` are installed explicitly rather than assumed.
+
+This leg is load-bearing, not decorative. The xlings Linux binary is
+static-musl so it *should* start on glibc 2.17, and gcc/llvm pull in a
+self-contained `xim:glibc@2.39` rather than the host's — but whether that whole
+stack works on a 2.17 host is unproven today.
+
+## Triggers
+
+Two stages, as requested.
+
+**Stage 1 (this PR)** — `pull_request` included so the workflow can be validated
+before it is trusted:
+
+```yaml
+on:
+  pull_request:          # STAGE 1 ONLY — remove once green
+    branches: [main, master, 'release/**']
+  workflow_dispatch:
+  workflow_run:
+    workflows: [release]
+    types: [completed]
+  schedule:
+    - cron: '0 6 * * *'
+```
+
+**Stage 2** — delete the `pull_request:` block. The other three triggers are
+already correct and are inert on a PR, so stage 2 is a pure deletion.
+
+`release: published` is deliberately **not** used. `release.yml` creates the
+release with `GITHUB_TOKEN`, and GitHub suppresses workflow triggers from
+`GITHUB_TOKEN`-generated events, so that trigger would never fire from the
+pipeline. `workflow_run` is a platform-generated event, exempt from the
+suppression, and needs no cross-repo PAT.
+
+## Deliberate omission: no `wait-index` job
+
+mcpp's workflow polls xim-pkgindex until it carries the just-released version,
+because mcpp pins an exact version and would otherwise fail with
+`version not found`.
+
+We install floating-latest, so the same race degrades differently: a
+post-release run that beats the index bump re-tests the *previous* release. That
+is a weak result, not a red build — so the added complexity is not yet paid for.
+Worth revisiting if the post-release run needs to be a hard gate on the new
+version, which would also mean introducing a pin to bump each release.
+
+## First finding — `llvm@22.1.8` is unusable on a clean machine
+
+Found by running the `llvm` suite locally before the workflow ever ran, which is
+a decent sign the design points at the right gap.
+
+On a fresh home containing only llvm and its declared deps:
+
+```
+$ xlings install llvm@22.1.8 -y -g && clang --version
+.../xpkgs/xim-x-llvm/22.1.8/bin/clang: error while loading shared libraries:
+libstdc++.so.6: cannot open shared object file: No such file or directory
+```
+
+Root cause, confirmed against the installed payloads:
+
+- `clang-20` (20.1.7) does **not** link `libstdc++.so.6` — its C++ runtime is
+  static, so it runs anywhere.
+- `clang-22` (22.1.8) **does** link `libstdc++.so.6`.
+- Both get the same baked RPATH — llvm's own `lib`, plus `glibc`, `zlib`,
+  `libxml2`, and `subos/default/lib` — and **none of them ships libstdc++**.
+- `llvm.lua`'s linux `deps` list (`xim:glibc`, `xim:linux-headers`, `xim:zlib`,
+  `xim:libxml2`) never gained `xim:gcc-runtime` when the 22.1.8 payload started
+  linking libstdc++ dynamically.
+
+Installing `gcc-runtime` afterwards does **not** repair it: the RPATH is baked
+at llvm install time, so a later arrival is invisible to the loader. The fix
+belongs in `xim-pkgindex`'s `llvm.lua` — declare the dep so its lib directory is
+in the RPATH from the start.
+
+Impact is wider than this test: `latest` resolves to 22.1.8, so plain
+`xlings install llvm` is broken on any machine that does not already happen to
+have a libstdc++ around. That is why it went unnoticed — dev machines and CI
+images all have gcc installed.
+
+The suite is deliberately **not** softened to work around this. A test adjusted
+until it passes against a broken package is the silent-success pattern this
+repo keeps getting bitten by.
+
+## Failure modes this cannot catch
+
+Stated so the green check is not over-read:
+
+- CN mirror paths — every leg forces `GLOBAL`, since gitee/gitcode endpoints are
+  not reachable from GitHub runners.
+- aarch64 Linux and Windows ARM — no runners in the matrix.
+- Anything about the PR's own code. This workflow tests the *released* binary;
+  on a PR it therefore validates the workflow itself, not the change.

--- a/tests/fresh-install/lib.ps1
+++ b/tests/fresh-install/lib.ps1
@@ -24,9 +24,12 @@ function Write-State {
         Write-Host "   (no xlings home at $home_dir)"
         return
     }
+    # Depth 3 reaches <pkg>/<version>/bin/<exe>. Anything shallower cannot
+    # distinguish "the payload never landed" from "it landed and the recipe
+    # registered nothing from it" — which is the whole point of this dump.
     Write-Host "   payload tree ($home_dir\data\xpkgs):"
-    Get-ChildItem -Path (Join-Path $home_dir 'data\xpkgs') -Depth 2 -ErrorAction SilentlyContinue |
-        Select-Object -First 40 -ExpandProperty FullName |
+    Get-ChildItem -Path (Join-Path $home_dir 'data\xpkgs') -Depth 3 -ErrorAction SilentlyContinue |
+        Select-Object -First 60 -ExpandProperty FullName |
         ForEach-Object { Write-Host "     $_" }
     Write-Host '   xlings list:'
     & (Join-Path $home_dir 'subos\current\bin\xlings.exe') list 2>&1 |

--- a/tests/fresh-install/lib.ps1
+++ b/tests/fresh-install/lib.ps1
@@ -12,9 +12,31 @@ function Write-Section { param([string]$Text) Write-Host "`n== $Text" -Foregroun
 function Write-Log     { param([string]$Text) Write-Host "   $Text" -ForegroundColor DarkGray }
 function Write-Ok      { param([string]$Text) Write-Host "   OK  $Text" -ForegroundColor Green }
 
+# Write-State — what was actually on disk when an assertion failed.
+#
+# The distinction this exists to settle: when a package installs "successfully"
+# but its shims do not resolve, did the payload never land, or did it land and
+# the recipe fail to register it? Those are bugs in different repositories.
+function Write-State {
+    $home_dir = Join-Path $env:USERPROFILE '.xlings'
+    Write-Host "`n-- state at failure" -ForegroundColor Yellow
+    if (-not (Test-Path $home_dir)) {
+        Write-Host "   (no xlings home at $home_dir)"
+        return
+    }
+    Write-Host "   payload tree ($home_dir\data\xpkgs):"
+    Get-ChildItem -Path (Join-Path $home_dir 'data\xpkgs') -Depth 2 -ErrorAction SilentlyContinue |
+        Select-Object -First 40 -ExpandProperty FullName |
+        ForEach-Object { Write-Host "     $_" }
+    Write-Host '   xlings list:'
+    & (Join-Path $home_dir 'subos\current\bin\xlings.exe') list 2>&1 |
+        ForEach-Object { Write-Host "     $_" }
+}
+
 function Fail {
     param([string]$Text)
     Write-Host "`nFAIL $Text" -ForegroundColor Red
+    Write-State
     exit 1
 }
 

--- a/tests/fresh-install/lib.ps1
+++ b/tests/fresh-install/lib.ps1
@@ -1,0 +1,135 @@
+# Assertion helpers for the fresh-install smoke suites (Windows).
+#
+# Dot-sourced by smoke.ps1. Mirrors lib.sh one-for-one so the two platforms
+# assert the same things; see lib.sh for the reasoning behind each helper.
+#
+# Written for both pwsh 7 and Windows PowerShell 5.1 — no `??`, no ternary — so
+# a user reproducing a CI failure locally is not forced to install pwsh first.
+
+$ErrorActionPreference = 'Stop'
+
+function Write-Section { param([string]$Text) Write-Host "`n== $Text" -ForegroundColor Yellow }
+function Write-Log     { param([string]$Text) Write-Host "   $Text" -ForegroundColor DarkGray }
+function Write-Ok      { param([string]$Text) Write-Host "   OK  $Text" -ForegroundColor Green }
+
+function Fail {
+    param([string]$Text)
+    Write-Host "`nFAIL $Text" -ForegroundColor Red
+    exit 1
+}
+
+# Get-EnvOr — env var if set and non-empty, else the fallback.
+function Get-EnvOr {
+    param([string]$Name, [string]$Default)
+    $v = [Environment]::GetEnvironmentVariable($Name)
+    if ([string]::IsNullOrEmpty($v)) { return $Default }
+    return $v
+}
+
+# Invoke-Step — echo, run, and fail on a non-zero native exit code.
+#
+# The whole command is one array rather than exe-plus-remaining-arguments:
+# PowerShell would try to bind a bare `-y` or `-g` as a parameter of THIS
+# function and abort with "a parameter cannot be found that matches parameter
+# name 'y'" before the real command ever ran.
+#
+# The $LASTEXITCODE check is not optional. PowerShell does not treat a non-zero
+# exit from a native executable as a terminating error no matter what
+# $ErrorActionPreference says, so an unchecked call fails silently.
+function Invoke-Step {
+    param([string]$Desc, [string[]]$Command)
+    Write-Log "$ $($Command -join ' ')"
+    $exe = $Command[0]
+    $rest = @()
+    if ($Command.Count -gt 1) { $rest = $Command[1..($Command.Count - 1)] }
+    & $exe @rest
+    if ($LASTEXITCODE -ne 0) {
+        Fail "${Desc}: '$($Command -join ' ')' exited $LASTEXITCODE"
+    }
+}
+
+# Write-TextFile — UTF-8 with NO byte-order mark.
+#
+# `Set-Content -Encoding utf8` emits a BOM on Windows PowerShell 5.1, and a BOM
+# at the head of .xlings.json makes the JSON parse fail on a character the
+# error message cannot show.
+function Write-TextFile {
+    param([string]$Path, [string]$Content)
+    [System.IO.File]::WriteAllText($Path, $Content, (New-Object System.Text.UTF8Encoding($false)))
+}
+
+# Get-VersionFrom — first dotted numeric run in a block of text.
+#   "gcc (GCC) 15.1.0"     -> 15.1.0
+#   "clang version 20.1.7" -> 20.1.7
+#   "mcpp 2026.7.29.1"     -> 2026.7.29.1
+function Get-VersionFrom {
+    param([string]$Text)
+    $m = [regex]::Match($Text, '[0-9]+(\.[0-9]+)+')
+    if ($m.Success) { return $m.Value }
+    return ''
+}
+
+# Get-ToolVersion — the version <Tool> reports, or fail with its raw output.
+function Get-ToolVersion {
+    param([string]$Tool)
+    if (-not (Get-Command $Tool -ErrorAction SilentlyContinue)) { Fail "'$Tool' is not on PATH" }
+    $global:LASTEXITCODE = 0
+    $out = (& $Tool --version 2>&1 | Out-String)
+    if ($LASTEXITCODE -ne 0) { Fail "'$Tool --version' exited ${LASTEXITCODE}:`n$out" }
+    $ver = Get-VersionFrom $out
+    if (-not $ver) { Fail "'$Tool --version' printed no version number:`n$out" }
+    return $ver
+}
+
+function Assert-ToolVersion {
+    param([string]$Tool, [string]$Expected)
+    $got = Get-ToolVersion $Tool
+    if ($got -ne $Expected) { Fail "$Tool reports $got, expected $Expected" }
+    Write-Ok "$Tool -> $got"
+}
+
+# Assert-Switch — switch to <Pkg>@<Version>, then assert EVERY listed command
+# reports exactly that version.
+#
+# For a release group (gcc ships gcc/g++/c++ as one unit) this is the real
+# assertion: a switch that moves `gcc` but strands `g++` passes any check that
+# only looks at `gcc --version`. All members are probed before failing, so the
+# error names every stranded member at once.
+#
+# Callers invoke this twice with two DIFFERENT versions — that is what makes it
+# differential. A `use` that silently no-ops cannot satisfy both calls.
+function Assert-Switch {
+    param([string]$Pkg, [string]$Version, [string[]]$Tools)
+    Invoke-Step "xlings use $Pkg@$Version" @('xlings', 'use', "$Pkg@$Version")
+
+    $stranded = @()
+    foreach ($t in $Tools) {
+        $got = Get-ToolVersion $t
+        if ($got -eq $Version) { Write-Log "  $t -> $got" }
+        else { $stranded += "     $t reports $got (expected $Version)" }
+    }
+    if ($stranded.Count -gt 0) {
+        Fail "$Pkg@${Version}: release group did not switch as a unit:`n$($stranded -join "`n")"
+    }
+    Write-Ok "$Pkg@$Version - [$($Tools -join ', ')] switched as a unit"
+}
+
+# Assert-Runs — execute a freshly compiled binary and check its output.
+function Assert-Runs {
+    param([string]$Desc, [string]$Path, [string]$Expected)
+    if (-not (Test-Path $Path)) { Fail "${Desc}: '$Path' was not produced" }
+    $global:LASTEXITCODE = 0
+    $out = (& $Path 2>&1 | Out-String).Trim()
+    if ($LASTEXITCODE -ne 0) { Fail "${Desc}: '$Path' exited $LASTEXITCODE" }
+    if ($out -notlike "*$Expected*") {
+        Fail "${Desc}: '$Path' printed '$out', expected it to contain '$Expected'"
+    }
+    Write-Ok "$Desc -> $out"
+}
+
+# New-TempDir — a fresh empty directory (New-TemporaryFile makes a *file*).
+function New-TempDir {
+    $p = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+    New-Item -ItemType Directory -Path $p -Force | Out-Null
+    return $p
+}

--- a/tests/fresh-install/lib.ps1
+++ b/tests/fresh-install/lib.ps1
@@ -114,6 +114,25 @@ function Assert-Switch {
     Write-Ok "$Pkg@$Version - [$($Tools -join ', ')] switched as a unit"
 }
 
+# Assert-GroupConsistent — assert every listed command reports the SAME
+# version, without switching.
+#
+# For a single-version package there is nothing to switch between, but the
+# group can still be mis-registered: wiring up `gcc` while leaving `g++`
+# pointing at some other toolchain is the same defect Assert-Switch catches on
+# platforms that do have two versions.
+function Assert-GroupConsistent {
+    param([string]$Label, [string[]]$Tools)
+    $seen = @{}
+    foreach ($t in $Tools) { $seen[$t] = Get-ToolVersion $t; Write-Log "  $t -> $($seen[$t])" }
+    $distinct = $seen.Values | Sort-Object -Unique
+    if ($distinct.Count -ne 1) {
+        $detail = ($seen.GetEnumerator() | ForEach-Object { "     $($_.Key) reports $($_.Value)" }) -join "`n"
+        Fail "${Label}: release group members disagree on version:`n$detail"
+    }
+    Write-Ok "$Label - [$($Tools -join ', ')] all report $($distinct[0])"
+}
+
 # Assert-Runs — execute a freshly compiled binary and check its output.
 function Assert-Runs {
     param([string]$Desc, [string]$Path, [string]$Expected)

--- a/tests/fresh-install/lib.sh
+++ b/tests/fresh-install/lib.sh
@@ -15,7 +15,35 @@ fi
 section() { printf '\n%s══ %s%s\n' "$YLW" "$*" "$RST"; }
 log()     { printf '   %s%s%s\n' "$DIM" "$*" "$RST"; }
 ok()      { printf '   %sOK%s  %s\n' "$GRN" "$RST" "$*"; }
-fail()    { printf '\n%sFAIL%s %s\n' "$RED" "$RST" "$*" >&2; exit 1; }
+
+# dump_state — what was actually on disk when an assertion failed.
+#
+# Attached to every failure rather than left to a separate `if: failure()`
+# workflow step, because the CentOS 7 leg runs in a `docker run --rm` container
+# whose filesystem is gone by the time a later step could look at it.
+#
+# The distinction this exists to settle: when a package installs "successfully"
+# but its shims do not resolve, did the payload never land, or did it land and
+# the recipe fail to register it? Those are bugs in different repositories.
+dump_state() {
+    local home_dir="${XLINGS_HOME_DIR:-$HOME/.xlings}"
+    printf '\n%s── state at failure %s\n' "$YLW" "$RST" >&2
+    if [ ! -d "$home_dir" ]; then
+        printf '   (no xlings home at %s)\n' "$home_dir" >&2
+        return 0
+    fi
+    printf '   payload tree (%s/data/xpkgs):\n' "$home_dir" >&2
+    find "$home_dir/data/xpkgs" -maxdepth 3 2>/dev/null | head -40 | sed 's/^/     /' >&2 \
+        || printf '     (none)\n' >&2
+    printf '   xlings list:\n' >&2
+    "$home_dir/subos/current/bin/xlings" list 2>&1 | tr -d '\0' | sed 's/^/     /' >&2 || true
+}
+
+fail() {
+    printf '\n%sFAIL%s %s\n' "$RED" "$RST" "$*" >&2
+    dump_state
+    exit 1
+}
 
 # run <description> <cmd...> — echo the command, then run it, failing loudly.
 run() {

--- a/tests/fresh-install/lib.sh
+++ b/tests/fresh-install/lib.sh
@@ -1,0 +1,109 @@
+# shellcheck shell=bash
+#
+# Assertion helpers for the fresh-install smoke suites.
+#
+# Sourced by smoke.sh. Kept separate so the assertions — especially the
+# release-group check, which is the whole point of the gcc suite — can be read
+# without wading through the suite bodies.
+
+RED=''; GRN=''; YLW=''; DIM=''; RST=''
+if [ -t 1 ]; then
+    RED=$'\033[31m'; GRN=$'\033[32m'; YLW=$'\033[33m'
+    DIM=$'\033[2m';  RST=$'\033[0m'
+fi
+
+section() { printf '\n%s══ %s%s\n' "$YLW" "$*" "$RST"; }
+log()     { printf '   %s%s%s\n' "$DIM" "$*" "$RST"; }
+ok()      { printf '   %sOK%s  %s\n' "$GRN" "$RST" "$*"; }
+fail()    { printf '\n%sFAIL%s %s\n' "$RED" "$RST" "$*" >&2; exit 1; }
+
+# run <description> <cmd...> — echo the command, then run it, failing loudly.
+run() {
+    local desc="$1"; shift
+    log "\$ $*"
+    "$@" || fail "$desc: '$*' exited $?"
+}
+
+# extract_version <text> — first dotted numeric run in <text>.
+#
+# Handles every --version shape in the matrix without per-tool parsing:
+#   "gcc (GCC) 16.1.0"        → 16.1.0
+#   "clang version 20.1.7"    → 20.1.7
+#   "1.12.1"                  → 1.12.1
+#   "mcpp 2026.7.29.1"        → 2026.7.29.1
+#
+# No `head -1` on purpose: under `set -o pipefail` a SIGPIPE'd grep would fail
+# the whole script. The first line is taken with parameter expansion instead.
+extract_version() {
+    local all
+    all="$(printf '%s\n' "$1" | grep -oE '[0-9]+(\.[0-9]+)+' || true)"
+    printf '%s' "${all%%
+*}"
+}
+
+# tool_version <cmd> — the version <cmd> reports, or fail with its raw output.
+tool_version() {
+    local cmd="$1" out rc=0 ver
+    command -v "$cmd" >/dev/null 2>&1 || fail "'$cmd' is not on PATH"
+    out="$("$cmd" --version 2>&1)" || rc=$?
+    [ "$rc" -eq 0 ] || fail "'$cmd --version' exited $rc:
+$out"
+    ver="$(extract_version "$out")"
+    [ -n "$ver" ] || fail "'$cmd --version' printed no version number:
+$out"
+    printf '%s' "$ver"
+}
+
+# assert_tool_version <cmd> <expected>
+assert_tool_version() {
+    local cmd="$1" want="$2" got
+    got="$(tool_version "$cmd")"
+    [ "$got" = "$want" ] || fail "$cmd reports $got, expected $want"
+    ok "$cmd → $got"
+}
+
+# assert_switch <pkg> <version> <cmd> [cmd...]
+#
+# Switch to <pkg>@<version>, then assert EVERY listed command reports exactly
+# that version. For a release group (gcc ships gcc/g++/c++/cpp/... as one unit)
+# this is the real assertion: a switch that moves `gcc` but strands `g++` on the
+# previous version passes any check that only looks at `gcc --version`.
+#
+# Every member is probed before failing, so the error names all stranded
+# members at once instead of stopping at the first.
+#
+# Callers invoke this twice with two DIFFERENT versions. That is what makes it
+# differential: a `use` that silently no-ops cannot satisfy both calls, whereas
+# a single call could pass merely because the version was already active.
+assert_switch() {
+    local pkg="$1" ver="$2"; shift 2
+    run "xlings use $pkg@$ver" xlings use "$pkg@$ver"
+
+    local cmd got stranded=''
+    for cmd in "$@"; do
+        got="$(tool_version "$cmd")"
+        if [ "$got" = "$ver" ]; then
+            log "  $cmd → $got"
+        else
+            stranded="$stranded
+     $cmd reports $got (expected $ver)"
+        fi
+    done
+
+    if [ -n "$stranded" ]; then
+        fail "$pkg@$ver: release group did not switch as a unit:$stranded"
+    fi
+    ok "$pkg@$ver — [$*] switched as a unit"
+}
+
+# assert_runs <description> <file> <expected-stdout-substring> — execute a
+# freshly compiled binary and check it actually produced output.
+assert_runs() {
+    local desc="$1" bin="$2" want="$3" out
+    [ -x "$bin" ] || fail "$desc: '$bin' was not produced or is not executable"
+    out="$("$bin")" || fail "$desc: '$bin' exited $?"
+    case "$out" in
+        *"$want"*) ok "$desc → $out" ;;
+        *) fail "$desc: '$bin' printed '$out', expected it to contain '$want'" ;;
+    esac
+}

--- a/tests/fresh-install/smoke.ps1
+++ b/tests/fresh-install/smoke.ps1
@@ -1,0 +1,222 @@
+# Fresh-install smoke suites — Windows.
+#
+# Verifies RELEASED xlings (floating latest, exactly what a new user gets) on a
+# machine with no xlings state, from `quick_install.ps1` through the mainstream
+# feature set. It does NOT test the code in the working tree — see
+# xlings-ci-windows.yml for that.
+#
+#   usage: pwsh -File tests/fresh-install/smoke.ps1 -Suite <core|gcc|llvm>
+#
+# Note the `gcc` suite cannot test a version SWITCH on Windows: the package
+# index ships exactly one Windows gcc (15.1.0, via mingw64). It asserts group
+# registration and mutual consistency instead. Real group switching is covered
+# by the Linux and CentOS 7 legs.
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('core', 'gcc', 'llvm')]
+    [string]$Suite
+)
+
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'lib.ps1')
+
+# ── Versions under test ───────────────────────────────────────────────
+# Pinned rather than `latest` so an assertion can name an exact expected
+# string. Two distinct versions per package, because the switch assertions are
+# differential: one version alone would pass even if `use` did nothing.
+# Overridable so a failure can be re-run against other versions locally.
+$QuickInstallUrl = Get-EnvOr 'QUICK_INSTALL_URL' 'https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.ps1'
+$NinjaVersion    = Get-EnvOr 'NINJA_VERSION' '1.12.1'
+$McppOld         = Get-EnvOr 'MCPP_OLD'      '2026.7.28.2'
+$McppNew         = Get-EnvOr 'MCPP_NEW'      '2026.7.29.1'
+$GccWin          = Get-EnvOr 'GCC_WIN'       '15.1.0'
+$LlvmOld         = Get-EnvOr 'LLVM_OLD'      '20.1.7'
+$LlvmNew         = Get-EnvOr 'LLVM_NEW'      '22.1.8'
+
+$XlingsHome = Join-Path $env:USERPROFILE '.xlings'
+
+# ── Phase 0: bootstrap ────────────────────────────────────────────────
+
+function Invoke-Bootstrap {
+    Write-Section 'Bootstrap - quick_install on a cold machine'
+
+    if (Test-Path $XlingsHome) {
+        Fail "not a fresh environment: $XlingsHome already exists"
+    }
+
+    # No version argument: resolve to the newest release, which is the whole
+    # point - this is the command printed in the README.
+    #
+    # ErrorActionPreference is relaxed to 'Continue' for exactly this call so
+    # the installer runs under the same conditions a user gets from a bare
+    # `irm ... | iex`. Under 'Stop' any non-terminating Write-Error inside the
+    # installer would abort the run and report a failure the user would never
+    # actually see.
+    Write-Log "$ irm $QuickInstallUrl | iex"
+    $prevEap = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try { Invoke-RestMethod $QuickInstallUrl | Invoke-Expression }
+    finally { $ErrorActionPreference = $prevEap }
+
+    $shim = Join-Path $XlingsHome 'subos\current\bin\xlings.exe'
+    if (-not (Test-Path $shim)) {
+        Fail "quick_install left no xlings shim at $shim - the published release is unusable"
+    }
+
+    # The installer writes profile hooks, but this process started before they
+    # existed; put the same directories on PATH by hand.
+    $env:PATH = "$XlingsHome\subos\current\bin;$XlingsHome\bin;$env:PATH"
+
+    if (-not (Get-Command xlings -ErrorAction SilentlyContinue)) {
+        Fail 'xlings is not on PATH after quick_install'
+    }
+    Write-Ok "xlings $(Get-ToolVersion xlings) installed at $XlingsHome"
+
+    # Runners reach github.com but not the gitee/gitcode endpoints, so force
+    # GLOBAL rather than letting region detection guess.
+    Invoke-Step 'config mirror' @('xlings', 'config', '--mirror', 'GLOBAL')
+    # The release archive carries an index snapshot frozen at build time;
+    # refresh it so recently added package versions resolve.
+    Invoke-Step 'index update'  @('xlings', 'update')
+}
+
+# ── core: lifecycle + multi-version switch on mcpp ────────────────────
+
+function Invoke-SuiteCore {
+    Write-Section 'Discovery - search on a cold index'
+    $global:LASTEXITCODE = 0
+    $out = (xlings search mcpp 2>&1 | Out-String)
+    if ($LASTEXITCODE -ne 0) { Fail "xlings search mcpp exited $LASTEXITCODE" }
+    if ($out -notlike '*mcpp*') { Fail "xlings search mcpp did not mention mcpp:`n$out" }
+    Write-Ok 'search found mcpp'
+
+    Write-Section 'Install and run - ninja'
+    # ninja is the install-and-run probe: tiny, self-contained, and present on
+    # every platform in the matrix, so a failure here is xlings's, not the
+    # package's.
+    Invoke-Step 'install ninja' @('xlings', 'install', "ninja@$NinjaVersion", '-y', '-g')
+    Assert-ToolVersion ninja $NinjaVersion
+
+    Write-Section 'Multi-version switch - mcpp'
+    Invoke-Step "install mcpp $McppOld" @('xlings', 'install', "mcpp@$McppOld", '-y', '-g')
+    Invoke-Step "install mcpp $McppNew" @('xlings', 'install', "mcpp@$McppNew", '-y', '-g')
+    # Two switches, two distinct versions: a `use` that silently no-ops fails
+    # one of them no matter which version happened to be active.
+    Assert-Switch mcpp $McppOld @('mcpp')
+    Assert-Switch mcpp $McppNew @('mcpp')
+
+    Write-Section 'Inventory - list'
+    $global:LASTEXITCODE = 0
+    $out = (xlings list 2>&1 | Out-String)
+    if ($LASTEXITCODE -ne 0) { Fail "xlings list exited $LASTEXITCODE" }
+    if ($out -notlike '*ninja*') { Fail "xlings list omits ninja:`n$out" }
+    if ($out -notlike '*mcpp*')  { Fail "xlings list omits mcpp:`n$out" }
+    Write-Ok 'list reports ninja and mcpp'
+
+    Write-Section 'Project mode - .xlings.json workspace'
+    $proj = New-TempDir
+    Write-TextFile (Join-Path $proj '.xlings.json') @"
+{
+  "mirror": "GLOBAL",
+  "workspace": {
+    "ninja": "$NinjaVersion"
+  }
+}
+"@
+
+    Push-Location $proj
+    try { Invoke-Step 'project install' @('xlings', 'install', '-y') }
+    finally { Pop-Location }
+
+    $projShim = Join-Path $proj '.xlings\subos\_\bin\ninja.exe'
+    if (-not (Test-Path $projShim)) {
+        Fail "project install produced no project-local shim at $projShim"
+    }
+    $got = Get-VersionFrom ((& $projShim --version 2>&1) | Out-String)
+    if ($got -ne $NinjaVersion) {
+        Fail "project-local ninja shim reports $got, expected $NinjaVersion"
+    }
+    Write-Ok "project-local shim resolves ninja $got"
+
+    Write-Section 'Self-management - doctor'
+    Invoke-Step 'self doctor' @('xlings', 'self', 'doctor')
+
+    Write-Section 'Teardown - self uninstall'
+    Invoke-Step 'self uninstall' @('xlings', 'self', 'uninstall', '-y')
+    if (Test-Path $XlingsHome) { Fail "self uninstall left $XlingsHome behind" }
+    Write-Ok "self uninstall removed $XlingsHome"
+}
+
+# ── gcc: group registration (no switch available on Windows) ──────────
+
+function Invoke-SuiteGcc {
+    Write-Section "Install gcc $GccWin (mingw64)"
+    Invoke-Step "install gcc $GccWin" @('xlings', 'install', "gcc@$GccWin", '-y', '-g')
+
+    Write-Section 'Release group - gcc/g++/c++ must agree'
+    # Only one Windows gcc exists in the index, so there is nothing to switch
+    # BETWEEN. What is still worth asserting is that `use` registers the whole
+    # group consistently: a registration that wires up `gcc` but leaves `g++`
+    # pointing elsewhere is the same defect the Linux switch test catches.
+    Assert-Switch gcc $GccWin @('gcc', 'g++', 'c++')
+
+    Write-Section 'The toolchain compiles and runs'
+    $work = New-TempDir
+    Write-TextFile (Join-Path $work 'hello.cpp') @'
+#include <iostream>
+#include <string>
+#include <vector>
+int main() {
+    std::vector<std::string> parts{"fresh", "install", "ok"};
+    for (const auto& p : parts) std::cout << p << ' ';
+    std::cout << '\n';
+}
+'@
+
+    Push-Location $work
+    try { Invoke-Step 'g++ compile' @('g++', '-std=c++20', 'hello.cpp', '-o', 'hello.exe') }
+    finally { Pop-Location }
+    Assert-Runs "g++ $GccWin binary" (Join-Path $work 'hello.exe') 'fresh install ok'
+}
+
+# ── llvm: version switch ──────────────────────────────────────────────
+
+function Invoke-SuiteLlvm {
+    Write-Section 'Install two llvm versions'
+    Invoke-Step "install llvm $LlvmOld" @('xlings', 'install', "llvm@$LlvmOld", '-y', '-g')
+    Invoke-Step "install llvm $LlvmNew" @('xlings', 'install', "llvm@$LlvmNew", '-y', '-g')
+
+    Write-Section 'Version switch - clang/clang++ must move together'
+    Assert-Switch llvm $LlvmOld @('clang', 'clang++')
+    Assert-Switch llvm $LlvmNew @('clang', 'clang++')
+
+    Write-Section 'The switched toolchain compiles and runs'
+    # C, not C++, on purpose: this asserts the compiler driver and its runtime
+    # work end to end without also betting on the C++ standard library wiring,
+    # which is a separate concern from the version switch under test here.
+    $work = New-TempDir
+    Write-TextFile (Join-Path $work 'hello.c') @'
+#include <stdio.h>
+int main(void) { printf("fresh install ok\n"); return 0; }
+'@
+
+    Push-Location $work
+    try { Invoke-Step 'clang compile' @('clang', 'hello.c', '-o', 'hello.exe') }
+    finally { Pop-Location }
+    Assert-Runs "clang $LlvmNew binary" (Join-Path $work 'hello.exe') 'fresh install ok'
+}
+
+# ── entry point ───────────────────────────────────────────────────────
+
+Write-Host "+- fresh-install: $Suite suite on Windows $env:PROCESSOR_ARCHITECTURE" -ForegroundColor Yellow
+
+Invoke-Bootstrap
+switch ($Suite) {
+    'core' { Invoke-SuiteCore }
+    'gcc'  { Invoke-SuiteGcc }
+    'llvm' { Invoke-SuiteLlvm }
+}
+
+Write-Section "PASS - $Suite suite"

--- a/tests/fresh-install/smoke.ps1
+++ b/tests/fresh-install/smoke.ps1
@@ -31,7 +31,7 @@ $QuickInstallUrl = Get-EnvOr 'QUICK_INSTALL_URL' 'https://raw.githubusercontent.
 $NinjaVersion    = Get-EnvOr 'NINJA_VERSION' '1.12.1'
 $McppOld         = Get-EnvOr 'MCPP_OLD'      '2026.7.28.2'
 $McppNew         = Get-EnvOr 'MCPP_NEW'      '2026.7.29.1'
-$GccWin          = Get-EnvOr 'GCC_WIN'       '15.1.0'
+$MingwVersion    = Get-EnvOr 'MINGW_VERSION' '13.0.0'
 $LlvmOld         = Get-EnvOr 'LLVM_OLD'      '20.1.7'
 $LlvmNew         = Get-EnvOr 'LLVM_NEW'      '22.1.8'
 
@@ -152,15 +152,20 @@ function Invoke-SuiteCore {
 # ── gcc: group registration (no switch available on Windows) ──────────
 
 function Invoke-SuiteGcc {
-    Write-Section "Install gcc $GccWin (mingw64)"
-    Invoke-Step "install gcc $GccWin" @('xlings', 'install', "gcc@$GccWin", '-y', '-g')
+    # `mingw-w64`, NOT `gcc`. On Windows gcc.lua registers nothing — its
+    # config() returns early with "config in mingw-w64.lua", and its lone
+    # windows entry declares no payload. mingw-w64.lua is what actually
+    # registers the gcc/g++/c++ shims, so that is the package a Windows user
+    # installs to get a C++ compiler.
+    Write-Section "Install mingw-w64 $MingwVersion (provides gcc/g++/c++)"
+    Invoke-Step "install mingw-w64 $MingwVersion" @('xlings', 'install', "mingw-w64@$MingwVersion", '-y', '-g')
 
     Write-Section 'Release group - gcc/g++/c++ must agree'
-    # Only one Windows gcc exists in the index, so there is nothing to switch
-    # BETWEEN. What is still worth asserting is that `use` registers the whole
-    # group consistently: a registration that wires up `gcc` but leaves `g++`
-    # pointing elsewhere is the same defect the Linux switch test catches.
-    Assert-Switch gcc $GccWin @('gcc', 'g++', 'c++')
+    # Only one mingw-w64 version exists in the index, so there is nothing to
+    # switch BETWEEN — hence consistency rather than a switch. A registration
+    # that wires up `gcc` but leaves `g++` pointing elsewhere is the same
+    # defect the Linux switch test catches.
+    Assert-GroupConsistent 'mingw-w64' @('gcc', 'g++', 'c++')
 
     Write-Section 'The toolchain compiles and runs'
     $work = New-TempDir
@@ -178,7 +183,7 @@ int main() {
     Push-Location $work
     try { Invoke-Step 'g++ compile' @('g++', '-std=c++20', 'hello.cpp', '-o', 'hello.exe') }
     finally { Pop-Location }
-    Assert-Runs "g++ $GccWin binary" (Join-Path $work 'hello.exe') 'fresh install ok'
+    Assert-Runs "mingw-w64 $MingwVersion g++ binary" (Join-Path $work 'hello.exe') 'fresh install ok'
 }
 
 # ── llvm: version switch ──────────────────────────────────────────────

--- a/tests/fresh-install/smoke.ps1
+++ b/tests/fresh-install/smoke.ps1
@@ -80,6 +80,35 @@ function Invoke-Bootstrap {
     # The release archive carries an index snapshot frozen at build time;
     # refresh it so recently added package versions resolve.
     Invoke-Step 'index update'  @('xlings', 'update')
+
+    Invoke-IndexOverlay
+}
+
+# Invoke-IndexOverlay — swap in a candidate xim-pkgindex, if one was requested.
+#
+# Recipe bugs are only ever caught on a real install, and a recipe fix
+# therefore cannot be validated until it is already published. This lets an
+# unmerged xim-pkgindex branch be run through the whole suite before it lands.
+# Only pkgs/ is replaced; the rest of the directory is metadata the fetch wrote.
+function Invoke-IndexOverlay {
+    $ref = Get-EnvOr 'XIM_PKGINDEX_REF' ''
+    if (-not $ref) { return }
+
+    Write-Section "Index override - xim-pkgindex@$ref"
+    $dst = Join-Path $XlingsHome 'data\xim-pkgindex'
+    if (-not (Test-Path (Join-Path $dst 'pkgs'))) {
+        Fail "no published index at $dst\pkgs to override"
+    }
+
+    $tmp = New-TempDir
+    Invoke-Step "clone xim-pkgindex@$ref" @(
+        'git', 'clone', '-q', '--depth', '1', '--branch', $ref,
+        'https://github.com/openxlings/xim-pkgindex.git', (Join-Path $tmp 'idx')
+    )
+
+    Remove-Item -Recurse -Force (Join-Path $dst 'pkgs')
+    Copy-Item -Recurse -Force (Join-Path $tmp 'idx\pkgs') (Join-Path $dst 'pkgs')
+    Write-Ok "pkgs/ replaced from xim-pkgindex@$ref"
 }
 
 # ── core: lifecycle + multi-version switch on mcpp ────────────────────

--- a/tests/fresh-install/smoke.sh
+++ b/tests/fresh-install/smoke.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+#
+# Fresh-install smoke suites — Linux, CentOS 7, macOS.
+#
+# Verifies RELEASED xlings (floating latest, exactly what a new user gets) on a
+# machine with no xlings state, from `quick_install` through the mainstream
+# feature set. It does NOT test the code in the working tree — see
+# xlings-ci-linux*.yml for that.
+#
+# The script bootstraps xlings itself rather than relying on the caller, so the
+# native Linux leg and the CentOS 7 `docker run` leg execute byte-identical code
+# and neither needs $GITHUB_PATH.
+#
+#   usage: bash tests/fresh-install/smoke.sh <core|gcc|llvm>
+#
+# Run it locally the same way CI does — but note it uninstalls xlings from $HOME
+# at the end of the `core` suite, so point HOME somewhere disposable:
+#
+#   HOME=$(mktemp -d) bash tests/fresh-install/smoke.sh core
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=tests/fresh-install/lib.sh
+. "$HERE/lib.sh"
+
+# ── Versions under test ───────────────────────────────────────────────
+# Pinned rather than `latest` so an assertion can name an exact expected
+# string. Two distinct versions per package, because the switch assertions are
+# differential: one version alone would pass even if `use` did nothing.
+# Overridable so a failure can be re-run against other versions locally.
+QUICK_INSTALL_URL="${QUICK_INSTALL_URL:-https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh}"
+NINJA_VERSION="${NINJA_VERSION:-1.12.1}"
+MCPP_OLD="${MCPP_OLD:-2026.7.28.2}"
+MCPP_NEW="${MCPP_NEW:-2026.7.29.1}"
+GCC_OLD="${GCC_OLD:-15.1.0}"
+GCC_NEW="${GCC_NEW:-16.1.0}"
+LLVM_OLD="${LLVM_OLD:-20.1.7}"
+LLVM_NEW="${LLVM_NEW:-22.1.8}"
+
+XLINGS_HOME_DIR="$HOME/.xlings"
+
+# quick_install.sh reads from /dev/tty when its stdin is a pipe, which would
+# hang a local run outside CI. Set it here rather than only in the workflow so
+# `bash smoke.sh` behaves identically in both places.
+export XLINGS_NON_INTERACTIVE=1
+
+# ── Phase 0: bootstrap ────────────────────────────────────────────────
+
+bootstrap() {
+    section "Bootstrap — quick_install on a cold machine"
+
+    if [ -e "$XLINGS_HOME_DIR" ]; then
+        fail "not a fresh environment: $XLINGS_HOME_DIR already exists"
+    fi
+
+    # No version argument: resolve to the newest release, which is the whole
+    # point — this is the command printed in the README.
+    log "\$ curl -fsSL $QUICK_INSTALL_URL | bash"
+    curl -fsSL "$QUICK_INSTALL_URL" | bash \
+        || fail "quick_install.sh exited $? — the published release is unusable"
+
+    [ -x "$XLINGS_HOME_DIR/subos/current/bin/xlings" ] \
+        || fail "quick_install left no xlings shim at $XLINGS_HOME_DIR/subos/current/bin/xlings"
+
+    # The installer writes shell-profile hooks, but this process was started
+    # before they existed; put the same directories on PATH by hand.
+    export PATH="$XLINGS_HOME_DIR/subos/current/bin:$XLINGS_HOME_DIR/bin:$PATH"
+
+    command -v xlings >/dev/null || fail "xlings is not on PATH after quick_install"
+    ok "xlings $(tool_version xlings) installed at $XLINGS_HOME_DIR"
+
+    # Runners reach github.com but not the gitee/gitcode endpoints, so force
+    # GLOBAL rather than letting region detection guess.
+    run "config mirror"  xlings config --mirror GLOBAL
+    # The release tarball carries an index snapshot frozen at build time;
+    # refresh it so recently added package versions resolve.
+    run "index update"   xlings update
+}
+
+# ── core: lifecycle + multi-version switch on mcpp ────────────────────
+
+suite_core() {
+    section "Discovery — search on a cold index"
+    # `tr -d '\0'`: the TUI writes null bytes, and command substitution warns
+    # about (and drops) them, which would spray noise across the CI log.
+    local out
+    out="$(xlings search mcpp 2>&1 | tr -d '\0')" || fail "xlings search mcpp exited $?"
+    case "$out" in
+        *mcpp*) ok "search found mcpp" ;;
+        *) fail "xlings search mcpp did not mention mcpp:
+$out" ;;
+    esac
+
+    section "Install and run — ninja"
+    # ninja is the install-and-run probe: tiny, statically linked, and present
+    # on every platform in the matrix, so a failure here is xlings's, not the
+    # package's.
+    run "install ninja" xlings install "ninja@$NINJA_VERSION" -y -g
+    assert_tool_version ninja "$NINJA_VERSION"
+
+    section "Multi-version switch — mcpp"
+    run "install mcpp $MCPP_OLD" xlings install "mcpp@$MCPP_OLD" -y -g
+    run "install mcpp $MCPP_NEW" xlings install "mcpp@$MCPP_NEW" -y -g
+    # Two switches, two distinct versions: a `use` that silently no-ops fails
+    # one of them no matter which version happened to be active.
+    assert_switch mcpp "$MCPP_OLD" mcpp
+    assert_switch mcpp "$MCPP_NEW" mcpp
+
+    section "Inventory — list"
+    out="$(xlings list 2>&1 | tr -d '\0')" || fail "xlings list exited $?"
+    case "$out" in *ninja*) ;; *) fail "xlings list omits ninja:
+$out" ;; esac
+    case "$out" in *mcpp*) ;; *) fail "xlings list omits mcpp:
+$out" ;; esac
+    ok "list reports ninja and mcpp"
+
+    section "Project mode — .xlings.json workspace"
+    local proj; proj="$(mktemp -d)"
+    cat > "$proj/.xlings.json" <<EOF
+{
+  "mirror": "GLOBAL",
+  "workspace": {
+    "ninja": "$NINJA_VERSION"
+  }
+}
+EOF
+    ( cd "$proj" && run "project install" xlings install -y )
+
+    local shim="$proj/.xlings/subos/_/bin/ninja"
+    [ -x "$shim" ] || fail "project install produced no project-local shim at $shim"
+    local got; got="$(extract_version "$("$shim" --version 2>&1)")"
+    [ "$got" = "$NINJA_VERSION" ] \
+        || fail "project-local ninja shim reports $got, expected $NINJA_VERSION"
+    ok "project-local shim resolves ninja $got"
+
+    section "Self-management — doctor"
+    run "self doctor" xlings self doctor
+
+    section "Teardown — self uninstall"
+    run "self uninstall" xlings self uninstall -y
+    if [ -d "$XLINGS_HOME_DIR" ]; then
+        fail "self uninstall left $XLINGS_HOME_DIR behind"
+    fi
+    ok "self uninstall removed $XLINGS_HOME_DIR"
+}
+
+# ── gcc: release-group switch ─────────────────────────────────────────
+
+suite_gcc() {
+    case "$(uname -s)" in
+        Linux) ;;
+        *) fail "the gcc suite is Linux-only — the package index ships no gcc for $(uname -s)" ;;
+    esac
+
+    section "Install two gcc versions"
+    run "install gcc $GCC_OLD" xlings install "gcc@$GCC_OLD" -y -g
+    run "install gcc $GCC_NEW" xlings install "gcc@$GCC_NEW" -y -g
+
+    section "Release-group switch — gcc/g++/c++/cpp must move together"
+    # gcc registers its drivers as one xvm group. Asserting only `gcc` here
+    # would pass while `g++` stayed on the other version — the exact failure
+    # this suite exists to catch.
+    assert_switch gcc "$GCC_OLD" gcc g++ c++ cpp
+    assert_switch gcc "$GCC_NEW" gcc g++ c++ cpp
+
+    section "The switched toolchain compiles and runs"
+    local work; work="$(mktemp -d)"
+    cat > "$work/hello.cpp" <<'EOF'
+#include <iostream>
+#include <string>
+#include <vector>
+int main() {
+    std::vector<std::string> parts{"fresh", "install", "ok"};
+    for (const auto& p : parts) std::cout << p << ' ';
+    std::cout << '\n';
+}
+EOF
+    ( cd "$work" && run "g++ compile" g++ -std=c++20 hello.cpp -o hello )
+    assert_runs "g++ $GCC_NEW binary" "$work/hello" "fresh install ok"
+
+    # Switch back and rebuild: proves the switch is real for compilation, not
+    # just for what --version prints.
+    assert_switch gcc "$GCC_OLD" gcc g++ c++ cpp
+    ( cd "$work" && run "g++ recompile" g++ -std=c++20 hello.cpp -o hello_old )
+    assert_runs "g++ $GCC_OLD binary" "$work/hello_old" "fresh install ok"
+}
+
+# ── llvm: version switch ──────────────────────────────────────────────
+
+suite_llvm() {
+    section "Install two llvm versions"
+    run "install llvm $LLVM_OLD" xlings install "llvm@$LLVM_OLD" -y -g
+    run "install llvm $LLVM_NEW" xlings install "llvm@$LLVM_NEW" -y -g
+
+    section "Version switch — clang/clang++ must move together"
+    assert_switch llvm "$LLVM_OLD" clang clang++
+    assert_switch llvm "$LLVM_NEW" clang clang++
+
+    section "The switched toolchain compiles and runs"
+    # C, not C++, on purpose: this asserts the compiler driver and the bundled
+    # libc work end to end without also betting on libc++ wiring, which is a
+    # separate concern from the version switch under test here.
+    local work; work="$(mktemp -d)"
+    cat > "$work/hello.c" <<'EOF'
+#include <stdio.h>
+int main(void) { printf("fresh install ok\n"); return 0; }
+EOF
+    ( cd "$work" && run "clang compile" clang hello.c -o hello )
+    assert_runs "clang $LLVM_NEW binary" "$work/hello" "fresh install ok"
+}
+
+# ── entry point ───────────────────────────────────────────────────────
+
+main() {
+    local suite="${1:-}"
+    case "$suite" in
+        core|gcc|llvm) ;;
+        '') fail "usage: $0 <core|gcc|llvm>" ;;
+        *)  fail "unknown suite '$suite' — expected core, gcc or llvm" ;;
+    esac
+
+    printf '%s┌─ fresh-install: %s suite on %s %s%s\n' \
+        "$YLW" "$suite" "$(uname -s)" "$(uname -m)" "$RST"
+
+    bootstrap
+    "suite_$suite"
+
+    section "PASS — $suite suite"
+}
+
+main "$@"

--- a/tests/fresh-install/smoke.sh
+++ b/tests/fresh-install/smoke.sh
@@ -76,6 +76,37 @@ bootstrap() {
     # The release tarball carries an index snapshot frozen at build time;
     # refresh it so recently added package versions resolve.
     run "index update"   xlings update
+
+    overlay_index
+}
+
+# overlay_index — swap in a candidate xim-pkgindex, if one was requested.
+#
+# Recipe bugs are only ever caught on a real install, and a recipe fix
+# therefore cannot be validated until it is already published. This lets an
+# unmerged xim-pkgindex branch be run through the whole suite, on every
+# platform, before it lands.
+#
+# Only `pkgs/` is replaced: the rest of the index directory is metadata the
+# fetch wrote (cache manifests, sub-index state) and swapping that out would
+# test a state no user is ever in. The directory is replaced in place rather
+# than symlinked, because a symlinked index turns later differentials into
+# unfalsifiable passes.
+overlay_index() {
+    [ -n "${XIM_PKGINDEX_REF:-}" ] || return 0
+
+    section "Index override — xim-pkgindex@$XIM_PKGINDEX_REF"
+    local dst="$XLINGS_HOME_DIR/data/xim-pkgindex"
+    [ -d "$dst/pkgs" ] || fail "no published index at $dst/pkgs to override"
+
+    local tmp; tmp="$(mktemp -d)"
+    git clone -q --depth 1 --branch "$XIM_PKGINDEX_REF" \
+        https://github.com/openxlings/xim-pkgindex.git "$tmp/idx" \
+        || fail "cannot clone xim-pkgindex@$XIM_PKGINDEX_REF"
+
+    rm -rf "$dst/pkgs"
+    cp -R "$tmp/idx/pkgs" "$dst/pkgs" || fail "failed to overlay pkgs/"
+    ok "pkgs/ replaced from xim-pkgindex@$XIM_PKGINDEX_REF ($(git -C "$tmp/idx" rev-parse --short HEAD))"
 }
 
 # ── core: lifecycle + multi-version switch on mcpp ────────────────────


### PR DESCRIPTION
Adds a fresh-install CI modelled on [mcpp's `ci-fresh-install.yml`](https://github.com/mcpp-community/mcpp/actions/workflows/ci-fresh-install.yml).

Every existing workflow builds xlings from the PR and tests that binary against a warm, cached environment. Nothing covered the path a real first-time user takes: bare host → `quick_install` → use the tool. This tests the **released** xlings at floating latest, which is exactly what a new user gets.

## Suites

Three suites × four platforms, each cell doing its **own** cold install (no caches anywhere — a warm cache would defeat the point).

| Suite | What it asserts |
|---|---|
| `core` | `quick_install` → `--version` → `update` → `search` → install/run ninja → **multi-version switch on mcpp** → `list` → project-mode `.xlings.json` → `self doctor` → `self uninstall` |
| `gcc` | **release-group switch** — `gcc`/`g++`/`c++`/`cpp` must move as one unit, then the switched compiler must actually build and run a binary |
| `llvm` | version switch — `clang`/`clang++` must move together, then compile and run |

| Platform | Runner | Suites |
|---|---|---|
| Linux | `ubuntu-24.04` | core, gcc, llvm |
| CentOS 7 | `ubuntu-24.04` + `docker run centos:7` | core, gcc, llvm |
| Windows | `windows-latest` | core, gcc\*, llvm |
| macOS | `macos-14` | core, llvm |

\* Windows installs `mingw-w64` (that is what registers gcc/g++/c++ there) and asserts group *consistency*, since only one version exists. macOS has no gcc cell — the index ships none.

## Results

| Suite | Linux | CentOS 7 | Windows | macOS |
|---|---|---|---|---|
| `core` | ✅ | ✅ | ✅ | ✅ |
| `gcc` | ✅ | ✅ | ❌ | n/a |
| `llvm` | ❌ | ❌ | ❌ | ❌ |

`core` green on all four platforms is the headline: bootstrap, index refresh, install, run, multi-version switch, project mode, doctor and uninstall all work from cold everywhere — **including CentOS 7**, which also passes the full gcc release-group switch on glibc 2.17. That was the leg most likely to be unsupportable, and it isn't.

## Every failure traced and filed

| Defect | Layer | Issue |
|---|---|---|
| `mingw-w64` config hook uses xvm node kind `binding`; xlings accepts only `program`/`lib`/`group`/`files`, so the hook aborts | xim-pkgindex | [#442](https://github.com/openxlings/xim-pkgindex/issues/442) |
| `gcc.lua`'s windows entry declares no payload and no deps despite its "deps mingw64" comment | xim-pkgindex | [#442 (comment)](https://github.com/openxlings/xim-pkgindex/issues/442#issuecomment-5111913429) |
| `llvm@22.1.8` does not carry its C++ runtime — `libstdc++.so.6` missing on Linux/CentOS 7, `__ZdaPv` on macOS. `latest` resolves to 22.1.8, so plain `xlings install llvm` is broken on any clean host | xim-pkgindex | [#443](https://github.com/openxlings/xim-pkgindex/issues/443) |
| `llvm`'s `collect_bin_apps` registers zero programs on Windows although `clang.exe` is on disk, logging nothing | xim-pkgindex | [#444](https://github.com/openxlings/xim-pkgindex/issues/444) |
| `install` prints `✓ N package(s) installed` without checking the package's own declared `programs` registered | **xlings** | [#447](https://github.com/openxlings/xlings/issues/447) |

Only the last is an xlings defect — and it is the one that turns the other four from "install failed, here is the missing program" into "everything said OK and nothing works".

**The headline finding: there is currently no working way to get a C++ compiler on Windows through xlings.** `gcc` installs nothing, `mingw-w64` aborts on the unsupported node kind, and `llvm` registers no `clang`. Every existing workflow was blind to this because they all run against warm, pre-provisioned environments.

## Notes on the design

**Switch assertions are differential by construction.** Each is invoked twice with two *different* versions, so a `use` that silently no-ops cannot satisfy both calls. And every group member is probed, not just `gcc` — a switch that moves `gcc` but strands `g++` passes any check that only looks at `gcc --version`.

**Failures dump the payload tree and `xlings list`**, attached to `fail()` rather than an `if: failure()` step, because the CentOS 7 leg runs in `docker run --rm` and its filesystem is gone by the time a later step could look. That dump is what settled #444 — it proved `clang.exe` was on disk, making it a registration bug rather than an extraction bug.

**CentOS 7 runs via `docker run` inside a normal ubuntu job**, not a `container:` job: `actions/checkout` and every other JS action need Node 20 → glibc 2.28, and CentOS 7 ships 2.17. The JS actions stay on the host, the repo is bind-mounted, only the smoke script enters the container. That leg also needs the `vault.centos.org` repo rewrite (EOL, mirrorlist is gone) and a CA-bundle refresh.

**Suites live in `tests/fresh-install/`**, not inline in the YAML, so the CentOS 7 leg can mount them and so a failure reproduces locally with one command:

```bash
HOME=$(mktemp -d) bash tests/fresh-install/smoke.sh gcc
```

**`release: published` is deliberately not used** — `release.yml` creates the release with `GITHUB_TOKEN`, and GitHub suppresses workflow triggers from `GITHUB_TOKEN` events, so it would never fire. `workflow_run` is the hook that actually works.

## Triggers

Both stages are done. It ran on `pull_request` for four runs while being validated; that trigger is now removed. Final state is `workflow_dispatch` + `workflow_run(release)` + daily schedule — so this PR itself no longer triggers it, and merging does not gate unrelated PRs on another repository's release state.

## The llvm suite is deliberately not softened

A test adjusted until it passes against a broken package is exactly the silent-success pattern this repo keeps getting bitten by. The `llvm` cells stay red until #443 and #444 are fixed.