### PR TITLE
fix(xim): fail an install that registers none of its declared programs

### DIFF
--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -1769,6 +1769,56 @@ bool run_config_hook_(const PlanNode& node,
         node, dataDir, executor, useAfterInstall);
 }
 
+// A package that promised programs and delivered none of them.
+//
+// `✓ N package(s) installed` counts recipes that did not raise, which is not
+// the same as packages that work. Two real installs printed that checkmark and
+// left the user with nothing: llvm on Windows registered no `clang` because
+// its recipe's directory listing came back empty, and gcc on Windows
+// registered nothing because the toolchain it delegates to aborted. Neither
+// emitted a single diagnostic (openxlings/xlings#447).
+//
+// Recipes state what they provide in `package.programs`, so that promise can
+// simply be checked against the version database.
+//
+// Deliberately checked after the WHOLE plan has run, not per node: a package
+// may legitimately register nothing itself and delegate to a deferred install
+// -- gcc on Windows hands off to mingw-w64 -- and that dep has not been
+// installed yet at the moment its consumer's config hook returns.
+//
+// Only total absence is reported. Partial registration is normal and correct:
+// recipes routinely declare one cross-platform program list and register the
+// subset that exists on this host. Zero out of N is what never has a benign
+// reading -- the package cannot do the thing it exists to do.
+std::vector<std::string> unfulfilled_program_promises_(const InstallPlan& plan) {
+    std::vector<std::string> broken;
+    // By value, per Config::versions()'s contract -- it merges global and
+    // project state into a fresh map, so a reference into the temporary would
+    // dangle at the end of the full expression.
+    const auto db = Config::versions();
+
+    for (const auto& node : plan.nodes) {
+        // Build-only deps are intentionally never registered or shimmed.
+        if (node.kind == DepKind::Build) continue;
+        if (node.programs.empty()) continue;
+
+        const bool anyRegistered = std::ranges::any_of(
+            node.programs,
+            [&](const std::string& prog) { return xvm::has_target(db, prog); });
+        if (anyRegistered) continue;
+
+        std::string names;
+        for (const auto& prog : node.programs) {
+            if (!names.empty()) names += ", ";
+            names += prog;
+        }
+        log::error("{} installed but registered none of the programs it "
+                   "declares: {}", node.name, names);
+        broken.push_back(node.name);
+    }
+    return broken;
+}
+
 }  // namespace detail_
 
 using InstallRequestHandler = std::function<void(const std::vector<mcpplibs::xpkg::InstallRequest>&)>;
@@ -2423,6 +2473,22 @@ public:
             } else {
                 log::debug("{}@{} installed successfully", node.name, node.version);
             }
+        }
+
+        // Every hook returned success; that is not the same as the packages
+        // being usable. Fail the install rather than let a checkmark stand for
+        // a package that registered none of the programs it promised.
+        if (auto broken = detail_::unfulfilled_program_promises_(plan);
+            !broken.empty()) {
+            for (const auto& name : broken) {
+                if (onStatus) {
+                    onStatus({ name, InstallPhase::Failed, 0.0f,
+                               "declared programs were not registered" });
+                }
+            }
+            return std::unexpected(std::format(
+                "{} installed but registered none of its declared programs",
+                broken.front()));
         }
 
         return {};

