### PR TITLE
fix(xim): stop writing a shim for a name install deliberately left inactive (2026.7.29.2)

### DIFF
--- a/.agents/docs/2026-07-29-orphan-shim-inactive-group-root-design.md
+++ b/.agents/docs/2026-07-29-orphan-shim-inactive-group-root-design.md
@@ -149,37 +149,53 @@ Three layers, independently shippable, deliberately overlapping.
 
 ### P1 — `ProgramShim` respects activation (installer)
 
-A shim is meaningful only if its name has an active version; that is exactly
+A shim is meaningful only if its name has an active version. That is exactly
 the invariant doctor Check 1 and Check 2 already encode, and the runtime proves
 it — an inactive shim can only print `no active version`. Install now obeys the
-same invariant that `remove` already does (`remove_target_shims_` has been
+same invariant `remove` already does (`remove_target_shims_` has been
 active-aware since 0.4.19).
 
-Scoped to **binding roots**, not to every inactive program:
+The condition is about the **name**, not this version:
 
 ```cpp
-if (!resolved->active
-    && xvm::is_binding_root(scopedDb, resolved->target, effect.version)) {
-    // a virtual anchor with no active pointer can only ever print
-    // "no active version" — writing the file creates doctor's orphan
-    continue;
-}
+const auto activeIt = scopedWorkspace.find(resolved->target);
+const bool nameHasActiveVersion =
+    activeIt != scopedWorkspace.end() && !activeIt->second.empty();
+if (!nameHasActiveVersion) continue;
 ```
 
-Why not "skip every inactive program": a real program that is registered but
-not active gives a *useful* error today —
+`!resolved->active` would be wrong. Installing a second version of an active
+program leaves `resolved->active` false for the new version while the name
+still needs the shim its active sibling dispatches through — and since the
+branch only ever *creates*, skipping there would be a silent no-op today and a
+missing shim the moment the file did not already exist.
+
+**Not scoped to binding roots**, though that was the first draft. Two reasons
+the general rule is the right one:
+
+- it covers the whole class, including the non-root members that produced the
+  29 orphan shims doctor's comment records — a root-only guard would leave
+  that case exactly as it is;
+- anything activated later still gets its file. `activate_requested_targets`
+  (`commands.cppm:365`) runs after the effects loop and calls `cmd_use`, which
+  resolves the *whole* release (`plan_use_switch`) and creates a shim for every
+  member (`commands.cppm:433`). Traced through llvm, whose group root is its
+  own package name: install while gcc owns `cc` leaves the group inactive, the
+  effects loop now writes nothing, and `cmd_use` immediately writes all of it.
+  Same end state as before.
+
+What is lost: a name that has *never* had an active version no longer gets a
+shim that would have printed
 
 ```
 [error] xlings: no active version of 'gcc-ar' in current subos
 [error]   hint: xlings use gcc-ar <version>
 ```
 
-— and dropping its shim downgrades that to the shell's `command not found`.
-A binding root has no such value: nobody types `xim-musl-gnu-gcc`.
-
-Safe against later activation: `activate_requested_targets`
-(`commands.cppm:365`) runs after the effects loop and calls `cmd_use`, which
-creates shims for every switched target (`commands.cppm:433`).
+and now gets the shell's `command not found` instead. That only reaches a
+package whose own name is not a registered target *and* whose group lost the
+vote — nothing in the index today — and in that state the command never worked
+either way.
 
 ### P2 — Check 2 exempts binding roots (doctor)
 
@@ -228,10 +244,33 @@ declared where it belongs.
 
 | level | test | what it pins |
 | --- | --- | --- |
-| unit | `test_xvm_bindings.cpp` — extend `InstallDoesNotSplitTheWorkspaceAcrossReleases` | the batch produces no `ProgramShim` effect for a root left inactive |
-| unit | `test_xvm_doctor.cpp` | an all-versions-are-anchors target with a shim is a notice, not an orphan |
-| e2e | `self_doctor_orphan_shim_test.sh` | **convergence**: `install → doctor --fix → install → doctor` is clean |
+| unit | `test_xvm_bindings.cpp::AnUncontestedRootStillLosesWithItsGroup` | the precondition the installer guard is built on — a private root is registered, not activated, and *is* a binding root |
+| e2e | `self_doctor_anchor_shim_test.sh` (E2E-45) | S1 no shim for an inactive root · S2 doctor clean · S3 anchor shim is a notice **and a genuine orphan is still an error** · S4 `--fix` removes it · S5 **convergence** |
 
-The e2e one is the property that actually matters. Every previous fix in this
-area made a single `--fix` converge; none of them checked that the install
-after it stays clean.
+doctor's `detect_` is not exported (only `cmd_doctor` is), so the Check 2 half
+is pinned at e2e level rather than in `test_xvm_doctor.cpp`.
+
+S5 is the property that actually matters. Every previous fix in this area made
+a single `--fix` converge; none checked that the install after it stays clean.
+
+Both halves were confirmed load-bearing by reverting them one at a time and
+rebuilding — pre-fix fails S1, installer-only fails S3, both pass.
+
+## Verified on the reported home
+
+Built with `.agents/tools/slice-real-home.sh`, same slice, two binaries:
+
+| | released 2026.7.29.1 | this change |
+| --- | --- | --- |
+| `self doctor` on the reported state | `orphan shims 1`, **exit 1**, "run --fix to repair" | `1 anchor shim` in the nothing-to-do line, **exit 0** |
+| `--fix` | removes the file | removes the file |
+| `remove musl-gcc@15` + `install musl-gcc@15` after that | shim back, exit 1 | **no shim, exit 0** |
+| `musl-gcc t.c -o t.out` after the reinstall | compiles | compiles |
+
+`verify-untouched` confirms the real `~/.xlings/data/xpkgs` was not written to.
+
+One pre-existing defect surfaced and was filed rather than folded in:
+`xlings use gcc 15.1.0-musl` leaves `gcc-ar`/`gcc-nm`/`gcc-ranlib` on the
+glibc release, because the musl flavor publishes only the five frontends —
+`xvm-active-group-incoherent` ×5, on both binaries
+(openxlings/xim-pkgindex#451).

--- a/.agents/docs/2026-07-29-orphan-shim-inactive-group-root-design.md
+++ b/.agents/docs/2026-07-29-orphan-shim-inactive-group-root-design.md
@@ -1,0 +1,237 @@
+# The orphan-shim loop: a file install writes, `--fix` deletes, install writes again
+
+Date: 2026-07-29
+Issue: [#452](https://github.com/openxlings/xlings/issues/452)
+Code: `src/core/xim/installer.cppm`, `src/core/xself/doctor.cppm`,
+`src/core/xvm/registration.cppm` (unchanged, but it is layer 2),
+`tests/unit/test_xvm_bindings.cpp`, `tests/e2e/self_doctor_orphan_shim_test.sh`
+Index: `openxlings/xim-pkgindex` — `pkgs/g/gcc.lua`, `pkgs/m/musl-gcc.lua`,
+`pkgs/a/aarch64-linux-musl-gcc.lua`
+
+## The report
+
+`xlings self doctor` on a real home, immediately after a successful install:
+
+```
+$ xlings install musl-gcc@15
+  ✓ 2 package(s) installed
+$ xlings self doctor
+  ✗ orphan shim  @xlings/subos/default/bin/xim-musl-gnu-gcc exists but
+                 workspace has no active version for xim-musl-gnu-gcc
+```
+
+The user's reading was "the reinstall did not clean up". It is the opposite:
+the install *created* the thing doctor is complaining about, and it does so
+every time.
+
+## What was actually happening
+
+The state, read straight off the home:
+
+```
+bin/xim-musl-gnu-gcc -> ../../../bin/xlings          # mtime == the install
+subos/default/.xlings.json:
+  xim-musl-gnu-gcc          {"installed": ["15.1.0-musl"]}         ← no active
+  xim-aarch64-musl-gnu-gcc  {"installed": ["15.1.0-aarch64-musl"]} ← no active
+  gcc                       {"active": "16.1.0", ...}
+```
+
+The shim is dead on arrival — it has nothing to dispatch to:
+
+```
+$ bin/xim-musl-gnu-gcc --version
+[error] xlings: no active version of 'xim-musl-gnu-gcc' in current subos
+[error]   available: 15.1.0-musl
+```
+
+`xim-aarch64-musl-gnu-gcc` is the same shape with the file already gone. That
+is the tell: an earlier `--fix` reaped it, and nothing has reinstalled that
+package since. The shell history closes the case:
+
+| time | command | doctor verdict |
+| --- | --- | --- |
+| 19:55:30 | `xlings self doctor --fix` | orphan shim **deleted** |
+| 19:57, 19:58 | `xlings self doctor` | clean |
+| 19:58:46 | `xlings remove musl-gcc@15` | clean |
+| 19:58:57 | `xlings install musl-gcc@15` | — |
+| 19:59:45 | `xlings self doctor` | orphan shim **back** |
+
+So `remove` is not the variable and neither is a dirty uninstall. `--fix` is
+why the home looked clean before; **`--fix` and `install` undo each other.**
+
+## Four layers, each locally correct
+
+**1 — the recipe registers a virtual anchor as a program.**
+`musl-gcc.lua:224` anchors the gcc-flavor subtree:
+
+```lua
+xvm.add(root_name, { version = flavor_ver })   -- "xim-musl-gnu-gcc"
+```
+
+No `bindir`, no `alias`. It exists only so `gcc`/`g++`/`cc`/`cpp`/`c++` at
+`15.1.0-musl` have a root to bind to. But `type` defaults to `"program"`, so
+every layer below treats it as an executable the user might run.
+
+**2 — registration withholds activation from the whole group.**
+`registration.cppm:921-925`:
+
+```cpp
+const bool anyMemberActive = std::ranges::any_of(
+    group.members, [&](const auto& member) {
+        return candidateWorkspace.contains(member.first);
+    });
+const bool activateGroup = batch.useAfterInstall || !anyMemberActive;
+```
+
+`gcc` is already in the workspace at glibc 16.1.0, so `activateGroup` is false
+and no member gets an active pointer — `installed[]` is written unconditionally
+(:952-966), `workspace` is not (:967-969).
+
+**This is deliberate and stays.** `InstallDoesNotSplitTheWorkspaceAcrossReleases`
+(`test_xvm_bindings.cpp:3044`) guards it: installing gcc must not take `cc`
+away from an active llvm, and a release must not be half-activated. The
+collateral is that a *private* root — contested by nobody — is swept into the
+same all-or-nothing decision.
+
+**3 — `ProgramShim` writes the file without asking whether it is active.**
+`installer.cppm`, the effects loop:
+
+```
+:1590  InstallHeaders → :1591  if (!resolved->active) { … continue; }   ← guarded
+:1611  ProgramShim    →        create_shim(...)                        ← NOT guarded
+:1657  FileAsset      → :1658  if (!resolved->active) { … continue; }   ← guarded
+```
+
+`resolved->active` is computed for every effect (:184-187) and `ProgramShim`
+consults it only at :1627, for the self-replace decision. So a name that
+registration deliberately left inactive still gets a file in `bin/`.
+
+**4 — doctor Check 2 lacks the exemption Check 3 already has.**
+Check 2 (`doctor.cppm:301-328`) is "shim file present + workspace has no active
+version" → **Error**. Check 3 (:477) faces the same entries and already knows
+better:
+
+```cpp
+if (xvm::is_binding_root(st.db, name, version) || !payload_has_any_executable_(expanded)) {
+    add({ .kind = FindingKind::ReleaseAnchor, .level = FindingLevel::Notice, … });
+```
+
+Those are the `release anchor` notices in every report. doctor already models
+"this name exists only to anchor a release"; Check 2 was never taught it.
+
+## Blast radius
+
+Not musl-specific, and not new. Any release that introduces a program name the
+previous release lacked, while the previous release stays active, ends up with
+a shim for a name that has no active version. `doctor.cppm:1430-1435` records
+the symptom and works around it:
+
+> Measured: one llvm re-registration produced 29 orphan shims and 29
+> incoherent-release findings that a single-pass repair reported as unfixed.
+
+The response then was a phase-3 re-run inside `--fix`. That makes one `--fix`
+converge; it does not stop the next `install` from re-creating the state. This
+change goes at the source.
+
+Three index recipes register a purely virtual root: `gcc.lua` (`xim-gnu-gcc`),
+`musl-gcc.lua` (`xim-musl-gnu-gcc`), `aarch64-linux-musl-gcc.lua`
+(`xim-aarch64-musl-gnu-gcc`). `xim-gnu-gcc`'s shim is equally dead — running it
+gives `executable 'xim-gnu-gcc' not found` — it just happens to hold an active
+pointer, so Check 2 never looked at it.
+
+This is the [silent-success](../../MEMORY.md) family inverted: three modules
+whose local judgements are each defensible produce a state only the
+cross-module view can call wrong.
+
+## The design
+
+Three layers, independently shippable, deliberately overlapping.
+
+### P1 — `ProgramShim` respects activation (installer)
+
+A shim is meaningful only if its name has an active version; that is exactly
+the invariant doctor Check 1 and Check 2 already encode, and the runtime proves
+it — an inactive shim can only print `no active version`. Install now obeys the
+same invariant that `remove` already does (`remove_target_shims_` has been
+active-aware since 0.4.19).
+
+Scoped to **binding roots**, not to every inactive program:
+
+```cpp
+if (!resolved->active
+    && xvm::is_binding_root(scopedDb, resolved->target, effect.version)) {
+    // a virtual anchor with no active pointer can only ever print
+    // "no active version" — writing the file creates doctor's orphan
+    continue;
+}
+```
+
+Why not "skip every inactive program": a real program that is registered but
+not active gives a *useful* error today —
+
+```
+[error] xlings: no active version of 'gcc-ar' in current subos
+[error]   hint: xlings use gcc-ar <version>
+```
+
+— and dropping its shim downgrades that to the shell's `command not found`.
+A binding root has no such value: nobody types `xim-musl-gnu-gcc`.
+
+Safe against later activation: `activate_requested_targets`
+(`commands.cppm:365`) runs after the effects loop and calls `cmd_use`, which
+creates shims for every switched target (`commands.cppm:433`).
+
+### P2 — Check 2 exempts binding roots (doctor)
+
+Existing homes already carry the file, and it is not the user's fault nor
+theirs to fix. Report it the way Check 3 reports the same entries — a
+`ReleaseAnchor` notice — instead of an Error that sets exit 1.
+
+Check 2 has no version in hand (that is the whole point: nothing is active), so
+the predicate is "**every** registered version of this target is a binding
+root". A target with one real program version and one anchor version stays an
+Error.
+
+`--fix` still deletes the file (it is genuinely useless); it is just no longer
+an error when it is there.
+
+### P0 — virtual roots declare `type = "group"` (xim-pkgindex)
+
+The real fix at the source. `group` produces no `ProgramShim` effect at all
+(`installer.cppm:421` only emits for `program`/`lib`/`files`) and doctor skips
+it in Checks 1, 2 and 3 (`type != "program"`). Six recipes already use this
+idiom, with the reason written down (`ripgrep.lua:78`):
+
+> `group` is the only kind that both avoids a bogus shim under the package name
+> and lets `xlings remove` find the package
+
+Verified: `apply_registration_batch` puts **no** kind constraint on a binding
+root (:440 checks only that the root is an exact node in the batch), so a
+`group` node is a valid root.
+
+Compatibility: an xlings older than 2026.7.x refuses to remove a group root and
+leaks the member shims — the same floor `ripgrep.lua` documents. P1+P2 ship
+first so the client that meets a group-rooted recipe is already the fixed one.
+
+## Why all three and not just P0
+
+- **P0 alone** fixes these three recipes and leaves the mechanism armed for the
+  next recipe that anchors a subtree.
+- **P1 alone** fixes every existing recipe with no index release, but leaves the
+  file already on disk in existing homes.
+- **P2 alone** silences the report without changing the state.
+
+P1 is the invariant, P2 is the existing-home migration, P0 is the intent
+declared where it belongs.
+
+## Tests
+
+| level | test | what it pins |
+| --- | --- | --- |
+| unit | `test_xvm_bindings.cpp` — extend `InstallDoesNotSplitTheWorkspaceAcrossReleases` | the batch produces no `ProgramShim` effect for a root left inactive |
+| unit | `test_xvm_doctor.cpp` | an all-versions-are-anchors target with a shim is a notice, not an orphan |
+| e2e | `self_doctor_orphan_shim_test.sh` | **convergence**: `install → doctor --fix → install → doctor` is clean |
+
+The e2e one is the property that actually matters. Every previous fix in this
+area made a single `--fix` converge; none of them checked that the install
+after it stays clean.

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlings"
-version = "2026.7.29.1"
+version = "2026.7.29.2"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "2026.7.29.1";
+    static constexpr std::string_view VERSION = "2026.7.29.2";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -1609,6 +1609,35 @@ bool process_xvm_operations_(const PlanNode& node,
         }
         if (resolved->kind
             == XpkgFilesystemEffectKind::ProgramShim) {
+            // A shim is only meaningful for a name that has an active
+            // version -- that is what shim_dispatch resolves against, and
+            // without one the file can only ever print "no active version
+            // of 'X' in current subos". Writing it anyway is what produced
+            // doctor's `orphan shim`, an error the user could not fix:
+            // `--fix` deleted the file and the next install recreated it.
+            //
+            // Registration deliberately withholds activation from a release
+            // whose group already has an active member (see
+            // registration.cppm, `activateGroup`), so every name that is new
+            // in that release lands here. The sibling effects below already
+            // guard on activation; this one did not.
+            //
+            // The question is about the NAME, not this version: a second
+            // version of an active program must not delete or skip the shim
+            // its active sibling needs. And a name activated later still
+            // gets its file -- `cmd_use` creates shims for every member of
+            // the release it switches to (xvm/commands.cppm).
+            const auto activeIt = scopedWorkspace.find(resolved->target);
+            const bool nameHasActiveVersion =
+                activeIt != scopedWorkspace.end()
+                && !activeIt->second.empty();
+            if (!nameHasActiveVersion) {
+                log::debug(
+                    "[xim] shim for {}@{} not created: no active version of "
+                    "'{}' in this subos",
+                    resolved->target, effect.version, resolved->target);
+                continue;
+            }
             if (std::filesystem::exists(xlings_bin)) {
                 std::string shimName = resolved->target;
                 if (!shim_ext.empty() && !shimName.ends_with(shim_ext)) {

--- a/src/core/xself/doctor.cppm
+++ b/src/core/xself/doctor.cppm
@@ -56,6 +56,8 @@ namespace fs = std::filesystem;
 // `--fix` policy:
 //   - missing shim   → recreate from the bootstrap binary  (safe, local)
 //   - orphan shim    → remove the file                     (safe, local)
+//     (a binding root's shim is reported as a notice, not an error -- it is
+//      equally useless, but no user action produced it; --fix removes it too)
 //   - dangling binding edge / incoherent release / active version that is not
 //     registered → drop the reference. Never re-point it at a survivor:
 //     choosing which version was meant is the user's call.
@@ -298,6 +300,22 @@ Scan detect_(const DoctorState& st, const CoordinateProbe& probe) {
         });
     }
 
+    // Does this name exist only to anchor releases? Check 3 asks the same
+    // question per (name, version) and answers it with a `release anchor`
+    // notice; Check 2 has no version to ask about -- nothing is active, that
+    // is the finding -- so it asks about every registered version instead.
+    //
+    // All of them, not any: a name with one real program version and one
+    // anchor version is a program whose shim genuinely has no active version.
+    const auto anchor_only_target_ = [&](const std::string& name,
+                                         const xvm::VInfo& vi) {
+        if (vi.versions.empty()) return false;
+        return std::ranges::all_of(
+            vi.versions, [&](const auto& entry) {
+                return xvm::is_binding_root(st.db, name, entry.first);
+            });
+    };
+
     // Check 2: orphan shims (program shim file present, workspace doesn't know
     // about it). Only names registered as type "program" count -- random files
     // under binDir aren't ours.
@@ -315,13 +333,27 @@ Scan detect_(const DoctorState& st, const CoordinateProbe& probe) {
 
             auto wit = st.ws.find(base);
             if (wit != st.ws.end() && !wit->second.empty()) continue;
+
+            // A binding root is not a program anyone runs -- it names the
+            // release its members belong to. Installs before 2026.7.29.2
+            // wrote a shim for one whenever registration withheld activation
+            // from the release (installer.cppm, the ProgramShim effect), so
+            // this file is on existing homes through no act of the user's.
+            // `--fix` still removes it; it is no longer an error that it is
+            // there.
+            const bool anchor = anchor_only_target_(base, *vi);
             add({
                 .kind   = FindingKind::OrphanShim,
-                .level  = FindingLevel::Error,
+                .level  = anchor ? FindingLevel::Notice : FindingLevel::Error,
                 .target = base,
-                .detail = std::format(
-                    "{} exists but workspace has no active version for {}",
-                    Config::display_path(entry.path()), base),
+                .detail = anchor
+                    ? std::format(
+                        "{} anchors a release and has no active version; "
+                        "nothing dispatches through it",
+                        Config::display_path(entry.path()))
+                    : std::format(
+                        "{} exists but workspace has no active version for {}",
+                        Config::display_path(entry.path()), base),
                 .shimPath = entry.path(),
             });
         }
@@ -1076,6 +1108,11 @@ Counts count_(const Scan& scan) {
         switch (f.kind) {
             case FindingKind::MissingShim:     ++c.missing; break;
             case FindingKind::OrphanShim:
+                // An anchor shim is Notice-level: the file is useless but
+                // its presence is not the user's doing, and it must not set
+                // the exit code. --fix still removes it.
+                if (f.level != FindingLevel::Notice) ++c.orphans;
+                break;
             case FindingKind::LegacyAliasShim: ++c.orphans; break;
             case FindingKind::BrokenPayload:   ++c.broken;  break;
             case FindingKind::ForeignPayload:  ++c.foreignPayloads; break;
@@ -1179,7 +1216,12 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
             case FindingKind::MissingShim:
                 add(glyph::mark(glyph::failed, "missing shim"), f.detail); break;
             case FindingKind::OrphanShim:
-                add(glyph::mark(glyph::failed, "orphan shim"), f.detail); break;
+                if (f.level == FindingLevel::Notice) {
+                    if (verbose) add(glyph::mark(glyph::note, "anchor shim"), f.detail);
+                } else {
+                    add(glyph::mark(glyph::failed, "orphan shim"), f.detail);
+                }
+                break;
             case FindingKind::LegacyAliasShim:
                 add(glyph::mark(glyph::failed, "legacy alias shim"), f.detail); break;
             case FindingKind::ShimAnchor:
@@ -1226,9 +1268,11 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
     // Thirty `release anchor` lines saying "nothing is wrong here" is how the
     // four lines that matter got lost.
     if (!verbose) {
-        int anchors = 0, bindingNotices = 0, subosNotices = 0;
+        int anchors = 0, anchorShims = 0, bindingNotices = 0, subosNotices = 0;
         for (const auto& f : scan.findings) {
             if (f.kind == FindingKind::ReleaseAnchor) ++anchors;
+            else if (f.kind == FindingKind::OrphanShim
+                     && f.level == FindingLevel::Notice) ++anchorShims;
             else if (f.kind == FindingKind::BindingState
                      && f.level == FindingLevel::Notice) ++bindingNotices;
             else if (f.kind == FindingKind::OtherSubos
@@ -1241,6 +1285,7 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
             summary += std::format("{} {}", n, what);
         };
         part(anchors, "release anchor");
+        part(anchorShims, "anchor shim");
         part(bindingNotices, "binding notice");
         part(subosNotices, "other-subos notice");
         if (!summary.empty()) {

--- a/tests/e2e/run_all.sh
+++ b/tests/e2e/run_all.sh
@@ -94,6 +94,7 @@ TESTS=(
     "E2E-42 |self_doctor_multi_subos_test.sh||"
     "E2E-43 |declared_programs_verified_test.sh||"
     "E2E-44 |tui_output_contract_test.sh||"
+    "E2E-45 |self_doctor_anchor_shim_test.sh||"
 )
 
 PASS=0; FAIL=0; SOFTFAIL=0

--- a/tests/e2e/self_doctor_anchor_shim_test.sh
+++ b/tests/e2e/self_doctor_anchor_shim_test.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# E2E: install must not write a shim for a name it deliberately left inactive,
+# and the loop that produced must not come back. Issue #452.
+#
+# The setup reproduces the real one (gcc + musl-gcc's gcc-flavor group):
+#
+#   anchor-base    registers program `shared-tool` → active
+#   anchor-flavor  registers  · `anchor-flavor`             (its own entry point)
+#                             · `xim-anchor-root@1.0-flavor` (virtual binding root)
+#                             · `shared-tool@1.0-flavor`     bound to that root
+#
+# Installing anchor-flavor second means its second group already has an active
+# member (`shared-tool`, owned by anchor-base), so registration withholds
+# activation from that whole release — including the root, which nobody else
+# contests. Before this fix the ProgramShim effect wrote a shim for the root
+# anyway, and `self doctor` called the result an `orphan shim` error.
+#
+# Scenarios:
+#   1. install leaves the inactive root with no shim
+#   2. doctor is clean, exit 0
+#   3. an existing home's leftover anchor shim is a notice, not an error
+#   4. --fix removes it
+#   5. CONVERGENCE: the install after --fix does not bring it back
+#
+# S5 is the point. Every earlier fix in this area made one --fix converge;
+# none checked that the next install stayed clean.
+
+set -euo pipefail
+
+# shellcheck source=./project_test_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
+
+require_fixture_index
+
+RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/self_doctor_anchor_shim"
+HOME_DIR="$RUNTIME_DIR/home"
+LOCAL_INDEX_DIR="$RUNTIME_DIR/xim-pkgindex"
+
+cleanup() { rm -rf "$RUNTIME_DIR"; }
+trap cleanup EXIT
+cleanup
+
+XLINGS_BIN="$(find_xlings_bin)"
+
+RUN() {
+  ( cd /tmp && env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@" )
+}
+
+mkdir -p "$HOME_DIR"
+
+cp -r "$FIXTURE_INDEX_DIR" "$LOCAL_INDEX_DIR"
+printf 'xim_indexrepos = {}\n' > "$LOCAL_INDEX_DIR/xim-indexrepos.lua"
+rm -f "$LOCAL_INDEX_DIR/.xlings-index-cache.json"
+mkdir -p "$LOCAL_INDEX_DIR/pkgs/a"
+
+cat > "$LOCAL_INDEX_DIR/pkgs/a/anchor-base.lua" <<'LUA'
+package = {
+    spec = "1",
+    name = "anchor-base",
+    description = "Owns `shared-tool` so the flavor release loses the activation vote",
+    authors = {"xlings-ci"},
+    licenses = {"MIT"},
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"test-fixture"},
+
+    xpm = {
+        linux   = { ["1.0.0"] = {} },
+        macosx  = { ["1.0.0"] = {} },
+        windows = { ["1.0.0"] = {} },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local bindir = path.join(pkginfo.install_dir(), "bin")
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(bindir)
+    io.writefile(path.join(bindir, "shared-tool"), "#!/bin/sh\necho base\n")
+    return true
+end
+
+function config()
+    xvm.add("shared-tool", { bindir = path.join(pkginfo.install_dir(), "bin") })
+    return true
+end
+
+function uninstall()
+    xvm.remove("shared-tool")
+    return true
+end
+LUA
+
+cat > "$LOCAL_INDEX_DIR/pkgs/a/anchor-flavor.lua" <<'LUA'
+package = {
+    spec = "1",
+    name = "anchor-flavor",
+    description = "Publishes a second `shared-tool` flavor under a virtual root",
+    authors = {"xlings-ci"},
+    licenses = {"MIT"},
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"test-fixture"},
+
+    xpm = {
+        linux   = { ["1.0.0"] = {} },
+        macosx  = { ["1.0.0"] = {} },
+        windows = { ["1.0.0"] = {} },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local bindir = path.join(pkginfo.install_dir(), "bin")
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(bindir)
+    io.writefile(path.join(bindir, "anchor-flavor"), "#!/bin/sh\necho flavor\n")
+    io.writefile(path.join(bindir, "shared-tool"), "#!/bin/sh\necho flavor\n")
+    return true
+end
+
+function config()
+    local bindir = path.join(pkginfo.install_dir(), "bin")
+    -- The package's own entry point: its own singleton group, activated
+    -- normally because nothing else owns the name.
+    xvm.add("anchor-flavor", { bindir = bindir })
+
+    -- The flavor subtree. `xim-anchor-root` is a pure anchor: no bindir,
+    -- no alias, nothing to dispatch to. Deliberately registered without
+    -- `type = "group"` — that is the shape the bug needs, and the shape
+    -- three real recipes had when #452 was filed.
+    xvm.add("xim-anchor-root", { version = "1.0.0-flavor" })
+    xvm.add("shared-tool", {
+        bindir  = bindir,
+        version = "1.0.0-flavor",
+        binding = "xim-anchor-root@1.0.0-flavor",
+    })
+    return true
+end
+
+function uninstall()
+    xvm.remove("anchor-flavor")
+    xvm.remove("shared-tool", "1.0.0-flavor")
+    xvm.remove("xim-anchor-root", "1.0.0-flavor")
+    return true
+end
+LUA
+
+mkdir -p "$HOME_DIR/subos/default/bin"
+cp "$XLINGS_BIN" "$HOME_DIR/xlings"
+cat > "$HOME_DIR/.xlings.json" <<EOF
+{
+  "mirror": "GLOBAL",
+  "index_repos": [
+    { "name": "xim", "url": "$LOCAL_INDEX_DIR" }
+  ]
+}
+EOF
+
+log "Initializing sandbox XLINGS_HOME at $HOME_DIR"
+RUN self init >/dev/null 2>&1 || fail "self init failed"
+mkdir -p "$HOME_DIR/data/xim-index-repos"
+printf '{}\n' > "$HOME_DIR/data/xim-index-repos/xim-indexrepos.json"
+
+BIN_DIR="$HOME_DIR/subos/default/bin"
+ROOT_SHIM="$BIN_DIR/xim-anchor-root"
+WS="$HOME_DIR/subos/default/.xlings.json"
+
+active_version_of() {
+  python3 - "$WS" "$1" <<'PY'
+import json, sys, pathlib
+ws = json.loads(pathlib.Path(sys.argv[1]).read_text()).get("workspace") or {}
+print((ws.get(sys.argv[2]) or {}).get("active", ""))
+PY
+}
+
+installed_versions_of() {
+  python3 - "$WS" "$1" <<'PY'
+import json, sys, pathlib
+ws = json.loads(pathlib.Path(sys.argv[1]).read_text()).get("workspace") or {}
+print(",".join((ws.get(sys.argv[2]) or {}).get("installed", [])))
+PY
+}
+
+RUN install anchor-base@1.0.0 -y >/dev/null 2>&1 \
+  || fail "setup: install anchor-base failed"
+[[ -e "$BIN_DIR/shared-tool" ]] || fail "setup: shared-tool shim should exist"
+[[ "$(active_version_of shared-tool)" == "1.0.0" ]] \
+  || fail "setup: anchor-base should own shared-tool"
+
+# ── S1: the inactive root gets no shim ─────────────────────────────
+log "S1: install leaves an inactive binding root without a shim"
+RUN install anchor-flavor@1.0.0 -y >/dev/null 2>&1 \
+  || fail "S1: install anchor-flavor failed"
+
+# Precondition — without this the test proves nothing: the flavor release
+# must actually have lost the activation vote.
+[[ "$(active_version_of xim-anchor-root)" == "" ]] \
+  || fail "S1 precondition: the root was activated, so there is no bug to catch"
+[[ "$(installed_versions_of xim-anchor-root)" == "1.0.0-flavor" ]] \
+  || fail "S1 precondition: the root was not registered at all"
+[[ "$(active_version_of shared-tool)" == "1.0.0" ]] \
+  || fail "S1 precondition: the flavor stole shared-tool from anchor-base"
+
+[[ ! -e "$ROOT_SHIM" ]] \
+  || fail "S1: install wrote a shim for a name with no active version"
+
+# ── S2: doctor is clean ────────────────────────────────────────────
+log "S2: doctor after the install → exit 0, no orphan"
+out=$(RUN self doctor 2>&1) || fail "S2: doctor should exit 0; got:\n$out"
+echo "$out" | grep -q "orphan shim" \
+  && fail "S2: doctor reported an orphan shim; got:\n$out"
+
+# ── S3: a leftover shim from an older client is a notice ───────────
+log "S3: pre-existing anchor shim → notice, not an error"
+ln -sf "$HOME_DIR/xlings" "$ROOT_SHIM"
+[[ -e "$ROOT_SHIM" ]] || fail "S3 setup: could not plant the shim"
+
+out=$(RUN self doctor 2>&1) || fail "S3: an anchor shim must not fail the run; got:\n$out"
+echo "$out" | grep -q "orphan shim" \
+  && fail "S3: an anchor shim was reported as an orphan error; got:\n$out"
+
+out=$(RUN self doctor --all 2>&1) || fail "S3: doctor --all should exit 0; got:\n$out"
+echo "$out" | grep -q "anchor shim" \
+  || fail "S3: --all should name the anchor shim; got:\n$out"
+
+# A real orphan — a program nothing anchors — must still be an error.
+# anchor-flavor's shim is already there; dropping its workspace entry is
+# what makes it an orphan.
+[[ -e "$BIN_DIR/anchor-flavor" ]] || fail "S3 setup: anchor-flavor shim missing"
+python3 - "$WS" <<'PY'
+import json, pathlib, sys
+p = pathlib.Path(sys.argv[1])
+data = json.loads(p.read_text())
+ws = data.get("workspace") or {}
+ws.pop("anchor-flavor", None)
+data["workspace"] = ws
+p.write_text(json.dumps(data))
+PY
+out=$(RUN self doctor 2>&1) || rc=$?; rc=${rc:-0}
+[[ $rc -ne 0 ]] || fail "S3: a genuine orphan shim must still exit non-zero"
+echo "$out" | grep -q "orphan shim" \
+  || fail "S3: a genuine orphan shim must still be reported; got:\n$out"
+
+# ── S4: --fix removes the anchor shim ──────────────────────────────
+log "S4: doctor --fix removes both"
+RUN self doctor --fix >/dev/null 2>&1 || fail "S4: doctor --fix should succeed"
+[[ ! -e "$ROOT_SHIM" ]] || fail "S4: --fix left the anchor shim behind"
+
+# ── S5: convergence ────────────────────────────────────────────────
+log "S5: the install after --fix does not bring it back"
+RUN remove anchor-flavor@1.0.0 -y >/dev/null 2>&1 \
+  || fail "S5: remove anchor-flavor failed"
+RUN install anchor-flavor@1.0.0 -y >/dev/null 2>&1 \
+  || fail "S5: re-install anchor-flavor failed"
+
+[[ ! -e "$ROOT_SHIM" ]] \
+  || fail "S5: the re-install recreated the anchor shim — the loop is still open"
+out=$(RUN self doctor 2>&1) || fail "S5: doctor should be clean after re-install; got:\n$out"
+echo "$out" | grep -q "orphan shim" \
+  && fail "S5: doctor reported an orphan after re-install; got:\n$out"
+
+log "PASS: an inactive binding root gets no shim, and the repair converges"

--- a/tests/unit/test_xvm_bindings.cpp
+++ b/tests/unit/test_xvm_bindings.cpp
@@ -3078,6 +3078,52 @@ TEST(XvmRegistrationTest, InstallDoesNotSplitTheWorkspaceAcrossReleases) {
            "15.1.0 — the workspace now spans two releases";
 }
 
+// The precondition installer.cppm's ProgramShim guard is built on, pinned
+// here so a future change to `activateGroup` cannot quietly turn that guard
+// into dead code.
+//
+// A release that publishes an alternate flavor of an already-active name
+// anchors it on a root of its own -- `xim-musl-gnu-gcc` for musl-gcc's
+// gcc-flavor group. Nothing contests that root, but it is a member of the
+// group that lost the activation vote, so it is registered as installed and
+// never activated. Writing a shim for it was issue #452: the file can only
+// print "no active version", `self doctor` called it an orphan, and `--fix`
+// deleted a file the next install put straight back.
+TEST(XvmRegistrationTest, AnUncontestedRootStillLosesWithItsGroup) {
+    auto glibcGcc = make_registration_node("gcc", "15.1.0");
+    xlings::xvm::VersionDB db;
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+    auto first = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, make_registration_batch({glibcGcc}));
+    ASSERT_TRUE(first.has_value()) << first.error().message;
+    ASSERT_EQ(workspace.at("gcc"), "15.1.0");
+
+    // The flavor release: a virtual root plus the same `gcc` name at a
+    // suffixed version.
+    auto root = make_registration_node("xim-musl-gnu-gcc", "15.1.0-musl");
+    auto flavorGcc = make_registration_node("gcc", "15.1.0-musl");
+    flavorGcc.binding = xlings::xvm::RegistrationBinding{
+        .rootTarget = "xim-musl-gnu-gcc", .rootVersion = "15.1.0-musl"};
+    auto batch = make_registration_batch({root, flavorGcc});
+    batch.providerVersion = "15.1.0-musl";
+
+    auto second = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, batch);
+    ASSERT_TRUE(second.has_value()) << second.error().message;
+
+    EXPECT_EQ(workspace.at("gcc"), "15.1.0")
+        << "the flavor took a name the glibc release still owns";
+    EXPECT_FALSE(workspace.contains("xim-musl-gnu-gcc"))
+        << "the root was activated on its own, splitting the release";
+    const auto& rootVersions = installed.at("xim-musl-gnu-gcc");
+    EXPECT_EQ(rootVersions.size(), 1u);
+    EXPECT_EQ(rootVersions.front(), "15.1.0-musl")
+        << "the root must still be registered — it is what the members bind to";
+    EXPECT_TRUE(xlings::xvm::is_binding_root(
+        db, "xim-musl-gnu-gcc", "15.1.0-musl"));
+}
+
 TEST(XvmRegistrationHeaderTest, UngroupedHeaderFallsBackToThePrimaryTarget) {
     auto program = make_registration_node("openssl", "repo:3.1.5");
     auto library = make_registration_node("libssl", "repo:3.1.5");


### PR DESCRIPTION
Closes #452

## Summary

`xlings install musl-gcc@15`, on a home where the glibc gcc is active, makes
the very next `xlings self doctor` print:

```
✗ orphan shim  @xlings/subos/default/bin/xim-musl-gnu-gcc exists but workspace
               has no active version for xim-musl-gnu-gcc
```

`--fix` deletes the file. The next install recreates it. The user's shell
history is the proof: `--fix` (clean) → `remove` (clean) → `install` (orphan
back).

Four layers, each locally correct, contradict each other:

| layer | what it does | where |
| --- | --- | --- |
| recipe | registers the gcc-flavor binding root as a plain `program` — no bindir, no alias | `xim-pkgindex/pkgs/m/musl-gcc.lua:224` |
| registration | withholds activation from a release whose group already has an active member, sweeping in the release's *private* root | `registration.cppm:921-925` |
| installer | `ProgramShim` creates the file without checking activation — `InstallHeaders` (:1591) and `FileAsset` (:1658) both check | `installer.cppm:1611` |
| doctor | Check 2 calls it an Error, without the binding-root exemption Check 3 applies at :477 | `doctor.cppm:301` |

The shim is dead on arrival — running it can only print
`no active version of 'xim-musl-gnu-gcc' in current subos`.

**Not musl-specific.** Any release introducing a program name its predecessor
lacked hits this. `doctor.cppm:1430-1435` already records the symptom — *"one
llvm re-registration produced 29 orphan shims"* — and works around it with a
phase-3 repair re-run rather than closing the source.

## Changes

- **installer** — a `ProgramShim` effect is skipped when the **name** has no
  active version in this subos. Deliberately about the name, not this version:
  a second version of an active program must not lose the shim its active
  sibling needs. Anything activated later still gets its file — `cmd_use`
  shims every member of the release it switches to (`commands.cppm:433`).
- **doctor** — an orphan shim whose *every* registered version is a binding
  root is a Notice (`anchor shim`), not an Error. `--fix` still removes it; it
  just no longer sets the exit code on homes carrying one through no act of
  the user's. A name with one real program version and one anchor version
  stays an Error.

Registration is **not** changed. `activateGroup` is deliberate and guarded by
`InstallDoesNotSplitTheWorkspaceAcrossReleases`; installing gcc must not take
`cc` away from an active llvm.

## Test plan

`tests/e2e/self_doctor_anchor_shim_test.sh` (wired in as E2E-45) builds the
real shape — one package owning `shared-tool`, a second publishing a flavor of
it under a virtual root — and asserts:

1. install leaves the inactive root with no shim
2. doctor is clean, exit 0
3. a leftover anchor shim is a notice; a *genuine* orphan is still an error
4. `--fix` removes it
5. **convergence** — the install after `--fix` does not bring it back

S5 is the point. Every earlier fix here made one `--fix` converge; none
checked that the next install stayed clean.

Both halves verified load-bearing by reverting them one at a time and
rebuilding:

| binary | result |
| --- | --- |
| pre-fix | S1 fails — install wrote the shim |
| installer fix only | S3 fails — `orphan shims 1`, exit 1 |
| both | PASS |

Also run locally: `mcpp test` (25/25), plus `self_doctor_test.sh`,
`self_doctor_multi_subos_test.sh`, `shim_owner_anchoring_test.sh`,
`declared_programs_verified_test.sh`, `remove_multi_version_test.sh`,
`xvm_group_switch_test.sh`, `xvm_library_switch_test.sh`,
`install_silent_failure_test.sh`, `subos_install_remove_isolation_test.sh` —
all pass.

`unfulfilled_program_promises_` is unaffected: it asks the versions DB
(`has_target`), not the shim files.

## Follow-up (separate repo)

`openxlings/xim-pkgindex`: the three recipes that register a purely virtual
root — `gcc.lua`, `musl-gcc.lua`, `aarch64-linux-musl-gcc.lua` — should
declare `type = "group"`, which emits no shim effect at all. Six recipes
already use that idiom, with the reason written down in `ripgrep.lua:78`.
This PR ships first so the client that meets a group-rooted recipe is the
fixed one.

Design: `.agents/docs/2026-07-29-orphan-shim-inactive-group-root-design.md`