### PR TITLE
fix(ui): make terminal width a contract instead of nine local guesses (2026.7.29.1)

### DIFF
--- a/.agents/docs/2026-07-29-tui-output-ux-survey.md
+++ b/.agents/docs/2026-07-29-tui-output-ux-survey.md
@@ -1,0 +1,441 @@
+# xlings 终端输出体验调研(宽度 / 一致性 / 优雅度 / 可发现性)
+
+> 日期: 2026-07-29
+> 类型: 调研 (survey)
+> 范围: `src/ui/*`(ftxui 渲染层)、`src/core/log.cppm`、`src/agent/text_renderer.cppm`,以及 `use / list / search / info / config / self doctor / --help` 的实际输出
+> 方法: 源码通读 + 受控 pty 复现(40 / 60 / 100 列)+ 管道/非 TTY 对照
+> 复现脚手架: `python3 runpty.py <cols> <rows> xlings ...`(见文末附录)
+
+---
+
+## TL;DR
+
+窄窗口下的"换行乱"不是一个 bug,是**四个互相矛盾的宽度决策**叠加出来的:
+
+1. `print_info_panel` 会把面板宽度**顶到超过终端宽度**,于是终端强制硬折行;
+2. 同一函数算这个宽度时用了错的公式,导致**右侧被静默截断**(`xlings use gcc` 实测丢掉最后 3 个字符 `bin`);
+3. 其余渲染器用 `Dimension::Full()`,超宽时 ftxui **等比压缩每一列**,把包名和版本号也一起吃掉(`xim:binutils@2`)——这已经不是难看,是**输出了错误的信息**;
+4. 所有对齐都按**字节数**而不是显示宽度算。
+
+更深的问题是:**xlings 没有"终端宽度"这个概念**。全树没有一个地方问过"这一行放得下吗、放不下怎么办",每个渲染函数各自决定,答案都不一样。
+
+同时存在三套并行的输出通道(ftxui / `log::` / 手写 ANSI),缩进、前缀、调色板来源、是否响应浅色主题**全都不一致**;而 `--agent` 的纯文本渲染器,输出比 TUI **更完整、更对齐、更正确**。
+
+---
+
+## 一、宽度模型:"换行乱"的根因
+
+### P0-1 — `print_info_panel` 主动把宽度顶超终端,必然硬折行
+
+`src/ui/info_panel.cppm:80-83`:
+
+```cpp
+auto termDim = Dimension::Full();
+int width = std::max(termDim.dimx, minWidth);   // ← 关键
+auto screen = Screen::Create(Dimension::Fixed(width), ...);
+```
+
+意图是"别截断内容",实现是"内容多宽,画布就多宽"。而 ftxui 的 `Screen::ToString()` 会**把每一行都用空格填满到画布宽度**(`screen.cpp:421-443`,没有 trailing-space trim),于是 60 列终端里出现 92 字符的行,终端把每一行折成两行,第二行几乎全是空格。
+
+实测(60 列 pty,`xlings use gcc`,已去 ANSI):
+
+```
+92 chars:   ◆ gcc versions (cu…
+92 chars:   ──────────────────…
+92 chars:   15.1.0          /h…
+92 chars:   15.1.0-aarch64-mus…
+```
+
+**这就是用户看到的"换行乱"。** 窗口越窄越乱,而且乱得没有规律(每行折断位置取决于内容)。
+
+> 顺带:`fit_full_height` 的注释("A report is not a viewport")的判断是对的,但它只解决了**高度**。宽度方向做了**相反**的选择——高度可以超屏(终端会滚动),宽度不可以超屏(终端会折行)。这个不对称没有被识别出来。
+
+### P0-2 — `minWidth` 公式用固定 label 宽,导致右侧静默截断
+
+`src/ui/info_panel.cppm:26` 只补齐、从不截断:
+
+```cpp
+while (padded.size() < 14) padded += ' ';   // label 可以超过 14
+```
+
+而 `:61` 算宽度时把 label 当成永远是 14:
+
+```cpp
+int w = 2 + 14 + 2 + static_cast<int>(f.value.size()) + 2;
+```
+
+label 长于 14 时,每多 1 个字符就少算 1 列。实测算术:
+
+| label | 实际行宽 | minWidth(=90) | 溢出 |
+|---|---|---|---|
+| `15.1.0` | 69 | 90 | -21 |
+| `15.1.0-aarch64-musl` | **93** | 90 | **+3** |
+| `15.1.0-musl` | 74 | 90 | -16 |
+
+溢出 3 → 末尾 3 个字符 `bin` 被丢掉,**无省略号、无任何提示**:
+
+```
+  15.1.0-aarch64-musl  /home/speak/.xlings/data/xpkgs/xim-x-aarch64-linux-musl-gcc/15.1.0/
+                                                                                          ↑ 丢了 "bin"
+```
+
+这条路径同时也解释了用户贴的原始输出里那一行为什么和别的行不齐——**长 label 既破坏对齐又触发截断**,两个症状同源。
+
+这又是 xlings 反复出现的那个 bug 形态:**截断了和没截断,输出形态一模一样**。
+
+### P0-3 — `Dimension::Full()` + hbox 等比压缩 = 把标识符也截掉
+
+其余 11 处渲染器用 `Dimension::Full()`。超宽时 ftxui 的 `hbox` 对**所有子元素等比压缩**,它不知道哪一列是"标识符不能动"、哪一列是"描述可以删"。
+
+`xlings search gcc` @ 60 列实测:
+
+```
+  ◆xim:aarch64-linu  Cross GCC toolchain: host -> aarch64-li
+  ◆ xim:gcc  GCC, the GNU Compiler Collection
+  xim:g GCC runtime libraries (libstdc++, libgcc_s, libgomp,
+  ◆xim:mingw-c  MinGW-w64 GCC cross toolchain (Linux host →
+```
+
+- 包名被截成 `xim:g` / `xim:mingw-c` —— **用户无法把它复制去 install**;
+- marker `◆` 后面的空格都被吃掉(`◆xim:`),甚至整个 marker 消失(第 3 行);
+- 每行截断量不同,看起来像渲染故障。
+
+`xlings list` @ 60 列更严重,截的是**版本号**:
+
+```
+  ◆ xim:binutils@2       ← 真实版本是 2.42
+  ◆ xim:bun@1.3          ← 真实版本是 1.3.x
+  ◆ xim:cairo@1.
+```
+
+`xim:binutils@2` 是一个**看起来完全合法、但是错的**版本号。这比截断更糟。
+
+`xlings --help` @ 40/60 列则表现为**逐行对不齐**(描述长的行把 name 列的 padding 吃掉了):
+
+```
+   install  Install packages (e.g. xling      ← name 列 8 宽
+    remove        Remove a package            ← name 列 14 宽
+   update    Update package index or a s
+    search        Search for packages
+```
+
+第一次接触 xlings 的用户看到的第一屏就是这个。
+
+### P0-4 — `self doctor` 单行 230 字符
+
+@ 60 列,每行折 4 次:
+
+```
+  ✗ binding state  'node' is active at 24.15.0 but 'npm' of the same release is active at 11.2.0 [npm@node-24.15.0] — xvm-active-group-incoherent — run `xlings use node 24.15.0` to bring the whole release back in step
+```
+
+`self doctor` 是**最需要被读懂**的输出(它的存在意义就是告诉用户哪里坏了、怎么修),却是折行最惨的一个。remedy 在行尾,恰好是折行后最难找到的位置。
+
+### P1-5 — 下载进度条的光标回退按逻辑行记账
+
+`src/ui/progress.cppm:352` 返回 `screen.dimy()`(文档行数),`:345` 用它做 `\033[NA` 回退。但终端折行后**物理行数 > dimy**,回退量不足 → 上一帧残留,逐帧堆积。
+
+阈值可算:每行宽度 = icon(6) + `nameWidth` + 1 + status(8),而 `nameWidth = max(20, 最长包名) + 2`(`downloader.cppm:874-878`)。装 `xim:aarch64-linux-musl-gcc@15.1.0`(33 字符)时 nameWidth=35 → 行宽 50。**终端窄于 ~50 列,安装进度就会糊。** 分屏 / 手机 SSH 场景可达。
+
+### P1-6 — 所有 padding 按字节数,不是显示宽度
+
+`info_panel.cppm:26`、`banner.cppm:15`、`selector.cppm:84/142`、`progress.cppm:83` 全部用 `std::string::size()`。中文描述(每字 3 字节 / 2 列)必然错列。`src/core/utf8.cppm` 只有 `safe_truncate`,**没有 display-width 函数**;ftxui 自带的 `string_width()` 从未被 `src/ui/` 调用过。
+
+考虑到 xlings 的用户基本盘,这条的实际影响比排位显示的要大。
+
+### P2-7 — 分隔线硬编码 40 个 `─`
+
+`info_panel.cppm:54/72`。面板实际渲染到 90 或 230 列时,底下压着一条 40 列的短横线,视觉上像没画完:
+
+```
+  ◆ xlings self doctor                                    ...(230 列)
+  ────────────────────────────────────────                          ← 40 列
+```
+
+---
+
+## 二、非 TTY / 管道:输出不可脚本化
+
+### P0-8 — 管道输出仍带 truecolor、行尾 `\r`、行尾空格、结尾 NUL
+
+`xlings use gcc | cat -A` 实测:
+
+```
+^[[38;2;168;85;247m  ◆ ^[[1mgcc versions (current subos)^[[22m ... (空格填充) ^M$
+                                                                  ^@$
+```
+
+- **ANSI 色码**:`Screen::ToString()` 只看 `COLORTERM`/`TERM`,不看 isatty;
+- **`\r`**:ftxui 行间用 `"\r\n"`,`grep`/`awk` 会看到 CR;
+- **行尾空格**:填充到画布宽度;
+- **NUL 字节**:`Screen::Print()` 是 `std::cout << ToString() << '\0'`(`screen.cpp:453`)。
+
+xlings **自己知道**怎么判断 TTY——`main.cpp:28` 和 `platform/linux.cppm:201` 都在用 `isatty`——但整条 ftxui 渲染链一次都没问过。
+
+### P0-9 — 不认 `NO_COLOR`,而 xlings 自己生成的 shell profile 认
+
+`NO_COLOR=1 xlings use gcc` 实测仍输出 truecolor。同时 `src/core/xself/profile_resources.cppm:113/166/209` **为三种 shell 都写了 `NO_COLOR` 判断**。xlings 要求自己生成的脚本尊重 `NO_COLOR`,自己却不尊重。
+
+### P1-10 — 非 TTY 时 fallback 80×24,报告被裁到 80 列
+
+ftxui `Terminal::Size()` 在非 TTY 下返回 80×24(`terminal.cpp:41-42`)。CI 日志、`| less`、重定向到文件时,所有 `Dimension::Full()` 的输出都按 80 列裁切。`fit_full_height` 已经处理过高度方向的同一个坑(注释里写得很清楚),宽度方向没有。
+
+---
+
+## 三、一致性:三套输出通道,四套规则
+
+### 三条并行通道
+
+| 通道 | 缩进 | 前缀 | 颜色来源 | 响应浅色主题 | 响应 `--agent` |
+|---|---|---|---|---|---|
+| `src/ui/*`(ftxui) | 2 空格 | 无 | `theme::` | ✅ | ✅ |
+| `log::info/warn/error` | 0 | `[xlings]` / `[warn]` | `log.cppm:68` 硬编码 | ❌ | ✅(`enable_color(false)`) |
+| `subos_ansi_`(`info_panel.cppm:208`) | 2 空格 | 无 | 硬编码 | ❌ | ❌ |
+| `confirm()` / `read_line()`(`selector.cppm:204/219`) | **0** | 无 | 硬编码 | ❌ | ❌ |
+
+一次 `xlings install` 会同时经过这四条,用户看到的缩进在 0 和 2 之间反复跳。
+
+### P0-11 — 浅色主题只覆盖了一半的输出
+
+`theme.cppm` 用 92 行注释 + OSC-11 探测 + `COLORFGBG` 回退实现了明暗自适应,理由写得很明确("near-white text became invisible on a light terminal background")。但:
+
+- `log.cppm:73-77` 硬编码 dark 调色板;
+- `info_panel.cppm:210-215`(subos 消息)硬编码 dark 调色板;
+- `selector.cppm:204/219`(输入提示、y/n 确认)硬编码 `38;2;34;211;238` 和 `38;2;148;163;184`。
+
+于是在浅色终端上,**主题要修的那个低对比问题原封不动地留在了确认提示和状态日志上**——而确认提示恰恰是必须看清的那一行。
+
+### P0-12 — "当前激活"有三种编码,其中一种只用颜色
+
+| 命令 | 编码方式 |
+|---|---|
+| `xlings use <t>` | **仅绿色**(`info_panel.cppm:29`) |
+| `xlings info <t>` | 尾部 `*`(`versions  ... 16.1.0 *`) |
+| `xlings subos list` | `▸` marker + 青色 |
+
+`use` 那条是纯颜色编码。实测 100 列输出里只有一段绿色转义 —— 一旦 `NO_COLOR`、管道、`| less -R` 失效、或用户有色觉障碍,**"哪个版本是当前激活的"这条信息完全消失**,而这正是 `xlings use <target>` 唯一要回答的问题。
+
+### P1-13 — `theme::icon` 定义了"安全字形集",`doctor.cppm` 绕过它
+
+`theme.cppm:153-176` 花了 20 行注释论证为什么只用某几个 BMP 字形,并点名 "Avoid: U+27D0 ⟐, U+2699 ⚙, U+27F0 ⟰ — spotty in older console fonts"。
+
+`src/core/xself/doctor.cppm` 用了 4 个不在集合里的字形:`⚠`(U+26A0)、`ⓘ`(U+24D8)、`·`(U+00B7)、`→`(U+2192)。其中 `ⓘ` 是 Enclosed Alphanumerics,和注释里点名回避的 U+2699 属于同一风险类(旧 console 字体覆盖不全)。两个都不在 ftxui 的全宽表里(`string.cpp:32` `g_full_width_characters`,`0x26a0` 恰好落在 `0x026a1` 之前),ftxui 按 1 列算;在把 East-Asian-Ambiguous 当双宽渲染的终端上会产生逐行右移。
+
+问题不在这几个字形本身,在于**有一个显式的字形治理约定,而它没有强制力**。
+
+### P1-14 — `xlings info` 一个面板里 "versions" 出现两次,含义不同
+
+```
+  versions        latest -> 16.1.0, 15.1.0, 11.5.0, 16.1.0, 13.3.0, 9.4.0   ← 索引里可装的
+  installed       yes
+  ────────────────────────────────────────                                   ← 无标题分隔
+  active          16.1.0
+  versions        15.1.0, 15.1.0-aarch64-musl, 15.1.0-musl, 16.1.0 *         ← 本地已装的
+```
+
+- 同名不同义,中间只有一条无标题的分隔线,读者无法知道上半区是"包(索引)"、下半区是"本地状态";
+- `latest -> 16.1.0, 15.1.0, 11.5.0, **16.1.0**, ...` —— 16.1.0 出现两次;
+- `bindings  xim-aarch64-musl-gnu-gcc, xim-gnu-gcc -> 16.1.0, xim-musl-gnu-gcc` —— 逗号分隔的列表里嵌了一个 `->`,无法判断它作用于哪一项。
+
+### P1-15 — 路径缩写策略不一致
+
+`Config::display_path()`(`config.cppm:872`)会把路径缩成 `@xlings/data/...`。`xlings config` 和 `self doctor` 用了它,`xlings use` / `xlings info` 没用:
+
+```
+xlings config:   XLINGS_DATA     @xlings/data
+xlings use gcc:  15.1.0          /home/speak/.xlings/data/xpkgs/xim-x-gcc/15.1.0/bin
+```
+
+而 `use` 恰恰是被路径长度撑爆的那个命令 —— **缩写函数已经存在,用上它就能让 P0-1/P0-2 的溢出直接消失**。
+
+### P1-16 — `--agent` 的纯文本输出比 TUI 更正确
+
+同一条命令:
+
+```
+$ xlings --agent use gcc
+gcc versions (current subos)
+  15.1.0: /home/speak/.xlings/data/xpkgs/xim-x-gcc/15.1.0/bin
+  15.1.0-aarch64-musl: /home/speak/.xlings/data/xpkgs/xim-x-aarch64-linux-musl-gcc/15.1.0/bin   ← 完整
+  15.1.0-musl: /home/speak/.xlings/data/xpkgs/xim-x-musl-gcc/15.1.0/bin
+  16.1.0: /home/speak/.xlings/data/xpkgs/xim-x-gcc/16.1.0/bin
+```
+
+不截断、不折行、无转义污染。**TUI 在这里没有增加任何信息,只减少了信息。**
+
+附带风险:`cli.cppm:47+` 和 `agent/text_renderer.cppm:22+` 是两份手写的 kind 分发,必须手工保持同步;`text_renderer` 漏掉一个 kind 就静默丢输出(注释里已经承认 "Silently skips event kinds")。
+
+---
+
+## 四、可发现性与"方便"
+
+### P1-17 — `xlings use gcc` 列了版本,却不告诉你下一步
+
+成功路径只打面板,没有 `xlings use gcc 16.1.0` 这样的下一步提示。而**失败**路径(`xvm/commands.cppm:520`)反而给了完整 hint。提示的密度和用户的困惑程度成反比。
+
+### P1-18 — 交互选择器已经写好,但没接上
+
+`src/ui/selector.cppm` 里的 `select_version()`(第 16 行)完全实现了"上下选版本 + 回车确认",**零调用者**。同样零调用者的还有 `select_option()`、`read_line()`、`print_progress()`。
+
+也就是说,`xlings use gcc` 最自然的行为——弹一个选择器——**代码已经在仓库里躺着了**。
+
+### P2-19 — 确认提示不缩进
+
+`selector.cppm:219`:
+
+```cpp
+std::print("\033[...m{}\033[0m{}...", std::string(theme::icon::arrow) + " ", message, prompt);
+```
+
+没有前导空格,`▸ Continue? [Y/n]` 从第 0 列开始,而它上面的 remove plan 是 2/4 空格缩进(`info_panel.cppm:326-334`)。视觉上确认行"掉出"了面板。
+
+---
+
+## 五、建议:引入一个宽度感知的渲染契约
+
+单点修 bug 会继续漏,因为缺的是**约定**。建议加一个 `src/ui/layout.cppm`,把下面五件事变成唯一入口:
+
+### 1. 单一宽度源
+
+```cpp
+// 终端宽度;非 TTY 返回 nullopt = "不裁切、不填充"
+std::optional<int> term_width();
+```
+
+规则:**任何画布宽度不得超过 `term_width()`**。P0-1 的 `std::max(term, minWidth)` 改成 `std::min(natural, term)`。
+
+### 2. 按列语义分级的收缩策略
+
+超宽时不能等比压缩,要按语义:
+
+| 列类型 | 策略 |
+|---|---|
+| 标识符(包名 / 版本 / subos 名) | **永不截断**,宽度优先分配 |
+| 路径 | 先 `Config::display_path()` 缩写,再中段省略 `…` |
+| 描述 / remedy | 末尾截断 + `…`,或换行续行(缩进对齐) |
+
+`self doctor` 的 remedy 建议直接改成独立续行,不参与列宽竞争。
+
+### 3. 显示宽度函数
+
+```cpp
+int display_width(std::string_view);   // 包装 ftxui::string_width
+std::string pad_to_width(std::string, int);
+std::string truncate_to_width(std::string_view, int);  // 带 … 且不切断 UTF-8
+```
+
+替换 `src/ui/` 里全部 `.size()` 形式的 padding(5 处)。
+
+### 4. 输出模式判定 + 自有 print
+
+```cpp
+enum class OutMode { Rich, Plain };   // isatty && !NO_COLOR && TERM!=dumb && !--agent
+void print_doc(ftxui::Element);       // 逐行 rtrim、用 "\n"、不写 '\0'
+```
+
+`Plain` 模式直接复用现成的 `agent::render_data_event` —— 它的输出已经被验证是更好的(P1-16)。同时这条修掉 P0-8 / P0-9 / P1-10。
+
+### 5. 进度条按物理行记账
+
+`render_download_progress` 返回值改为 `Σ ceil(行宽 / term_width)`;或更简单:把行宽 clamp 到 `term_width()-1`,让物理行数恒等于逻辑行数。
+
+### 另外两条约定
+
+- **`theme::icon` 是唯一字形来源**,`doctor.cppm` 的 `⚠ ⓘ · →` 收编进去(补 `warn` / `note` / `bullet` / `remedy`),加一条 grep 测试防回归;
+- **"激活/当前"必须有非颜色编码**(统一用 `▸` 或 `*` 之一),颜色只做增强。
+
+---
+
+## 六、优先级
+
+| 编号 | 问题 | 影响 | 成本 |
+|---|---|---|---|
+| P0-1 | info_panel 画布顶超终端宽 → 硬折行 | 用户直接报告的症状 | 小(一行) |
+| P0-2 | minWidth 用固定 14 → 静默截断 | 输出丢字符,无提示 | 小 |
+| P0-3 | hbox 等比压缩截掉包名/版本号 | **输出错误信息** | 中 |
+| P0-4 | `self doctor` 单行 230 字符 | 最该读懂的输出最难读 | 中 |
+| P0-8 | 管道输出带色/CR/NUL/尾空格 | 不可脚本化 | 中 |
+| P0-9 | 不认 `NO_COLOR`(自己生成的脚本却认) | 自相矛盾 | 小 |
+| P0-11 | 浅色主题只覆盖一半输出 | 确认提示看不清 | 小 |
+| P0-12 | "激活版本"仅用颜色编码 | 无障碍 + 管道下信息全失 | 小 |
+| P1-5 | 进度条按逻辑行回退光标 | 窄窗口安装画面糊 | 小 |
+| P1-6 | 按字节 padding | 中文必然错列 | 中 |
+| P1-13 | doctor 绕过 `theme::icon` | 字形治理失效 | 小 |
+| P1-14 | `info` 面板 versions 二义 + 重复 | 读者误解 | 小 |
+| P1-15 | 路径缩写不一致 | 顺手修掉 P0-1 溢出 | 小 |
+| P1-17 | `use` 成功路径无下一步提示 | 可发现性 | 小 |
+| P1-18 | 交互选择器是死代码 | 已有实现未接线 | 小 |
+| P2-7 | 分隔线硬编码 40 列 | 观感 | 小 |
+| P2-19 | 确认提示不缩进 | 观感 | 小 |
+
+建议的第一批(一个 PR 内可完成,风险低、收益最直接):
+**P0-1 + P0-2 + P1-15**(三处都在 `info_panel.cppm`,合起来直接消灭用户贴出来的那个症状)。
+
+---
+
+## 实施记录(2026.7.29.1)
+
+全部 17 项在一个 PR 内落地。核心是新增三个「单一来源」模块,把原先散落各处的决策收敛:
+
+| 模块 | 收敛了什么 |
+|---|---|
+| `src/ui/layout.cppm` | 宽度与输出契约:`term_width()` / `fit_width()` / `display_width()` / `truncate_to_width()` / `wrap_to_width()` / `plan_two_column()` / `render_to_string()` |
+| `src/core/glyph.cppm` | 字形表(放在 core,因为 `self doctor` 在 core 里拼标签) |
+| `src/core/palette.cppm` | 调色板 + 背景探测 + `colors_enabled()`(同上,`log::` 在 core 里写 SGR) |
+
+`ui::theme` 变成前两者的 ftxui 适配层。规则:
+
+1. 画布**永不宽于终端**;放不下由**调用方**决定裁剪方式,不交给 ftxui。
+2. 非终端(管道/文件)**没有宽度上限** —— 拿到完整未截断的文本。
+3. 宽度一律按显示列,不按字节。
+4. 输出是纯文本 + 可选 SGR:无 NUL、无 CR、无行尾空格;非交互终端或用户拒绝时无颜色。
+5. **标识符(包名/版本/subos 名)永不截断** —— 放不下就换行;描述才加 `…`。
+
+新增 `XLINGS_TERM_WIDTH`(整数,`0` = 不限)覆盖宽度探测,测试与用户逃生口共用。
+
+### 实施中发现的三个额外问题
+
+- **第三张字形表**:`src/platform/{linux,macos,windows}.cppm` 各有一份 `Icon`,**零调用者**,而且正好包含注释点名要避免的 `⚙`(U+2699)和 `⟐`(U+27D0)。已删除 —— 与规则矛盾的死代码正是规则失效的方式。
+- **stacked 模式仍在裁包名**:名字宽于终端时改成整行,但没让它换行,ftxui 照样在画布边缘剪掉。已改为换行,一个字符不丢。
+- **测试本身是静默通过的**:`python3 - <<'PY'` 会把 heredoc 当成 python 的**程序**,管道进来的数据永远读不到,`sys.stdin.read()` 返回 `""` —— 宽度检查因此对任何输入都通过。改为独立脚本文件,并加了 S0 自检(空输入直接报错 + 一条故意超宽的行必须被抓到)。这正是本文反复讲的那类 bug 出现在了检查它的工具里。
+
+### 覆盖
+
+- `tests/unit/test_ui_layout.cpp` —— 25 个用例:显示宽度、UTF-8 边界截断、路径优先按 `/` 换行、列规划、`fit_width` 钳制。
+- `tests/e2e/tui_output_contract_test.sh`(E2E-44)—— S1 无行超宽(40/60/100/200 列 × 7 条命令)、S2 包名不截断且 help 列对齐、S3 管道干净、S4 真 pty 下 `NO_COLOR` 生效、S5 激活项有非颜色标记 + 下一步提示、S6 字形只来自字形表。
+
+对 2026.7.29.0 的二进制跑同一个 e2e,**在 S1 立刻失败**(40 列终端里出现 81 列的填充行)—— 说明它确实是回归护栏,不是摆设。
+
+---
+
+## 附录:复现脚手架
+
+```python
+# runpty.py — 在指定尺寸的 pty 里跑命令,原样 dump 输出
+import os, sys, pty, fcntl, termios, struct, select, subprocess
+cols, rows, cmd = int(sys.argv[1]), int(sys.argv[2]), sys.argv[3:]
+mfd, sfd = pty.openpty()
+fcntl.ioctl(sfd, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
+p = subprocess.Popen(cmd, stdin=sfd, stdout=sfd, stderr=sfd, close_fds=True)
+os.close(sfd)
+out = b""
+while True:
+    r, _, _ = select.select([mfd], [], [], 20)
+    if not r: break
+    try: d = os.read(mfd, 65536)
+    except OSError: break
+    if not d: break
+    out += d
+p.wait(); sys.stdout.buffer.write(out)
+```
+
+用法:
+
+```bash
+python3 runpty.py 60 24 xlings use gcc | sed 's/\x1b\[[0-9;]*m//g' | awk '{printf "%d: %s\n", length($0), $0}'
+python3 runpty.py 40 24 xlings --help
+xlings use gcc | cat -A          # 管道行为
+NO_COLOR=1 xlings use gcc | cat -v
+```
+
+> 注意:文件名不能叫 `pty.py`,会 shadow 标准库。

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlings"
-version = "2026.7.29.0"
+version = "2026.7.29.1"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"