--- a/src/core/xim/libxpkg/types/type.cppm
+++ b/src/core/xim/libxpkg/types/type.cppm
@@ -73,6 +73,12 @@ struct PlanNode {
     // provider"; predicate-driven elfpatch trigger reads this + dep nodes'
     // exports to decide whether and how to patch.
     ExportsRuntime exports;
+    // The program names the recipe promises this package provides
+    // (`package.programs`). Carried so the installer can check, after
+    // everything has run, that the promise was kept -- see
+    // verify_declared_programs_. Empty means the recipe made no promise and
+    // nothing is verified.
+    std::vector<std::string> programs;
     bool alreadyInstalled { false };
     bool isSystemPM { false };
     PackageScope scope { PackageScope::Global };

--- a/src/core/xim/resolver.cppm
+++ b/src/core/xim/resolver.cppm
@@ -184,6 +184,12 @@ resolve(IndexManager& index,
                 node.exports.abi     = exIt->second.runtime.abi;
             }
 
+            // What the recipe promises this package provides. Verified after
+            // the whole install completes -- not here -- because a package may
+            // legitimately delegate its registration to a deferred install
+            // (gcc on Windows hands off to mingw-w64).
+            node.programs = pkg->programs;
+
             // Walk the two kinds. Build subtrees stay Build (the dep is
             // only being installed to satisfy an upstream consumer's
             // install hook); Runtime parents fork their build_deps to
@@ -349,6 +355,12 @@ resolve(PackageCatalog& catalog,
                 node.exports.libdirs = exIt->second.runtime.libdirs;
                 node.exports.abi     = exIt->second.runtime.abi;
             }
+
+            // What the recipe promises this package provides. Verified after
+            // the whole install completes -- not here -- because a package may
+            // legitimately delegate its registration to a deferred install
+            // (gcc on Windows hands off to mingw-w64).
+            node.programs = pkg->programs;
 
             DepKind rt_kind = (kind == DepKind::Build) ? DepKind::Build
                                                        : DepKind::Runtime;

--- a/tests/e2e/declared_programs_verified_test.sh
+++ b/tests/e2e/declared_programs_verified_test.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# declared_programs_verified_test.sh — a package that promises programs and
+# registers none of them must fail the install, not print a checkmark.
+#
+# Two real installs printed `✓ 1 package(s) installed` and left the user with
+# nothing (#447):
+#
+#   llvm on Windows   — its recipe's directory listing came back empty, so no
+#                       `clang` shim was ever registered. `xlings use llvm`
+#                       then also reported success, and `clang --version` said
+#                       "'clang' is not installed".
+#   gcc on Windows    — the toolchain it delegates to aborted in its config
+#                       hook, so nothing registered.
+#
+# In both cases every hook returned success. The install count counts recipes
+# that did not raise, which is not the same as packages that work. Recipes
+# state what they provide in `package.programs`, so the promise is checkable.
+#
+# Scenarios:
+#   S1  declares programs, registers none  → install exits non-zero, and the
+#       message names the missing program
+#   S2  declares NO programs, registers none → install succeeds
+#
+# S2 is the falsifiability control and is the whole reason this test is worth
+# having. Without it, S1 passing would be equally consistent with "the fixture
+# fails to install for some unrelated reason" — the two fixtures are identical
+# apart from the `programs` line, so S2 pins the failure to that field.
+
+set -euo pipefail
+
+# shellcheck source=./project_test_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
+
+RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/declared_programs_verified"
+HOME_DIR="$RUNTIME_DIR/home"
+LOCAL_INDEX_DIR="$RUNTIME_DIR/xim-pkgindex"
+
+cleanup() { rm -rf "$RUNTIME_DIR"; }
+trap cleanup EXIT
+cleanup
+
+XLINGS_BIN="$(find_xlings_bin)"
+
+mkdir -p "$HOME_DIR/subos/default/bin" "$LOCAL_INDEX_DIR/pkgs/p"
+
+# Fixture A — promises `ghostprog`, registers nothing. Both hooks return true,
+# so nothing in the install pipeline has any other reason to complain.
+cat > "$LOCAL_INDEX_DIR/pkgs/p/promiser.lua" <<'LUA'
+package = {
+    spec = "1",
+    name = "promiser",
+    description = "Test fixture: declares a program and registers none",
+    type = "package",
+    archs = {"x86_64", "aarch64"},
+    status = "stable",
+    programs = {"ghostprog"},
+    xpm = {
+        linux   = { ["latest"] = { ref = "1.0.0" }, ["1.0.0"] = {} },
+        macosx  = { ["latest"] = { ref = "1.0.0" }, ["1.0.0"] = {} },
+        windows = { ["latest"] = { ref = "1.0.0" }, ["1.0.0"] = {} },
+    },
+}
+
+function install() return true end
+function config()  return true end
+LUA
+
+# Fixture B — byte-identical except it promises nothing. Registering nothing is
+# then correct, and the install must still succeed.
+sed -e 's/name = "promiser"/name = "quietpkg"/' \
+    -e '/programs = {"ghostprog"},/d' \
+    -e 's/declares a program and registers none/declares no programs/' \
+    "$LOCAL_INDEX_DIR/pkgs/p/promiser.lua" \
+    > "$LOCAL_INDEX_DIR/pkgs/p/quietpkg.lua"
+
+# Keep the test offline: no sub-index repos to fetch.
+printf 'xim_indexrepos = {}\n' > "$LOCAL_INDEX_DIR/xim-indexrepos.lua"
+
+cat > "$HOME_DIR/.xlings.json" <<JSON
+{
+  "version": "0.4.39",
+  "activeSubos": "default",
+  "mirror": "GLOBAL",
+  "subos": {"default": {"dir": ""}},
+  "index_repos": [
+    {"name": "xim", "url": "$LOCAL_INDEX_DIR"}
+  ]
+}
+JSON
+
+RUN() {
+  ( cd /tmp && env -i HOME="$HOME" USER="$USER" SHELL="${SHELL:-/bin/sh}" \
+      PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@" )
+}
+
+RUN self init >/dev/null 2>&1 || fail "self init failed"
+mkdir -p "$HOME_DIR/data/xim-index-repos"
+printf '{}\n' > "$HOME_DIR/data/xim-index-repos/xim-indexrepos.json"
+
+# ── S1: promises a program, registers none → must fail ───────────────
+log "S1: xlings install promiser -y → expect non-zero exit"
+
+set +e
+out_s1="$(RUN install promiser -y 2>&1 | tr -d "\0"; exit "${PIPESTATUS[0]}")"
+rc_s1=$?
+set -e
+
+echo "$out_s1" | tail -6 | sed 's/^/    /'
+
+[[ "$rc_s1" -ne 0 ]] \
+  || fail "S1: exit code was $rc_s1, expected non-zero — an install that
+registered none of its declared programs reported success
+$out_s1"
+
+# The message has to name the program, or a user cannot act on it.
+echo "$out_s1" | grep -q "ghostprog" \
+  || fail "S1: failure message does not name the missing program 'ghostprog'
+$out_s1"
+log "  ✓ exit=$rc_s1 and the message names ghostprog"
+
+# ── S2: promises nothing, registers nothing → must succeed ───────────
+log "S2: xlings install quietpkg -y → expect success (control)"
+
+set +e
+out_s2="$(RUN install quietpkg -y 2>&1 | tr -d "\0"; exit "${PIPESTATUS[0]}")"
+rc_s2=$?
+set -e
+
+[[ "$rc_s2" -eq 0 ]] \
+  || fail "S2: exit code was $rc_s2, expected 0 — a package that declares no
+programs must not be caught by the declared-programs check. Without this
+passing, S1 proves nothing about which field drove the failure.
+$out_s2"
+log "  ✓ exit=0 — the check keys off package.programs, not the fixture shape"
+
+log "PASS: declared programs are verified after install"

--- a/tests/e2e/run_all.sh
+++ b/tests/e2e/run_all.sh
@@ -92,6 +92,7 @@ TESTS=(
     "E2E-40 |subos_shell_level_test.sh||"
     "E2E-41 |index_artifact_update_test.sh||"
     "E2E-42 |self_doctor_multi_subos_test.sh||"
+    "E2E-43 |declared_programs_verified_test.sh||"
 )
 
 PASS=0; FAIL=0; SOFTFAIL=0


### PR DESCRIPTION
Fixes #447.

## The problem

`✓ N package(s) installed` counts recipes that did not raise, which is not the same as packages that work. Two real installs printed that checkmark and left the user with nothing:

```
$ xlings install gcc@15.1.0 -y -g
  ✓ 1 package(s) installed
$ xlings use gcc@15.1.0
[error] [xlings:use] 'gcc' not found in version database
```

```
$ xlings install llvm@20.1.7 -y -g
  ✓ 1 package(s) installed
$ xlings use llvm@20.1.7
[xlings] llvm -> 20.1.7          ← also reports success
$ clang --version
[error] xlings: 'clang' is not installed
```

Neither emitted a single diagnostic. Both proximate causes were recipe bugs (openxlings/xim-pkgindex#442, #443, #444, all fixed in openxlings/xim-pkgindex#445) — but the reason a user meets them as *confusing* rather than as an error is here.

## The fix

Recipes already state what they provide in `package.programs`. `PlanNode` now carries it, and after the plan has run, a package that registered **none** of its declared programs fails the install instead of reporting success.

Three deliberate choices:

- **Checked after the whole plan, not per node.** A package may legitimately register nothing itself and delegate to a deferred install — gcc on Windows hands off to mingw-w64 via `pkgmanager.install()` — and that dep is not installed yet at the moment its consumer's config hook returns. A per-node check would false-fail there.
- **Only total absence is reported.** Partial registration is normal and correct: recipes routinely declare one cross-platform program list and register the subset that exists on this host. Zero out of N is what never has a benign reading.
- **Build-kind deps are skipped** — they are intentionally never registered or shimmed.

## Verification

**E2E-43** (`tests/e2e/declared_programs_verified_test.sh`) carries its own falsifiability control:

| | Fixture | Expected |
|---|---|---|
| S1 | declares `ghostprog`, registers nothing | install exits non-zero **and** the message names `ghostprog` |
| S2 | byte-identical except it declares no programs | install succeeds |

S2 is the reason the test is worth having. Without it, S1 passing would be equally consistent with "the fixture fails to install for some unrelated reason" — the two fixtures differ only in the `programs` line, so S2 pins the failure to that field.

```
[project-e2e]   ✓ exit=1 and the message names ghostprog
[project-e2e]   ✓ exit=0 — the check keys off package.programs, not the fixture shape
[project-e2e] PASS: declared programs are verified after install
```

**Against real packages**, to check the false-positive risk — `ninja`, `ripgrep`, `codex` and `git` all install clean. And the same binary fails `ripgrep` against the *unfixed* index and passes it against the fixed one, which is the differential that matters:

```
# unfixed index (ripgrep's config hook aborts on an invalid node kind)
[error] ripgrep installed but registered none of the programs it declares: rg
[error] install failed: ripgrep installed but registered none of its declared programs

# fixed index
ok: ripgrep
```

## Note

`Config::versions()` is bound by value here, per its documented contract — it merges global and project state into a fresh map, so a reference into the temporary would dangle.