--- a/src/agent/text_renderer.cppm
+++ b/src/agent/text_renderer.cppm
@@ -31,6 +31,9 @@ export void render_data_event(const DataEvent& e) {
         if (json.contains("fields")) print_fields(json["fields"]);
         if (json.contains("extra_fields")) print_fields(json["extra_fields"]);
     }
+    else if (e.kind == "tip") {
+        std::println("hint: {}", json.value("message", ""));
+    }
     else if (e.kind == "search_results") {
         if (json.contains("results") && json["results"].is_array()) {
             for (auto& r : json["results"]) {

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -92,6 +92,9 @@ static void dispatch_data_event(const DataEvent& e) {
         }
         ui::print_subcommand_help(name, desc, args, opts);
     }
+    else if (e.kind == "tip") {
+        ui::print_tip(json.value("message", ""));
+    }
     else if (e.kind == "styled_list") {
         std::string title = json.value("title", "");
         bool numbered = json.value("numbered", false);
@@ -247,7 +250,17 @@ static void handle_prompt(EventStream& stream, const PromptEvent& p) {
         return;
     }
 
-    // Multiple options → package/version selector
+    // A version choice has its own picker — titled with the target, and
+    // without the description column a version list has nothing to put in.
+    // It existed in ui:: from the start and was never reachable, because
+    // every multi-option prompt landed in select_package below.
+    if (p.id == "select_version" && !p.options.empty()) {
+        auto result = ui::select_version(p.question, p.options, p.defaultValue);
+        stream.respond(p.id, result.value_or(""));
+        return;
+    }
+
+    // Multiple options → package selector
     if (!p.options.empty()) {
         std::vector<std::pair<std::string, std::string>> items;
         for (auto& opt : p.options) {
@@ -722,6 +735,8 @@ export int run(int argc, char* argv[]) {
     if (agent_mode) {
         stream.set_enabled(tui_listener, false);
         log::enable_color(false);
+        // One switch for every writer, not just log's own prefixes.
+        ui::layout::set_plain(true);
         stream.on_event([&stream](const Event& e) {
             if (auto* d = std::get_if<DataEvent>(&e)) {
                 agent::render_data_event(*d);

--- a/src/core.cppm
+++ b/src/core.cppm
@@ -1,6 +1,8 @@
 export module xlings.core;
 
 export import xlings.core.log;
+export import xlings.core.glyph;
+export import xlings.core.palette;
 export import xlings.core.utils;
 export import xlings.core.i18n;
 export import xlings.core.config;

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "2026.7.29.0";
+    static constexpr std::string_view VERSION = "2026.7.29.1";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/glyph.cppm
+++ b/src/core/glyph.cppm
@@ -1,0 +1,55 @@
+export module xlings.core.glyph;
+
+import std;
+
+// The glyph table. This is the ONLY place a glyph is chosen.
+//
+// Every character here is a BMP-region character that ships in the default
+// monospace fonts of every mainstream terminal we care about: Cascadia
+// Code/Mono (Windows Terminal default), Consolas (conhost), Lucida Console
+// (legacy conhost), DejaVu Sans Mono / Liberation Mono / Noto Mono (Linux),
+// and SF Mono / Menlo (macOS). There is no platform-conditional ASCII
+// fallback — a single glyph set is what makes Linux / macOS / Windows look
+// the same, which is the whole point.
+//
+// Avoid: U+27D0 ⟐, U+2699 ⚙, U+27F0 ⟰ — spotty in older console fonts and
+// the main offenders behind Windows mojibake. U+24D8 ⓘ is the same bet
+// (Enclosed Alphanumerics); `note` uses U+2022 • instead.
+//
+// This table lives in core rather than in the UI layer for one reason:
+// `self doctor` composes its finding labels in core and used to spell ⚠ / ⓘ
+// / · / → inline. A curated set with no single home is not a curated set —
+// the policy above had no force over the module that produced most of the
+// glyphs on screen. `ui::theme::icon` is defined in terms of this table.
+export namespace xlings::glyph {
+
+inline constexpr auto pending     = "\xe2\x97\x8b";   // ○ U+25CB
+inline constexpr auto downloading = "\xe2\x86\x93";   // ↓ U+2193
+inline constexpr auto extracting  = "\xe2\x96\xbe";   // ▾ U+25BE
+inline constexpr auto installing  = "\xe2\x8a\x95";   // ⊕ U+2295
+inline constexpr auto configuring = "\xe2\x8a\x95";   // ⊕ U+2295
+inline constexpr auto done        = "\xe2\x9c\x93";   // ✓ U+2713
+inline constexpr auto failed      = "\xe2\x9c\x97";   // ✗ U+2717
+inline constexpr auto info        = "\xe2\x80\xba";   // › U+203A
+inline constexpr auto arrow       = "\xe2\x96\xb8";   // ▸ U+25B8
+inline constexpr auto package     = "\xe2\x97\x86";   // ◆ U+25C6
+inline constexpr auto warn        = "\xe2\x9a\xa0";   // ⚠ U+26A0
+inline constexpr auto note        = "\xe2\x80\xa2";   // • U+2022
+inline constexpr auto bullet      = "\xc2\xb7";       // · U+00B7
+inline constexpr auto remedy      = "\xe2\x86\x92";   // → U+2192
+inline constexpr auto ellipsis    = "\xe2\x80\xa6";   // … U+2026
+inline constexpr auto divider     = "\xe2\x94\x80";   // ─ U+2500 (one unit)
+
+// The marker that means "this is the active one". It exists so that state is
+// never carried by color alone: `xlings use <t>` used to paint the active
+// version green and nothing else, so NO_COLOR, a pipe, or a colorblind
+// reader lost the single fact the command is asked for.
+inline constexpr auto active      = "\xe2\x96\xb8";   // ▸ U+25B8
+
+// `<glyph> <text>` — how a marked label is built. Callers never concatenate
+// a glyph literal themselves.
+inline auto mark(std::string_view g, std::string_view text) -> std::string {
+    return std::string(g) + " " + std::string(text);
+}
+
+} // namespace xlings::glyph

--- a/src/core/log.cppm
+++ b/src/core/log.cppm
@@ -6,6 +6,7 @@ export module xlings.core.log;
 
 import std;
 import xlings.platform;
+import xlings.core.palette;
 
 namespace xlings::log {
 
@@ -64,22 +65,23 @@ export void enable_color(bool enabled) {
     gColor_ = enabled;
 }
 
-// ANSI color helpers (matching theme palette)
-namespace ansi_ {
-    constexpr auto reset   = "\033[0m";
-    constexpr auto bold    = "\033[1m";
-    constexpr auto dim     = "\033[2m";
-    // Theme colors as RGB ANSI sequences
-    constexpr auto cyan    = "\033[38;2;34;211;238m";   // #22D3EE
-    constexpr auto green   = "\033[38;2;34;197;94m";    // #22C55E
-    constexpr auto amber   = "\033[38;2;245;158;11m";   // #F59E0B
-    constexpr auto red     = "\033[38;2;239;68;68m";    // #EF4444
-    constexpr auto gray    = "\033[38;2;148;163;184m";  // #94A3B8
-} // namespace ansi_
+// Colors come from xlings.core.palette, so these prefixes follow the
+// terminal background like the rendered panels do and go quiet under
+// NO_COLOR / TERM=dumb / a pipe. They used to be dark-palette SGR literals
+// spelled out here, which is why a light terminal kept getting the
+// low-contrast text the palette exists to avoid.
+bool color_on_()     { return gColor_ && palette::colors_enabled(); }
+bool color_on_err_() { return gColor_ && palette::colors_enabled_err(); }
 
-std::string colored_(const char* color, const char* text) {
-    if (!gColor_) return text;
-    return std::string(color) + text + ansi_::reset;
+std::string colored_(palette::Rgb c, const char* text) {
+    if (!color_on_()) return text;
+    return palette::sgr_fg(c) + text + palette::reset;
+}
+
+// warn/error write to stderr, which can be a terminal when stdout is not.
+std::string colored_err_(palette::Rgb c, const char* text) {
+    if (!color_on_err_()) return text;
+    return palette::sgr_fg(c) + text + palette::reset;
 }
 
 std::string timestamp_() {
@@ -114,8 +116,8 @@ void debug(std::format_string<Args...> fmt, Args&&... args) {
     if (gLevel_ <= Level::Debug) {
         auto msg = std::format(fmt, std::forward<Args>(args)...);
         if (!platform::is_tui_mode()) {
-            std::print("{} ", colored_(ansi_::gray, "[debug]"));
-            if (!gContext_.empty()) std::print("{} ", colored_(ansi_::gray, std::format("[{}]", gContext_).c_str()));
+            std::print("{} ", colored_(palette::dim(), "[debug]"));
+            if (!gContext_.empty()) std::print("{} ", colored_(palette::dim(), std::format("[{}]", gContext_).c_str()));
             std::println("{}", msg);
         }
         write_to_file_("[debug] ", msg);
@@ -127,8 +129,8 @@ void info(std::format_string<Args...> fmt, Args&&... args) {
     if (gLevel_ <= Level::Info) {
         auto msg = std::format(fmt, std::forward<Args>(args)...);
         if (!platform::is_tui_mode()) {
-            std::print("{} ", colored_(ansi_::cyan, "[xlings]"));
-            if (!gContext_.empty()) std::print("{} ", colored_(ansi_::cyan, std::format("[{}]", gContext_).c_str()));
+            std::print("{} ", colored_(palette::cyan(), "[xlings]"));
+            if (!gContext_.empty()) std::print("{} ", colored_(palette::cyan(), std::format("[{}]", gContext_).c_str()));
             std::println("{}", msg);
         }
         write_to_file_("[xlings] ", msg);
@@ -140,8 +142,8 @@ void warn(std::format_string<Args...> fmt, Args&&... args) {
     if (gLevel_ <= Level::Warn) {
         auto msg = std::format(fmt, std::forward<Args>(args)...);
         if (!platform::is_tui_mode()) {
-            std::print(stderr, "{} ", colored_(ansi_::amber, "[warn]"));
-            if (!gContext_.empty()) std::print(stderr, "{} ", colored_(ansi_::amber, std::format("[{}]", gContext_).c_str()));
+            std::print(stderr, "{} ", colored_err_(palette::amber(), "[warn]"));
+            if (!gContext_.empty()) std::print(stderr, "{} ", colored_err_(palette::amber(), std::format("[{}]", gContext_).c_str()));
             std::println(stderr, "{}", msg);
         }
         write_to_file_("[warn] ", msg);
@@ -152,12 +154,13 @@ export template<typename... Args>
 void error(std::format_string<Args...> fmt, Args&&... args) {
     auto msg = std::format(fmt, std::forward<Args>(args)...);
     if (!platform::is_tui_mode()) {
-        if (gColor_) {
-            std::print(stderr, "{}{}[error]{} ", ansi_::bold, ansi_::red, ansi_::reset);
+        if (color_on_err_()) {
+            std::print(stderr, "{}{}[error]{} ",
+                       palette::bold, palette::sgr_fg(palette::red()), palette::reset);
         } else {
             std::print(stderr, "[error] ");
         }
-        if (!gContext_.empty()) std::print(stderr, "{} ", colored_(ansi_::red, std::format("[{}]", gContext_).c_str()));
+        if (!gContext_.empty()) std::print(stderr, "{} ", colored_err_(palette::red(), std::format("[{}]", gContext_).c_str()));
         std::println(stderr, "{}", msg);
     }
     write_to_file_("[error] ", msg);

--- a/src/core/palette.cppm
+++ b/src/core/palette.cppm
@@ -1,0 +1,191 @@
+export module xlings.core.palette;
+
+import std;
+import xlings.platform;
+
+// The color table and the single answer to "may we emit color at all".
+//
+// Both used to live in `ui::theme`, which meant they only governed the ftxui
+// renderers. Everything else that writes to the terminal — `log::` with its
+// `[xlings]` prefix, the sub-OS status lines, the y/n prompt — carried its
+// own copy of the dark palette spelled out as SGR literals. So the
+// background detection below, which exists because near-white text is
+// invisible on a light terminal, did not reach the one line the user has to
+// read before answering it.
+//
+// `ui::theme` is now an adapter over this table.
+export namespace xlings::palette {
+
+// ─── Output mode ───────────────────────────────────────────
+
+namespace detail {
+inline bool& plain_override_() {
+    static bool v = false;
+    return v;
+}
+}  // namespace detail
+
+// Forced plain by the caller (`--agent`).
+inline void set_plain(bool on) { detail::plain_override_() = on; }
+inline auto plain_forced() -> bool { return detail::plain_override_(); }
+
+inline auto stdout_is_terminal() -> bool {
+    // A console on Windows, isatty on POSIX — the same probe the download
+    // progress renderer already trusts before it moves the cursor.
+    return platform::supports_rewrite_output();
+}
+
+// The de-facto opt-outs. xlings already honors both in the shell profiles it
+// generates for the user (xself/profile_resources.cppm) — it just never
+// honored them in its own output, so `NO_COLOR=1 xlings use gcc` still came
+// out in true color and a redirect to a file captured every escape.
+inline auto opted_out_() -> bool {
+    if (detail::plain_override_()) return true;
+    if (std::getenv("NO_COLOR") != nullptr) return true;
+    if (auto* term = std::getenv("TERM"); term != nullptr && std::string_view{term} == "dumb")
+        return true;
+    return false;
+}
+
+inline auto colors_enabled() -> bool {
+    return !opted_out_() && stdout_is_terminal();
+}
+
+// Warnings and errors go to stderr, which is a different stream with a
+// different destination: `xlings install > log` still has an interactive
+// stderr, and `2>&1 | cat` has neither.
+inline auto colors_enabled_err() -> bool {
+    return !opted_out_() && platform::stderr_is_terminal();
+}
+
+// ─── Background detection ──────────────────────────────────
+//
+//   1. XLINGS_THEME=dark|light  — explicit override, no querying.
+//   2. XLINGS_THEME=auto / unset — try (in order):
+//      a. platform::query_terminal_is_light() — POSIX OSC-11 query
+//         on Linux/macOS; std::nullopt on Windows.
+//      b. COLORFGBG env (rxvt-style "fg;bg" — bg 7 or 9-15 = light).
+//      c. Fall back to Dark — the safe default for most modern terms.
+//
+// Detection runs at most once per process (cached). Cost is one terminal
+// round-trip on first color access, bounded by a monotonic deadline (default
+// 500 ms, XLINGS_TERM_QUERY_TIMEOUT_MS) but normally returning in a few ms
+// via a DSR/CPR fence; the result is reused for the lifetime of the program.
+
+enum class Background { Dark, Light };
+
+namespace detail {
+
+inline auto from_env_override_() -> std::optional<Background> {
+    if (auto* v = std::getenv("XLINGS_THEME")) {
+        std::string_view s{v};
+        if (s == "dark")  return Background::Dark;
+        if (s == "light") return Background::Light;
+        // "auto" / unknown → fall through to detection
+    }
+    return std::nullopt;
+}
+
+inline auto from_colorfgbg_() -> std::optional<Background> {
+    auto* v = std::getenv("COLORFGBG");
+    if (!v) return std::nullopt;
+    std::string_view s{v};
+    auto sep = s.rfind(';');
+    if (sep == std::string_view::npos) return std::nullopt;
+    int bg = 0;
+    for (char c : s.substr(sep + 1)) {
+        if (c < '0' || c > '9') return std::nullopt;
+        bg = bg * 10 + (c - '0');
+        if (bg > 99) return std::nullopt;
+    }
+    // rxvt convention: 0..6 + 8 are dark; 7 and 9..15 are light.
+    return (bg == 7 || bg >= 9) ? Background::Light : Background::Dark;
+}
+
+inline auto detect_() -> Background {
+    if (auto e = from_env_override_()) return *e;
+    if (auto t = platform::query_terminal_is_light()) {
+        return *t ? Background::Light : Background::Dark;
+    }
+    if (auto c = from_colorfgbg_())    return *c;
+    return Background::Dark;
+}
+
+inline auto cached_() -> Background& {
+    static Background bg = detect_();
+    return bg;
+}
+
+}  // namespace detail
+
+inline auto current_background() -> Background { return detail::cached_(); }
+inline void set_background(Background bg)      { detail::cached_() = bg; }
+
+// ─── Color table ───────────────────────────────────────────
+
+struct Rgb { unsigned char r, g, b; };
+
+namespace dark_ {
+    inline constexpr Rgb cyan    {  34, 211, 238 };  // cyan-400
+    inline constexpr Rgb green   {  34, 197,  94 };  // green-500
+    inline constexpr Rgb amber   { 245, 158,  11 };  // amber-500
+    inline constexpr Rgb red     { 239,  68,  68 };  // red-500
+    inline constexpr Rgb magenta { 168,  85, 247 };  // purple-500
+    inline constexpr Rgb dim     { 148, 163, 184 };  // slate-400
+    inline constexpr Rgb text    { 248, 250, 252 };  // slate-50
+    inline constexpr Rgb surface {  30,  41,  59 };  // slate-800
+    inline constexpr Rgb border  {  51,  65,  85 };  // slate-700
+}
+
+namespace light_ {
+    inline constexpr Rgb cyan    {   8, 145, 178 };  // cyan-700
+    inline constexpr Rgb green   {  21, 128,  61 };  // green-700
+    inline constexpr Rgb amber   { 180,  83,   9 };  // amber-700
+    inline constexpr Rgb red     { 185,  28,  28 };  // red-700
+    inline constexpr Rgb magenta { 126,  34, 206 };  // purple-700
+    inline constexpr Rgb dim     { 100, 116, 139 };  // slate-500
+    inline constexpr Rgb text    {  15,  23,  42 };  // slate-900
+    inline constexpr Rgb surface { 241, 245, 249 };  // slate-100
+    inline constexpr Rgb border  { 203, 213, 225 };  // slate-300
+}
+
+inline auto pick_(const Rgb& d, const Rgb& l) -> Rgb {
+    return current_background() == Background::Light ? l : d;
+}
+
+inline auto cyan()    -> Rgb { return pick_(dark_::cyan,    light_::cyan); }
+inline auto green()   -> Rgb { return pick_(dark_::green,   light_::green); }
+inline auto amber()   -> Rgb { return pick_(dark_::amber,   light_::amber); }
+inline auto red()     -> Rgb { return pick_(dark_::red,     light_::red); }
+inline auto magenta() -> Rgb { return pick_(dark_::magenta, light_::magenta); }
+inline auto dim()     -> Rgb { return pick_(dark_::dim,     light_::dim); }
+inline auto text()    -> Rgb { return pick_(dark_::text,    light_::text); }
+inline auto surface() -> Rgb { return pick_(dark_::surface, light_::surface); }
+inline auto border()  -> Rgb { return pick_(dark_::border,  light_::border); }
+
+// ─── SGR, for the writers that do not go through ftxui ─────
+
+inline constexpr auto reset = "\033[0m";
+inline constexpr auto bold  = "\033[1m";
+
+// Foreground escape, or "" when color is off. Callers concatenate freely;
+// paired `reset` is likewise empty, so a plain run emits no escapes at all
+// rather than bare resets.
+inline auto sgr_fg(Rgb c) -> std::string {
+    return std::format("\033[38;2;{};{};{}m", int(c.r), int(c.g), int(c.b));
+}
+
+inline auto fg(Rgb c) -> std::string {
+    if (!colors_enabled()) return {};
+    return sgr_fg(c);
+}
+
+inline auto off() -> std::string {
+    return colors_enabled() ? std::string{reset} : std::string{};
+}
+
+inline auto strong() -> std::string {
+    return colors_enabled() ? std::string{bold} : std::string{};
+}
+
+} // namespace xlings::palette

--- a/src/core/xim/commands.cppm
+++ b/src/core/xim/commands.cppm
@@ -943,13 +943,25 @@ int cmd_info(const std::string& target, EventStream& stream) {
     auto platform = detect_platform();
     auto platformIt = pkg->xpm.entries.find(platform);
     if (platformIt != pkg->xpm.entries.end()) {
+        // Concrete versions and aliases used to share one comma-joined
+        // `versions` row, so `latest` and the version it points at appeared
+        // side by side — `latest -> 16.1.0, 16.1.0` reads as the list
+        // repeating itself. They are two different facts; they get two rows.
         std::string verStr;
+        std::string aliasStr;
         for (auto& [ver, res] : platformIt->second) {
+            if (!res.ref.empty()) {
+                if (!aliasStr.empty()) aliasStr += ", ";
+                aliasStr += ver + " -> " + res.ref;
+                continue;
+            }
             if (!verStr.empty()) verStr += ", ";
             verStr += ver;
-            if (!res.ref.empty()) verStr += " -> " + res.ref;
         }
-        addField(fieldsJson, "versions", verStr);
+        // `available` rather than `versions`: the panel's second half also
+        // had a row called `versions`, meaning the locally installed ones.
+        if (!verStr.empty())   addField(fieldsJson, "available", verStr);
+        if (!aliasStr.empty()) addField(fieldsJson, "aliases", aliasStr);
     }
 
     auto join_deps = [](const std::vector<std::string>& v) {
@@ -978,7 +990,11 @@ int cmd_info(const std::string& target, EventStream& stream) {
         }
     }
 
-    addField(fieldsJson, "installed", match->installed ? "yes" : "no", match->installed);
+    // Only when the answer is "no". When it is installed the second half of
+    // the panel says so in detail — `active`, `installed`, the payload path —
+    // and a bare `installed  yes` above it is a third label competing to mean
+    // the same thing.
+    if (!match->installed) addField(fieldsJson, "installed", "no");
 
     nlohmann::json extraJson = nlohmann::json::array();
     if (match->installed) {
@@ -997,19 +1013,21 @@ int cmd_info(const std::string& target, EventStream& stream) {
             for (auto& v : allVers) {
                 if (!verList.empty()) verList += ", ";
                 verList += v;
-                if (v == activeVer) verList += " *";
+                // Spelled out rather than a bare `*`, which needed a legend
+                // the panel never printed.
+                if (v == activeVer) verList += " (active)";
             }
-            addField(extraJson, "versions", verList);
+            addField(extraJson, "installed", verList);
         }
 
         auto storeName = package_store_name(match->namespaceName, match->name);
         auto storePath = match->storeRoot / storeName;
-        addField(extraJson, "xpkg path", storePath.string());
+        addField(extraJson, "xpkg path", Config::display_path(storePath));
 
         auto binDir = Config::global_subos_bin_dir();
         auto shimPath = binDir / target;
         if (std::filesystem::exists(shimPath)) {
-            addField(extraJson, "shim", shimPath.string());
+            addField(extraJson, "shim", Config::display_path(shimPath));
         }
 
         auto* vinfo = xvm::get_vinfo(db, target);

--- a/src/core/xim/downloader.cppm
+++ b/src/core/xim/downloader.cppm
@@ -870,7 +870,9 @@ download_all(std::span<const DownloadTask> tasks,
     std::atomic<bool> allDone { false };
     std::atomic<bool> sizesReady { false };
 
-    // Compute max name width for alignment
+    // A byte-count floor for the name column. The renderer re-measures it in
+    // display columns and fits it to the terminal — measuring here would
+    // mean pulling the UI's width table into core.
     std::size_t nameWidth = 20;
     for (auto& t : tasks) {
         if (t.name.size() > nameWidth) nameWidth = t.name.size();

--- a/src/core/xself/doctor.cppm
+++ b/src/core/xself/doctor.cppm
@@ -7,6 +7,7 @@ import xlings.core.xself.init;   // create_shim, LinkResult
 import xlings.core.xself.compat;
 
 import xlings.core.config;
+import xlings.core.glyph;
 import xlings.libs.json;
 import xlings.core.log;
 import xlings.platform;
@@ -696,9 +697,9 @@ void repair_local_(const DoctorState& st, const Scan& scan,
             std::error_code ec;
             fs::create_directories(p.binDir, ec);
             if (create_shim(st.xlingsBin, f.shimPath) != LinkResult::Failed) {
-                note("· shim recreated", Config::display_path(f.shimPath));
+                note(glyph::mark(glyph::bullet, "shim recreated"), Config::display_path(f.shimPath));
             } else {
-                note("✗ shim repair failed", std::format(
+                note(glyph::mark(glyph::failed, "shim repair failed"), std::format(
                     "could not recreate {}",
                     Config::display_path(f.shimPath)));
             }
@@ -707,9 +708,9 @@ void repair_local_(const DoctorState& st, const Scan& scan,
             std::error_code ec;
             fs::remove(f.shimPath, ec);
             if (!ec) {
-                note("· shim removed", Config::display_path(f.shimPath));
+                note(glyph::mark(glyph::bullet, "shim removed"), Config::display_path(f.shimPath));
             } else {
-                note("✗ shim repair failed", std::format(
+                note(glyph::mark(glyph::failed, "shim repair failed"), std::format(
                     "could not remove {}", Config::display_path(f.shimPath)));
             }
         }
@@ -732,7 +733,7 @@ void repair_state_(RepairReport& out) {
     if (auto pruning = xvm::plan_dangling_edge_pruning(db); !pruning.empty()) {
         auto lock = xvm::acquire_state_lock(Config::paths().homeDir);
         if (!lock) {
-            note("✗ binding state", std::format(
+            note(glyph::mark(glyph::failed, "binding state"), std::format(
                 "cannot drop dangling binding edges: {}", lock.error()));
         } else {
             Config::reload_state();
@@ -741,7 +742,7 @@ void repair_state_(RepairReport& out) {
             if (xvm::apply_dangling_edge_pruning(mutableDb, replanned) > 0) {
                 Config::save_versions();
                 for (const auto& e : replanned.edges) {
-                    note("· edge dropped", std::format(
+                    note(glyph::mark(glyph::bullet, "edge dropped"), std::format(
                         "{} no longer points at unregistered {}",
                         xvm::display_coordinate(e.target, e.version),
                         xvm::display_coordinate(e.peerTarget, e.peerVersion)));
@@ -756,7 +757,7 @@ void repair_state_(RepairReport& out) {
         !stale.empty()) {
         auto lock = xvm::acquire_state_lock(Config::paths().homeDir);
         if (!lock) {
-            note("✗ binding state", std::format(
+            note(glyph::mark(glyph::failed, "binding state"), std::format(
                 "cannot deactivate unregistered versions: {}", lock.error()));
         } else {
             Config::reload_state();
@@ -765,7 +766,7 @@ void repair_state_(RepairReport& out) {
             for (const auto& target : stale) {
                 const auto it = mutableWs.find(target);
                 if (it == mutableWs.end()) continue;
-                note("· deactivated", std::format(
+                note(glyph::mark(glyph::bullet, "deactivated"), std::format(
                     "{} was active at a version that is not registered — run "
                     "`xlings use {} <version>` to select one",
                     xvm::display_coordinate(target, it->second), target));
@@ -782,7 +783,7 @@ void repair_state_(RepairReport& out) {
         !plan.targets.empty()) {
         auto lock = xvm::acquire_state_lock(Config::paths().homeDir);
         if (!lock) {
-            note("✗ binding state", std::format(
+            note(glyph::mark(glyph::failed, "binding state"), std::format(
                 "cannot deactivate incoherent releases: {}", lock.error()));
         } else {
             Config::reload_state();
@@ -791,7 +792,7 @@ void repair_state_(RepairReport& out) {
             for (const auto& [target, label] : plan.targets) {
                 if (mutableWs.erase(target) == 0) continue;
                 ++dropped;
-                note("· deactivated", std::format(
+                note(glyph::mark(glyph::bullet, "deactivated"), std::format(
                     "{} (was part of {}) — run `xlings use {} <version>` to "
                     "select a release", target, label, target));
             }
@@ -814,7 +815,7 @@ void repair_other_subos_(const DoctorState& st, RepairReport& out) {
 
     auto lock = xvm::acquire_state_lock(Config::paths().homeDir);
     if (!lock) {
-        out.notes.emplace_back("✗ other subos", std::format(
+        out.notes.emplace_back(glyph::mark(glyph::failed, "other subos"), std::format(
             "cannot repair other subos state: {}", lock.error()));
         return;
     }
@@ -837,19 +838,19 @@ void repair_other_subos_(const DoctorState& st, RepairReport& out) {
             xvm::apply_subos_metadata_repair(workspace, entry);
         if (dropped == 0) continue;
         if (!profile::save_subos_workspace(snapshotIt->dir, workspace)) {
-            out.notes.emplace_back("✗ other subos", std::format(
+            out.notes.emplace_back(glyph::mark(glyph::failed, "other subos"), std::format(
                 "could not write the state file of subos '{}'", entry.subos));
             continue;
         }
         for (const auto& target : entry.deactivate) {
-            out.notes.emplace_back("· other subos repaired", std::format(
+            out.notes.emplace_back(glyph::mark(glyph::bullet, "other subos repaired"), std::format(
                 "{}: deactivated '{}' — it named a version that is not "
                 "registered; run `xlings subos use {}` then `xlings use {} "
                 "<version>` to choose one", entry.subos, target,
                 entry.subos, target));
         }
         for (const auto& [target, version] : entry.dropInstalled) {
-            out.notes.emplace_back("· other subos repaired", std::format(
+            out.notes.emplace_back(glyph::mark(glyph::bullet, "other subos repaired"), std::format(
                 "{}: dropped stale installed entry {}", entry.subos,
                 xvm::display_coordinate(target, version)));
         }
@@ -933,7 +934,7 @@ void repair_payloads_(const DoctorState& st, const Scan& scan,
             for (const auto* c : covered) {
                 out.failedEntries.emplace_back(c->target, c->version);
             }
-            out.notes.emplace_back("✗ repair failed", std::format(
+            out.notes.emplace_back(glyph::mark(glyph::failed, "repair failed"), std::format(
                 "{} — {}", coord.canonical(),
                 result.note.empty() ? "the finding it covers is still there"
                                     : result.note));
@@ -983,7 +984,7 @@ void prune_dead_registrations_(const DoctorState& st, const Scan& remaining,
                 if (!list.empty()) list += ", ";
                 list += other;
             }
-            out.notes.emplace_back("✗ kept", std::format(
+            out.notes.emplace_back(glyph::mark(glyph::failed, "kept"), std::format(
                 "{} could not be restored, but subos {} still uses it — "
                 "repair or remove it there",
                 xvm::display_coordinate(f.target, f.version), list));
@@ -996,7 +997,7 @@ void prune_dead_registrations_(const DoctorState& st, const Scan& remaining,
 
     auto lock = xvm::acquire_state_lock(Config::paths().homeDir);
     if (!lock) {
-        out.notes.emplace_back("✗ prune", std::format(
+        out.notes.emplace_back(glyph::mark(glyph::failed, "prune"), std::format(
             "cannot drop dead registrations: {}", lock.error()));
         for (const auto& victim : victims) out.failedEntries.push_back(victim);
         return;
@@ -1012,7 +1013,7 @@ void prune_dead_registrations_(const DoctorState& st, const Scan& remaining,
         if (infoIt == db.end()) continue;
         if (infoIt->second.versions.erase(version) == 0) continue;
         ++dropped;
-        out.notes.emplace_back("· dropped", std::format(
+        out.notes.emplace_back(glyph::mark(glyph::bullet, "dropped"), std::format(
             "{} — its payload is gone and nothing can restore it",
             xvm::display_coordinate(target, version)));
 
@@ -1128,7 +1129,8 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
         const auto* head = group.front();
         const bool foreign = head->kind == FindingKind::ForeignPayload;
         std::string label = foreign
-            ? std::format("✗ broken payload [subos: {}]",
+            ? glyph::mark(glyph::failed,
+                          std::format("broken payload [subos: {}]",
                           [&] {
                               std::string list;
                               for (const auto& s : head->subos) {
@@ -1136,11 +1138,11 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
                                   list += s;
                               }
                               return list;
-                          }())
+                          }()))
             : (std::ranges::any_of(group, [](const Finding* f) {
                    return f->active;
-               }) ? std::string("✗ broken payload [active]")
-                  : std::string("✗ broken payload"));
+               }) ? glyph::mark(glyph::failed, "broken payload [active]")
+                  : glyph::mark(glyph::failed, "broken payload"));
 
         std::string detail = head->detail;
         if (group.size() > 1) {
@@ -1154,11 +1156,11 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
         }
         add(label, std::move(detail));
         if (!head->remedy.empty()) {
-            add("  → run", head->remedy);
+            add("  " + glyph::mark(glyph::remedy, "run"), head->remedy);
         } else {
             // No command would help. Saying that is the useful output; a
             // plausible-looking `xlings install <target>` is not.
-            add("  ⓘ no remedy", fix
+            add("  " + glyph::mark(glyph::note, "no remedy"), fix
                 ? std::string("no package provides this entry — the "
                               "registration was dropped")
                 : std::string("no package in any index provides this entry; "
@@ -1175,13 +1177,13 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
     for (const auto& f : scan.findings) {
         switch (f.kind) {
             case FindingKind::MissingShim:
-                add("✗ missing shim", f.detail); break;
+                add(glyph::mark(glyph::failed, "missing shim"), f.detail); break;
             case FindingKind::OrphanShim:
-                add("✗ orphan shim", f.detail); break;
+                add(glyph::mark(glyph::failed, "orphan shim"), f.detail); break;
             case FindingKind::LegacyAliasShim:
-                add("✗ legacy alias shim", f.detail); break;
+                add(glyph::mark(glyph::failed, "legacy alias shim"), f.detail); break;
             case FindingKind::ShimAnchor:
-                add("⚠ shim anchor", f.detail); break;
+                add(glyph::mark(glyph::warn, "shim anchor"), f.detail); break;
             case FindingKind::AliasUnresolved:
                 // One line per TARGET, not per version. The alias is a
                 // property of the recipe, so every version of a package
@@ -1191,7 +1193,7 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
                 // a genuinely missing alias binary is the only signal there
                 // is.
                 if (verbose || aliasTargetsShown.insert(f.target).second) {
-                    add("⚠ alias unresolved", verbose ? f.detail
+                    add(glyph::mark(glyph::warn, "alias unresolved"), verbose ? f.detail
                         : std::format("{}{}", f.detail,
                             aliasVersionCount.at(f.target) > 1
                                 ? std::format("  (+{} other version(s))",
@@ -1201,20 +1203,20 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
                 break;
             case FindingKind::BindingState:
                 if (f.level == FindingLevel::Notice) {
-                    if (verbose) add("ⓘ binding state", f.detail);
+                    if (verbose) add(glyph::mark(glyph::note, "binding state"), f.detail);
                 } else {
-                    add("✗ binding state", f.detail);
+                    add(glyph::mark(glyph::failed, "binding state"), f.detail);
                 }
                 break;
             case FindingKind::OtherSubos:
                 if (verbose || f.level != FindingLevel::Notice) {
-                    add(f.level == FindingLevel::Notice ? "ⓘ other subos"
-                                                        : "⚠ other subos",
+                    add(f.level == FindingLevel::Notice ? glyph::mark(glyph::note, "other subos")
+                                                        : glyph::mark(glyph::warn, "other subos"),
                         f.detail);
                 }
                 break;
             case FindingKind::ReleaseAnchor:
-                if (verbose) add("ⓘ release anchor", f.detail);
+                if (verbose) add(glyph::mark(glyph::note, "release anchor"), f.detail);
                 break;
             default: break;
         }
@@ -1235,19 +1237,19 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
         std::string summary;
         const auto part = [&](int n, std::string_view what) {
             if (n == 0) return;
-            if (!summary.empty()) summary += " · ";
+            if (!summary.empty()) summary += std::format(" {} ", glyph::bullet);
             summary += std::format("{} {}", n, what);
         };
         part(anchors, "release anchor");
         part(bindingNotices, "binding notice");
         part(subosNotices, "other-subos notice");
         if (!summary.empty()) {
-            add("ⓘ nothing to do", summary + "  —  `--all` to list them");
+            add(glyph::mark(glyph::note, "nothing to do"), summary + "  —  `--all` to list them");
         }
     }
 
     for (const auto& [label, text] : repair.notes) add(label, text);
-    for (const auto& planned : repair.planned) add("→ would run", planned);
+    for (const auto& planned : repair.planned) add(glyph::mark(glyph::remedy, "would run"), planned);
     if (dryRun) {
         add("dry run", std::format(
             "{} action(s) planned; nothing was changed",
@@ -1297,7 +1299,7 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
     // it.
     if (auto hint = migration_hint(Config::recorded_client_version(),
                                    Info::VERSION)) {
-        add("ⓘ migration", *hint);
+        add(glyph::mark(glyph::note, "migration"), *hint);
     }
 
     nlohmann::json payload;
@@ -1346,7 +1348,7 @@ export int cmd_doctor(EventStream& stream, bool fix,
         if (auto reset = xvm::plan_metadata_reset(state.db); !reset.empty()) {
             auto lock = xvm::acquire_state_lock(Config::paths().homeDir);
             if (!lock) {
-                repair.notes.emplace_back("✗ binding state", std::format(
+                repair.notes.emplace_back(glyph::mark(glyph::failed, "binding state"), std::format(
                     "cannot reset binding metadata: {}", lock.error()));
             } else {
                 Config::reload_state();
@@ -1363,7 +1365,7 @@ export int cmd_doctor(EventStream& stream, bool fix,
                         // Name what was discarded. This is the one repair that
                         // loses information, so a bare count would be the
                         // wrong report.
-                        repair.notes.emplace_back("· metadata reset",
+                        repair.notes.emplace_back(glyph::mark(glyph::bullet, "metadata reset"),
                             std::format(
                                 "{} dropped its release metadata ({}) and is "
                                 "now switchable on its own — reinstall it to "

--- a/src/core/xvm/commands.cppm
+++ b/src/core/xvm/commands.cppm
@@ -5,6 +5,7 @@ import std;
 import xlings.core.common;
 import xlings.core.config;
 import xlings.core.log;
+import xlings.core.palette;
 import xlings.platform;
 import xlings.runtime;
 import xlings.libs.json;
@@ -528,11 +529,43 @@ int cmd_list_versions(const std::string& target, EventStream& stream, bool all =
         title = target + " versions (current subos)";
     }
 
+    // With a person at the keyboard, `xlings use <target>` offers the
+    // versions instead of only listing them. The picker has been implemented
+    // in ui::select_version since the panel was written and had no caller —
+    // the command printed a list and left the user to retype one of the rows.
+    //
+    // Off a terminal, in `--agent`, or under the NDJSON interface it still
+    // prints the panel: a prompt that auto-answers with a default would
+    // switch versions in a script that only asked to see them.
+    const bool interactive = versions.size() > 1
+        && platform::stdin_is_terminal()
+        && platform::supports_rewrite_output()
+        && !platform::is_tui_mode()
+        && !palette::plain_forced();
+
+    if (interactive) {
+        PromptEvent req;
+        req.id = "select_version";
+        req.question = "Select version for " + target;
+        req.options = versions;
+        req.defaultValue = active;
+        auto chosen = stream.prompt(std::move(req));
+        if (chosen.empty()) {
+            log::println("cancelled");
+            return 0;
+        }
+        return cmd_use(target, chosen, stream);
+    }
+
     nlohmann::json fieldsJson = nlohmann::json::array();
     for (auto& ver : versions) {
         auto vdata = get_vdata(db, target, ver);
         std::string path_info;
-        if (vdata && !vdata->path.empty()) path_info = vdata->path;
+        // `@xlings/...` rather than the absolute path. `self config` and
+        // `self doctor` already abbreviate; this panel did not, and it is the
+        // one whose rows are payload paths — the ~20 columns the prefix costs
+        // are exactly what pushed it past the terminal.
+        if (vdata && !vdata->path.empty()) path_info = Config::display_path(vdata->path);
         bool highlight = (ver == active);
         fieldsJson.push_back({{"label", ver}, {"value", path_info}, {"highlight", highlight}});
     }
@@ -540,6 +573,19 @@ int cmd_list_versions(const std::string& target, EventStream& stream, bool all =
     payload["title"] = title;
     payload["fields"] = std::move(fieldsJson);
     stream.emit(DataEvent{"info_panel", payload.dump()});
+
+    // Say what to do with the list. The failure path above already spells the
+    // next command out; the path where the user got exactly what they asked
+    // for and still has to guess did not.
+    //
+    // As a `tip` event rather than a bare println so it goes through the same
+    // width contract as the panel it follows — a hint that runs off the edge
+    // of a narrow terminal is the problem it was added to solve.
+    if (versions.size() > 1) {
+        nlohmann::json tip;
+        tip["message"] = std::format("xlings use {} <version>", target);
+        stream.emit(DataEvent{"tip", tip.dump()});
+    }
 
     return 0;
 }

--- a/src/platform.cppm
+++ b/src/platform.cppm
@@ -36,6 +36,8 @@ namespace platform {
     export using platform_impl::println;
     export using platform_impl::init_console_output;
     export using platform_impl::supports_rewrite_output;
+    export using platform_impl::stderr_is_terminal;
+    export using platform_impl::stdin_is_terminal;
     export using platform_impl::get_pid;
     export using platform_impl::is_process_alive;
     export using platform_impl::query_terminal_is_light;
@@ -49,7 +51,6 @@ namespace platform {
     export using platform_impl::ProcessHandle;
     export using platform_impl::spawn_command;
     export using platform_impl::wait_or_kill;
-    export using platform_impl::Icon;
     export using platform_impl::atomic_replace_executable;
     export using platform_impl::atomic_swap_paths;
     export using platform_impl::FileLock;

--- a/src/platform/linux.cppm
+++ b/src/platform/linux.cppm
@@ -201,6 +201,19 @@ namespace platform_impl {
         return ::isatty(STDOUT_FILENO) != 0;
     }
 
+    // Check if stderr is a TTY. Separate from stdout because warnings and
+    // errors go to stderr: `xlings install > log` still has an interactive
+    // stderr, and `2>&1 | cat` has neither.
+    export bool stderr_is_terminal() {
+        return ::isatty(STDERR_FILENO) != 0;
+    }
+
+    // Check if stdin is a TTY — i.e. whether there is someone there to answer
+    // an interactive prompt.
+    export bool stdin_is_terminal() {
+        return ::isatty(STDIN_FILENO) != 0;
+    }
+
     export template<typename... Args>
     void println(std::format_string<Args...> fmt, Args&&... args) {
         std::println(fmt, std::forward<Args>(args)...);
@@ -223,24 +236,6 @@ namespace platform_impl {
 
     // query_terminal_is_light() lives in :unix — shared with macOS.
 
-    export struct Icon {
-        static constexpr auto pending    = "\xe2\x97\x8b";   // ○
-        static constexpr auto running    = "\xe2\x9f\xb3";   // ⟳
-        static constexpr auto done       = "\xe2\x9c\x93";   // ✓
-        static constexpr auto failed     = "\xe2\x9c\x97";   // ✗
-        static constexpr auto skipped    = "\xe2\x96\xb7";   // ▷
-        static constexpr auto turn       = "\xe2\x8f\xb5";   // ⏵
-        static constexpr auto reply      = "\xe2\x97\x86";   // ◆
-        static constexpr auto exec       = "\xe2\x9a\x99";   // ⚙
-        static constexpr auto thinking   = "\xe2\x97\x87";   // ◇
-        static constexpr auto approval   = "\xe2\x9a\xa0";   // ⚠
-        static constexpr auto download   = "\xe2\x86\x93";   // ↓
-        static constexpr auto upload     = "\xe2\x86\x91";   // ↑
-        static constexpr auto extracting = "\xe2\x9f\x90";   // ⟐
-        static constexpr auto arrow      = "\xe2\x96\xb8";   // ▸
-        static constexpr auto package    = "\xe2\x97\x86";   // ◆
-        static constexpr auto info       = "\xe2\x80\xba";   // ›
-    };
 
 } // namespace platform_impl
 }

--- a/src/platform/macos.cppm
+++ b/src/platform/macos.cppm
@@ -181,6 +181,19 @@ namespace platform_impl {
         return ::isatty(STDOUT_FILENO) != 0;
     }
 
+    // Check if stderr is a TTY. Separate from stdout because warnings and
+    // errors go to stderr: `xlings install > log` still has an interactive
+    // stderr, and `2>&1 | cat` has neither.
+    export bool stderr_is_terminal() {
+        return ::isatty(STDERR_FILENO) != 0;
+    }
+
+    // Check if stdin is a TTY — i.e. whether there is someone there to answer
+    // an interactive prompt.
+    export bool stdin_is_terminal() {
+        return ::isatty(STDIN_FILENO) != 0;
+    }
+
     export template<typename... Args>
     void println(std::format_string<Args...> fmt, Args&&... args) {
         std::println(fmt, std::forward<Args>(args)...);
@@ -202,24 +215,6 @@ namespace platform_impl {
 
     // query_terminal_is_light() lives in :unix — shared with Linux.
 
-    export struct Icon {
-        static constexpr auto pending    = "\xe2\x97\x8b";   // ○
-        static constexpr auto running    = "\xe2\x9f\xb3";   // ⟳
-        static constexpr auto done       = "\xe2\x9c\x93";   // ✓
-        static constexpr auto failed     = "\xe2\x9c\x97";   // ✗
-        static constexpr auto skipped    = "\xe2\x96\xb7";   // ▷
-        static constexpr auto turn       = "\xe2\x8f\xb5";   // ⏵
-        static constexpr auto reply      = "\xe2\x97\x86";   // ◆
-        static constexpr auto exec       = "\xe2\x9a\x99";   // ⚙
-        static constexpr auto thinking   = "\xe2\x97\x87";   // ◇
-        static constexpr auto approval   = "\xe2\x9a\xa0";   // ⚠
-        static constexpr auto download   = "\xe2\x86\x93";   // ↓
-        static constexpr auto upload     = "\xe2\x86\x91";   // ↑
-        static constexpr auto extracting = "\xe2\x9f\x90";   // ⟐
-        static constexpr auto arrow      = "\xe2\x96\xb8";   // ▸
-        static constexpr auto package    = "\xe2\x97\x86";   // ◆
-        static constexpr auto info       = "\xe2\x80\xba";   // ›
-    };
 
 } // namespace platform_impl
 }

--- a/src/platform/windows.cppm
+++ b/src/platform/windows.cppm
@@ -266,6 +266,26 @@ namespace platform_impl {
         return (mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING) != 0;
     }
 
+    // Check if stderr is a console. Separate from stdout because warnings
+    // and errors go to stderr: `xlings install > log` still has an
+    // interactive stderr, and `2>&1 | cat` has neither.
+    export bool stderr_is_terminal() {
+        HANDLE hErr = ::GetStdHandle(STD_ERROR_HANDLE);
+        if (hErr == INVALID_HANDLE_VALUE) return false;
+        DWORD mode = 0;
+        if (!::GetConsoleMode(hErr, &mode)) return false;
+        return (mode & ENABLE_VIRTUAL_TERMINAL_PROCESSING) != 0;
+    }
+
+    // Check if stdin is a console — i.e. whether there is someone there to
+    // answer an interactive prompt.
+    export bool stdin_is_terminal() {
+        HANDLE hIn = ::GetStdHandle(STD_INPUT_HANDLE);
+        if (hIn == INVALID_HANDLE_VALUE) return false;
+        DWORD mode = 0;
+        return ::GetConsoleMode(hIn, &mode) != 0;
+    }
+
     export template<typename... Args>
     void println(std::format_string<Args...> fmt, Args&&... args) {
         std::println(fmt, std::forward<Args>(args)...);
@@ -311,24 +331,6 @@ namespace platform_impl {
         return {};
     }
 
-    export struct Icon {
-        static constexpr auto pending    = "o";
-        static constexpr auto running    = "*";
-        static constexpr auto done       = "+";
-        static constexpr auto failed     = "x";
-        static constexpr auto skipped    = "-";
-        static constexpr auto turn       = ">";
-        static constexpr auto reply      = "#";
-        static constexpr auto exec       = "*";
-        static constexpr auto thinking   = "~";
-        static constexpr auto approval   = "!";
-        static constexpr auto download   = "v";
-        static constexpr auto upload     = "^";
-        static constexpr auto extracting = ">";
-        static constexpr auto arrow      = ">";
-        static constexpr auto package    = "#";
-        static constexpr auto info       = ">";
-    };
 
     // Atomically replace `dst` with the contents of `src`, even when `dst`
     // is a currently running executable.

--- a/src/platform/windows.cppm
+++ b/src/platform/windows.cppm
@@ -247,12 +247,17 @@ namespace platform_impl {
         ::SetConsoleOutputCP(CP_UTF8);
         ::SetConsoleCP(CP_UTF8);
 
-        HANDLE hOut = ::GetStdHandle(STD_OUTPUT_HANDLE);
-        if (hOut != INVALID_HANDLE_VALUE) {
+        // Both handles. Only stdout used to be switched into VT mode, but
+        // `log::warn` and `log::error` write to stderr — so on a console
+        // their SGR was emitted to a handle that does not interpret it, and
+        // the user read the escape bytes instead of a colored `[warn]`.
+        for (DWORD which : { STD_OUTPUT_HANDLE, STD_ERROR_HANDLE }) {
+            HANDLE h = ::GetStdHandle(which);
+            if (h == INVALID_HANDLE_VALUE) continue;
             DWORD mode = 0;
-            if (::GetConsoleMode(hOut, &mode)) {
+            if (::GetConsoleMode(h, &mode)) {
                 mode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
-                ::SetConsoleMode(hOut, mode);
+                ::SetConsoleMode(h, mode);
             }
         }
     }

--- a/src/ui.cppm
+++ b/src/ui.cppm
@@ -1,6 +1,7 @@
 export module xlings.ui;
 
 export import :theme;
+export import :layout;
 export import :progress;
 export import :selector;
 export import :table;

--- a/src/ui/banner.cppm
+++ b/src/ui/banner.cppm
@@ -8,24 +8,9 @@ export module xlings.ui:banner;
 
 import std;
 import :theme;
+import :layout;
 
 export namespace xlings::ui {
-
-// Pad string to desired width (avoids std::format width specifiers - GCC 15 crash)
-std::string pad_to(std::string s, std::size_t width) {
-    while (s.size() < width) s += ' ';
-    return s;
-}
-
-// Render FTXUI rows and print to stdout
-void render_rows_(ftxui::Elements rows) {
-    using namespace ftxui;
-    auto doc = vbox(std::move(rows));
-    auto screen = Screen::Create(Dimension::Full(), theme::fit_full_height(doc));
-    Render(screen, doc);
-    screen.Print();
-    std::println("");
-}
 
 // --- Option / Arg descriptors for subcommand help ---
 struct HelpOpt {
@@ -39,6 +24,63 @@ struct HelpArg {
     bool required { false };
 };
 
+// Help pages are the `[indent][name]  [description]` list too, and they were
+// the most visible casualty of ftxui's proportional shrink: rows with a long
+// description had their name column squeezed harder than rows with a short
+// one, so `xlings --help` in a narrow terminal came out with a name column
+// that changed width line by line and read as a rendering fault.
+//
+// One plan for the whole page, so every section shares a column.
+constexpr int kHelpIndent = 4;
+constexpr int kHelpGap = 2;
+
+// Build a help section: heading plus name/description rows sharing `P`.
+void help_section_(ftxui::Elements& rows, std::string_view heading,
+                   std::span<const std::pair<std::string, std::string>> entries,
+                   const layout::ColumnPlan& P, ftxui::Decorator nameStyle) {
+    using namespace ftxui;
+    if (entries.empty()) return;
+
+    rows.push_back(text("  " + std::string(heading)) | bold | color(theme::text_color()));
+    for (auto& [name, desc] : entries) {
+        if (P.stacked) {
+            for (auto& part : layout::wrap_to_width(
+                     name, std::max(1, P.width - kHelpIndent))) {
+                rows.push_back(text(std::string(kHelpIndent, ' ') + part) | nameStyle);
+            }
+            if (P.descW > 0 && !desc.empty()) {
+                rows.push_back(text(std::string(kHelpIndent + kHelpGap, ' ')
+                                    + layout::truncate_to_width(desc, P.descW))
+                               | color(theme::text_color()));
+            }
+            continue;
+        }
+        Elements cells;
+        cells.push_back(text(std::string(kHelpIndent, ' ')));
+        cells.push_back(text(layout::pad_to_width(name, P.nameW)) | nameStyle);
+        if (P.descW > 0 && !desc.empty()) {
+            cells.push_back(text(std::string(kHelpGap, ' ')));
+            cells.push_back(text(layout::truncate_to_width(desc, P.descW))
+                            | color(theme::text_color()));
+        }
+        rows.push_back(hbox(std::move(cells)));
+    }
+    rows.push_back(text(""));
+}
+
+layout::ColumnPlan plan_help_(
+        std::span<const std::span<const std::pair<std::string, std::string>>> sections,
+        int titleW) {
+    int nameMax = 0, descMax = 0;
+    for (auto& sec : sections) {
+        for (auto& [name, desc] : sec) {
+            nameMax = std::max(nameMax, layout::display_width(name));
+            descMax = std::max(descMax, layout::display_width(desc));
+        }
+    }
+    return layout::plan_two_column(kHelpIndent, kHelpGap, nameMax, descMax, titleW);
+}
+
 // Print TUI-styled subcommand help
 void print_subcommand_help(std::string_view name,
                            std::string_view description,
@@ -46,6 +88,33 @@ void print_subcommand_help(std::string_view name,
                            std::span<const HelpOpt> opts,
                            std::span<const HelpOpt> subcmds = {}) {
     using namespace ftxui;
+
+    using Pair = std::pair<std::string, std::string>;
+
+    std::vector<Pair> subEntries;
+    for (auto& s : subcmds) subEntries.emplace_back(s.flag, s.desc);
+
+    std::vector<Pair> argEntries;
+    for (auto& a : args) {
+        if (a.desc.empty()) continue;
+        argEntries.emplace_back("<" + a.name + ">", a.desc);
+    }
+
+    std::vector<Pair> optEntries;
+    for (auto& o : opts) optEntries.emplace_back(o.flag, o.desc);
+
+    std::string usage = "    xlings " + std::string(name);
+    if (!subcmds.empty()) usage += " [SUBCOMMAND]";
+    if (!opts.empty()) usage += " [OPTIONS]";
+    for (auto& a : args) {
+        usage += a.required ? " <" + a.name + ">" : " [" + a.name + "]";
+    }
+
+    std::span<const Pair> sections[] = { subEntries, argEntries, optEntries };
+    auto P = plan_help_(sections,
+                        std::max({ layout::display_width(usage) + 2,
+                                   layout::display_width(description) + 4,
+                                   40 }));
 
     Elements rows;
     rows.push_back(text(""));
@@ -59,99 +128,32 @@ void print_subcommand_help(std::string_view name,
 
     // Description
     if (!description.empty()) {
-        rows.push_back(
-            text("  " + std::string(description)) | color(theme::text_color()));
+        for (auto& line : layout::wrap_to_width(description, std::max(1, P.width - 2))) {
+            rows.push_back(text("  " + line) | color(theme::text_color()));
+        }
         rows.push_back(text(""));
     }
 
     // USAGE
     rows.push_back(text("  USAGE") | bold | color(theme::text_color()));
-    {
-        std::string usage = "    xlings " + std::string(name);
-        if (!subcmds.empty()) usage += " [SUBCOMMAND]";
-        if (!opts.empty()) usage += " [OPTIONS]";
-        for (auto& a : args) {
-            if (a.required)
-                usage += " <" + a.name + ">";
-            else
-                usage += " [" + a.name + "]";
-        }
-        rows.push_back(text(usage) | color(theme::dim_color()));
-    }
+    rows.push_back(text(usage) | color(theme::dim_color()));
     rows.push_back(text(""));
 
-    // SUBCOMMANDS
-    if (!subcmds.empty()) {
-        rows.push_back(text("  SUBCOMMANDS") | bold | color(theme::text_color()));
-        for (auto& s : subcmds) {
-            rows.push_back(hbox({
-                text("    "),
-                text(pad_to(s.flag, 24)) | bold | color(theme::magenta()),
-                text("  " + s.desc) | color(theme::text_color()),
-            }));
-        }
-        rows.push_back(text(""));
-    }
+    help_section_(rows, "SUBCOMMANDS", subEntries, P,
+                  bold | color(theme::magenta()));
+    help_section_(rows, "ARGS", argEntries, P,
+                  bold | color(theme::magenta()));
+    help_section_(rows, "OPTIONS", optEntries, P,
+                  color(theme::dim_color()));
 
-    // ARGS
-    bool hasArgs = false;
-    for (auto& a : args) {
-        if (!a.desc.empty()) { hasArgs = true; break; }
-    }
-    if (hasArgs) {
-        rows.push_back(text("  ARGS") | bold | color(theme::text_color()));
-        for (auto& a : args) {
-            if (a.desc.empty()) continue;
-            rows.push_back(hbox({
-                text("    "),
-                text(pad_to("<" + a.name + ">", 24)) | bold | color(theme::magenta()),
-                text("  " + a.desc) | color(theme::text_color()),
-            }));
-        }
-        rows.push_back(text(""));
-    }
-
-    // OPTIONS
-    if (!opts.empty()) {
-        rows.push_back(text("  OPTIONS") | bold | color(theme::text_color()));
-        for (auto& o : opts) {
-            rows.push_back(hbox({
-                text("    "),
-                text(pad_to(o.flag, 24)) | color(theme::dim_color()),
-                text("  " + o.desc) | color(theme::text_color()),
-            }));
-        }
-        rows.push_back(text(""));
-    }
-
-    render_rows_(std::move(rows));
+    layout::print_rows(std::move(rows), P.width);
 }
 
 // Print styled top-level help text
 void print_help(std::string_view version) {
     using namespace ftxui;
 
-    Elements rows;
-
-    rows.push_back(text(""));
-    rows.push_back(hbox({
-        text("  xlings") | theme::title(),
-        text(" " + std::string(version)) | color(theme::dim_color()),
-    }));
-    rows.push_back(text(""));
-    rows.push_back(
-        text("  A modern package manager and development environment tool")
-            | color(theme::text_color()));
-    rows.push_back(text(""));
-
-    // USAGE
-    rows.push_back(text("  USAGE") | bold | color(theme::text_color()));
-    rows.push_back(
-        text("    xlings [OPTIONS] [SUBCOMMAND]") | color(theme::dim_color()));
-    rows.push_back(text(""));
-
-    // SUBCOMMANDS
-    rows.push_back(text("  SUBCOMMANDS") | bold | color(theme::text_color()));
+    using Pair = std::pair<std::string, std::string>;
 
     struct CmdEntry { std::string name; std::string desc; };
     CmdEntry cmds[] = {
@@ -168,18 +170,6 @@ void print_help(std::string_view version) {
         {"script",   "Run xlings scripts"},
         {"agent",    "Built-in skills and plain-text mode for LLM agents"},
     };
-    for (auto& cmd : cmds) {
-        rows.push_back(hbox({
-            text("    "),
-            text(pad_to(cmd.name, 12)) | bold | color(theme::magenta()),
-            text("  " + cmd.desc) | color(theme::text_color()),
-        }));
-    }
-    rows.push_back(text(""));
-
-    // OPTIONS
-    rows.push_back(text("  OPTIONS") | bold | color(theme::text_color()));
-
     struct OptEntry { std::string flag; std::string desc; };
     OptEntry opts[] = {
         {"-y, --yes",       "Skip confirmation prompts"},
@@ -187,54 +177,92 @@ void print_help(std::string_view version) {
         {"-q, --quiet",     "Suppress non-essential output"},
         {"    --agent",     "Plain-text output for LLM agents (no TUI/ANSI)"},
     };
-    for (auto& opt : opts) {
-        rows.push_back(hbox({
-            text("    "),
-            text(pad_to(opt.flag, 24)) | color(theme::dim_color()),
-            text("  " + opt.desc) | color(theme::text_color()),
-        }));
+
+    std::vector<Pair> cmdEntries;
+    for (auto& c : cmds) cmdEntries.emplace_back(c.name, c.desc);
+    std::vector<Pair> optEntries;
+    for (auto& o : opts) optEntries.emplace_back(o.flag, o.desc);
+
+    constexpr std::string_view kTagline =
+        "A modern package manager and development environment tool";
+    constexpr std::string_view kAgentLine1 =
+        "If you are an LLM/AI agent, run `xlings agent` FIRST.";
+    constexpr std::string_view kAgentLine2 =
+        "It contains usage instructions designed specifically for you.";
+
+    std::span<const Pair> sections[] = { cmdEntries, optEntries };
+    auto P = plan_help_(sections,
+                        std::max({ layout::display_width(kTagline) + 4,
+                                   layout::display_width(kAgentLine2) + 6,
+                                   40 }));
+
+    Elements rows;
+    rows.push_back(text(""));
+    rows.push_back(hbox({
+        text("  xlings") | theme::title(),
+        text(" " + std::string(version)) | color(theme::dim_color()),
+    }));
+    rows.push_back(text(""));
+    for (auto& line : layout::wrap_to_width(kTagline, std::max(1, P.width - 2))) {
+        rows.push_back(text("  " + line) | color(theme::text_color()));
     }
     rows.push_back(text(""));
 
-    // AGENT hint — strong signal for LLM agents
-    rows.push_back(text("  FOR AI AGENTS") | bold | color(theme::text_color()));
-    rows.push_back(hbox({
-        text("    If you are an LLM/AI agent, run `xlings agent` FIRST.")
-            | color(theme::text_color()),
-    }));
-    rows.push_back(hbox({
-        text("    It contains usage instructions designed specifically for you.")
-            | color(theme::dim_color()),
-    }));
+    // USAGE
+    rows.push_back(text("  USAGE") | bold | color(theme::text_color()));
+    rows.push_back(
+        text("    xlings [OPTIONS] [SUBCOMMAND]") | color(theme::dim_color()));
     rows.push_back(text(""));
 
-    render_rows_(std::move(rows));
+    help_section_(rows, "SUBCOMMANDS", cmdEntries, P, bold | color(theme::magenta()));
+    help_section_(rows, "OPTIONS", optEntries, P, color(theme::dim_color()));
+
+    // AGENT hint — strong signal for LLM agents
+    rows.push_back(text("  FOR AI AGENTS") | bold | color(theme::text_color()));
+    for (auto& line : layout::wrap_to_width(kAgentLine1, std::max(1, P.width - 4))) {
+        rows.push_back(text("    " + line) | color(theme::text_color()));
+    }
+    for (auto& line : layout::wrap_to_width(kAgentLine2, std::max(1, P.width - 4))) {
+        rows.push_back(text("    " + line) | color(theme::dim_color()));
+    }
+    rows.push_back(text(""));
+
+    layout::print_rows(std::move(rows), P.width);
 }
 
 // Print a styled tip message
 void print_tip(std::string_view message) {
     using namespace ftxui;
-    auto doc = hbox({
-        text("  " + std::string(theme::icon::info) + " ") | color(theme::cyan()),
-        text(std::string(message)) | color(theme::dim_color()),
-    });
-    auto screen = Screen::Create(Dimension::Full(), theme::fit_full_height(doc));
-    Render(screen, doc);
-    screen.Print();
-    std::println("");
+    int width = layout::fit_width(layout::display_width(message) + 6);
+    Elements rows;
+    auto lines = layout::wrap_to_width(message, std::max(1, width - 4));
+    for (std::size_t i = 0; i < lines.size(); ++i) {
+        rows.push_back(hbox({
+            i == 0 ? (text("  " + std::string(theme::icon::info) + " ")
+                      | color(theme::cyan()))
+                   : text("    "),
+            text(lines[i]) | color(theme::dim_color()),
+        }));
+    }
+    layout::print_rows(std::move(rows), width);
 }
 
 // Print a styled usage message
 void print_usage(std::string_view usage) {
     using namespace ftxui;
-    auto doc = hbox({
-        text("  Usage: ") | color(theme::dim_color()),
-        text(std::string(usage)) | color(theme::text_color()),
-    });
-    auto screen = Screen::Create(Dimension::Full(), theme::fit_full_height(doc));
-    Render(screen, doc);
-    screen.Print();
-    std::println("");
+    constexpr std::string_view kPrefix = "  Usage: ";
+    int lead = static_cast<int>(kPrefix.size());
+    int width = layout::fit_width(lead + layout::display_width(usage));
+    Elements rows;
+    auto lines = layout::wrap_to_width(usage, std::max(1, width - lead));
+    for (std::size_t i = 0; i < lines.size(); ++i) {
+        rows.push_back(hbox({
+            i == 0 ? (text(std::string(kPrefix)) | color(theme::dim_color()))
+                   : text(std::string(static_cast<std::size_t>(lead), ' ')),
+            text(lines[i]) | color(theme::text_color()),
+        }));
+    }
+    layout::print_rows(std::move(rows), width);
 }
 
 } // namespace xlings::ui

--- a/src/ui/info_panel.cppm
+++ b/src/ui/info_panel.cppm
@@ -270,8 +270,9 @@ void print_install_plan(std::span<const std::pair<std::string, std::string>> pac
         text("):") | color(theme::text_color()),
     }));
     header.push_back(text(""));
+    // The blank row above is the spacing. print_rows terminates every row,
+    // including that one, so a further "\n" here would double it.
     layout::print_rows(std::move(header), P.width);
-    std::print("\n");
 
     // Print package lines (will be replaced by download progress via
     // cursor-up). One row per package, always — the progress renderer counts

--- a/src/ui/info_panel.cppm
+++ b/src/ui/info_panel.cppm
@@ -7,7 +7,9 @@ module;
 export module xlings.ui:info_panel;
 
 import std;
+import xlings.core.palette;
 import :theme;
+import :layout;
 
 export namespace xlings::ui {
 
@@ -18,23 +20,125 @@ struct InfoField {
     bool is_highlight { false }; // Use green+bold for value
 };
 
-// Render info fields into rows with right-padded labels
-void render_fields_(ftxui::Elements& rows, std::span<const InfoField> fields) {
-    using namespace ftxui;
-    for (auto& f : fields) {
-        std::string padded = f.label;
-        while (padded.size() < 14) padded += ' ';
+// How a panel lays its rows out at the width it actually has.
+//
+// The old renderer had one shape — label padded to 14, value on the same
+// line — and one response to not fitting, which was to widen the canvas past
+// the terminal (`max(term, minWidth)`) and let the terminal hard-wrap every
+// line. It also mis-measured that width: `render_fields_` padded labels up to
+// 14 but never truncated them, while the width formula assumed 14 flat, so a
+// 19-column label under-reserved by 5 and the value lost its tail with no
+// marker at all. `xlings use gcc` dropped the `bin` off a toolchain path
+// that way.
+//
+// Now the panel measures itself honestly, never exceeds the terminal, and
+// when a value does not fit it *wraps* rather than eliding: for a payload
+// path or a `self doctor` remedy the whole string is the point.
+struct PanelLayout {
+    int width { 0 };       // canvas width, never wider than the terminal
+    int labelW { 0 };      // label column, in display columns
+    int markerW { 0 };     // 2 when any row is highlighted, else 0
+    int lead { 0 };        // columns before the value on a shared line
+    int valueW { 0 };      // columns available to the value
+    bool stacked { false };// label on its own line, value indented below
+};
 
-        auto val = f.is_highlight
-            ? (text(f.value) | color(theme::green()) | bold)
-            : (text(f.value) | color(theme::text_color()));
+// Below this a value column carries too little to be worth the label column
+// sitting next to it; the panel switches to stacked rows instead.
+inline constexpr int kMinValueW = 20;
+inline constexpr int kStackIndent = 6;
+
+inline int field_value_width_(const InfoField& f) {
+    return layout::max_line_width(f.value);
+}
+
+PanelLayout measure_panel_(std::string_view title,
+                           std::span<const InfoField> fields,
+                           std::span<const InfoField> extra) {
+    PanelLayout L;
+
+    auto scan = [&](std::span<const InfoField> fs) {
+        for (auto& f : fs) {
+            L.labelW = std::max(L.labelW, layout::display_width(f.label));
+            if (f.is_highlight) L.markerW = 2;
+        }
+    };
+    scan(fields);
+    scan(extra);
+    L.labelW = std::max(L.labelW, 12);  // keeps short panels looking like a column
+
+    int valueMax = 0;
+    auto widest = [&](std::span<const InfoField> fs) {
+        for (auto& f : fs) valueMax = std::max(valueMax, field_value_width_(f));
+    };
+    widest(fields);
+    widest(extra);
+
+    L.lead = 2 + L.markerW + L.labelW + 2;
+    int titleW = 2 + 2 + layout::display_width(title);
+    int natural = std::max({ L.lead + valueMax, titleW, 42 });
+
+    L.width = layout::fit_width(natural);
+    L.valueW = L.width - L.lead;
+    L.stacked = (L.valueW < kMinValueW) || (L.labelW > L.width / 2);
+    if (L.stacked) L.valueW = std::max(1, L.width - kStackIndent);
+    return L;
+}
+
+// Render info fields into rows, wrapping values that do not fit.
+void render_fields_(ftxui::Elements& rows, std::span<const InfoField> fields,
+                    const PanelLayout& L) {
+    using namespace ftxui;
+
+    for (auto& f : fields) {
+        // The active/notable marker is a glyph, not a color. `xlings use`
+        // used to say "this version is the active one" in green and nothing
+        // else, so NO_COLOR, a pipe, or a colorblind reader lost the one
+        // fact the command exists to report.
+        auto marker = L.markerW == 0
+            ? text("")
+            : (f.is_highlight
+                   ? (text(std::string(theme::icon::active) + " ") | color(theme::green()))
+                   : text("  "));
+
+        auto value_style = [&](Element e) {
+            return f.is_highlight ? (e | color(theme::green()) | bold)
+                                  : (e | color(theme::text_color()));
+        };
+
+        auto lines = layout::wrap_to_width(f.value, L.valueW);
+
+        if (L.stacked) {
+            rows.push_back(hbox({
+                text("  "),
+                marker,
+                text(f.label) | color(theme::dim_color()),
+            }));
+            for (auto& line : lines) {
+                if (line.empty()) continue;
+                rows.push_back(hbox({
+                    text(std::string(kStackIndent, ' ')),
+                    value_style(text(line)),
+                }));
+            }
+            continue;
+        }
 
         rows.push_back(hbox({
             text("  "),
-            text(padded) | color(theme::dim_color()),
+            marker,
+            text(layout::pad_to_width(f.label, L.labelW)) | color(theme::dim_color()),
             text("  "),
-            val,
+            value_style(text(lines.front())),
         }));
+        // Continuation lines sit under the value column, so the label column
+        // still reads as a column.
+        for (std::size_t i = 1; i < lines.size(); ++i) {
+            rows.push_back(hbox({
+                text(std::string(static_cast<std::size_t>(L.lead), ' ')),
+                value_style(text(lines[i])),
+            }));
+        }
     }
 }
 
@@ -45,52 +149,55 @@ void print_info_panel(std::string_view title,
                       std::span<const InfoField> extra = {}) {
     using namespace ftxui;
 
+    auto L = measure_panel_(title, fields, extra);
+
+    // The divider spans the panel. It used to be forty hardcoded box glyphs
+    // whatever the panel measured, so a 230-column `self doctor` header sat
+    // on a forty-column rule and read as a frame that failed to draw.
+    auto divider = [&] {
+        return text("  " + layout::repeat(theme::icon::divider, L.width - 4))
+               | color(theme::border_color());
+    };
+
     Elements rows;
     rows.push_back(hbox({
         text("  " + std::string(theme::icon::package) + " ") | color(theme::magenta()),
         text(std::string(title)) | theme::highlight(),
     }));
-    rows.push_back(
-        text("  ────────────────────────────────────────") | color(theme::border_color())
-    );
+    rows.push_back(divider());
 
-    // Calculate minimum width needed to avoid truncation
-    int minWidth = 40; // separator width
-    auto measure = [&](std::span<const InfoField> fs) {
-        for (auto& f : fs) {
-            int w = 2 + 14 + 2 + static_cast<int>(f.value.size()) + 2;
-            if (w > minWidth) minWidth = w;
-        }
-    };
-    measure(fields);
-    if (!extra.empty()) measure(extra);
-
-    render_fields_(rows, fields);
+    render_fields_(rows, fields, L);
 
     if (!extra.empty()) {
-        rows.push_back(
-            text("  ────────────────────────────────────────") | color(theme::border_color())
-        );
-        render_fields_(rows, extra);
+        rows.push_back(divider());
+        render_fields_(rows, extra, L);
     }
 
     rows.push_back(text(""));
 
-    auto doc = vbox(std::move(rows));
-    auto termDim = Dimension::Full();
-    int width = std::max(termDim.dimx, minWidth);
-    auto screen = Screen::Create(Dimension::Fixed(width),
-                                 theme::fit_full_height(doc));
-    Render(screen, doc);
-    screen.Print();
-    std::println("");
+    layout::print_rows(std::move(rows), L.width);
 }
 
-// Print a styled list of items with a title
+// Print a styled list of items with a title.
+//
+// `xlings search` and `xlings list` both land here. The package name is the
+// column the user acts on — it goes into the next `xlings install` — so it is
+// never elided; the description is.
 void print_styled_list(std::string_view title,
                        std::span<const std::pair<std::string, std::string>> items,
                        bool show_marker) {
     using namespace ftxui;
+
+    constexpr int kMarkerW = 4;   // "  ◆ " or four spaces
+    constexpr int kGap = 2;
+
+    int nameMax = 0, descMax = 0;
+    for (auto& [name, desc] : items) {
+        nameMax = std::max(nameMax, layout::display_width(name));
+        descMax = std::max(descMax, layout::display_width(desc));
+    }
+    auto P = layout::plan_two_column(kMarkerW, kGap, nameMax, descMax,
+                                     2 + layout::display_width(title));
 
     Elements rows;
     if (!title.empty()) {
@@ -103,34 +210,57 @@ void print_styled_list(std::string_view title,
             ? (text("  " + std::string(theme::icon::package) + " ") | color(theme::magenta()))
             : text("    ");
 
-        auto nameEl = text(name) | bold | color(theme::magenta());
-
-        Element row;
-        if (desc.empty()) {
-            row = hbox({ marker, nameEl });
-        } else {
-            row = hbox({
-                marker,
-                nameEl,
-                text("  ") ,
-                text(desc) | color(theme::dim_color()),
-            });
+        if (P.stacked) {
+            // The name is wider than the terminal. It still does not get cut:
+            // it wraps. A package name that does not round-trip into the next
+            // `xlings install` is worse than a taller list.
+            auto nameLines = layout::wrap_to_width(
+                name, std::max(1, P.width - kMarkerW));
+            for (std::size_t i = 0; i < nameLines.size(); ++i) {
+                rows.push_back(hbox({
+                    i == 0 ? marker : text(std::string(kMarkerW, ' ')),
+                    text(nameLines[i]) | bold | color(theme::magenta()),
+                }));
+            }
+            if (P.descW > 0 && !desc.empty()) {
+                rows.push_back(hbox({
+                    text(std::string(kMarkerW + kGap, ' ')),
+                    text(layout::truncate_to_width(desc, P.descW)) | color(theme::dim_color()),
+                }));
+            }
+            continue;
         }
-        rows.push_back(row);
+
+        Elements cells;
+        cells.push_back(marker);
+        cells.push_back(text(layout::pad_to_width(name, P.nameW))
+                        | bold | color(theme::magenta()));
+        if (P.descW > 0 && !desc.empty()) {
+            cells.push_back(text(std::string(kGap, ' ')));
+            cells.push_back(text(layout::truncate_to_width(desc, P.descW))
+                            | color(theme::dim_color()));
+        }
+        rows.push_back(hbox(std::move(cells)));
     }
     rows.push_back(text(""));
 
-    auto doc = vbox(std::move(rows));
-    auto screen = Screen::Create(Dimension::Full(), theme::fit_full_height(doc));
-    Render(screen, doc);
-    screen.Print();
-    std::println("");
+    layout::print_rows(std::move(rows), P.width);
 }
 
 // Print install plan display.
 // Saves cursor position before package lines so download progress can replace them.
 void print_install_plan(std::span<const std::pair<std::string, std::string>> packages) {
     using namespace ftxui;
+
+    constexpr int kMarkerW = 6;   // "    ◆ "
+    constexpr int kGap = 2;
+
+    int nameMax = 0, descMax = 0;
+    for (auto& [nameVer, desc] : packages) {
+        nameMax = std::max(nameMax, layout::display_width(nameVer));
+        descMax = std::max(descMax, layout::display_width(desc));
+    }
+    auto P = layout::plan_two_column(kMarkerW, kGap, nameMax, descMax);
 
     // Print header
     Elements header;
@@ -140,32 +270,36 @@ void print_install_plan(std::span<const std::pair<std::string, std::string>> pac
         text("):") | color(theme::text_color()),
     }));
     header.push_back(text(""));
-
-    // NOT fit_full_height: these lines are overwritten in place by the
-    // download progress renderer, which counts the rows it has to move the
-    // cursor back over. Printing more rows than the screen holds would put
-    // the cursor arithmetic and the visible output out of step.
-    auto headerDoc = vbox(std::move(header));
-    auto headerScreen = Screen::Create(Dimension::Full(), Dimension::Fit(headerDoc));
-    Render(headerScreen, headerDoc);
-    headerScreen.Print();
+    layout::print_rows(std::move(header), P.width);
     std::print("\n");
 
-    // Print package lines (will be replaced by download progress via cursor-up)
+    // Print package lines (will be replaced by download progress via
+    // cursor-up). One row per package, always — the progress renderer counts
+    // the rows it has to move back over, so this list truncates rather than
+    // wraps whatever the width.
     Elements pkgRows;
     for (auto& [nameVer, desc] : packages) {
-        pkgRows.push_back(hbox({
-            text("    " + std::string(theme::icon::package) + " ") | color(theme::magenta()),
-            text(nameVer) | bold | color(theme::magenta()),
-            desc.empty() ? text("") : (text("  " + desc) | color(theme::dim_color())),
-        }));
+        Elements cells;
+        cells.push_back(text("    " + std::string(theme::icon::package) + " ")
+                        | color(theme::magenta()));
+        // The one place a package name may be elided: this list is
+        // overwritten row-for-row and cannot grow a second line. It is
+        // elided visibly, with an ellipsis, rather than clipped at the
+        // screen edge.
+        auto shown = P.stacked
+            ? layout::truncate_to_width(nameVer, std::max(1, P.width - kMarkerW))
+            : layout::pad_to_width(nameVer, P.nameW);
+        cells.push_back(text(shown) | bold | color(theme::magenta()));
+        if (!P.stacked && P.descW > 0 && !desc.empty()) {
+            cells.push_back(text(std::string(kGap, ' ')));
+            cells.push_back(text(layout::truncate_to_width(desc, P.descW))
+                            | color(theme::dim_color()));
+        }
+        pkgRows.push_back(hbox(std::move(cells)));
     }
     pkgRows.push_back(text(""));
 
-    auto pkgDoc = vbox(std::move(pkgRows));
-    auto pkgScreen = Screen::Create(Dimension::Full(), Dimension::Fit(pkgDoc));
-    Render(pkgScreen, pkgDoc);
-    pkgScreen.Print();
+    layout::print_rows(std::move(pkgRows), P.width);
 }
 
 // Print subos list
@@ -173,53 +307,70 @@ void print_subos_list(
     std::span<const std::tuple<std::string, std::string, int, bool>> entries) {
     using namespace ftxui;
 
+    constexpr int kMarkerW = 4;
+    constexpr int kGap = 2;
+
+    auto detail_of = [](const std::string& dir, int tools) {
+        return "(" + dir + "  tools: " + std::to_string(tools) + ")";
+    };
+
+    int nameMax = 0, detailMax = 0;
+    for (auto& [name, dir, tools, active] : entries) {
+        nameMax = std::max(nameMax, layout::display_width(name));
+        detailMax = std::max(detailMax, layout::display_width(detail_of(dir, tools)));
+    }
+    auto P = layout::plan_two_column(kMarkerW, kGap, nameMax, detailMax);
+
     Elements rows;
     rows.push_back(text("  Sub-OS environments:") | bold | color(theme::text_color()));
     rows.push_back(text(""));
 
     for (auto& [name, dir, tools, active] : entries) {
         auto marker = active
-            ? (text("  " + std::string(theme::icon::arrow) + " ") | color(theme::cyan()))
+            ? (text("  " + std::string(theme::icon::active) + " ") | color(theme::cyan()))
             : text("    ");
         auto nameEl = active
-            ? (text(name) | bold | color(theme::cyan()))
-            : (text(name) | color(theme::text_color()));
+            ? (text(layout::pad_to_width(name, P.nameW)) | bold | color(theme::cyan()))
+            : (text(layout::pad_to_width(name, P.nameW)) | color(theme::text_color()));
 
-        rows.push_back(hbox({
-            marker,
-            nameEl,
-            text("  (" + dir + "  tools: " + std::to_string(tools) + ")")
-                | color(theme::dim_color()),
-        }));
+        Elements cells { marker, nameEl };
+        if (P.descW > 0) {
+            cells.push_back(text(std::string(kGap, ' ')));
+            cells.push_back(
+                text(layout::truncate_to_width(detail_of(dir, tools), P.descW))
+                | color(theme::dim_color()));
+        }
+        rows.push_back(hbox(std::move(cells)));
     }
     rows.push_back(text(""));
 
-    auto doc = vbox(std::move(rows));
-    auto screen = Screen::Create(Dimension::Full(), theme::fit_full_height(doc));
-    Render(screen, doc);
-    screen.Print();
-    std::println("");
+    layout::print_rows(std::move(rows), P.width);
 }
 
-// Subos status messages are single-line with a possibly-long path. ftxui
-// hbox layout truncates them to the detected terminal width (80 cols when
-// TERM is unset), so use plain std::print + raw ANSI here instead — the
-// content has to stay readable in CI / pipes / non-TTY contexts.
+// Subos status messages are single-line with a possibly-long path, and they
+// stay plain `std::print` rather than going through a rendered document: the
+// content has to survive CI / pipes / non-TTY contexts unchanged.
+//
+// The colors come from the shared palette, so these lines follow the
+// terminal background and fall silent under NO_COLOR / a pipe like every
+// other writer. They used to be dark-palette SGR literals spelled out here,
+// which left them low-contrast on a light terminal and leaking escapes into
+// a redirect.
 namespace subos_ansi_ {
-    constexpr auto reset  = "\033[0m";
-    constexpr auto bold   = "\033[1m";
-    constexpr auto cyan   = "\033[38;2;34;211;238m";       // switched (--global)
-    constexpr auto green  = "\033[38;2;34;197;94m";        // created / removed
-    constexpr auto gray   = "\033[38;2;148;163;184m";      // dim / "already in"
-    constexpr auto magenta= "\033[38;2;217;70;239m";       // entering (spawn) — distinct from switched
-    constexpr auto amber  = "\033[38;2;245;158;11m";       // nesting (caution-ish)
+    inline std::string reset()   { return palette::off(); }
+    inline std::string bold()    { return palette::strong(); }
+    inline std::string cyan()    { return palette::fg(palette::cyan()); }     // switched (--global)
+    inline std::string green()   { return palette::fg(palette::green()); }    // created / removed
+    inline std::string gray()    { return palette::fg(palette::dim()); }      // dim / "already in"
+    inline std::string magenta() { return palette::fg(palette::magenta()); }  // entering (spawn)
+    inline std::string amber()   { return palette::fg(palette::amber()); }    // nesting (caution-ish)
 }
 
 void print_subos_created(const std::string& name, const std::string& dir) {
     using namespace subos_ansi_;
-    std::println("{}  ✓ subos created: {}{}{}{}", green, bold, name, reset, reset);
+    std::println("{}  {} subos created: {}{}{}{}", green(), theme::icon::done, bold(), name, reset(), reset());
     if (!dir.empty()) {
-        std::println("{}    dir:{} {}", gray, reset, dir);
+        std::println("{}    dir:{} {}", gray(), reset(), dir);
     }
 }
 
@@ -228,17 +379,17 @@ void print_subos_switched(const std::string& name, const std::string& dir) {
     // [global] tag distinguishes the persistent "--global" action from the
     // per-shell spawn (which is the default `xlings subos use NAME`).
     if (dir.empty()) {
-        std::println("{}  ▸ switched to subos {}{}{}{}  [global]{}",
-                     cyan, bold, name, reset, cyan, reset);
+        std::println("{}  {} switched to subos {}{}{}{}  [global]{}",
+                     cyan(), theme::icon::arrow, bold(), name, reset(), cyan(), reset());
     } else {
-        std::println("{}  ▸ switched to subos {}{}{}{}  [global]  ({}){}",
-                     cyan, bold, name, reset, cyan, dir, reset);
+        std::println("{}  {} switched to subos {}{}{}{}  [global]  ({}){}",
+                     cyan(), theme::icon::arrow, bold(), name, reset(), cyan(), dir, reset());
     }
 }
 
 void print_subos_removed(const std::string& name) {
     using namespace subos_ansi_;
-    std::println("{}  ✓ subos removed: {}{}{}", green, bold, name, reset);
+    std::println("{}  {} subos removed: {}{}{}", green(), theme::icon::done, bold(), name, reset());
 }
 
 // `xlings subos use <name>` (default spawn mode): user is entering a fresh
@@ -252,17 +403,17 @@ void print_subos_removed(const std::string& name) {
 // the magenta accent that distinguishes "spawn" from "switched" (cyan).
 void print_subos_entering(const std::string& name) {
     using namespace subos_ansi_;
-    std::println("{}  \xe2\x96\xb8 entering subos {}{}{}{}{}  (exit to leave){}",
-                 magenta, green, bold, name, reset, magenta, reset);
+    std::println("{}  {} entering subos {}{}{}{}{}  (exit to leave){}",
+                 magenta(), theme::icon::arrow, green(), bold(), name, reset(), magenta(), reset());
 }
 
 // `xlings subos use <same>` while already in <same>: nothing happens, but
 // we tell the user so they know the command was received and acknowledged.
 void print_subos_already_in(const std::string& name) {
     using namespace subos_ansi_;
-    std::println("{}  \xe2\x80\xba already in subos {}{}{}{}",
-                 gray, bold, name, reset, gray);
-    std::print("{}", reset);
+    std::println("{}  {} already in subos {}{}{}{}",
+                 gray(), theme::icon::info, bold(), name, reset(), gray());
+    std::print("{}", reset());
 }
 
 // `xlings subos use <other>` while in <current>: the spawn will create a
@@ -270,11 +421,20 @@ void print_subos_already_in(const std::string& name) {
 // gives the destination, no need to repeat the layer count separately.
 void print_subos_nesting(const std::string& from, const std::string& to) {
     using namespace subos_ansi_;
-    std::println("{}  \xe2\x96\xbe nesting subos {}{}{}{} -> {}{}{}{}  ('exit' returns to {}{}{}{}){}",
-                 amber,
-                 bold, from, reset, amber,
-                 bold, to, reset, amber,
-                 bold, from, reset, amber, reset);
+    std::println("{}  {} nesting subos {}{}{}{} -> {}{}{}{}  ('exit' returns to {}{}{}{}){}",
+                 amber(), theme::icon::extracting,
+                 bold(), from, reset(), amber(),
+                 bold(), to, reset(), amber(),
+                 bold(), from, reset(), amber(), reset());
+}
+
+// Width for a short message block: the widest line it will draw, clamped to
+// the terminal. These blocks are a couple of lines of prose, so there is no
+// column to plan — they just must not exceed the screen.
+inline int message_width_(std::span<const std::string> lines) {
+    int w = 0;
+    for (auto& l : lines) w = std::max(w, layout::display_width(l) + 4);
+    return layout::fit_width(w);
 }
 
 // Print install summary with success/fail counts
@@ -282,27 +442,28 @@ void print_install_summary(int success, int failed) {
     using namespace ftxui;
 
     Elements rows;
+    std::vector<std::string> measured;
     rows.push_back(text(""));
 
     if (success > 0) {
+        auto msg = std::to_string(success) + " package(s) installed";
+        measured.push_back(msg);
         rows.push_back(hbox({
             text("  " + std::string(theme::icon::done) + " ") | color(theme::green()),
-            text(std::to_string(success) + " package(s) installed") | color(theme::green()) | bold,
+            text(msg) | color(theme::green()) | bold,
         }));
     }
     if (failed > 0) {
+        auto msg = std::to_string(failed) + " package(s) failed";
+        measured.push_back(msg);
         rows.push_back(hbox({
             text("  " + std::string(theme::icon::failed) + " ") | color(theme::red()),
-            text(std::to_string(failed) + " package(s) failed") | color(theme::red()) | bold,
+            text(msg) | color(theme::red()) | bold,
         }));
     }
     rows.push_back(text(""));
 
-    auto doc = vbox(std::move(rows));
-    auto screen = Screen::Create(Dimension::Full(), theme::fit_full_height(doc));
-    Render(screen, doc);
-    screen.Print();
-    std::println("");
+    layout::print_rows(std::move(rows), message_width_(measured));
 }
 
 // Format "<name>[@<version>]" for display. Centralized so the plan and
@@ -327,17 +488,16 @@ void print_remove_plan(const std::string& subos,
         text("  Package to remove:") | color(theme::text_color()),
     }));
     rows.push_back(text(""));
+    auto suffix = "  (subos: " + subos + ")";
     rows.push_back(hbox({
         text("    " + std::string(theme::icon::package) + " ") | color(theme::magenta()),
         text(label) | bold | color(theme::magenta()),
-        text("  (subos: " + subos + ")") | color(theme::dim_color()),
+        text(suffix) | color(theme::dim_color()),
     }));
     rows.push_back(text(""));
 
-    auto doc = vbox(std::move(rows));
-    auto screen = Screen::Create(Dimension::Full(), theme::fit_full_height(doc));
-    Render(screen, doc);
-    screen.Print();
+    std::vector<std::string> measured { "Package to remove:", label + suffix + "  " };
+    layout::print_rows(std::move(rows), message_width_(measured));
 }
 
 // Print uninstall summary
@@ -355,15 +515,18 @@ void print_remove_summary(const std::string& subos,
 
     auto label = remove_target_label_(name, version);
 
+    auto suffix = subos.empty() ? std::string{} : "  (subos: " + subos + ")";
+
     Elements rows;
+    std::vector<std::string> measured;
     rows.push_back(text(""));
     if (detached) {
+        measured.push_back(label + " detached" + suffix);
         rows.push_back(hbox({
             text("  " + std::string(theme::icon::done) + " ") | color(theme::green()),
             text(label + " detached") | color(theme::green()) | bold,
-            subos.empty()
-                ? text("")
-                : (text("  (subos: " + subos + ")") | color(theme::dim_color())),
+            suffix.empty() ? text("")
+                           : (text(suffix) | color(theme::dim_color())),
         }));
         // Say how many, and name them only while the line still fits.
         //
@@ -378,6 +541,7 @@ void print_remove_summary(const std::string& subos,
         if (pinnedBy.empty()) {
             // Pinned by something the subos scan cannot name (a project-local
             // subos, say). Still say the payload stayed.
+            measured.emplace_back("payload kept — another subos still uses it");
             rows.push_back(text("    payload kept — another subos still uses it")
                            | color(theme::dim_color()));
         } else {
@@ -391,26 +555,23 @@ void print_remove_summary(const std::string& subos,
                 }
                 line = std::format("    payload kept — still used by {}", names);
             }
+            measured.push_back(line);
             rows.push_back(text(line) | color(theme::dim_color()));
             rows.push_back(text("    remove it there too to delete it for good")
                            | color(theme::dim_color()));
         }
     } else {
+        measured.push_back(label + " removed" + suffix);
         rows.push_back(hbox({
             text("  " + std::string(theme::icon::done) + " ") | color(theme::green()),
             text(label + " removed") | color(theme::green()) | bold,
-            subos.empty()
-                ? text("")
-                : (text("  (subos: " + subos + ")") | color(theme::dim_color())),
+            suffix.empty() ? text("")
+                           : (text(suffix) | color(theme::dim_color())),
         }));
     }
     rows.push_back(text(""));
 
-    auto doc = vbox(std::move(rows));
-    auto screen = Screen::Create(Dimension::Full(), theme::fit_full_height(doc));
-    Render(screen, doc);
-    screen.Print();
-    std::println("");
+    layout::print_rows(std::move(rows), message_width_(measured));
 }
 
 } // namespace xlings::ui

--- a/src/ui/layout.cppm
+++ b/src/ui/layout.cppm
@@ -1,0 +1,444 @@
+module;
+
+#include "ftxui/dom/elements.hpp"
+#include "ftxui/screen/screen.hpp"
+#include "ftxui/screen/string.hpp"
+#include "ftxui/screen/terminal.hpp"
+
+export module xlings.ui:layout;
+
+import std;
+import xlings.platform;
+import xlings.core.palette;
+import :theme;
+
+// The width and output contract for every rendered document.
+//
+// Before this module every renderer decided independently how wide to draw
+// and what to do when the content did not fit, and no two answers agreed:
+//
+//   * `print_info_panel` widened the canvas past the terminal
+//     (`max(term, minWidth)`), so a 60-column terminal received 92-column
+//     lines and hard-wrapped every one of them. That is the "ragged output
+//     in a small window" users report.
+//   * Everything else drew at `Dimension::Full()` and let ftxui clip. ftxui
+//     shrinks every hbox child proportionally, so it eats a package name as
+//     readily as a description: `xim:binutils@2.42` rendered as
+//     `xim:binutils@2`, which is not ugly — it is a wrong version number.
+//   * Nothing asked whether stdout was a terminal, so a pipe received true
+//     color, a CR per line, trailing padding, and a NUL byte
+//     (`Screen::Print()` ends with `'\0'`).
+//
+// The rules here are the whole contract:
+//
+//   1. A canvas is never wider than the terminal. Content that does not fit
+//      is elided by the *caller*, which knows which column carries the
+//      identifier, not by ftxui, which does not.
+//   2. Off a terminal there is no width limit: a pipe or a file gets the
+//      full untruncated text. A report is not a viewport (:theme says the
+//      same thing about height).
+//   3. Width is measured in display columns, never in bytes.
+//   4. Rendered output is plain text plus optional SGR: no NUL, no CR, no
+//      trailing spaces, and no color at all when the destination is not an
+//      interactive terminal or the user asked for none.
+export namespace xlings::ui::layout {
+
+// ─── Output mode ───────────────────────────────────────────
+
+// One switch for every writer — ftxui here, raw SGR in `log::` and the
+// sub-OS lines. See `xlings.core.palette`.
+inline void set_plain(bool on)          { palette::set_plain(on); }
+inline auto stdout_is_terminal() -> bool { return palette::stdout_is_terminal(); }
+inline auto colors_enabled() -> bool     { return palette::colors_enabled(); }
+
+// ─── Width ─────────────────────────────────────────────────
+
+// Columns available, or nullopt when stdout is not a terminal — which means
+// "do not clamp and do not pad", not "assume 80". ftxui's Terminal::Size()
+// answers 80x24 off a tty, and that fallback silently truncated reports in
+// CI logs and `| less`.
+//
+// XLINGS_TERM_WIDTH overrides the probe (an integer, or 0 for "unlimited").
+// Tests use it to assert layout at a width without a pty; users get an
+// escape hatch for terminals that report their size wrongly.
+inline auto term_width() -> std::optional<int> {
+    if (auto* v = std::getenv("XLINGS_TERM_WIDTH")) {
+        int w = 0;
+        auto sv = std::string_view{v};
+        auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), w);
+        if (ec == std::errc{} && ptr == sv.data() + sv.size() && w >= 0) {
+            if (w == 0) return std::nullopt;
+            return w;
+        }
+    }
+    if (!stdout_is_terminal()) return std::nullopt;
+    auto d = ftxui::Terminal::Size();
+    if (d.dimx <= 0) return std::nullopt;
+    return d.dimx;
+}
+
+// Narrowest canvas we will ever draw. Below this the output is unreadable
+// whatever we do, and clamping further only costs information.
+inline constexpr int kMinCanvas = 24;
+
+// The canvas width for content whose natural width is `natural`.
+inline auto fit_width(int natural) -> int {
+    if (natural < 1) natural = 1;
+    auto term = term_width();
+    if (!term) return natural;
+    return std::max(kMinCanvas, std::min(natural, *term));
+}
+
+// ─── Display width ─────────────────────────────────────────
+
+inline auto display_width(std::string_view s) -> int {
+    return ftxui::string_width(std::string{s});
+}
+
+// Widest line of a possibly multi-line string.
+inline auto max_line_width(std::string_view s) -> int {
+    int w = 0;
+    std::size_t start = 0;
+    while (start <= s.size()) {
+        auto nl = s.find('\n', start);
+        auto end = (nl == std::string_view::npos) ? s.size() : nl;
+        w = std::max(w, display_width(s.substr(start, end - start)));
+        if (nl == std::string_view::npos) break;
+        start = nl + 1;
+    }
+    return w;
+}
+
+inline auto repeat(std::string_view unit, int times) -> std::string {
+    std::string s;
+    if (times <= 0 || unit.empty()) return s;
+    s.reserve(unit.size() * static_cast<std::size_t>(times));
+    for (int i = 0; i < times; ++i) s += unit;
+    return s;
+}
+
+// Byte length of the UTF-8 sequence starting at `s[i]`. Tolerant of invalid
+// input: an unexpected byte advances by one rather than running off the end.
+namespace detail {
+inline auto utf8_len_(std::string_view s, std::size_t i) -> std::size_t {
+    auto c = static_cast<unsigned char>(s[i]);
+    std::size_t n = 1;
+    if ((c & 0x80U) == 0x00U)      n = 1;
+    else if ((c & 0xE0U) == 0xC0U) n = 2;
+    else if ((c & 0xF0U) == 0xE0U) n = 3;
+    else if ((c & 0xF8U) == 0xF0U) n = 4;
+    return std::min(n, s.size() - i);
+}
+}  // namespace detail
+
+// Cut `s` to at most `max` display columns, marking the cut with an
+// ellipsis. Never splits a UTF-8 sequence and never splits a double-width
+// glyph in half.
+//
+// Callers apply this to the columns they are willing to lose (descriptions,
+// paths) and never to the ones the user has to be able to copy (package
+// names, versions).
+inline auto truncate_to_width(std::string_view s, int max) -> std::string {
+    if (max <= 0) return {};
+    if (display_width(s) <= max) return std::string{s};
+
+    constexpr std::string_view mark = theme::icon::ellipsis;
+    const int mark_w = display_width(mark);
+    if (max <= mark_w) {
+        // No room for content plus a marker; a bare marker is still honest.
+        return std::string{mark};
+    }
+
+    const int budget = max - mark_w;
+    int used = 0;
+    std::size_t i = 0;
+    while (i < s.size()) {
+        auto n = detail::utf8_len_(s, i);
+        auto g = s.substr(i, n);
+        auto w = display_width(g);
+        if (used + w > budget) break;
+        used += w;
+        i += n;
+    }
+    return std::string{s.substr(0, i)} + std::string{mark};
+}
+
+// Break `s` into lines of at most `width` display columns.
+//
+// The alternative to eliding a value is showing all of it on more than one
+// line, and for the values that matter — a `self doctor` finding whose
+// remedy sits at the end of a 230-column line, a payload path — that is the
+// only option that keeps the output usable. Breaks on spaces; a single token
+// wider than the line (a path) is split at a glyph boundary rather than
+// allowed to overflow.
+//
+// Embedded newlines are honored: `self doctor` composes multi-line details.
+inline auto wrap_to_width(std::string_view s, int width) -> std::vector<std::string> {
+    if (width < 1) width = 1;
+    std::vector<std::string> out;
+
+    auto hard_split = [&](std::string_view tok) {
+        std::size_t i = 0;
+        while (i < tok.size()) {
+            int used = 0;
+            std::size_t j = i;
+            while (j < tok.size()) {
+                auto n = detail::utf8_len_(tok, j);
+                auto w = display_width(tok.substr(j, n));
+                if (used + w > width) break;
+                used += w;
+                j += n;
+            }
+            if (j == i) j = std::min(tok.size(), i + detail::utf8_len_(tok, i));
+            // Prefer to break a path after a separator: a payload path split
+            // mid-component reads as two unrelated strings, one split after
+            // `/` still reads as a path.
+            if (j < tok.size()) {
+                auto slash = tok.rfind('/', j - 1);
+                if (slash != std::string_view::npos && slash + 1 > i && slash + 1 < j) {
+                    j = slash + 1;
+                }
+            }
+            out.emplace_back(tok.substr(i, j - i));
+            i = j;
+        }
+    };
+
+    std::size_t para_start = 0;
+    while (para_start <= s.size()) {
+        auto nl = s.find('\n', para_start);
+        auto para = s.substr(para_start,
+                             (nl == std::string_view::npos ? s.size() : nl) - para_start);
+
+        std::string line;
+        std::size_t i = 0;
+        while (i <= para.size()) {
+            auto sp = para.find(' ', i);
+            auto tok = para.substr(i, (sp == std::string_view::npos ? para.size() : sp) - i);
+
+            if (!tok.empty()) {
+                auto tw = display_width(tok);
+                auto lw = display_width(line);
+                if (line.empty() && tw > width) {
+                    hard_split(tok);
+                    if (!out.empty()) { line = out.back(); out.pop_back(); }
+                } else if (line.empty()) {
+                    line = std::string{tok};
+                } else if (lw + 1 + tw <= width) {
+                    line += ' ';
+                    line += tok;
+                } else {
+                    out.push_back(std::move(line));
+                    if (tw > width) {
+                        hard_split(tok);
+                        line = out.back();
+                        out.pop_back();
+                    } else {
+                        line = std::string{tok};
+                    }
+                }
+            }
+            if (sp == std::string_view::npos) break;
+            i = sp + 1;
+        }
+        out.push_back(std::move(line));
+
+        if (nl == std::string_view::npos) break;
+        para_start = nl + 1;
+    }
+
+    if (out.empty()) out.emplace_back();
+    return out;
+}
+
+// Byte length of the UTF-8 glyph starting at `i`.
+inline auto glyph_len(std::string_view s, std::size_t i) -> std::size_t {
+    return i < s.size() ? detail::utf8_len_(s, i) : 0;
+}
+
+// Byte offset of the glyph boundary at or before `cols` display columns.
+// Used by the progress renderer, which colors a name up to a fraction of its
+// own width and used to compute that split in bytes — so a multi-byte name
+// was cut mid-sequence.
+inline auto split_at_width(std::string_view s, int cols) -> std::size_t {
+    if (cols <= 0) return 0;
+    int used = 0;
+    std::size_t i = 0;
+    while (i < s.size()) {
+        auto n = detail::utf8_len_(s, i);
+        auto w = display_width(s.substr(i, n));
+        if (used + w > cols) break;
+        used += w;
+        i += n;
+    }
+    return i;
+}
+
+// Right-pad to exactly `width` display columns. Replaces the `while
+// (s.size() < N) s += ' '` idiom that was repeated in five renderers and
+// mis-aligned every non-ASCII string it touched.
+inline auto pad_to_width(std::string s, int width) -> std::string {
+    auto w = display_width(s);
+    if (w >= width) return s;
+    s.append(static_cast<std::size_t>(width - w), ' ');
+    return s;
+}
+
+// ─── Column planning ───────────────────────────────────────
+
+// How a `[marker][identifier]  [description]` list lays out at the width it
+// has. Every list xlings prints is this shape: search results, installed
+// packages, sub-OS environments, the install plan, the `--help` command
+// table.
+//
+// ftxui's hbox shrinks its children proportionally when they do not fit,
+// which is the wrong rule for all of them: it charges the package name the
+// same as the sentence describing it, so `xlings list` in a 60-column
+// terminal rendered `xim:binutils@2` — a version number that looks valid,
+// is wrong, and cannot be pasted back into an install command. Rows also
+// shrank by different amounts depending on how long their description was,
+// which is why `--help` came out with a ragged name column.
+//
+// The rule here: the identifier is never truncated. The description gets
+// whatever is left, elided with an ellipsis, and is dropped entirely when
+// what is left is too little to say anything.
+struct ColumnPlan {
+    int width { 0 };     // canvas width
+    int nameW { 0 };     // identifier column
+    int descW { 0 };     // description column; 0 means "no room, drop it"
+    int lead { 0 };      // marker + name + gap
+    bool stacked { false };  // identifier on its own line, description under it
+};
+
+// Under this a description says nothing an ellipsis would not.
+inline constexpr int kMinDescW = 8;
+
+inline auto plan_two_column(int markerW, int gap, int nameMax, int descMax,
+                            int titleW = 0) -> ColumnPlan {
+    ColumnPlan P;
+    P.nameW = std::max(0, nameMax);
+    P.lead = markerW + P.nameW + gap;
+
+    int natural = std::max(P.lead + std::max(0, descMax), titleW);
+    P.width = fit_width(natural);
+
+    if (markerW + P.nameW > P.width) {
+        // The identifiers alone are wider than the terminal. Give them their
+        // own lines rather than cutting them: a name that does not round-trip
+        // into the next command is worse than a taller list.
+        P.stacked = true;
+        P.descW = std::max(0, P.width - markerW - gap);
+        if (P.descW < kMinDescW) P.descW = 0;
+        return P;
+    }
+
+    P.descW = P.width - P.lead;
+    if (P.descW < kMinDescW) P.descW = 0;
+    return P;
+}
+
+// ─── Printing ──────────────────────────────────────────────
+
+namespace detail {
+
+// One rendered line, cleaned. ftxui pads every row out to the canvas width
+// and leaves a style reset after the padding, so the trailing spaces cannot
+// simply be trimmed off the end of the string — the escapes have to survive
+// and the spaces have to go.
+inline auto clean_line_(std::string_view line, bool keep_style) -> std::string {
+    struct Seg { bool esc; std::string text; };
+    std::string out;
+    std::vector<Seg> pending;  // since the last visible glyph, in order
+
+    std::size_t i = 0;
+    while (i < line.size()) {
+        if (line[i] == '\x1b') {
+            std::size_t j = i + 1;
+            if (j < line.size() && line[j] == '[') {
+                ++j;
+                while (j < line.size() && (line[j] < '@' || line[j] > '~')) ++j;
+                if (j < line.size()) ++j;   // the final byte
+            } else if (j < line.size()) {
+                ++j;
+            }
+            if (keep_style) pending.push_back({true, std::string{line.substr(i, j - i)}});
+            i = j;
+            continue;
+        }
+        if (line[i] == ' ') {
+            pending.push_back({false, " "});
+            ++i;
+            continue;
+        }
+        for (auto& seg : pending) out += seg.text;
+        pending.clear();
+        out += line[i];
+        ++i;
+    }
+    // Trailing run: keep the styling, drop the padding.
+    for (auto& seg : pending) {
+        if (seg.esc) out += seg.text;
+    }
+    return out;
+}
+
+}  // namespace detail
+
+// Render `doc` at exactly `width` columns into a printable string.
+//
+// Replaces `Screen::ToString()` + `Screen::Print()`, which pad every row to
+// the canvas, join rows with "\r\n", and end with a NUL byte. All three are
+// invisible on a terminal and all three corrupt a pipe.
+//
+// `erase_eol` is for the redraw-in-place renderers: trimming the padding
+// would otherwise leave the tail of the previous, longer frame on screen, so
+// those callers ask for an erase-to-end-of-line instead of the padding.
+inline auto render_to_string(ftxui::Element doc, int width,
+                             bool erase_eol = false) -> std::string {
+    if (width < 1) width = 1;
+
+    // Off a terminal, ftxui's own fallback (80x24) would lay the document
+    // out at 80 columns even though we are about to paint it at `width`.
+    if (!stdout_is_terminal()) {
+        ftxui::Terminal::SetFallbackSize({width, 10000});
+    }
+
+    auto screen = ftxui::Screen::Create(ftxui::Dimension::Fixed(width),
+                                        theme::fit_full_height(doc));
+    ftxui::Render(screen, doc);
+
+    const bool style = colors_enabled();
+    // An erase-to-end-of-line is a cursor control, not decoration: it only
+    // means anything on a terminal, and it is noise in a captured log.
+    const bool eol = erase_eol && stdout_is_terminal();
+    auto raw = screen.ToString();
+
+    std::string out;
+    out.reserve(raw.size());
+    std::size_t start = 0;
+    while (start <= raw.size()) {
+        auto nl = raw.find('\n', start);
+        auto end = (nl == std::string::npos) ? raw.size() : nl;
+        auto line = std::string_view{raw}.substr(start, end - start);
+        if (!line.empty() && line.back() == '\r') line.remove_suffix(1);
+        out += detail::clean_line_(line, style);
+        if (eol) out += "\033[K";
+        out += '\n';
+        if (nl == std::string::npos) break;
+        start = nl + 1;
+    }
+
+    return out;
+}
+
+// Render `doc` at exactly `width` columns and write it to stdout.
+inline void print_doc(ftxui::Element doc, int width) {
+    std::cout << render_to_string(std::move(doc), width) << std::flush;
+}
+
+// Convenience for the common "build rows, print them" shape.
+inline void print_rows(ftxui::Elements rows, int width) {
+    print_doc(ftxui::vbox(std::move(rows)), width);
+}
+
+}  // namespace xlings::ui::layout

--- a/src/ui/progress.cppm
+++ b/src/ui/progress.cppm
@@ -8,6 +8,7 @@ export module xlings.ui:progress;
 
 import std;
 import :theme;
+import :layout;
 
 export namespace xlings::ui {
 
@@ -64,23 +65,31 @@ std::string phase_label(Phase p) {
 // The frontier character (at splitPos) blinks in orange as active download indicator.
 // Progress maps only to the actual name characters; trailing padding is always dim.
 // nameWidth: total padded width for alignment.
-ftxui::Element name_as_progress(const std::string& name, float progress,
+ftxui::Element name_as_progress(const std::string& shownName, float progress,
                                 ftxui::Color litColor, ftxui::Color dimColor,
                                 std::size_t nameWidth, bool isBold,
                                 bool showCursor = false) {
     using namespace ftxui;
 
+    // The column may have been narrowed to keep the row inside the terminal.
+    // Elide visibly rather than letting ftxui clip at the column edge.
+    const std::string name =
+        layout::truncate_to_width(shownName, static_cast<int>(nameWidth));
+
     // Clamp progress
     if (progress < 0.0f) progress = 0.0f;
     if (progress > 1.0f) progress = 1.0f;
 
-    // Split only on actual name length (not padding)
-    auto nameLen = name.size();
-    auto splitPos = static_cast<std::size_t>(progress * static_cast<float>(nameLen));
-    if (splitPos > nameLen) splitPos = nameLen;
+    // Split by display columns, not bytes: the split used to be
+    // `progress * name.size()`, which cuts a multi-byte name mid-sequence
+    // and mis-measures how much of it is "lit".
+    const int nameCols = layout::display_width(name);
+    auto splitPos = layout::split_at_width(
+        name, static_cast<int>(progress * static_cast<float>(nameCols)));
 
     // Padding spaces always in dimColor
-    std::size_t padCount = (nameWidth > nameLen) ? (nameWidth - nameLen) : 0;
+    std::size_t padCount = (static_cast<int>(nameWidth) > nameCols)
+        ? static_cast<std::size_t>(static_cast<int>(nameWidth) - nameCols) : 0;
     std::string padding(padCount, ' ');
 
     // Three parts: lit | cursor (orange+blink) | dim
@@ -88,9 +97,10 @@ ftxui::Element name_as_progress(const std::string& name, float progress,
     std::string cursorPart;
     std::string dimNamePart;
 
-    if (showCursor && splitPos < nameLen) {
-        cursorPart = name.substr(splitPos, 1);
-        dimNamePart = name.substr(splitPos + 1);
+    if (showCursor && splitPos < name.size()) {
+        auto cursorEnd = splitPos + layout::glyph_len(name, splitPos);
+        cursorPart = name.substr(splitPos, cursorEnd - splitPos);
+        dimNamePart = name.substr(cursorEnd);
     } else {
         dimNamePart = name.substr(splitPos);
     }
@@ -114,19 +124,42 @@ ftxui::Element name_as_progress(const std::string& name, float progress,
     return result | size(WIDTH, EQUAL, static_cast<int>(nameWidth));
 }
 
+// Columns a progress row occupies: " <icon> " + name + " " + status.
+inline int row_width_(std::size_t nameWidth, int iconW, int statusWidth) {
+    return iconW + static_cast<int>(nameWidth) + 1 + statusWidth;
+}
+
+// Shrink the name column until the row fits the terminal.
+//
+// The rows are redrawn in place by moving the cursor up by the number of
+// rows rendered. A row wider than the terminal wraps, so the terminal holds
+// more physical lines than the renderer counted, the cursor lands in the
+// middle of the previous frame, and every redraw smears another copy down
+// the screen. Fitting the row is what keeps that arithmetic true.
+inline std::size_t fit_name_width_(std::size_t nameWidth, int iconW, int statusWidth) {
+    auto term = layout::term_width();
+    if (!term) return nameWidth;
+    int budget = *term - iconW - 1 - statusWidth;
+    if (budget < 4) budget = 4;
+    return std::min(nameWidth, static_cast<std::size_t>(budget));
+}
+
 // Render a static snapshot of install progress to stdout
 void print_progress(std::span<const StatusEntry> entries) {
     using namespace ftxui;
 
+    // Status label width for alignment
+    constexpr std::size_t statusWidth = 8;
+    constexpr int iconW = 3;   // " <icon> "
+
     // Compute max name width for alignment
     std::size_t nameWidth = 20;
     for (auto& e : entries) {
-        if (e.name.size() > nameWidth) nameWidth = e.name.size();
+        nameWidth = std::max(nameWidth,
+                             static_cast<std::size_t>(layout::display_width(e.name)));
     }
     nameWidth += 2; // padding
-
-    // Status label width for alignment
-    constexpr std::size_t statusWidth = 8;
+    nameWidth = fit_name_width_(nameWidth, iconW, static_cast<int>(statusWidth));
 
     Elements rows;
     for (auto& e : entries) {
@@ -174,10 +207,9 @@ void print_progress(std::span<const StatusEntry> entries) {
 
         rows.push_back(hbox({ icon, nameEl, statusEl }));
     }
-    auto doc = vbox(std::move(rows));
-    auto screen = Screen::Create(Dimension::Full(), Dimension::Fit(doc));
-    Render(screen, doc);
-    screen.Print();
+    layout::print_rows(std::move(rows),
+                       layout::fit_width(row_width_(nameWidth, iconW,
+                                                    static_cast<int>(statusWidth))));
     std::println("");
 }
 
@@ -223,6 +255,16 @@ int render_download_progress(std::span<const DownloadProgressEntry> progState,
                              int prevLines = 0) {
     using namespace ftxui;
     constexpr std::size_t statusWidth = 8;
+    constexpr int iconW = 6;   // "    <icon> "
+
+    // The caller measures the name column in bytes (core has no display-width
+    // table). Re-measure it here in columns, then fit it to the terminal.
+    std::size_t measured = 20;
+    for (auto& p : progState) {
+        measured = std::max(measured,
+                            static_cast<std::size_t>(layout::display_width(p.name)));
+    }
+    nameWidth = fit_name_width_(measured + 2, iconW, static_cast<int>(statusWidth));
 
     Elements rows;
     double totalBytes = 0.0;
@@ -326,30 +368,47 @@ int render_download_progress(std::span<const DownloadProgressEntry> progState,
     int pctFrac = static_cast<int>(overallPct * 1000.0f) % 10;
     std::string pctStr = std::to_string(pctWhole) + "." + std::to_string(pctFrac) + "%";
 
+    // The bar shares its line with the percentage, speed and ETA, so it gives
+    // ground first rather than pushing the line past the edge.
+    constexpr int kGaugeMax = 30;
+    const int gaugeTail = 4
+        + layout::display_width("  " + pctStr)
+        + layout::display_width(speedStr)
+        + layout::display_width(etaStr);
+
+    int width = layout::fit_width(
+        std::max(row_width_(nameWidth, iconW, static_cast<int>(statusWidth)),
+                 gaugeTail + kGaugeMax));
+    int gaugeW = std::clamp(width - gaugeTail, 8, kGaugeMax);
+
     rows.push_back(text(""));
     rows.push_back(hbox({
         text("  " + std::string(theme::icon::arrow) + " ") | color(theme::cyan()),
-        gauge(overallPct) | size(WIDTH, EQUAL, 30) | color(theme::cyan()),
+        gauge(overallPct) | size(WIDTH, EQUAL, gaugeW) | color(theme::cyan()),
         text("  " + pctStr) | bold | color(theme::text_color()),
         text(speedStr) | color(theme::cyan()),
         text(etaStr) | color(theme::dim_color()),
     }));
+    // erase_eol rather than padding: the frame is drawn over the previous
+    // one, and a trimmed line that is shorter than its predecessor would
+    // otherwise leave the old tail behind.
+    auto body = layout::render_to_string(vbox(std::move(rows)), width,
+                                         /*erase_eol=*/true);
 
-    auto doc = vbox(std::move(rows));
-    auto screen = Screen::Create(Dimension::Full(), Dimension::Fit(doc));
-    Render(screen, doc);
-
-    // Build single output buffer: cursor-up + content + clear trailing + newline
+    // Build single output buffer: cursor-up + content + clear trailing.
     std::string output;
     if (prevLines > 0) {
         output += "\033[" + std::to_string(prevLines) + "A\r";
     }
-    output += screen.ToString();
-    output += "\033[J\n";  // clear any leftover lines below, then newline
+    output += body;
+    output += "\033[J";  // clear any leftover lines below
 
     std::cout << output << std::flush;
 
-    return screen.dimy();
+    // Every row fits the terminal (fit_name_width_ above), so rendered rows
+    // and physical lines are the same number and the cursor-up on the next
+    // frame lands where this frame started.
+    return static_cast<int>(std::ranges::count(body, '\n'));
 }
 
 } // namespace xlings::ui

--- a/src/ui/selector.cppm
+++ b/src/ui/selector.cppm
@@ -8,13 +8,17 @@ module;
 export module xlings.ui:selector;
 
 import std;
+import xlings.core.palette;
 import :theme;
+import :layout;
 
 export namespace xlings::ui {
 
-// Interactive version selector -- returns chosen version or nullopt if cancelled
+// Interactive version selector -- returns chosen version or nullopt if
+// cancelled. `title` is shown as-is (the caller phrases the question).
 std::optional<std::string>
-select_version(std::string_view pkgName, std::span<const std::string> versions) {
+select_version(std::string_view title, std::span<const std::string> versions,
+               std::string_view active = {}) {
     using namespace ftxui;
 
     if (versions.empty()) return std::nullopt;
@@ -24,9 +28,18 @@ select_version(std::string_view pkgName, std::span<const std::string> versions) 
     bool confirmed { false };
     bool cancelled { false };
 
+    // Start on the version that is already active, and say which one that is
+    // in words rather than by color alone.
     std::vector<std::string> labels;
     labels.reserve(versions.size());
-    for (auto& v : versions) labels.push_back(v);
+    for (std::size_t i = 0; i < versions.size(); ++i) {
+        if (!active.empty() && versions[i] == active) {
+            selected = static_cast<int>(i);
+            labels.push_back(versions[i] + "  (active)");
+        } else {
+            labels.push_back(versions[i]);
+        }
+    }
 
     auto menu = Menu(&labels, &selected);
 
@@ -48,7 +61,7 @@ select_version(std::string_view pkgName, std::span<const std::string> versions) 
 
     auto renderer = Renderer(component, [&] {
         return vbox({
-            text(std::format(" Select version for {}:", pkgName)) | theme::title(),
+            text(" " + std::string(title) + ":") | theme::title(),
             separator() | color(theme::border_color()),
             component->Render() | vscroll_indicator | frame
                 | size(HEIGHT, LESS_THAN, 15),
@@ -78,11 +91,12 @@ select_package(std::span<const std::pair<std::string, std::string>> items) {
 
     std::vector<std::string> labels;
     labels.reserve(items.size());
+    int nameW = 20;
     for (auto& [name, desc] : items) {
-        // Avoid {:<20s} -- GCC 15 modules crash on width specifiers
-        std::string padded = name;
-        while (padded.size() < 20) padded += ' ';
-        labels.push_back(padded + " " + desc);
+        nameW = std::max(nameW, layout::display_width(name));
+    }
+    for (auto& [name, desc] : items) {
+        labels.push_back(layout::pad_to_width(name, nameW) + " " + desc);
     }
 
     auto menu = Menu(&labels, &selected);
@@ -137,10 +151,12 @@ select_option(std::string_view title,
     // Build labels: "name   description"
     std::vector<std::string> labels;
     labels.reserve(items.size() + (done_label.empty() ? 0 : 1));
+    int nameW = 24;
     for (auto& [name, desc] : items) {
-        std::string padded = name;
-        while (padded.size() < 24) padded += ' ';
-        labels.push_back(padded + desc);
+        nameW = std::max(nameW, layout::display_width(name));
+    }
+    for (auto& [name, desc] : items) {
+        labels.push_back(layout::pad_to_width(name, nameW) + desc);
     }
     if (!done_label.empty()) {
         labels.push_back(std::string(done_label));
@@ -199,9 +215,13 @@ select_option(std::string_view title,
     return std::nullopt;
 }
 
-// Read a line from stdin with ANSI-colored prompt
+// Read a line from stdin with ANSI-colored prompt.
+//
+// Colors come from the shared palette rather than a dark-palette literal, so
+// the prompt follows the terminal background and goes quiet under NO_COLOR —
+// it is the one line the user has to read before they can answer it.
 std::string read_line(std::string_view prompt) {
-    std::print("\033[38;2;34;211;238m  {} \033[0m", prompt);
+    std::print("{}  {} {}", palette::fg(palette::cyan()), prompt, palette::off());
     std::cout.flush();
     std::string line;
     std::getline(std::cin, line);
@@ -212,12 +232,19 @@ std::string read_line(std::string_view prompt) {
     return line;
 }
 
-// Simple yes/no confirmation with styled prompt
+// Simple yes/no confirmation with styled prompt.
+//
+// Indented two columns like every panel above it. It used to start at column
+// 0, so the question sat outside the block it was asking about.
 bool confirm(std::string_view message, bool defaultYes) {
     std::string prompt = defaultYes ? "[Y/n] " : "[y/N] ";
-    // Use ANSI colors for inline prompt (not ftxui rendered)
-    std::print("\033[38;2;34;211;238m{}\033[0m{}\033[38;2;148;163;184m{}\033[0m",
-               std::string(theme::icon::arrow) + " ", message, prompt);
+    // Inline prompt (not an ftxui-rendered document), so it writes SGR
+    // directly — from the shared palette, which also turns it off under
+    // NO_COLOR / a pipe.
+    std::print("{}  {} {}{}{}{}{}",
+               palette::fg(palette::cyan()), theme::icon::arrow, palette::off(),
+               message,
+               palette::fg(palette::dim()), prompt, palette::off());
     std::cout.flush();
 
     std::string input;

--- a/src/ui/table.cppm
+++ b/src/ui/table.cppm
@@ -9,8 +9,60 @@ export module xlings.ui:table;
 
 import std;
 import :theme;
+import :layout;
 
 export namespace xlings::ui {
+
+namespace detail {
+
+// Fit a bordered table to the terminal.
+//
+// A table that does not fit used to be clipped at the screen edge, which
+// takes the right-hand border with it and leaves something that reads as a
+// half-drawn frame. Column 0 carries the identifier and keeps its natural
+// width; the rest give ground, widest first, until the table fits.
+inline int fit_columns_(std::vector<std::vector<std::string>>& data) {
+    if (data.empty() || data.front().empty()) return layout::fit_width(0);
+
+    const std::size_t cols = data.front().size();
+    std::vector<int> w(cols, 0);
+    for (auto& row : data) {
+        for (std::size_t c = 0; c < cols && c < row.size(); ++c) {
+            w[c] = std::max(w[c], layout::display_width(row[c]));
+        }
+    }
+
+    // Borders: one leading, one trailing, one between each pair of columns,
+    // plus a space of padding either side of every cell.
+    const int chrome = static_cast<int>(cols) + 1 + 2 * static_cast<int>(cols);
+    auto total = [&] {
+        int t = chrome;
+        for (auto x : w) t += x;
+        return t;
+    };
+
+    const int avail = layout::fit_width(total());
+    while (total() > avail) {
+        // Widest shrinkable column (never column 0).
+        std::size_t victim = 0;
+        int best = 0;
+        for (std::size_t c = 1; c < cols; ++c) {
+            if (w[c] > best) { best = w[c]; victim = c; }
+        }
+        if (victim == 0 || best <= layout::kMinDescW) break;
+        w[victim] = std::max(layout::kMinDescW, best - (total() - avail));
+        if (w[victim] == best) break;   // no progress; stop rather than spin
+    }
+
+    for (auto& row : data) {
+        for (std::size_t c = 0; c < cols && c < row.size(); ++c) {
+            row[c] = layout::truncate_to_width(row[c], w[c]);
+        }
+    }
+    return std::min(avail, total());
+}
+
+}  // namespace detail
 
 // Print a formatted table with headers and rows
 void print_table(std::span<const std::string> headers,
@@ -22,6 +74,7 @@ void print_table(std::span<const std::string> headers,
     for (auto& row : rows) {
         tableData.push_back(row);
     }
+    int width = detail::fit_columns_(tableData);
 
     auto table = Table(std::move(tableData));
     table.SelectAll().Border(ROUNDED);
@@ -30,10 +83,7 @@ void print_table(std::span<const std::string> headers,
     table.SelectRow(0).SeparatorVertical(LIGHT);
     table.SelectRow(0).BorderBottom(LIGHT);
 
-    auto doc = table.Render();
-    auto screen = Screen::Create(Dimension::Full(), theme::fit_full_height(doc));
-    Render(screen, doc);
-    screen.Print();
+    layout::print_doc(table.Render(), width);
     std::println("");
 }
 
@@ -49,6 +99,7 @@ void print_search_results(
     for (auto& [name, desc] : results) {
         tableData.push_back({ name, desc });
     }
+    int width = detail::fit_columns_(tableData);
 
     auto table = Table(std::move(tableData));
     table.SelectAll().Border(ROUNDED);
@@ -62,10 +113,7 @@ void print_search_results(
         table.SelectCell(i, 0).Decorate(color(theme::magenta()));
     }
 
-    auto doc = table.Render();
-    auto screen = Screen::Create(Dimension::Full(), theme::fit_full_height(doc));
-    Render(screen, doc);
-    screen.Print();
+    layout::print_doc(table.Render(), width);
     std::println("");
 }
 

--- a/src/ui/theme.cppm
+++ b/src/ui/theme.cppm
@@ -7,138 +7,36 @@ export module xlings.ui:theme;
 
 import std;
 import xlings.platform;
+import xlings.core.glyph;
+import xlings.core.palette;
 
 export namespace xlings::ui::theme {
 
 using ftxui::Color;
 using ftxui::Decorator;
 
-// ─── Background detection ──────────────────────────────────
-//
-// xlings used near-white text by default which became invisible on a
-// light terminal background. The theme now picks one of two palettes
-// based on the actual terminal background, with explicit override:
-//
-//   1. XLINGS_THEME=dark|light  — explicit override, no querying.
-//   2. XLINGS_THEME=auto / unset — try (in order):
-//      a. platform::query_terminal_is_light() — POSIX OSC-11 query
-//         on Linux/macOS; std::nullopt on Windows.
-//      b. COLORFGBG env (rxvt-style "fg;bg" — bg 7 or 9-15 = light).
-//      c. Fall back to Dark — the safe default for most modern terms.
-//
-// Detection runs at most once per process (cached). Cost is one
-// terminal round-trip on first color access, bounded by a monotonic
-// deadline (default 500 ms, XLINGS_TERM_QUERY_TIMEOUT_MS) but normally
-// returning in a few ms via a DSR/CPR fence; the result is reused for
-// the lifetime of the program.
+// The palette and the background detection live in `xlings.core.palette`,
+// because `log::`, the sub-OS status lines and the y/n prompt write SGR
+// directly and have to draw from the same table — see the rationale there.
+// This is the ftxui-facing adapter over it.
+using Background = palette::Background;
 
-enum class Background { Dark, Light };
+inline auto current_background() -> Background { return palette::current_background(); }
+inline void set_background(Background bg)      { palette::set_background(bg); }
 
 namespace detail {
-
-inline auto from_env_override_() -> std::optional<Background> {
-    if (auto* v = std::getenv("XLINGS_THEME")) {
-        std::string_view s{v};
-        if (s == "dark")  return Background::Dark;
-        if (s == "light") return Background::Light;
-        // "auto" / unknown → fall through to detection
-    }
-    return std::nullopt;
+inline auto rgb_(palette::Rgb c) -> Color { return Color::RGB(c.r, c.g, c.b); }
 }
 
-inline auto from_colorfgbg_() -> std::optional<Background> {
-    auto* v = std::getenv("COLORFGBG");
-    if (!v) return std::nullopt;
-    std::string_view s{v};
-    auto sep = s.rfind(';');
-    if (sep == std::string_view::npos) return std::nullopt;
-    int bg = 0;
-    for (char c : s.substr(sep + 1)) {
-        if (c < '0' || c > '9') return std::nullopt;
-        bg = bg * 10 + (c - '0');
-        if (bg > 99) return std::nullopt;
-    }
-    // rxvt convention: 0..6 + 8 are dark; 7 and 9..15 are light.
-    return (bg == 7 || bg >= 9) ? Background::Light : Background::Dark;
-}
-
-inline auto detect_() -> Background {
-    if (auto e = from_env_override_()) return *e;
-    if (auto t = platform::query_terminal_is_light()) {
-        return *t ? Background::Light : Background::Dark;
-    }
-    if (auto c = from_colorfgbg_())    return *c;
-    return Background::Dark;
-}
-
-inline auto cached_() -> Background& {
-    static Background bg = detect_();
-    return bg;
-}
-
-}  // namespace detail
-
-inline auto current_background() -> Background { return detail::cached_(); }
-inline void set_background(Background bg)      { detail::cached_() = bg; }
-
-// ─── Color palette ─────────────────────────────────────────
-//
-// Two palettes, chosen at color-access time by the cached background.
-// All public color accessors below are one-liners that pick from
-// `dark_` or `light_` — no macros, no template tricks; the duplication
-// is small enough that the obvious code reads better.
-
-namespace dark_ {
-    inline auto cyan()         -> Color { return Color::RGB( 34, 211, 238); }  // cyan-400
-    inline auto green()        -> Color { return Color::RGB( 34, 197,  94); }  // green-500
-    inline auto amber()        -> Color { return Color::RGB(245, 158,  11); }  // amber-500
-    inline auto red()          -> Color { return Color::RGB(239,  68,  68); }  // red-500
-    inline auto magenta()      -> Color { return Color::RGB(168,  85, 247); }  // purple-500
-    inline auto dim_color()    -> Color { return Color::RGB(148, 163, 184); }  // slate-400
-    inline auto text_color()   -> Color { return Color::RGB(248, 250, 252); }  // slate-50
-    inline auto surface()      -> Color { return Color::RGB( 30,  41,  59); }  // slate-800
-    inline auto border_color() -> Color { return Color::RGB( 51,  65,  85); }  // slate-700
-}
-
-namespace light_ {
-    inline auto cyan()         -> Color { return Color::RGB(  8, 145, 178); }  // cyan-700
-    inline auto green()        -> Color { return Color::RGB( 21, 128,  61); }  // green-700
-    inline auto amber()        -> Color { return Color::RGB(180,  83,   9); }  // amber-700
-    inline auto red()          -> Color { return Color::RGB(185,  28,  28); }  // red-700
-    inline auto magenta()      -> Color { return Color::RGB(126,  34, 206); }  // purple-700
-    inline auto dim_color()    -> Color { return Color::RGB(100, 116, 139); }  // slate-500
-    inline auto text_color()   -> Color { return Color::RGB( 15,  23,  42); }  // slate-900
-    inline auto surface()      -> Color { return Color::RGB(241, 245, 249); }  // slate-100
-    inline auto border_color() -> Color { return Color::RGB(203, 213, 225); }  // slate-300
-}
-
-inline auto cyan() -> Color {
-    return current_background() == Background::Light ? light_::cyan() : dark_::cyan();
-}
-inline auto green() -> Color {
-    return current_background() == Background::Light ? light_::green() : dark_::green();
-}
-inline auto amber() -> Color {
-    return current_background() == Background::Light ? light_::amber() : dark_::amber();
-}
-inline auto red() -> Color {
-    return current_background() == Background::Light ? light_::red() : dark_::red();
-}
-inline auto magenta() -> Color {
-    return current_background() == Background::Light ? light_::magenta() : dark_::magenta();
-}
-inline auto dim_color() -> Color {
-    return current_background() == Background::Light ? light_::dim_color() : dark_::dim_color();
-}
-inline auto text_color() -> Color {
-    return current_background() == Background::Light ? light_::text_color() : dark_::text_color();
-}
-inline auto surface() -> Color {
-    return current_background() == Background::Light ? light_::surface() : dark_::surface();
-}
-inline auto border_color() -> Color {
-    return current_background() == Background::Light ? light_::border_color() : dark_::border_color();
-}
+inline auto cyan()         -> Color { return detail::rgb_(palette::cyan()); }
+inline auto green()        -> Color { return detail::rgb_(palette::green()); }
+inline auto amber()        -> Color { return detail::rgb_(palette::amber()); }
+inline auto red()          -> Color { return detail::rgb_(palette::red()); }
+inline auto magenta()      -> Color { return detail::rgb_(palette::magenta()); }
+inline auto dim_color()    -> Color { return detail::rgb_(palette::dim()); }
+inline auto text_color()   -> Color { return detail::rgb_(palette::text()); }
+inline auto surface()      -> Color { return detail::rgb_(palette::surface()); }
+inline auto border_color() -> Color { return detail::rgb_(palette::border()); }
 
 // ─── Decorator helpers ─────────────────────────────────────
 auto title()     -> Decorator { return ftxui::bold | ftxui::color(cyan()); }
@@ -152,27 +50,27 @@ auto body()      -> Decorator { return ftxui::color(text_color()); }
 
 // ─── Icons ─────────────────────────────────────────────────
 //
-// All glyphs are BMP-region characters that ship in the default monospace
-// fonts of every mainstream terminal we care about: Cascadia Code/Mono
-// (Windows Terminal default), Consolas (conhost), Lucida Console (legacy
-// conhost), DejaVu Sans Mono / Liberation Mono / Noto Mono (Linux), and
-// SF Mono / Menlo (macOS). No platform-conditional ASCII fallback —
-// keeping a single glyph set is what makes Linux / macOS / Windows look
-// the same, which is the whole point.
-//
-// Avoid: U+27D0 ⟐, U+2699 ⚙, U+27F0 ⟰ — these are spotty in older
-// console fonts and were the main offenders behind Windows mojibake.
+// The glyph table itself lives in `xlings.core.glyph`, because `self doctor`
+// composes marked labels in core and must draw from the same table — see the
+// rationale there. This is the UI-facing name for it.
 namespace icon {
-    inline constexpr auto pending     = "\xe2\x97\x8b";   // ○ U+25CB
-    inline constexpr auto downloading = "\xe2\x86\x93";   // ↓ U+2193
-    inline constexpr auto extracting  = "\xe2\x96\xbe";   // ▾ U+25BE
-    inline constexpr auto installing  = "\xe2\x8a\x95";   // ⊕ U+2295
-    inline constexpr auto configuring = "\xe2\x8a\x95";   // ⊕ U+2295
-    inline constexpr auto done        = "\xe2\x9c\x93";   // ✓ U+2713
-    inline constexpr auto failed      = "\xe2\x9c\x97";   // ✗ U+2717
-    inline constexpr auto info        = "\xe2\x80\xba";   // › U+203A
-    inline constexpr auto arrow       = "\xe2\x96\xb8";   // ▸ U+25B8
-    inline constexpr auto package     = "\xe2\x97\x86";   // ◆ U+25C6
+    inline constexpr auto pending     = glyph::pending;
+    inline constexpr auto downloading = glyph::downloading;
+    inline constexpr auto extracting  = glyph::extracting;
+    inline constexpr auto installing  = glyph::installing;
+    inline constexpr auto configuring = glyph::configuring;
+    inline constexpr auto done        = glyph::done;
+    inline constexpr auto failed      = glyph::failed;
+    inline constexpr auto info        = glyph::info;
+    inline constexpr auto arrow       = glyph::arrow;
+    inline constexpr auto package     = glyph::package;
+    inline constexpr auto warn        = glyph::warn;
+    inline constexpr auto note        = glyph::note;
+    inline constexpr auto bullet      = glyph::bullet;
+    inline constexpr auto remedy      = glyph::remedy;
+    inline constexpr auto ellipsis    = glyph::ellipsis;
+    inline constexpr auto divider     = glyph::divider;
+    inline constexpr auto active      = glyph::active;
 } // namespace icon
 
 // Height for a document we intend to print in full.

--- a/tests/e2e/run_all.sh
+++ b/tests/e2e/run_all.sh
@@ -93,6 +93,7 @@ TESTS=(
     "E2E-41 |index_artifact_update_test.sh||"
     "E2E-42 |self_doctor_multi_subos_test.sh||"
     "E2E-43 |declared_programs_verified_test.sh||"
+    "E2E-44 |tui_output_contract_test.sh||"
 )
 
 PASS=0; FAIL=0; SOFTFAIL=0

--- a/tests/e2e/tui_output_contract_test.sh
+++ b/tests/e2e/tui_output_contract_test.sh
@@ -1,0 +1,395 @@
+#!/usr/bin/env bash
+# E2E: the terminal output contract.
+#
+# Every renderer used to pick its own width and its own answer to "what if it
+# does not fit", and no two agreed. `print_info_panel` widened the canvas past
+# the terminal and let the terminal hard-wrap every line (the reported "ragged
+# output in a small window"); everything else drew at the full terminal width
+# and let ftxui shrink each hbox child proportionally, which eats a package
+# name as readily as a description — `xim:binutils@2.42` rendered as
+# `xim:binutils@2`, a version number that looks valid and is wrong. Nothing
+# asked whether stdout was a terminal, so a pipe got true color, a CR per
+# line, trailing padding and a NUL byte.
+#
+# The invariants asserted here:
+#   S1. No rendered line exceeds the terminal width, at any width.
+#   S2. A package name is never truncated; the description is.
+#   S3. A pipe gets no NUL, no CR, no trailing spaces and no ANSI.
+#   S4. NO_COLOR silences color even on a terminal.
+#   S5. The active version is marked by a glyph, not by color alone, and the
+#       command says what to do next.
+#   S6. Glyphs come from the single table in src/core/glyph.cppm.
+#
+# Widths are measured in display columns, never bytes — measuring in bytes is
+# the bug, so a test that measured in bytes would pass over it.
+#
+# The checkers are files rather than heredocs on purpose. `python3 - <<'PY'`
+# feeds the heredoc to python as its *program*, so a piped-in payload never
+# arrives and `sys.stdin.read()` returns "" — a width check written that way
+# passes on every input, including a broken one. That is the same
+# looks-like-it-ran-and-did-nothing failure this suite exists to catch.
+
+set -euo pipefail
+
+# shellcheck source=./project_test_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
+
+require_fixture_index
+command -v python3 >/dev/null 2>&1 || { log "SKIP: python3 not available"; exit 0; }
+
+RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/tui_output_contract"
+HOME_DIR="$RUNTIME_DIR/home"
+LOCAL_INDEX_DIR="$RUNTIME_DIR/xim-pkgindex"
+BIN_DIR="$RUNTIME_DIR/checkers"
+STATE="$HOME_DIR/.xlings.json"
+
+cleanup() { rm -rf "$RUNTIME_DIR"; }
+trap cleanup EXIT
+cleanup
+
+XLINGS_BIN="$(find_xlings_bin)"
+# RUN cds to /tmp, so a relative XLINGS_BIN would resolve to nothing there.
+XLINGS_BIN="$(cd "$(dirname "$XLINGS_BIN")" && pwd)/$(basename "$XLINGS_BIN")"
+
+# A deliberately long name: at 40 columns it is wider than the whole terminal,
+# which is exactly the case where the old renderer started cutting into it.
+PKG="widthfixture-with-a-deliberately-long-name"
+
+RUN() {
+  local width="$1"; shift
+  ( cd /tmp && env -i HOME="$HOME" PATH=/usr/bin:/bin \
+      XLINGS_HOME="$HOME_DIR" XLINGS_TERM_WIDTH="$width" \
+      "$XLINGS_BIN" "$@" )
+}
+
+mkdir -p "$BIN_DIR"
+
+# ── checkers ────────────────────────────────────────────────────────
+
+cat > "$BIN_DIR/common.py" <<'PY'
+import re, sys, unicodedata
+
+SGR = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
+
+def plain(text):
+    return SGR.sub("", text)
+
+def cols(s):
+    n = 0
+    for ch in s:
+        if unicodedata.combining(ch):
+            continue
+        n += 2 if unicodedata.east_asian_width(ch) in ("W", "F") else 1
+    return n
+
+def read_stdin():
+    data = sys.stdin.buffer.read()
+    if not data:
+        # An empty payload would make every check below pass. Say so instead.
+        print("no input reached the checker")
+        sys.exit(2)
+    return data
+PY
+
+# Fails if any line of stdin is wider than $1 display columns.
+cat > "$BIN_DIR/check_width.py" <<'PY'
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from common import plain, cols, read_stdin
+
+limit = int(sys.argv[1])
+text = plain(read_stdin().decode("utf-8", "replace"))
+bad = [(cols(l), l) for l in text.split("\n") if cols(l) > limit]
+if bad:
+    w, l = bad[0]
+    print(f"{len(bad)} line(s) exceed {limit} columns; first is {w}: {l!r}")
+    sys.exit(1)
+PY
+
+# Fails if stdin holds anything a pipe should never receive.
+cat > "$BIN_DIR/check_pipe.py" <<'PY'
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from common import read_stdin
+
+data = read_stdin()
+problems = []
+if b"\x00" in data: problems.append("NUL byte")
+if b"\r" in data:   problems.append("carriage return")
+if b"\x1b" in data: problems.append("ANSI escape")
+for line in data.split(b"\n"):
+    if line != line.rstrip(b" "):
+        problems.append("trailing spaces")
+        break
+if problems:
+    print("piped output contains: " + ", ".join(sorted(set(problems))))
+    sys.exit(1)
+PY
+
+# Fails unless $1 appears in stdin once whitespace is ignored. A wrapped
+# identifier keeps every character and splits across lines; a truncated one
+# loses characters. Comparing whitespace-free tells those two apart.
+cat > "$BIN_DIR/check_contains.py" <<'PY'
+import sys, os, re
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from common import plain, read_stdin
+
+want = re.sub(r"\s+", "", sys.argv[1])
+got = re.sub(r"\s+", "", plain(read_stdin().decode("utf-8", "replace")))
+if want not in got:
+    print(f"{want!r} is missing or was cut")
+    sys.exit(1)
+PY
+
+# Fails if the SUBCOMMANDS rows of `--help` do not share a description column.
+cat > "$BIN_DIR/check_help_align.py" <<'PY'
+import sys, os, re
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from common import plain, read_stdin
+
+lines = plain(read_stdin().decode("utf-8", "replace")).split("\n")
+try:
+    start = lines.index("  SUBCOMMANDS") + 1
+except ValueError:
+    print("no SUBCOMMANDS section found")
+    sys.exit(1)
+
+starts, rows = set(), 0
+for l in lines[start:]:
+    if not l.strip():
+        break
+    m = re.match(r"^(\s{4}\S+\s{2,})\S", l)
+    if m:
+        rows += 1
+        starts.add(len(m.group(1)))
+if rows < 2:
+    print(f"expected several two-column rows, saw {rows}")
+    sys.exit(1)
+if len(starts) > 1:
+    print(f"description starts at differing columns: {sorted(starts)}")
+    sys.exit(1)
+PY
+
+# Fails unless exactly one version row carries the active marker glyph.
+cat > "$BIN_DIR/check_active_marker.py" <<'PY'
+import sys, os, re
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from common import plain, read_stdin
+
+lines = plain(read_stdin().decode("utf-8", "replace")).split("\n")
+rows = [l for l in lines if re.search(r"\b[12]\.0\.0\b", l) and "hint" not in l]
+marked = [l for l in rows if l.lstrip().startswith("▸")]
+if len(rows) < 2:
+    print(f"expected two version rows, got {len(rows)}: {rows}")
+    sys.exit(1)
+if len(marked) != 1:
+    print(f"expected exactly one glyph-marked row, got {len(marked)}: {rows}")
+    sys.exit(1)
+PY
+
+# Runs xlings on a real pty so the color decision is exercised for real.
+cat > "$BIN_DIR/run_pty.py" <<'PY'
+import os, pty, fcntl, termios, struct, select, subprocess, sys
+
+nocolor, home, binary, *args = sys.argv[1:]
+env = {"HOME": os.environ.get("HOME", "/tmp"), "PATH": "/usr/bin:/bin",
+       "XLINGS_HOME": home, "TERM": "xterm-256color"}
+if nocolor == "1":
+    env["NO_COLOR"] = "1"
+mfd, sfd = pty.openpty()
+fcntl.ioctl(sfd, termios.TIOCSWINSZ, struct.pack("HHHH", 24, 80, 0, 0))
+p = subprocess.Popen([binary, *args], stdin=subprocess.DEVNULL,
+                     stdout=sfd, stderr=sfd, env=env, close_fds=True)
+os.close(sfd)
+out = b""
+while True:
+    r, _, _ = select.select([mfd], [], [], 20)
+    if not r:
+        break
+    try:
+        d = os.read(mfd, 65536)
+    except OSError:
+        break
+    if not d:
+        break
+    out += d
+p.wait()
+sys.stdout.buffer.write(out)
+PY
+
+check_width()    { python3 "$BIN_DIR/check_width.py" "$@"; }
+check_pipe()     { python3 "$BIN_DIR/check_pipe.py"; }
+check_contains() { python3 "$BIN_DIR/check_contains.py" "$@"; }
+
+# The checkers refuse an empty payload, so prove the plumbing before relying
+# on it: a deliberately over-wide line must be reported.
+printf 'x%.0s' $(seq 1 50) | check_width 40 >/dev/null 2>&1 \
+  && fail "S0: the width checker accepted a 50-column line at limit 40"
+log "S0: checkers are wired to their input"
+
+# ── fixture index with a two-version package ────────────────────────
+mkdir -p "$HOME_DIR"
+cp -r "$FIXTURE_INDEX_DIR" "$LOCAL_INDEX_DIR"
+printf 'xim_indexrepos = {}\n' > "$LOCAL_INDEX_DIR/xim-indexrepos.lua"
+rm -f "$LOCAL_INDEX_DIR/.xlings-index-cache.json"
+mkdir -p "$LOCAL_INDEX_DIR/pkgs/w"
+
+cat > "$LOCAL_INDEX_DIR/pkgs/w/$PKG.lua" <<LUA
+package = {
+    spec = "1",
+    name = "$PKG",
+    description = "A fixture whose description is long enough that a narrow terminal has to shorten it, while the name above must survive intact",
+    authors = {"xlings-ci"},
+    licenses = {"MIT"},
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"test-fixture"},
+
+    xpm = {
+        linux   = { ["1.0.0"] = {}, ["2.0.0"] = {} },
+        macosx  = { ["1.0.0"] = {}, ["2.0.0"] = {} },
+        windows = { ["1.0.0"] = {}, ["2.0.0"] = {} },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mkdir(path.join(dir, "bin"))
+    io.writefile(path.join(dir, "bin", "widthfixture"), "#!/bin/sh\necho widthfixture\n")
+    os.exec("chmod +x " .. path.join(dir, "bin", "widthfixture"))
+    return true
+end
+
+function config()
+    xvm.add("widthfixture", { bindir = path.join(pkginfo.install_dir(), "bin") })
+    return true
+end
+
+function uninstall() return true end
+LUA
+
+mkdir -p "$HOME_DIR/subos/default/bin"
+cp "$XLINGS_BIN" "$HOME_DIR/xlings"
+cat > "$STATE" <<EOF
+{
+  "mirror": "GLOBAL",
+  "index_repos": [
+    { "name": "xim", "url": "$LOCAL_INDEX_DIR" }
+  ]
+}
+EOF
+
+log "Initializing sandbox XLINGS_HOME at $HOME_DIR"
+RUN 100 self init >/dev/null 2>&1 || fail "self init failed"
+mkdir -p "$HOME_DIR/data/xim-index-repos"
+printf '{}\n' > "$HOME_DIR/data/xim-index-repos/xim-indexrepos.json"
+
+RUN 100 install "$PKG@1.0.0" -y >/dev/null 2>&1 || fail "fixture install 1.0.0 failed"
+RUN 100 install "$PKG@2.0.0" -y >/dev/null 2>&1 || fail "fixture install 2.0.0 failed"
+
+# The commands that render something. `use widthfixture` lists versions rather
+# than prompting, because stdin here is not a terminal.
+COMMANDS=(
+  "--help"
+  "list --all"
+  "search widthfixture"
+  "info $PKG"
+  "config"
+  "use widthfixture"
+  "self doctor"
+)
+
+# ── S1: nothing exceeds the terminal width ──────────────────────────
+log "S1: no rendered line exceeds the terminal width"
+for width in 40 60 100 200; do
+  for cmd in "${COMMANDS[@]}"; do
+    # shellcheck disable=SC2086
+    out="$(RUN "$width" $cmd 2>&1 || true)"
+    msg="$(printf '%s\n' "$out" | check_width "$width")" \
+      || fail "S1: \`xlings $cmd\` at $width cols: $msg"
+  done
+done
+
+# ── S2: identifiers survive, descriptions give way ──────────────────
+log "S2: the package name is never truncated"
+# Below a width that fits it the identifier wraps rather than being cut, so
+# the assertion is on the characters and not on them being contiguous.
+for width in 40 60 100; do
+  out="$(RUN "$width" list --all 2>&1 || true)"
+  msg="$(printf '%s\n' "$out" | check_contains "$PKG@2.0.0")" \
+    || fail "S2: at $width cols, $msg
+$out"
+done
+
+# S1 already proved the line fits, so the remaining risk is that it fits
+# because the *name* gave way and the description survived whole.
+out="$(RUN 60 list --all 2>&1 || true)"
+if grep -qF "while the name above must survive intact" <<<"$out"; then
+  fail "S2: the full description fit at 60 cols — the fixture is not exercising the case"
+fi
+
+log "S2: the name column stays a column (help rows align)"
+out="$(RUN 60 --help 2>&1 || true)"
+msg="$(printf '%s\n' "$out" | python3 "$BIN_DIR/check_help_align.py")" \
+  || fail "S2: $msg
+$out"
+
+# ── S3: a pipe is a pipe ────────────────────────────────────────────
+log "S3: piped output carries no NUL / CR / trailing space / ANSI"
+for cmd in "${COMMANDS[@]}"; do
+  # shellcheck disable=SC2086
+  RUN 0 $cmd > "$RUNTIME_DIR/out.bin" 2>/dev/null || true
+  msg="$(check_pipe < "$RUNTIME_DIR/out.bin")" || fail "S3: \`xlings $cmd\`: $msg"
+done
+
+# ── S4: NO_COLOR is honored on a real terminal ──────────────────────
+log "S4: NO_COLOR silences color on a terminal"
+# SGR specifically, not "any escape": restoring cursor visibility on exit is
+# a cursor control and stays, NO_COLOR governs color.
+has_color() { grep -qE $'\033\[[0-9;]*m'; }
+
+colored="$(python3 "$BIN_DIR/run_pty.py" 0 "$HOME_DIR" "$XLINGS_BIN" config || true)"
+printf '%s' "$colored" | has_color \
+  || fail "S4: a terminal got no color at all — the check would prove nothing"
+plain_out="$(python3 "$BIN_DIR/run_pty.py" 1 "$HOME_DIR" "$XLINGS_BIN" config || true)"
+if printf '%s' "$plain_out" | has_color; then
+  fail "S4: NO_COLOR=1 still emitted color:
+$plain_out"
+fi
+
+# ── S5: active version is a glyph, and the next step is stated ──────
+log "S5: the active version is marked without color, and a hint follows"
+out="$(RUN 100 use widthfixture 2>&1 || true)"
+grep -q 'xlings use widthfixture <version>' <<<"$out" \
+  || fail "S5: no next-step hint:
+$out"
+msg="$(printf '%s\n' "$out" | python3 "$BIN_DIR/check_active_marker.py")" \
+  || fail "S5: $msg
+$out"
+
+# ── S6: one glyph table ─────────────────────────────────────────────
+log "S6: glyphs come only from src/core/glyph.cppm"
+# Two glyphs stand for the rule, in both spellings (literal and \x-escaped):
+#
+#   U+24D8 ⓘ — the coverage bet the table explicitly refuses, and what
+#               `self doctor` used to spell inline;
+#   U+26A0 ⚠ — the other label glyph doctor owned, and the one a second,
+#               dead icon table in src/platform/ also carried.
+#
+# Neither appears in ordinary prose, so a hit outside the table is a real
+# regression rather than a comment. The other marks (→, ·) are left out on
+# purpose: they are common in comments and checking them is all noise.
+GOVERNED='ⓘ|\\xe2\\x93\\x98|⚠|\\xe2\\x9a\\xa0'
+if grep -rnE "$GOVERNED" "$ROOT_DIR/src" --include='*.cppm' --include='*.cpp' \
+     | grep -v 'src/core/glyph.cppm' | grep -q .; then
+  grep -rnE "$GOVERNED" "$ROOT_DIR/src" --include='*.cppm' --include='*.cpp' \
+    | grep -v 'src/core/glyph.cppm'
+  fail "S6: a governed glyph was spelled outside src/core/glyph.cppm"
+fi
+
+log "PASS: terminal output contract holds"

--- a/tests/unit/test_ui_layout.cpp
+++ b/tests/unit/test_ui_layout.cpp
@@ -1,0 +1,293 @@
+// Unit tests for the width and output contract in `xlings.ui:layout`.
+//
+// The bugs these cover all had the same shape: a renderer decided how wide to
+// draw from something that was not the terminal width, or measured a string in
+// bytes and called the answer columns. Nothing in the output said so — a
+// truncated line and a complete one look identical, which is why
+// `xlings use gcc` shipped for months silently dropping the `bin` off a
+// toolchain path.
+#include <gtest/gtest.h>
+
+#include "ftxui/dom/elements.hpp"
+
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+import std;
+import xlings.ui;
+
+using namespace xlings::ui;
+
+namespace {
+
+// XLINGS_TERM_WIDTH is read on every call, so a test can set the width it
+// wants without a pty. 0 means "not a terminal" — no clamping, no padding.
+struct TermWidth {
+    explicit TermWidth(const char* v) {
+#if defined(_WIN32)
+        _putenv_s("XLINGS_TERM_WIDTH", v);
+#else
+        ::setenv("XLINGS_TERM_WIDTH", v, 1);
+#endif
+    }
+    ~TermWidth() {
+#if defined(_WIN32)
+        _putenv_s("XLINGS_TERM_WIDTH", "");
+#else
+        ::unsetenv("XLINGS_TERM_WIDTH");
+#endif
+    }
+};
+
+const std::string kHan = "\xe4\xb8\xad\xe6\x96\x87";      // 中文 — 6 bytes, 4 columns
+const std::string kEllipsis = "\xe2\x80\xa6";              // …
+
+// True when every byte of `s` belongs to a complete UTF-8 sequence.
+bool well_formed_utf8(std::string_view s) {
+    std::size_t i = 0;
+    while (i < s.size()) {
+        auto c = static_cast<unsigned char>(s[i]);
+        std::size_t n = 0;
+        if ((c & 0x80U) == 0x00U)      n = 1;
+        else if ((c & 0xE0U) == 0xC0U) n = 2;
+        else if ((c & 0xF0U) == 0xE0U) n = 3;
+        else if ((c & 0xF8U) == 0xF0U) n = 4;
+        else return false;                       // stray continuation byte
+        if (i + n > s.size()) return false;      // truncated sequence
+        for (std::size_t k = 1; k < n; ++k) {
+            if ((static_cast<unsigned char>(s[i + k]) & 0xC0U) != 0x80U) return false;
+        }
+        i += n;
+    }
+    return true;
+}
+
+std::vector<std::string> split_lines(const std::string& s) {
+    std::vector<std::string> out;
+    std::size_t start = 0;
+    while (start <= s.size()) {
+        auto nl = s.find('\n', start);
+        out.push_back(s.substr(start, (nl == std::string::npos ? s.size() : nl) - start));
+        if (nl == std::string::npos) break;
+        start = nl + 1;
+    }
+    return out;
+}
+
+}  // namespace
+
+// ─── display width ────────────────────────────────────────────────
+
+TEST(UiLayoutWidth, AsciiWidthIsLength) {
+    EXPECT_EQ(layout::display_width("gcc@15.1.0"), 10);
+    EXPECT_EQ(layout::display_width(""), 0);
+}
+
+TEST(UiLayoutWidth, WideGlyphsCountTwoColumnsNotThreeBytes) {
+    EXPECT_EQ(kHan.size(), 6u);
+    EXPECT_EQ(layout::display_width(kHan), 4);
+}
+
+TEST(UiLayoutWidth, MaxLineWidthTakesTheWidestLine) {
+    EXPECT_EQ(layout::max_line_width("ab\nabcd\na"), 4);
+    EXPECT_EQ(layout::max_line_width("solo"), 4);
+}
+
+// ─── padding ──────────────────────────────────────────────────────
+
+TEST(UiLayoutPad, PadsToColumnsNotBytes) {
+    EXPECT_EQ(layout::display_width(layout::pad_to_width("ab", 6)), 6);
+    // The byte-based idiom this replaces padded 中文 by 6 and produced a
+    // 10-column cell where a 6-column one was asked for.
+    EXPECT_EQ(layout::display_width(layout::pad_to_width(kHan, 6)), 6);
+}
+
+TEST(UiLayoutPad, NeverShrinks) {
+    EXPECT_EQ(layout::pad_to_width("abcdef", 3), "abcdef");
+}
+
+// ─── truncation ───────────────────────────────────────────────────
+
+TEST(UiLayoutTruncate, LeavesAFittingStringAlone) {
+    EXPECT_EQ(layout::truncate_to_width("abcdef", 6), "abcdef");
+    EXPECT_EQ(layout::truncate_to_width("abc", 10), "abc");
+}
+
+TEST(UiLayoutTruncate, MarksTheCut) {
+    auto out = layout::truncate_to_width("abcdefgh", 5);
+    EXPECT_EQ(layout::display_width(out), 5);
+    EXPECT_TRUE(out.ends_with(kEllipsis));
+}
+
+TEST(UiLayoutTruncate, NeverExceedsTheBudgetOnWideGlyphs) {
+    // 中文中文 is 8 columns; asking for 5 must not emit 6 by keeping a
+    // double-width glyph that only half fits.
+    auto out = layout::truncate_to_width(kHan + kHan, 5);
+    EXPECT_LE(layout::display_width(out), 5);
+    EXPECT_TRUE(out.ends_with(kEllipsis));
+}
+
+TEST(UiLayoutTruncate, NeverSplitsAUtf8Sequence) {
+    // Every cut, at every budget, has to land on a sequence boundary — a
+    // half-written glyph is a mojibake byte in the middle of the output.
+    for (int budget = 0; budget <= 10; ++budget) {
+        auto out = layout::truncate_to_width(kHan + kHan, budget);
+        EXPECT_TRUE(well_formed_utf8(out)) << "budget " << budget;
+        EXPECT_LE(layout::display_width(out), std::max(budget, 0));
+    }
+}
+
+TEST(UiLayoutTruncate, DegradesToABareMarker) {
+    EXPECT_EQ(layout::truncate_to_width("abcdef", 1), kEllipsis);
+    EXPECT_EQ(layout::truncate_to_width("abcdef", 0), "");
+}
+
+// ─── glyph splitting (progress bar) ───────────────────────────────
+
+TEST(UiLayoutSplit, SplitsOnGlyphBoundaries) {
+    EXPECT_EQ(layout::split_at_width("abcdef", 3), 3u);
+    // Halfway through 中文 in columns is a whole glyph in bytes, never 3.
+    EXPECT_EQ(layout::split_at_width(kHan, 2), 3u);
+    EXPECT_EQ(layout::split_at_width(kHan, 1), 0u);
+    EXPECT_EQ(layout::split_at_width(kHan, 0), 0u);
+}
+
+// ─── wrapping ─────────────────────────────────────────────────────
+
+TEST(UiLayoutWrap, BreaksOnSpaces) {
+    auto lines = layout::wrap_to_width("one two three four", 9);
+    ASSERT_GE(lines.size(), 2u);
+    for (auto& l : lines) EXPECT_LE(layout::display_width(l), 9);
+    // Nothing is lost: joining the pieces back gives the original words.
+    std::string joined;
+    for (auto& l : lines) { if (!joined.empty()) joined += ' '; joined += l; }
+    EXPECT_EQ(joined, "one two three four");
+}
+
+TEST(UiLayoutWrap, HardSplitsATokenWiderThanTheLine) {
+    auto lines = layout::wrap_to_width("aaaaaaaaaaaaaaa", 5);
+    ASSERT_EQ(lines.size(), 3u);
+    for (auto& l : lines) EXPECT_LE(layout::display_width(l), 5);
+    EXPECT_EQ(lines[0] + lines[1] + lines[2], "aaaaaaaaaaaaaaa");
+}
+
+TEST(UiLayoutWrap, PrefersToBreakAPathAfterASeparator) {
+    auto lines = layout::wrap_to_width("@xlings/data/xpkgs/xim-x-gcc/16.1.0/bin", 20);
+    ASSERT_GE(lines.size(), 2u);
+    for (std::size_t i = 0; i + 1 < lines.size(); ++i) {
+        EXPECT_TRUE(lines[i].ends_with("/")) << "line " << i << ": " << lines[i];
+    }
+    std::string joined;
+    for (auto& l : lines) joined += l;
+    EXPECT_EQ(joined, "@xlings/data/xpkgs/xim-x-gcc/16.1.0/bin");
+}
+
+TEST(UiLayoutWrap, HonorsEmbeddedNewlines) {
+    auto lines = layout::wrap_to_width("first\nsecond", 40);
+    ASSERT_EQ(lines.size(), 2u);
+    EXPECT_EQ(lines[0], "first");
+    EXPECT_EQ(lines[1], "second");
+}
+
+TEST(UiLayoutWrap, LosesNothingOnWideGlyphs) {
+    auto lines = layout::wrap_to_width(kHan + kHan + kHan, 5);
+    std::string joined;
+    for (auto& l : lines) joined += l;
+    EXPECT_EQ(joined, kHan + kHan + kHan);
+    for (auto& l : lines) EXPECT_LE(layout::display_width(l), 5);
+}
+
+// ─── terminal width ───────────────────────────────────────────────
+
+TEST(UiLayoutTermWidth, EnvOverrideWins) {
+    TermWidth w("57");
+    ASSERT_TRUE(layout::term_width().has_value());
+    EXPECT_EQ(*layout::term_width(), 57);
+}
+
+TEST(UiLayoutTermWidth, ZeroMeansUnlimited) {
+    TermWidth w("0");
+    EXPECT_FALSE(layout::term_width().has_value());
+}
+
+TEST(UiLayoutFit, ClampsToTheTerminalAndNeverPast) {
+    TermWidth w("60");
+    EXPECT_EQ(layout::fit_width(200), 60);
+    EXPECT_EQ(layout::fit_width(30), 30);
+    // The old formula was max(term, natural), which is what produced
+    // 92-column lines in a 60-column terminal.
+    EXPECT_LE(layout::fit_width(1000), 60);
+}
+
+TEST(UiLayoutFit, KeepsAFloorSoOutputStaysReadable) {
+    TermWidth w("5");
+    EXPECT_GE(layout::fit_width(80), layout::kMinCanvas);
+}
+
+TEST(UiLayoutFit, OffATerminalTheNaturalWidthStands) {
+    TermWidth w("0");
+    EXPECT_EQ(layout::fit_width(200), 200);
+}
+
+// ─── column planning ──────────────────────────────────────────────
+
+TEST(UiLayoutColumns, IdentifierColumnKeepsItsFullWidth) {
+    TermWidth w("60");
+    auto P = layout::plan_two_column(/*markerW=*/4, /*gap=*/2,
+                                     /*nameMax=*/33, /*descMax=*/80);
+    EXPECT_EQ(P.nameW, 33);          // never shrunk to make room for prose
+    EXPECT_FALSE(P.stacked);
+    EXPECT_EQ(P.width, 60);
+    EXPECT_EQ(P.lead + P.descW, 60);
+}
+
+TEST(UiLayoutColumns, DescriptionIsDroppedRatherThanTheName) {
+    TermWidth w("40");
+    auto P = layout::plan_two_column(4, 2, /*nameMax=*/33, /*descMax=*/80);
+    EXPECT_EQ(P.nameW, 33);
+    EXPECT_EQ(P.descW, 0);
+}
+
+TEST(UiLayoutColumns, StacksWhenTheIdentifiersAloneDoNotFit) {
+    TermWidth w("30");
+    auto P = layout::plan_two_column(4, 2, /*nameMax=*/40, /*descMax=*/20);
+    EXPECT_TRUE(P.stacked);
+    EXPECT_LE(P.width, 30);
+}
+
+TEST(UiLayoutColumns, NarrowContentDoesNotStretchToTheTerminal) {
+    TermWidth w("200");
+    auto P = layout::plan_two_column(4, 2, /*nameMax=*/10, /*descMax=*/20);
+    EXPECT_EQ(P.width, 4 + 10 + 2 + 20);
+}
+
+// ─── rendered output ──────────────────────────────────────────────
+
+TEST(UiLayoutRender, EmitsNoNulNoCrAndNoTrailingSpaces) {
+    TermWidth w("40");
+    auto doc = ftxui::vbox({
+        ftxui::text("short"),
+        ftxui::text("a rather longer line here"),
+    });
+    auto out = layout::render_to_string(doc, 40);
+
+    EXPECT_EQ(out.find('\0'), std::string::npos);   // Screen::Print() wrote one
+    EXPECT_EQ(out.find('\r'), std::string::npos);   // ToString() joins with \r\n
+    for (auto& s : split_lines(out)) {
+        if (s.empty()) continue;
+        EXPECT_FALSE(s.ends_with(" ")) << "padded line: [" << s << "]";
+    }
+}
+
+TEST(UiLayoutRender, NoLineExceedsTheCanvas) {
+    TermWidth w("32");
+    auto doc = ftxui::vbox({
+        ftxui::text("0123456789012345678901234567890123456789"),
+        ftxui::text("short"),
+    });
+    auto out = layout::render_to_string(doc, layout::fit_width(120));
+    for (auto& s : split_lines(out)) {
+        EXPECT_LE(layout::display_width(s), 32) << "[" << s << "]";
+    }
+}


### PR DESCRIPTION
## Summary

Narrow terminals produced ragged, wrapped, silently-truncated output. It was not one bug: every renderer decided independently how wide to draw and what to do when the content did not fit, and no two answers agreed.

- `print_info_panel` set its canvas to `max(term, minWidth)` — **wider than the terminal** — so a 60-column window received 92-column lines and hard-wrapped every one. That is the reported symptom.
- The same function mis-measured that width: labels were padded up to 14 but never truncated, while the formula assumed 14 flat. A 19-column label under-reserved by five, and the value lost its tail with no marker. `xlings use gcc` dropped the `bin` off a toolchain path this way.
- Everything else drew at `Dimension::Full()` and let ftxui shrink each hbox child proportionally, which charges a package name the same as the sentence describing it: `xim:binutils@2.42` rendered as `xim:binutils@2` — a version number that looks valid and is wrong.
- Nothing asked whether stdout was a terminal, so a pipe received true color, a CR per line, trailing padding and a NUL byte (`Screen::Print()` ends with `'\0'`).

Full analysis: `.agents/docs/2026-07-29-tui-output-ux-survey.md`.

## What changed

Three modules now hold decisions that were spread across nine files:

| module | holds |
|---|---|
| `src/ui/layout.cppm` | width + output contract (`term_width`, `fit_width`, `display_width`, `truncate_to_width`, `wrap_to_width`, `plan_two_column`, `render_to_string`) |
| `src/core/glyph.cppm` | the glyph table |
| `src/core/palette.cppm` | the color table, background detection, the color switch |

The latter two sit in `core` because `self doctor` composes marked labels and `log::` writes SGR there. `ui::theme` is the ftxui adapter over them.

The rules:

1. A canvas is never wider than the terminal. Content that does not fit is elided by the **caller**, which knows which column carries the identifier — ftxui does not.
2. Off a terminal there is no width limit: a pipe or a file gets the full untruncated text.
3. Width is measured in display columns, never bytes.
4. Output is text plus optional SGR — no NUL, no CR, no trailing spaces, and no color when the destination is not an interactive terminal or the user asked for none.
5. **Identifiers are never truncated. They wrap.** Descriptions get the ellipsis.

`XLINGS_TERM_WIDTH` (integer, `0` = unlimited) overrides the probe — used by the tests, and an escape hatch for terminals that report their size wrongly.

### The 17 items from the survey

| # | item | where |
|---|---|---|
| P0-1 | canvas exceeded the terminal | `layout::fit_width`, `info_panel` |
| P0-2 | `minWidth` used a fixed label width → silent truncation | `measure_panel_` |
| P0-3 | proportional shrink ate names/versions | `layout::plan_two_column` + all list renderers |
| P0-4 | `self doctor` at 230 columns | values wrap onto continuation lines |
| P0-8 | pipe got color / CR / NUL / padding | `layout::render_to_string` |
| P0-9 | `NO_COLOR` ignored (honored in generated profiles) | `palette::colors_enabled` |
| P0-11 | light theme covered only ftxui output | `log::`, subos lines, prompts now use `palette::` |
| P0-12 | active version encoded in color alone | `▸` marker; `info` says `(active)` |
| P1-5 | progress cursor-up counted logical rows | rows are fitted, count is physical |
| P1-6 | byte-based padding | `display_width` / `pad_to_width` everywhere |
| P1-13 | doctor bypassed `theme::icon` | single table in `core/glyph.cppm` |
| P1-14 | two rows named `versions`; duplicated `latest` | `available` / `aliases` / `installed` |
| P1-15 | paths abbreviated in some commands only | `Config::display_path` in `use`/`info` |
| P1-17 | success path gave no next step | `tip` event (wraps like everything else) |
| P1-18 | `ui::select_version` had no caller | wired via a `select_version` prompt id |
| P2-7 | divider hardcoded to 40 glyphs | spans the panel |
| P2-19 | confirm prompt started at column 0 | indented to match |

### Three things found while implementing

- **A third glyph table.** `src/platform/{linux,macos,windows}.cppm` each carried an `Icon` struct with **zero callers**, containing exactly the two glyphs the policy comment names as unsafe (`⚙` U+2699, `⟐` U+27D0). Removed — dead code that contradicts a rule is how the rule stops being one.
- **Stacked mode still clipped names.** When an identifier is wider than the terminal the row was given its own line but not wrapped, so ftxui cut it at the canvas edge anyway. It wraps now; nothing is lost.
- **The test was passing vacuously.** `python3 - <<'PY'` feeds the heredoc to python as its *program*, so the piped payload never arrives and `sys.stdin.read()` returns `""` — the width check passed on every input. Checkers are files now, and S0 proves the plumbing before anything relies on it. The bug class this PR is about had reached the tool checking for it.

## Test plan

- `mcpp build && mcpp test` — 25/25 green, including the new `tests/unit/test_ui_layout.cpp` (display width, UTF-8 boundary truncation, path-aware wrapping, column planning, clamping).
- `tests/e2e/tui_output_contract_test.sh` (registered as **E2E-44**):
  - **S0** the checkers are wired to their input
  - **S1** no rendered line exceeds the terminal, at 40/60/100/200 columns across `--help`, `list`, `search`, `info`, `config`, `use`, `self doctor`
  - **S2** the package name is never truncated; the `--help` name column stays a column
  - **S3** a pipe carries no NUL / CR / trailing space / ANSI
  - **S4** `NO_COLOR=1` silences color on a real pty (and a pty without it still gets color, so the check means something)
  - **S5** the active version carries a glyph, and a next-step hint follows
  - **S6** governed glyphs appear only in `src/core/glyph.cppm`
- **Run against the 2026.7.29.0 binary the same test fails at S1** — 81-column padded lines in a 40-column terminal — so it is a real regression guard.
- Swept the 40 tarball-free tests in the E2E manifest: all pass. `project_e2e_test.sh` fails identically on `main`'s released binary (it picks up the developer's real `node` via PATH) — pre-existing and environment-dependent, not a regression.

## Version

`2026.7.29.1` (`N` starts at 1; `.0` is reserved for a formal release).