### PR TITLE
fix(xvm,xim): 让 subos 切换真正到达工具链，让 already-installed 分得清平台 (2026.7.30.1)

### DIFF
--- a/.agents/docs/2026-07-30-subos-selection-leak-and-foreign-payload-plan.md
+++ b/.agents/docs/2026-07-30-subos-selection-leak-and-foreign-payload-plan.md
@@ -592,6 +592,20 @@ mcpplibs/libxpkg           不需要改动             ← 方案 2 相对方案
 | **B-1 载荷戳的读写** | 用 `nlohmann::json` | 手写/手读三个字段 | 在 `installer.cppm` 顶部实例化 JSON 解析器触发 GCC 16 modules 故障：`failed to load pendings for 'std::map'`，且报错指名的是**另一个**模块（`xlings.core.xvm.commands`）。同 memory `reference_gcc16_modules_map_ide` 的形状。戳只有三个字符串字段、无用户输入，手写是完备的 |
 | **A-1 归一化规则** | 只处理 `/subos/` 前缀判定 | 追加两条边界修正 | ① Windows 盘符：`:` 是 token 边界，会把 `C:` 切掉并拼出第二个盘符 → 回退两个字符；② 紧贴路径的 flag：`-B/h/.xlings/subos/a` 会把 `-B` 一起吞掉 → 向右推进到路径真正开始处。两条都有单测 |
 
+### 真实环境验证暴露的两个追加问题（B-1 的两次返工）
+
+拿实测 home 的切片跑真实 `install llvm@20.1.7`，第一版 B-1 **判对了却修不好**，而且比原来更糟：
+
+1. **判定层次错了。** 平台校验放在 installer 里，可那时 plan 已经按"已安装"建好 —— **没有下载任何产物**。install 钩子于是空手运行，而 `llvm.lua` 的 `os.tryrm(install_dir)` 把原本还在的载荷删了。
+   → 判定**上移到 catalog 的 `exists && !is_empty` 探针**（`catalog.cppm:368`）—— 正是它让 `installed` 为真、让 plan 为空。异平台载荷现在从计划阶段就不算已装，于是像任何缺失包一样下载重装。分类器因此拆成独立模块 `xim/payload.cppm`（catalog 不能 import installer）。
+2. **戳写早了。** 戳是在 install 块之后**无条件**写的，包括什么都没装的情况。于是上一条那个被清空的目录带上了**本平台的戳**，之后每次运行都信它 —— 自愈变成了自我欺骗。
+   → 只在**确实走过安装路径**（`!payloadInstalled`）且**文件内容不矛盾**时才写；内容判定用 `classify_payload_content`（不读戳），否则一次运行可以自证自话。
+3. **戳本身骗过了空目录探针。** 只含一个戳的目录 `!is_empty` 为真 = "已安装"。
+   → `payload_has_content()` 忽略我方 bookkeeping 文件；`.xim-installed` **故意仍然计入** —— 对 wrapper 包它的含义正是"已装，这里本就没东西"。
+
+**验证结果**（切片，真实 store + 真实网络）：`install llvm@20.1.7` 真的重新下载并安装了 Linux 载荷（`bin/clang -> clang-20`、`clang.cfg` 出现），`.exe/.dll` 注册数 **29 → 0**，`clang`/`clang++`/`cc`/`c++`/`llvm-ar` 都在 20.1.7 上注册，`xlings use clang 20.1.7` 后 `clang --version` 输出 **clang version 20.1.7**。
+首次 install 会在 config 阶段停在既有的 `xvm-owned-group-incomplete` 门禁（旧的 29 条 `.exe` 注册属于同一个 owned group），提示"先 uninstall 再 install"——**这是既有守卫，不是本次引入**；`remove` → `install` 走通全流程。
+
 **交付清单**（xlings 侧 11 个文件）：`db.cppm`(+归一化纯函数) / `shim.cppm`(alias+envs 接入) / `doctor.cppm`(2 个新 finding + 2 条修复) / `installer.cppm`(载荷平台判定+戳) / `xim/commands.cppm`(未激活提示) / `xvm/commands.cppm`(越界告警) / 2 个新 e2e + `run_all.sh` 注册 / 2 个单测文件 +18 个断言 / 版本号。
 
 **测试**：单测 25 文件全绿（新增 `SubosPathNormalizeTest` 10 例、`PayloadPlatformTest` 8 例）；新增 2 个 e2e 均已确认是**真差分**（对 `2026.7.29.2` 的二进制运行会失败，且失败在正确的断言上）；另跑通 10 个回归敏感的既有 e2e。pkgindex 侧 613 个 static 测试全绿，2 个新断言同样确认差分。

--- a/.agents/docs/2026-07-30-subos-selection-leak-and-foreign-payload-plan.md
+++ b/.agents/docs/2026-07-30-subos-selection-leak-and-foreign-payload-plan.md
@@ -1,0 +1,607 @@
+# subos 选择泄漏 与 异平台载荷 —— 修复/优化方案
+
+**日期**: 2026-07-30
+**类型**: 计划 (plan) + 设计 (design)
+**起因**: 用户真实环境现场取证（`g++` 一直对着 `subos/dev-hello` 编译；`install llvm@20.1.7` 报成功但注册了 29 个 Windows `.exe/.dll`）
+**基线**: xlings `518e525` = `2026.7.29.2`；xim-pkgindex `origin/main` `10cf9dbf`
+**涉及仓库**: `openxlings/xlings`、`openxlings/xim-pkgindex`（**不涉及 `mcpplibs/libxpkg`** —— 见 §3.2 方案对比）
+**相关 issue**: [#408](https://github.com/openxlings/xlings/issues/408)（sysroot/bin/lib 多版本共存模型，设计讨论/0.5）、[#419](https://github.com/openxlings/xlings/issues/419)、[#423](https://github.com/openxlings/xlings/issues/423)、[#447](https://github.com/openxlings/xlings/issues/447)（已由 `a71f2a2` 修复）
+
+---
+
+## 0. 摘要与分批策略
+
+现场是两个**互不相关**的缺陷族，共同点只有一个：**"什么都没发生"和"成功了"的输出完全一致**（memory `project_silent_success_pattern`）。
+
+| 族 | 一句话 | 全新装能否复现 |
+|---|---|---|
+| **A. subos 选择泄漏** | 安装时把活动 subos 的**绝对路径**烧进 xvm alias（`g++ --sysroot=/…/subos/dev-hello`），`subos use` 从不重写它 | **能**，且必然 |
+| **B. 异平台载荷谎报成功** | `already-installed` 快路径只检查"目录非空"，5 月遗留的 Windows 载荷完美通过；config 钩子照跑，把 `.exe/.dll` 注册成 program | 缺陷在最新版，但触发需 store 里先有异平台载荷 |
+
+两族**技术上完全独立**，可并行、可分别发布。A 是唯一"任何用户全新装都会踩"的，优先。
+
+| 批次 | 主题 | 仓库 | 独立价值 | 阻塞关系 |
+|---|---|---|---|---|
+| **A-1** | alias 执行期归一化 subos 路径 | xlings | ★ 让 `subos use` 对已装工具链真正生效，且**无需重装即修好所有存量 home** | 无 |
+| **A-2** | `envs` 同源归一化 | xlings | 关掉同一风险的另一半出口 | A-1（复用同一函数） |
+| **A-3** | doctor 报告 + `--fix` 一次性重写 DB | xlings | 让这个状态从"对所有诊断工具隐形"变为可见可清 | A-1（复用同一函数与规则） |
+| **A-4** | 悬空 sysroot 链接的检测与清理 | xlings | 修 #419/#423 残留的现场（3 个指向已删 `/tmp` 的链接） | 无（与 A-3 同一 PR 更省事） |
+| **A-5** | 隔离护栏：拒绝物化指向 `dataDir` 之外的 sysroot 链接 | xlings | 从源头阻止隔离 home 往真实 home 里写链接 | 无 |
+| **B-1** | 载荷平台戳 + `already-installed` 平台校验 | xlings | ★ 异平台/半解压载荷不再被当成"已装好" | 无 |
+| **B-2** | `llvm.lua` 的 `.dll/.exe` 判定改为 payload-gated | xim-pkgindex | Linux 上不再把 `libomp.dll` 注册成 program | 无 |
+| **B-3** | alias 全军覆没 → 安装失败 | xim-pkgindex | 补上 #447 门禁的补集 | 无 |
+| **B-4** | already-installed 但未激活时显式提示 | xlings | silent-success 家族的一条 | 无 |
+
+**发布建议**：A-1..A-5 一个 PR 串（可分 2 个 PR：A-1/A-2 与 A-3/A-4/A-5），随下一个补丁版本发；B-1/B-4 一个 PR；B-2/B-3 pkgindex 一个 PR（注意索引发布滞后，见 §6）。
+
+---
+
+## 1. 现场证据
+
+> 全部为只读取证，未改动用户真实 home。
+
+### 1.1 A 族
+
+`~/.xlings/.xlings.json`（**全 home 共享**的 xvm 库）里 14 条烧死路径：
+
+```json
+"g++": { "versions": { "16.1.0": {
+    "alias": ["g++ --sysroot=/home/speak/.xlings/subos/dev-hello"] }}}
+```
+
+`gcc` / `cc` / `c++` / `x86_64-linux-gnu-{gcc,g++,c++}` 的 15.1.0 与 16.1.0 全是这一条。而同一文件里：
+
+```
+activeSubos = "default"        subos/current -> default
+```
+
+来源 `xim-pkgindex/pkgs/g/gcc.lua:200`：
+
+```lua
+local sysroot_dir = system.subos_sysrootdir()
+local alias_args = ""
+if sysroot_dir and sysroot_dir ~= "" then
+    alias_args = string.format(' --sysroot=%s', sysroot_dir)
+else
+    log.warn("subos dir is empty, skip alias sysroot injection")
+end
+```
+
+`system.subos_sysrootdir()` 的值由 `installer.cppm:805-810` 注入，最终来自 `config.cppm:354-361`：
+
+```cpp
+auto activeSubos = utils::get_env_or_default("XLINGS_ACTIVE_SUBOS");
+if (activeSubos.empty()) { activeSubos = globalActiveSubos_; }
+return paths_.homeDir / "subos" / activeSubos;   // 具体名字，不是 subos/current
+```
+
+**注意 `XLINGS_ACTIVE_SUBOS` 优先于 `activeSubos` 字段** —— 不需要 `subos use --global`，在一个 `subos use dev-hello` spawn 出的子 shell 里 `install gcc` 就足以烧死。
+
+执行侧没有任何逃生口：`shim.cppm:443` `std::string alias_cmd = vdata->alias[0];`，随后原样拼参数 `platform::exec`。`db.cppm:482` 的 `expand_path` 只展开 `${XLINGS_HOME}`，且**只作用于 `vdata.path`，不作用于 `alias`**。`subos.cppm` 全文对 `alias` 只有两处提及，都是 `xvm-alias` 这个内建 shim 名 —— **没有任何 alias 重写、没有 config 钩子重跑**。
+
+诊断侧也看不见：`doctor.cppm:70` 明确写 `alias warning → not auto-fixed (could be intentional external)`，而 `g++` 这条 alias 的**程序名本身可解析**（坏的只有 `--sysroot=` 的目标），所以连 `AliasUnresolved` 警告都不会产生。
+
+**为什么反复卸载重装无效**：`linux-headers` 的 config 落在活动 subos = `default`（输出里也如实写了 `subos: default`），而编译器读的是 `dev-hello`：
+
+```
+subos/default/usr/include/linux   -> ~/.xlings/data/xpkgs/xim-x-linux-headers/5.11.1/include/linux   ✓
+subos/dev-hello/usr/include/linux -> /tmp/tmp.7eGKbPHC46/mcpp-home/registry/data/.../include/linux   ✗ 悬空
+```
+
+两条路径从来没有交集。`dev-hello/usr/include/{linux,asm,asm-generic}` 三个链接（7-29 16:45）全部指向已删除的 `/tmp/tmp.7eGKbPHC46/...` —— 某次**隔离 home 的 mcpp 运行**：registry/载荷被隔离到 `/tmp`，但 subos 路径仍由 `XLINGS_ACTIVE_SUBOS=dev-hello` + **真实 homeDir** 拼出，于是链接物化进了真实 home。这是 A-5 的直接依据。
+
+### 1.2 B 族
+
+```
+$ file ~/.xlings/data/xpkgs/xim-x-llvm/20.1.7/bin/clang.exe
+PE32+ executable (console) x86-64, for MS Windows
+```
+
+`20.1.7/bin` mtime 5-19、`lib` 5-17（几个月前 Windows 目标测试留在真实 store 里的载荷）；`.xpkg.lua` mtime 7-30 12:33（说明 config 钩子跑了，载荷没重解压）。旁证：`22.1.8/bin` 有 `clang.cfg`/`clang++.cfg`，`20.1.7/bin` 一个都没有 —— `install()`（唯一会解压 Linux tarball 并写 `.cfg` 的地方）**从未在 Linux 上执行过**。
+
+`installer.cppm:2213`：
+
+```cpp
+bool payloadInstalled = node.alreadyInstalled;
+```
+
+其 trust-but-verify 兜底只做 `is_directory(expanded) && !is_empty(expanded)` —— **零平台校验**。
+
+`llvm.lua` 两个过滤器都是 host-gated：
+
+```lua
+-- :104  只有 host==windows 才跳过 .dll
+if os.host() == "windows" and name:sub(-4) == ".dll" then return false end
+-- :118  只有 host==windows 才剥掉 .exe
+if os.host() == "windows" and filename:sub(-4):lower() == ".exe" then
+    return filename:sub(1, -5), filename
+end
+```
+
+于是 Linux 上真的注册了 29 个条目，含 `libomp.dll` / `libiomp5md.dll` **作为 program**。`a71f2a2`（#447）加的"注册零个程序即失败"门禁拦不住 —— 它确实注册了 29 个，只不过全是 `.exe`。随后 Linux 的 alias 表（`cc→clang`）在 20.1.7 下找不到 `clang`，六条警告全 fail-open：
+
+```lua
+for _, app in ipairs(aliases) do
+    if os.isfile(path.join(bindir, app.alias)) then
+        xvm.add(app.name, {...})
+    else
+        log.warn("skip xvm add alias (not found): " .. app.name .. " -> " .. app.alias)
+    end
+end
+```
+
+补充：`commands.cppm:365-395` 的 `activate_requested_targets` 只在 `active.empty() || useAfterInstall` 时切换，`clang++` 的活动版本是 22.1.8，所以 20.1.7 **既没生效也没提示没生效**（B-4）。
+
+---
+
+## 2. 缺陷编号与归因
+
+| # | 缺陷 | 位置 | 任务 |
+|---|---|---|---|
+| ① | alias 里烧死 subos 绝对路径，切 subos 无效 | `gcc.lua:200` + `config.cppm:354` + `shim.cppm:443` | A-1 |
+| ② | `envs` 同一风险（gcc 目前注释掉了，llvm 等可能用） | `shim.cppm:295-304` | A-2 |
+| ③ | 该状态对 doctor 完全隐形 | `doctor.cppm:497-554` | A-3 |
+| ④ | 悬空 sysroot 链接无人检测、卸载不清 | 与 #419/#423 重叠 | A-4 |
+| ⑤ | 隔离 home 把链接物化进真实 home | `sysroot.declare_headers` 路径 | A-5 |
+| ⑥ | `already-installed` 不校验载荷平台 | `installer.cppm:2213` | B-1 |
+| ⑦ | `.dll/.exe` 判定 host-gated 而非 payload-gated | `llvm.lua:104,118` | B-2 |
+| ⑧ | alias 全军覆没仍报成功 | `llvm.lua:~420` | B-3 |
+| ⑨ | already-installed 未激活无提示 | `commands.cppm:365-395` | B-4 |
+
+---
+
+## 3. Track A 设计
+
+### 3.1 目标不变量
+
+> **`subos use` 之后，该 home 里所有工具链看到的 sysroot 必须是新 subos 的 sysroot。**
+> 这一点必须在**不重装任何包**的前提下对**存量 home** 成立。
+
+### 3.2 三方案对比（决策：方案 2）
+
+| | 方案 1：recipe 写占位符 | 方案 2：**shim 执行期归一化** | 方案 3：`subos use` 时重写 DB |
+|---|---|---|---|
+| 做法 | `gcc.lua` 写 `--sysroot=${XLINGS_SUBOS}`，shim 展开 | alias/env 里凡指向 `<home>/subos/<X>` 的绝对路径，执行时改指当前活动 subos | `use` 时扫全库改写 alias |
+| 跨仓 | xlings + pkgindex（+ 能力探测） | **仅 xlings** | 仅 xlings |
+| 版本门 | 需要 recipe capability probe（memory `reference_recipe_capability_probe`），否则新 recipe 打旧客户端 | **不需要** | 不需要 |
+| 修存量 home | **修不了**（旧 alias 已烧死，须重装） | **全修**（不重装） | 需要用户主动跑一次 `use` |
+| 三种选择模式（project / env / global）是否都对 | 是（若展开点唯一） | **是**（复用唯一解析点 `Config::xvm_artifact_subos_dir()`） | **不对**：env-spawn 与 project 模式**从不写 DB** |
+| 其他风险 | — | 需要精确的"哪些路径算我们的"规则 | 重复 #443 的整文档重写窗口 |
+
+**方案 2 胜出**：单仓、无版本门、修存量、三模式都对。方案 1 保留为"未来让 recipe 少烧路径"的清洁化，非本次必需。
+
+> 与 #408 的关系：#408 的根因表述是 *"Selection 被复制进别人的产物"*（RPATH / `clang.cfg` / `specs`）。**xvm `alias` 字符串本身是这一族里第四个、也是最便宜的一个** —— 它完全在我们进程内，执行时可重解析。本方案就是 #408 的**单边廉价子集**，不预判 0.5 的整体重设计。
+
+### 3.3 归一化规则（精确）
+
+对一个字符串（alias 命令行 或 env 值）：
+
+1. 找出每一处 `/subos/` 子串（Windows 上同时找 `\subos\`）。
+2. 向左扩到"路径 token"起点：遇到 `空格 \t = : ; , " '` 或串首即停。得到 **prefix**。
+3. **仅当** prefix 等于 `homeDir`，**或** prefix 以 `.xlings` 结尾时才改写；否则原样透传。
+   （后者覆盖 project 模式的 `<projectDir>/.xlings/subos/<name>`，以及 `$HOME` 经软链到达的等价路径。）
+4. 向右取到下一个路径分隔符或 token 边界，得到 **subos 名字段**；空则透传。
+5. 用 `Config::xvm_artifact_subos_dir()` 整体替换 `prefix + "/subos/" + name`，**后缀（如 `/usr/include`）、周围的 flag、引号一律不动**。
+
+**性质**：幂等（已是活动 subos 时替换结果字节相同）；对非我方路径（`/opt/subos/foo`）零影响；对 `--sysroot=` 之外的任何 flag 同样有效（未来 `-I`、`PATH=a:b` 都覆盖）。
+
+**关键选择**：替换目标是 `Config::xvm_artifact_subos_dir()` 而**不是** `subos/current` 符号链接。理由：`xvm_artifact_subos_dir()` 是唯一同时正确处理 project / env / global 三种模式的解析点（`config.cppm:1084-1096`），而 `subos/current` 只反映 global 模式。
+
+---
+
+## 4. Track B 设计
+
+### 4.1 B-1 载荷平台戳
+
+安装钩子成功后，在载荷根目录写 `.xpkg-install.json`：
+
+```json
+{ "os": "linux", "arch": "x86_64", "xlings_version": "2026.7.29.2",
+  "index_ref": "10cf9dbf", "installed_at": "2026-07-30T12:33:11Z" }
+```
+
+`already-installed` 快路径改为：**戳存在且 `os` 与本机一致** 才算已装；不一致 → 重跑 install 钩子。
+
+**存量 home 没有戳**，所以需要一次性启发式，且必须**宁放过不误杀**（误判会触发一次不必要的重装）：探测载荷 `bin/` 下最多 8 个常规文件的魔数 —— ELF `7F 45 4C 46`、PE `4D 5A`、Mach-O `CF FA ED FE`/`FE ED FA CF`。
+
+- 至少一个被识别、且**全部**与本机格式不符 → 判为异平台，重跑 install；
+- 无法识别（脚本、纯数据）或 `bin/` 不存在 → **判为已装**（不动）；
+- 判定后无论结论如何都补写戳，实现自愈（下次不再启发式）。
+
+### 4.2 B-2 payload-gated 过滤
+
+`llvm.lua` 的两个 `os.host() == "windows"` 条件改为看**文件名本身**：`.dll` 永远不是 program（任何 host）；`.exe` 后缀永远剥掉（任何 host）。载荷内容决定语义，不是 host。
+
+### 4.3 B-3 alias 门禁
+
+alias 循环计命中数；`#aliases > 0 且命中 == 0` → `log.error` + `return false`。这是 #447 门禁（"声明了 program 却零注册即失败"）的补集。
+
+---
+
+## 5. 任务拆分（TDD）
+
+> 约定：xlings 侧 `mcpp build` / `mcpp test`（**不用裸 xmake**，memory `reference_build_xlings_via_mcpp`）；单测 gtest + C++23 modules；e2e bash。pkgindex 侧 pytest。
+
+### A-1 alias 执行期归一化 ★
+
+**A-1.1 先写测试**（`tests/unit/test_xvm_shim.cpp` 末尾新增一节）
+
+```cpp
+// ── subos path normalization (2026-07-30) ────────────────────────────
+//
+// An install-time absolute subos path baked into an alias survives every
+// `subos use`, because the versions DB is shared by the whole home and
+// nothing rewrites it. These pin the rewrite that happens at exec time.
+
+namespace {
+std::string norm(const std::string& text,
+                 const std::string& home,
+                 const std::string& active) {
+    return xlings::xvm::normalize_subos_paths(text, home, active);
+}
+}  // namespace
+
+TEST(SubosPathNormalizeTest, RewritesBakedSysrootToActiveSubos) {
+    EXPECT_EQ(norm("g++ --sysroot=/home/u/.xlings/subos/dev-hello",
+                   "/home/u/.xlings", "/home/u/.xlings/subos/default"),
+              "g++ --sysroot=/home/u/.xlings/subos/default");
+}
+
+TEST(SubosPathNormalizeTest, KeepsSuffixAfterSubosName) {
+    EXPECT_EQ(norm("cc -I/home/u/.xlings/subos/dev/usr/include -O2",
+                   "/home/u/.xlings", "/home/u/.xlings/subos/default"),
+              "cc -I/home/u/.xlings/subos/default/usr/include -O2");
+}
+
+TEST(SubosPathNormalizeTest, LeavesForeignSubosPathsAlone) {
+    // A user's own /opt/subos/... is not ours. Byte-identical passthrough.
+    const std::string cmd = "tool --root=/opt/subos/foo/bar";
+    EXPECT_EQ(norm(cmd, "/home/u/.xlings", "/home/u/.xlings/subos/default"),
+              cmd);
+}
+
+TEST(SubosPathNormalizeTest, AcceptsProjectSubosByDotXlingsSuffix) {
+    // Project mode bakes <projectDir>/.xlings/subos/<name>, which is not
+    // under homeDir at all -- the `.xlings` suffix rule is what catches it.
+    EXPECT_EQ(norm("g++ --sysroot=/w/proj/.xlings/subos/anon",
+                   "/home/u/.xlings", "/w/proj/.xlings/subos/dev"),
+              "g++ --sysroot=/w/proj/.xlings/subos/dev");
+}
+
+TEST(SubosPathNormalizeTest, IsIdempotent) {
+    const std::string cmd = "g++ --sysroot=/home/u/.xlings/subos/default";
+    EXPECT_EQ(norm(cmd, "/home/u/.xlings", "/home/u/.xlings/subos/default"),
+              cmd);
+    EXPECT_EQ(norm(norm(cmd, "/home/u/.xlings", "/home/u/.xlings/subos/default"),
+                   "/home/u/.xlings", "/home/u/.xlings/subos/default"),
+              cmd);
+}
+
+TEST(SubosPathNormalizeTest, RewritesEveryOccurrence) {
+    EXPECT_EQ(norm("g++ --sysroot=/h/.xlings/subos/a -B/h/.xlings/subos/a/usr/lib",
+                   "/h/.xlings", "/h/.xlings/subos/b"),
+              "g++ --sysroot=/h/.xlings/subos/b -B/h/.xlings/subos/b/usr/lib");
+}
+
+TEST(SubosPathNormalizeTest, EmptyActiveDirIsNoOp) {
+    // Never rewrite to nothing: an unresolvable active subos must leave the
+    // alias as it was, so the failure names the real path.
+    const std::string cmd = "g++ --sysroot=/h/.xlings/subos/a";
+    EXPECT_EQ(norm(cmd, "/h/.xlings", ""), cmd);
+}
+
+TEST(SubosPathNormalizeTest, HandlesWindowsSeparators) {
+    EXPECT_EQ(norm("g++ --sysroot=C:\\Users\\u\\.xlings\\subos\\dev",
+                   "C:\\Users\\u\\.xlings", "C:\\Users\\u\\.xlings\\subos\\default"),
+              "g++ --sysroot=C:\\Users\\u\\.xlings\\subos\\default");
+}
+```
+
+`mcpp test` → 编译失败（函数不存在）。
+
+**A-1.2 实现**（`src/core/xvm/db.cppm`，紧接 `expand_path` 之后 —— shim / doctor / registration 都已 `import xlings.core.xvm.db`，且此函数不依赖 `Config`，保持纯函数可测）
+
+```cpp
+// ── subos-relative alias/env normalization (2026-07-30) ──────────────
+//
+// `gcc.lua` bakes `--sysroot=<subos_sysrootdir()>` -- the ABSOLUTE path of
+// whichever subos was active at install time -- into the alias. The versions
+// DB is shared by the entire home and `subos use` rewrites nothing, so that
+// path outlives every switch: the user switches to `default` and their g++
+// keeps compiling against `dev-hello`. Re-point such paths at the subos THIS
+// process resolves to, at the moment the alias is executed. Doing it here
+// rather than at install time is what makes existing homes correct without a
+// reinstall.
+//
+// Only provably-ours paths are touched: the segment before /subos/ must be the
+// home itself, or end in `.xlings` (which is how a PROJECT subos --
+// <projectDir>/.xlings/subos/<name>, not under homeDir at all -- is caught).
+// A user's own /opt/subos/foo, the flags around the path, and all quoting come
+// through byte-identical.
+std::string normalize_subos_paths(const std::string& text,
+                                  const std::string& xlings_home,
+                                  const std::string& active_subos_dir) {
+    if (active_subos_dir.empty() || text.empty()) return text;
+
+    static constexpr std::string_view kPosix = "/subos/";
+    static constexpr std::string_view kWin   = "\\subos\\";
+
+    auto is_sep = [](char c) { return c == '/' || c == '\\'; };
+    // Where a path token can start: whitespace, plus the punctuation that
+    // glues a path onto a flag (`--sysroot=`, `-I` is not a boundary but the
+    // preceding space is, `PATH=a:b`, quotes).
+    auto is_boundary = [](char c) {
+        return c == ' ' || c == '\t' || c == '=' || c == ':' || c == ';'
+            || c == ',' || c == '"' || c == '\'';
+    };
+    auto path_equal = [](std::string_view a, std::string_view b) {
+#if defined(_WIN32)
+        if (a.size() != b.size()) return false;
+        for (std::size_t i = 0; i < a.size(); ++i) {
+            char ca = a[i], cb = b[i];
+            if (ca == '\\') ca = '/';
+            if (cb == '\\') cb = '/';
+            ca = static_cast<char>(std::tolower(static_cast<unsigned char>(ca)));
+            cb = static_cast<char>(std::tolower(static_cast<unsigned char>(cb)));
+            if (ca != cb) return false;
+        }
+        return true;
+#else
+        return a == b;
+#endif
+    };
+
+    std::string out;
+    out.reserve(text.size());
+    std::size_t cursor = 0;
+
+    while (cursor < text.size()) {
+        auto p1 = text.find(kPosix, cursor);
+        auto p2 = text.find(kWin, cursor);
+        auto hit = std::min(p1, p2);   // npos is max, so min() picks the real one
+        if (hit == std::string::npos) break;
+
+        // Widen left to the start of the path token.
+        std::size_t start = hit;
+        while (start > cursor && !is_boundary(text[start - 1])) --start;
+        // ':' is a boundary (PATH=a:b), which would cut the drive letter off
+        // `--sysroot=C:\Users\...`: prefix becomes `\Users\u\.xlings` and the
+        // replacement splices a second drive spec onto the surviving `C:`.
+        // Step back over a drive letter that is itself token-initial.
+        if (start >= cursor + 2 && text[start - 1] == ':'
+            && std::isalpha(static_cast<unsigned char>(text[start - 2]))
+            && (start < cursor + 3 || is_boundary(text[start - 3]))) {
+            start -= 2;
+        }
+        std::string_view prefix(text.data() + start, hit - start);
+
+        // Right: the subos NAME segment only.
+        std::size_t nameStart = hit + kPosix.size();
+        std::size_t nameEnd = nameStart;
+        while (nameEnd < text.size()
+               && !is_sep(text[nameEnd]) && !is_boundary(text[nameEnd])) {
+            ++nameEnd;
+        }
+
+        const bool ours =
+            path_equal(prefix, xlings_home)
+            || (prefix.size() >= 7
+                && path_equal(prefix.substr(prefix.size() - 7), ".xlings"));
+
+        if (!ours || nameEnd == nameStart) {
+            out.append(text, cursor, nameEnd - cursor);   // passthrough
+        } else {
+            out.append(text, cursor, start - cursor);
+            out.append(active_subos_dir);
+        }
+        cursor = nameEnd;
+    }
+    out.append(text, cursor, std::string::npos);
+    return out;
+}
+```
+
+`mcpp test` → 8 个断言全绿。
+
+**A-1.3 接入 shim**（`src/core/xvm/shim.cppm:443`）
+
+```cpp
+        // The alias may carry an install-time subos path; re-point it at the
+        // subos this process resolves to (project / env / global all handled
+        // by xvm_artifact_subos_dir).
+        std::string alias_cmd = normalize_subos_paths(
+            vdata->alias[0], xlings_home,
+            Config::xvm_artifact_subos_dir().string());
+```
+
+**A-1.4 e2e 差分测试**（`tests/e2e/subos_alias_sysroot_follows_active_test.sh`）
+
+沿用 `self_doctor_multi_subos_test.sh` 的 fixture-index 模式（`RUN_IN <subos>` + `XLINGS_ACTIVE_SUBOS`）。fixture recipe：
+
+```lua
+package = {
+    spec = "1", name = "sr-probe",
+    description = "alias sysroot normalization fixture",
+    authors = {"xlings-ci"}, licenses = {"MIT"}, type = "package",
+    archs = {"x86_64"}, status = "stable", categories = {"test-fixture"},
+    xpm = { linux = { ["1.0.0"] = {} }, macosx = { ["1.0.0"] = {} },
+            windows = { ["1.0.0"] = {} } },
+}
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
+import("xim.libxpkg.xvm")
+function install()
+    local bindir = path.join(pkginfo.install_dir(), "bin")
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(bindir)
+    -- the alias TARGET: prints whatever sysroot it was handed
+    io.writefile(path.join(bindir, "sr-real"),
+                 "#!/bin/sh\necho \"probe-args: $*\"\n")
+    return true
+end
+function config()
+    local bindir = path.join(pkginfo.install_dir(), "bin")
+    -- exactly what gcc.lua does: bake the install-time absolute subos path
+    xvm.add("sr-probe", {
+        bindir = bindir,
+        alias  = "sr-real --sysroot=" .. system.subos_sysrootdir(),
+    })
+    return true
+end
+function uninstall() xvm.remove("sr-probe") return true end
+```
+
+断言：
+
+```bash
+chmod +x "$HOME_DIR/data/xpkgs/xim-x-sr-probe/1.0.0/bin/sr-real"
+
+# 1) installed while `dev` is active -> the DB really does bake dev
+RUN_IN dev install sr-probe >/dev/null 2>&1 || fail "install failed"
+grep -q '/subos/dev' "$HOME_DIR/.xlings.json" \
+  || fail "precondition lost: the alias no longer bakes the install-time subos"
+
+# 2) THE ASSERTION: running from `default` must target default's sysroot
+out="$(RUN_IN default "$HOME_DIR/subos/default/bin/sr-probe" 2>&1 || true)"
+case "$out" in
+  *"/subos/default"*) : ;;
+  *) fail "shim still targets the install-time subos: $out" ;;
+esac
+case "$out" in
+  *"/subos/dev"*) fail "install-time subos leaked into exec: $out" ;;
+esac
+```
+
+> 差分性要求：**先确认第 1 步的前置条件仍然成立**。否则 recipe 哪天不再烧路径，这个测试就变成不可伪证的空过（memory `reference_isolated_home_test_traps`）。
+> `XLINGS_BIN` 用绝对路径，不要 `find … | head -1`（memory `reference_e2e_xlings_bin_selection`）。
+
+### A-2 `envs` 同源归一化 —— 依赖 A-1
+
+`setup_envs` 增第 4 参 `const std::string& active_subos_dir`，两个调用点（`shim.cppm:441`、`:491`）传 `Config::xvm_artifact_subos_dir().string()`：
+
+```cpp
+    for (auto& [key, value] : vdata.envs) {
+        auto expanded = normalize_subos_paths(
+            expand_path(value, xlings_home), xlings_home, active_subos_dir);
+```
+
+测试：`SubosPathNormalizeTest` 已覆盖纯函数；再加一条 env 路径的单测（`envs = {{"SYSROOT", "/h/.xlings/subos/a"}}` → 读出 `/h/.xlings/subos/b`）。
+（`gcc.lua` 当前的 `envs` 是注释掉的，但 llvm/其他 recipe 随时会用 —— 这是关掉出口，不是修现象。）
+
+### A-3 doctor 可见 + `--fix` 一次性重写 —— 依赖 A-1
+
+1. `FindingKind` 新增 `SubosPathBaked`（`doctor.cppm:92` 附近）；level = **Warning**（不计入退出码：执行期已被 A-1 修正，它是"该清理的历史包袱"，不是"坏了"）。
+2. detect：遍历 DB 每个 `alias[0]` 与每个 `envs` 值，`normalize_subos_paths(...) != 原值` 即命中，报 `target = "<program>@<version>"` 并给出 old→new。
+3. `--fix`：把归一化结果写回 DB。注意 `doctor.cppm:70` 现有策略 `alias warning → not auto-fixed` 说的是 `AliasUnresolved`（可能是有意的外部命令）；`SubosPathBaked` 不同 —— 它的改写目标由我方唯一解析点算出，无歧义，**可以自动修**。这条策略差异必须写进 `doctor.cppm` 头部注释，否则下一个人会以为是漏改。
+4. 写回走既有原子写；**不要**对已 flock 的文件 rename（memory `reference_atomic_write_vs_flock`）。
+
+测试：`tests/unit/test_xvm_doctor.cpp` 加两例（命中 + `--fix` 后 detect 为空，即幂等）。
+
+### A-4 悬空 sysroot 链接 —— 与 #419/#423 重叠
+
+1. detect：遍历 `<subos>/usr/include`、`<subos>/usr/lib` 下的符号链接，`[ -L ] && ! [ -e ]` 即悬空。
+2. `--fix`：删除悬空链接（安全、本地，与 orphan shim 同级）。
+3. **测试必须用 `[ -L ]` + `[ -e ]` 两条**：悬空链接 `[ -e ]` 为假，只用 `-e` 会把"链接还在"读成"已经清干净了" —— #423 的原测试就是这么假过的。
+
+### A-5 隔离护栏
+
+在物化 sysroot 链接的地方，若 link target 不在 `Config::paths().dataDir` 之下（且不在 project 的 data 根之下），拒绝并具名报错。这会直接阻止 `/tmp/tmp.XXXX/mcpp-home/registry/...` 落进真实 home。
+
+测试：单测构造 target 在 dataDir 外 → 期望失败且**磁盘零改动**。
+
+### B-1 载荷平台戳
+
+**测试先行**（`tests/unit/test_xim_install.cpp`）：
+1. 造 `bin/clang.exe`（写入 `MZ` 魔数）的假载荷 + `alreadyInstalled=true` → 期望**判为异平台**（重跑 install）；
+2. 造 `bin/clang`（`\x7fELF`）→ 期望判为已装；
+3. `bin/` 只有 `#!/bin/sh` 脚本 → **inconclusive → 判为已装**（宁放过不误杀）；
+4. 戳存在且 `os` 匹配 → 直接已装，不做魔数探测；
+5. 无戳且判为已装 → **补写了戳**（自愈）。
+
+实现：`installer.cppm:2213` 改为 `bool payloadInstalled = node.alreadyInstalled && payload_matches_host_(expanded);`，成功安装后写戳。
+
+### B-2 / B-3 pkgindex
+
+`pkgs/l/llvm.lua`：去掉两处 `os.host() == "windows" and`；alias 循环加命中计数与失败返回。
+
+pytest（`tests/l/test_llvm.py`，沿用 `parse_xpkg(PKG_FILE)` + `meta.raw_content` + `@pytest.mark.static`）：
+
+```python
+@pytest.mark.static
+def test_dll_filter_is_not_host_gated():
+    src = parse_xpkg(PKG_FILE).raw_content
+    assert 'os.host() == "windows" and name:sub(-4) == ".dll"' not in src, \
+        "a .dll is never a program on any host -- payload decides, not os.host()"
+
+@pytest.mark.static
+def test_alias_loop_fails_when_nothing_registered():
+    src = parse_xpkg(PKG_FILE).raw_content
+    assert "alias_hits" in src and "log.error" in src, \
+        "an alias table where every entry missed must fail the install (#447's complement)"
+```
+
+### B-4 未激活提示
+
+`commands.cppm:394` 的 `"{}@{} is already installed"` 之后，若该 target 有活动版本且不是本次请求的版本，追加一行具名提示 + `--use` 出口。e2e 断言输出里出现该提示。
+
+---
+
+## 6. 跨仓库依赖与发布顺序
+
+```
+openxlings/xlings          A-1 → A-2 → A-3        (A-1 是三者的共同依赖)
+                           A-4, A-5, B-1, B-4     (彼此独立)
+openxlings/xim-pkgindex    B-2, B-3               (独立，可与上面并行)
+mcpplibs/libxpkg           不需要改动             ← 方案 2 相对方案 1 的决定性优势
+```
+
+顺序要点：
+
+1. **A 与 B 无顺序依赖**，可并行合入。
+2. pkgindex 的 B-2/B-3 合并后，CI 仍会拉到**旧索引产物**一段时间（memory `reference_index_publish_lag`）—— 此期间 llvm 相关失败可能是陈旧索引而非新 bug，不要据此回滚。
+3. 若希望 xlings CI 立刻验证新 `llvm.lua`，需同步 bump **6 个 workflow 的 `XIM_PKGINDEX_REF`**（memory `project_ci_index_ref_pin`）。
+4. fresh-install CI 的 llvm 单元格目前是**已知红**（memory `project_fresh_install_ci`）；B-2 可能改变其表现，判读时以"是否仍是同一原因"为准。
+5. PR 合并用 Sunrisepeak 账号 squash + `--admin`（memory `feedback_merge_as_sunrisepeak_bypass_squash`）。
+
+**建议开的 issue**（当前最大号 #453，下一个 ≈ #454）：①②③ 合一（A 族，引用 #408 作为上位设计）、④ 挂到 #419/#423、⑤ 单独一条（隔离泄漏）、⑥⑦⑧ 合一（B 族，引用 #447）、⑨ 单独一条。
+
+---
+
+## 7. 验收标准
+
+| # | 判据 | 方法 |
+|---|---|---|
+| V1 | 全新 home：`subos create dev` → `use dev` → `install gcc` → `use --global default` → `g++` 的 sysroot 指向 **default** | A-1.4 的 e2e |
+| V2 | 存量 home（用户现场）**不重装**即修好 | 从真实 home 切片复现（`.agents/tools/slice-real-home.sh`，memory `reference_repro_from_real_home_slice`），跑 `verify-untouched` |
+| V3 | `xlings self doctor` 报出 14 条烧死 alias；`--fix` 后再 detect 为空且幂等 | A-3 单测 + 切片手测 |
+| V4 | `dev-hello` 的 3 个悬空链接被 doctor 报出并可清 | A-4，断言用 `[ -L ]` + `[ -e ]` |
+| V5 | 隔离 home 的运行**不再**往真实 home 写 sysroot 链接 | A-5 单测 + 一次隔离 mcpp 运行后 `verify-untouched` |
+| V6 | Linux 上 `install llvm@20.1.7`（store 里留着 Windows 载荷）**重跑 install 钩子**，注册的是 `clang` 而非 `clang.exe`；`libomp.dll` 不再是 program | B-1 单测 + 切片手测 |
+| V7 | alias 表全 miss 时安装**失败**（非成功 + 6 条 warn） | B-3 pytest + 一次真实 llvm 安装 |
+| V8 | 六个 workflow 全绿 | CI |
+
+---
+
+## 7.1 实施记录（与计划的偏差）
+
+实施于 2026-07-30，随 `2026.7.30.1` 发布。三处与本文原计划不同，记录理由：
+
+| 项 | 计划 | 实际 | 理由 |
+|---|---|---|---|
+| **A-5 隔离护栏** | 拒绝物化 `dataDir` 之外的 sysroot 链接 | **降级为 warning，仍然物化** | 硬拒绝打掉了 3 个既有单测（`XvmHeaderSymlinkTest`），而它们的 `/tmp` 源路径是合法用法的缩影：recipe 完全可以合法暴露 store 之外的头文件（包装系统头文件是最明显的一种）。拒绝会破坏今天能用的包，与"生态全部可用"直接冲突。**告警在事发当场给出**，而残留由 A-4 清理 —— 这一组合覆盖了实测损害，且不改变任何现有行为 |
+| **B-1 载荷戳的读写** | 用 `nlohmann::json` | 手写/手读三个字段 | 在 `installer.cppm` 顶部实例化 JSON 解析器触发 GCC 16 modules 故障：`failed to load pendings for 'std::map'`，且报错指名的是**另一个**模块（`xlings.core.xvm.commands`）。同 memory `reference_gcc16_modules_map_ide` 的形状。戳只有三个字符串字段、无用户输入，手写是完备的 |
+| **A-1 归一化规则** | 只处理 `/subos/` 前缀判定 | 追加两条边界修正 | ① Windows 盘符：`:` 是 token 边界，会把 `C:` 切掉并拼出第二个盘符 → 回退两个字符；② 紧贴路径的 flag：`-B/h/.xlings/subos/a` 会把 `-B` 一起吞掉 → 向右推进到路径真正开始处。两条都有单测 |
+
+**交付清单**（xlings 侧 11 个文件）：`db.cppm`(+归一化纯函数) / `shim.cppm`(alias+envs 接入) / `doctor.cppm`(2 个新 finding + 2 条修复) / `installer.cppm`(载荷平台判定+戳) / `xim/commands.cppm`(未激活提示) / `xvm/commands.cppm`(越界告警) / 2 个新 e2e + `run_all.sh` 注册 / 2 个单测文件 +18 个断言 / 版本号。
+
+**测试**：单测 25 文件全绿（新增 `SubosPathNormalizeTest` 10 例、`PayloadPlatformTest` 8 例）；新增 2 个 e2e 均已确认是**真差分**（对 `2026.7.29.2` 的二进制运行会失败，且失败在正确的断言上）；另跑通 10 个回归敏感的既有 e2e。pkgindex 侧 613 个 static 测试全绿，2 个新断言同样确认差分。
+
+---
+
+## 8. 不做什么（边界）
+
+- **不做 #408 的整体重设计**。sysroot / bin / lib / 头文件的多版本共存与切换模型仍归 0.5 线。本方案只做其中"alias 里的 selection 副本"这一条，因为它 100% 在我方进程内、执行期可重解析、且能修存量。
+- **不改 `gcc.lua` 的 `--sysroot` 注入方式**（方案 1）。它需要 recipe capability probe 与跨仓协调，而收益（少烧一次路径）在方案 2 落地后接近于零。留作后续清洁化。
+- **不在 `subos use` 时批量重写 DB**（方案 3）。env-spawn 与 project 模式从不写 DB，做了也不对，还多一个整文档重写窗口。
+- **不动 `subos/current` 的现有用途**（`XLINGS_BIN`、shim 发现）。本方案不引入第二套 subos 解析路径 —— 恰恰相反，它把 alias 收拢到已有的唯一解析点 `Config::xvm_artifact_subos_dir()`。
+- **不自动删除异平台载荷目录**。B-1 只是重跑 install 钩子（钩子自己会 `os.tryrm(install_dir())`）；直接 `rm -rf` store 目录属于卸载语义，不该由"已装判定"顺手做。

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlings"
-version = "2026.7.29.2"
+version = "2026.7.30.1"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "2026.7.29.2";
+    static constexpr std::string_view VERSION = "2026.7.30.1";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/xim/catalog.cppm
+++ b/src/core/xim/catalog.cppm
@@ -5,6 +5,7 @@ import mcpplibs.xpkg;
 
 import xlings.core.config;
 import xlings.core.log;
+import xlings.core.xim.payload;
 import xlings.core.xim.index;
 import xlings.core.xim.repo;
 import xlings.core.xim.libxpkg.types.type;
@@ -366,7 +367,19 @@ class PackageCatalog {
                 std::error_code ec;
                 match.installed = std::filesystem::exists(installDir, ec)
                     && std::filesystem::is_directory(installDir, ec)
-                    && !std::filesystem::is_empty(installDir, ec);
+                    && payload_has_content(installDir);
+                // A payload built for another platform is not installed,
+                // whatever the directory looks like. This has to be decided
+                // HERE and not only at install time: `installed` is what
+                // makes the plan empty, and an empty plan downloads nothing,
+                // so a later "reinstall this" has no artifact to install
+                // from. Only a PROVABLE mismatch counts -- Unknown keeps the
+                // fast path, so nothing that works today starts reinstalling.
+                if (match.installed
+                    && classify_payload_platform(installDir)
+                           == PayloadPlatform::Foreign) {
+                    match.installed = false;
+                }
             }
             matches.push_back(std::move(match));
         }

--- a/src/core/xim/commands.cppm
+++ b/src/core/xim/commands.cppm
@@ -377,6 +377,16 @@ int cmd_install(std::span<const std::string> targets, bool yes, bool noDeps,
                     log::warn("failed to activate {}@{} in current subos",
                               match.name, match.version);
                 }
+            } else if (!active.empty() && active != match.version) {
+                // Declining to switch is a decision, and it used to be a
+                // silent one: `install llvm@20.1.7` printed nothing but
+                // success while `clang++` stayed on 22.1.8, so the version
+                // the user asked for was installed and unreachable.
+                log::println(
+                    "{}@{} installed, but '{}' still resolves to {} "
+                    "— `xlings use {} {}` to switch",
+                    match.canonicalName, match.version, match.name, active,
+                    match.name, match.version);
             }
             log::debug("version: {}", match.version);
             if (requestedAlreadyInstalled[plan_key(match)]) {

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -30,6 +30,131 @@ import xlings.runtime.cancellation;
 
 export namespace xlings::xim {
 
+// ── payload platform identity ────────────────────────────────────────
+//
+// "Already installed" used to mean "the directory exists and is not empty".
+// A payload left behind by a run that targeted ANOTHER platform passes that
+// test perfectly, so the install hook -- the only code that unpacks the right
+// tarball -- was skipped, while the config hook ran and registered whatever
+// was lying there. The measured case: a May-era Windows llvm@20.1.7 in a
+// Linux store, which registered `clang.exe` … `libomp.dll` as programs, then
+// warned six times that `cc -> clang` could not be found, and reported
+// success. The payload is stamped on install so the question is answerable;
+// payloads installed before the stamp existed are classified by magic number.
+enum class PayloadPlatform {
+    Host,      // provably this platform
+    Foreign,   // provably some other platform
+    Unknown,   // nothing conclusive -- scripts, data, empty
+};
+
+constexpr std::string_view kPayloadStampFile = ".xpkg-install.json";
+
+std::string_view host_platform_tag() {
+#if defined(_WIN32)
+    return "windows";
+#elif defined(__APPLE__)
+    return "macosx";
+#else
+    return "linux";
+#endif
+}
+
+// Classify one executable by its first bytes. Returns "" when unrecognized.
+std::string_view executable_format_(const std::filesystem::path& file) {
+    std::ifstream in(file, std::ios::binary);
+    if (!in) return "";
+    unsigned char m[4] = {0, 0, 0, 0};
+    in.read(reinterpret_cast<char*>(m), 4);
+    const auto n = in.gcount();
+    if (n >= 4 && m[0] == 0x7F && m[1] == 'E' && m[2] == 'L' && m[3] == 'F')
+        return "linux";
+    if (n >= 2 && m[0] == 'M' && m[1] == 'Z')
+        return "windows";
+    if (n >= 4) {
+        const std::uint32_t w = (std::uint32_t(m[0]) << 24) | (std::uint32_t(m[1]) << 16)
+                              | (std::uint32_t(m[2]) << 8) | std::uint32_t(m[3]);
+        // Mach-O 32/64, both byte orders, plus the fat/universal magic.
+        if (w == 0xFEEDFACEu || w == 0xFEEDFACFu || w == 0xCEFAEDFEu
+            || w == 0xCFFAEDFEu || w == 0xCAFEBABEu || w == 0xBEBAFECAu)
+            return "macosx";
+    }
+    return "";
+}
+
+PayloadPlatform classify_payload_platform(const std::filesystem::path& dir) {
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    if (!fs::is_directory(dir, ec)) return PayloadPlatform::Unknown;
+
+    // The stamp is authoritative when present.
+    if (auto stamp = dir / std::filesystem::path(kPayloadStampFile);
+        fs::is_regular_file(stamp, ec)) {
+        // Read as text rather than through the JSON parser: this function is
+        // the first thing in the module and instantiating the parser here
+        // trips a GCC 16 modules failure ("failed to load pendings for
+        // 'std::map'") whose error message names an unrelated module. The
+        // stamp is written by write_payload_stamp below and has exactly one
+        // shape, so a scan for the field is sufficient and total.
+        auto content = platform::read_file_to_string(stamp.string());
+        if (auto key = content.find("\"os\""); key != std::string::npos) {
+            auto colon = content.find(':', key);
+            auto open = colon == std::string::npos
+                ? std::string::npos : content.find('"', colon);
+            auto close = open == std::string::npos
+                ? std::string::npos : content.find('"', open + 1);
+            if (close != std::string::npos) {
+                const auto recorded =
+                    content.substr(open + 1, close - open - 1);
+                return recorded == host_platform_tag()
+                    ? PayloadPlatform::Host : PayloadPlatform::Foreign;
+            }
+        }
+        {
+            // Unreadable stamp: fall through to the heuristic rather than
+            // treating an unparseable file as a verdict.
+        }
+    }
+
+    // No stamp: sample the payload. Deliberately biased toward Unknown --
+    // a false Foreign costs a needless reinstall of a working package, so
+    // ONE file of the host's own format is enough to settle it, and a
+    // payload of scripts settles nothing.
+    const auto probeDir = fs::is_directory(dir / "bin", ec) ? dir / "bin" : dir;
+    int examined = 0;
+    bool sawForeign = false;
+    for (const auto& entry : platform::dir_entries(probeDir)) {
+        if (examined >= 8) break;
+        std::error_code fec;
+        if (!fs::is_regular_file(entry.path(), fec)) continue;
+        const auto fmt = executable_format_(entry.path());
+        if (fmt.empty()) continue;   // script, data, unrecognized
+        ++examined;
+        if (fmt == host_platform_tag()) return PayloadPlatform::Host;
+        sawForeign = true;
+    }
+    return sawForeign ? PayloadPlatform::Foreign : PayloadPlatform::Unknown;
+}
+
+// Record what this platform installed, so the next run does not have to guess.
+void write_payload_stamp(const std::filesystem::path& dir,
+                         std::string_view version) {
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    if (!fs::is_directory(dir, ec)) return;
+    // An empty install dir belongs to a wrapper package whose real payload
+    // lives elsewhere. Writing here would make it look non-empty, which is
+    // the very signal the installed-probe reads.
+    if (fs::is_empty(dir, ec) || ec) return;
+    // Written by hand for the same reason classify_payload_platform reads by
+    // hand (see there). Three string fields, no user input in any of them.
+    const auto text = std::format(
+        "{{\n  \"os\": \"{}\",\n  \"version\": \"{}\",\n"
+        "  \"xlings_version\": \"{}\"\n}}\n",
+        host_platform_tag(), version, Info::VERSION);
+    platform::write_string_to_file(
+        (dir / std::filesystem::path(kPayloadStampFile)).string(), text);
+}
+
 enum class XpkgRegistrationErrorKind {
     InvalidVersion,
     InvalidBinding,
@@ -2210,10 +2335,29 @@ public:
                 }
             }
 
-            bool payloadInstalled = node.alreadyInstalled;
+            // A payload that belongs to another platform is not installed,
+            // whatever the records say. Only a PROVABLE mismatch overrides
+            // them: Unknown (scripts, data, a type-only package) keeps the
+            // fast path, so nothing that works today starts reinstalling.
+            const auto payloadVerdict =
+                classify_payload_platform(ctx.install_dir);
+            const bool foreignPayload =
+                payloadVerdict == PayloadPlatform::Foreign;
+            if (foreignPayload) {
+                log::warn("{}: installed payload is not for {} — reinstalling",
+                          node.name, host_platform_tag());
+                log::warn("  payload: {}",
+                          Config::display_path(ctx.install_dir));
+            }
+
+            bool payloadInstalled = node.alreadyInstalled && !foreignPayload;
 
             // Check if already installed via hook
-            if (!payloadInstalled && executor.has_hook(mcpplibs::xpkg::HookType::Installed)) {
+            if (foreignPayload) {
+                // The hooks below all answer "is it installed", and every one
+                // of them would say yes about the wrong platform's files.
+            }
+            else if (!payloadInstalled && executor.has_hook(mcpplibs::xpkg::HookType::Installed)) {
                 auto hookResult = executor.check_installed(ctx);
                 if (hookResult.success && !hookResult.version.empty()) {
                     log::debug("{} already installed (version {})",
@@ -2395,6 +2539,15 @@ public:
                 // would make an otherwise empty config directory look
                 // installed.
                 executor.apply_install_stamp_if_empty(ctx);
+            }
+
+            // Record which platform produced this payload. Written on every
+            // path that just installed one, and also when the fast path was
+            // taken and the heuristic had to be consulted -- that second case
+            // is the self-heal: a pre-stamp payload is classified once and
+            // never again.
+            if (node.pkgType != 3 /* Config */) {
+                write_payload_stamp(ctx.install_dir, node.version);
             }
 
             // Apply elfpatch auto-patching if the install hook enabled it

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -6,6 +6,7 @@ import mcpplibs.xpkg.loader;
 import mcpplibs.xpkg.compat;
 import mcpplibs.xpkg.executor;
 import xlings.core.xim.libxpkg.types.type;
+import xlings.core.xim.payload;
 import xlings.core.xim.index;
 import xlings.core.xim.catalog;
 import xlings.core.xim.resolver;
@@ -29,131 +30,6 @@ import xlings.core.xim.libxpkg.types.subos;
 import xlings.runtime.cancellation;
 
 export namespace xlings::xim {
-
-// ── payload platform identity ────────────────────────────────────────
-//
-// "Already installed" used to mean "the directory exists and is not empty".
-// A payload left behind by a run that targeted ANOTHER platform passes that
-// test perfectly, so the install hook -- the only code that unpacks the right
-// tarball -- was skipped, while the config hook ran and registered whatever
-// was lying there. The measured case: a May-era Windows llvm@20.1.7 in a
-// Linux store, which registered `clang.exe` … `libomp.dll` as programs, then
-// warned six times that `cc -> clang` could not be found, and reported
-// success. The payload is stamped on install so the question is answerable;
-// payloads installed before the stamp existed are classified by magic number.
-enum class PayloadPlatform {
-    Host,      // provably this platform
-    Foreign,   // provably some other platform
-    Unknown,   // nothing conclusive -- scripts, data, empty
-};
-
-constexpr std::string_view kPayloadStampFile = ".xpkg-install.json";
-
-std::string_view host_platform_tag() {
-#if defined(_WIN32)
-    return "windows";
-#elif defined(__APPLE__)
-    return "macosx";
-#else
-    return "linux";
-#endif
-}
-
-// Classify one executable by its first bytes. Returns "" when unrecognized.
-std::string_view executable_format_(const std::filesystem::path& file) {
-    std::ifstream in(file, std::ios::binary);
-    if (!in) return "";
-    unsigned char m[4] = {0, 0, 0, 0};
-    in.read(reinterpret_cast<char*>(m), 4);
-    const auto n = in.gcount();
-    if (n >= 4 && m[0] == 0x7F && m[1] == 'E' && m[2] == 'L' && m[3] == 'F')
-        return "linux";
-    if (n >= 2 && m[0] == 'M' && m[1] == 'Z')
-        return "windows";
-    if (n >= 4) {
-        const std::uint32_t w = (std::uint32_t(m[0]) << 24) | (std::uint32_t(m[1]) << 16)
-                              | (std::uint32_t(m[2]) << 8) | std::uint32_t(m[3]);
-        // Mach-O 32/64, both byte orders, plus the fat/universal magic.
-        if (w == 0xFEEDFACEu || w == 0xFEEDFACFu || w == 0xCEFAEDFEu
-            || w == 0xCFFAEDFEu || w == 0xCAFEBABEu || w == 0xBEBAFECAu)
-            return "macosx";
-    }
-    return "";
-}
-
-PayloadPlatform classify_payload_platform(const std::filesystem::path& dir) {
-    namespace fs = std::filesystem;
-    std::error_code ec;
-    if (!fs::is_directory(dir, ec)) return PayloadPlatform::Unknown;
-
-    // The stamp is authoritative when present.
-    if (auto stamp = dir / std::filesystem::path(kPayloadStampFile);
-        fs::is_regular_file(stamp, ec)) {
-        // Read as text rather than through the JSON parser: this function is
-        // the first thing in the module and instantiating the parser here
-        // trips a GCC 16 modules failure ("failed to load pendings for
-        // 'std::map'") whose error message names an unrelated module. The
-        // stamp is written by write_payload_stamp below and has exactly one
-        // shape, so a scan for the field is sufficient and total.
-        auto content = platform::read_file_to_string(stamp.string());
-        if (auto key = content.find("\"os\""); key != std::string::npos) {
-            auto colon = content.find(':', key);
-            auto open = colon == std::string::npos
-                ? std::string::npos : content.find('"', colon);
-            auto close = open == std::string::npos
-                ? std::string::npos : content.find('"', open + 1);
-            if (close != std::string::npos) {
-                const auto recorded =
-                    content.substr(open + 1, close - open - 1);
-                return recorded == host_platform_tag()
-                    ? PayloadPlatform::Host : PayloadPlatform::Foreign;
-            }
-        }
-        {
-            // Unreadable stamp: fall through to the heuristic rather than
-            // treating an unparseable file as a verdict.
-        }
-    }
-
-    // No stamp: sample the payload. Deliberately biased toward Unknown --
-    // a false Foreign costs a needless reinstall of a working package, so
-    // ONE file of the host's own format is enough to settle it, and a
-    // payload of scripts settles nothing.
-    const auto probeDir = fs::is_directory(dir / "bin", ec) ? dir / "bin" : dir;
-    int examined = 0;
-    bool sawForeign = false;
-    for (const auto& entry : platform::dir_entries(probeDir)) {
-        if (examined >= 8) break;
-        std::error_code fec;
-        if (!fs::is_regular_file(entry.path(), fec)) continue;
-        const auto fmt = executable_format_(entry.path());
-        if (fmt.empty()) continue;   // script, data, unrecognized
-        ++examined;
-        if (fmt == host_platform_tag()) return PayloadPlatform::Host;
-        sawForeign = true;
-    }
-    return sawForeign ? PayloadPlatform::Foreign : PayloadPlatform::Unknown;
-}
-
-// Record what this platform installed, so the next run does not have to guess.
-void write_payload_stamp(const std::filesystem::path& dir,
-                         std::string_view version) {
-    namespace fs = std::filesystem;
-    std::error_code ec;
-    if (!fs::is_directory(dir, ec)) return;
-    // An empty install dir belongs to a wrapper package whose real payload
-    // lives elsewhere. Writing here would make it look non-empty, which is
-    // the very signal the installed-probe reads.
-    if (fs::is_empty(dir, ec) || ec) return;
-    // Written by hand for the same reason classify_payload_platform reads by
-    // hand (see there). Three string fields, no user input in any of them.
-    const auto text = std::format(
-        "{{\n  \"os\": \"{}\",\n  \"version\": \"{}\",\n"
-        "  \"xlings_version\": \"{}\"\n}}\n",
-        host_platform_tag(), version, Info::VERSION);
-    platform::write_string_to_file(
-        (dir / std::filesystem::path(kPayloadStampFile)).string(), text);
-}
 
 enum class XpkgRegistrationErrorKind {
     InvalidVersion,
@@ -2386,7 +2262,7 @@ public:
                             vdata->path, Config::paths().homeDir.string());
                         std::error_code ec;
                         payload_ok = std::filesystem::is_directory(expanded, ec)
-                                  && !std::filesystem::is_empty(expanded, ec);
+                                  && payload_has_content(expanded);
                     }
                     if (payload_ok) {
                         log::debug("{} already installed in xvm (version {})",
@@ -2546,7 +2422,16 @@ public:
             // taken and the heuristic had to be consulted -- that second case
             // is the self-heal: a pre-stamp payload is classified once and
             // never again.
-            if (node.pkgType != 3 /* Config */) {
+            // Record which platform produced this payload -- but ONLY after a
+            // path that actually installed one, and only if the files on disk
+            // agree. Stamping unconditionally is worse than not stamping at
+            // all: an install hook that started with os.tryrm(install_dir) and
+            // then had no artifact to unpack (the shape a foreign payload
+            // reaches here in) would leave an empty directory carrying this
+            // platform's stamp, and every later run would believe it.
+            if (!payloadInstalled && node.pkgType != 3 /* Config */
+                && classify_payload_content(ctx.install_dir)
+                       != PayloadPlatform::Foreign) {
                 write_payload_stamp(ctx.install_dir, node.version);
             }
 

--- a/src/core/xim/payload.cppm
+++ b/src/core/xim/payload.cppm
@@ -1,0 +1,165 @@
+export module xlings.core.xim.payload;
+
+import std;
+
+import xlings.platform;
+import xlings.core.config;
+
+export namespace xlings::xim {
+
+// ── payload platform identity ────────────────────────────────────────
+//
+// "Already installed" used to mean "the directory exists and is not empty".
+// A payload left behind by a run that targeted ANOTHER platform passes that
+// test perfectly, so the install hook -- the only code that unpacks the right
+// tarball -- was skipped, while the config hook ran and registered whatever
+// was lying there. The measured case: a May-era Windows llvm@20.1.7 in a
+// Linux store, which registered `clang.exe` … `libomp.dll` as programs, then
+// warned six times that `cc -> clang` could not be found, and reported
+// success. The payload is stamped on install so the question is answerable;
+// payloads installed before the stamp existed are classified by magic number.
+enum class PayloadPlatform {
+    Host,      // provably this platform
+    Foreign,   // provably some other platform
+    Unknown,   // nothing conclusive -- scripts, data, empty
+};
+
+constexpr std::string_view kPayloadStampFile = ".xpkg-install.json";
+
+std::string_view host_platform_tag() {
+#if defined(_WIN32)
+    return "windows";
+#elif defined(__APPLE__)
+    return "macosx";
+#else
+    return "linux";
+#endif
+}
+
+// Classify one executable by its first bytes. Returns "" when unrecognized.
+std::string_view executable_format_(const std::filesystem::path& file) {
+    std::ifstream in(file, std::ios::binary);
+    if (!in) return "";
+    unsigned char m[4] = {0, 0, 0, 0};
+    in.read(reinterpret_cast<char*>(m), 4);
+    const auto n = in.gcount();
+    if (n >= 4 && m[0] == 0x7F && m[1] == 'E' && m[2] == 'L' && m[3] == 'F')
+        return "linux";
+    if (n >= 2 && m[0] == 'M' && m[1] == 'Z')
+        return "windows";
+    if (n >= 4) {
+        const std::uint32_t w = (std::uint32_t(m[0]) << 24) | (std::uint32_t(m[1]) << 16)
+                              | (std::uint32_t(m[2]) << 8) | std::uint32_t(m[3]);
+        // Mach-O 32/64, both byte orders, plus the fat/universal magic.
+        if (w == 0xFEEDFACEu || w == 0xFEEDFACFu || w == 0xCEFAEDFEu
+            || w == 0xCFFAEDFEu || w == 0xCAFEBABEu || w == 0xBEBAFECAu)
+            return "macosx";
+    }
+    return "";
+}
+
+// Whether the payload holds anything besides our own bookkeeping.
+//
+// The emptiness probe ("directory exists and is not empty") is what lets a
+// broken payload be reinstalled at all, and a stamp file would satisfy it on
+// its own -- turning the record of an install into evidence of one. The
+// `.xim-installed` marker is deliberately NOT excluded: wrapper packages
+// whose real payload lives in a dependency use it to mean exactly "installed,
+// nothing here".
+bool payload_has_content(const std::filesystem::path& dir) {
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    if (!fs::is_directory(dir, ec)) return false;
+    for (const auto& entry : platform::dir_entries(dir)) {
+        if (entry.path().filename().string() != kPayloadStampFile) return true;
+    }
+    return false;
+}
+
+// What the FILES say, ignoring any stamp. Separate from the function below
+// because "should this payload be stamped" must never be answered by reading
+// the stamp: a run that wrote one over a payload it did not actually install
+// would then confirm its own claim forever.
+PayloadPlatform classify_payload_content(const std::filesystem::path& dir) {
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    if (!fs::is_directory(dir, ec)) return PayloadPlatform::Unknown;
+
+    const auto probeDir = fs::is_directory(dir / "bin", ec) ? dir / "bin" : dir;
+    int examined = 0;
+    bool sawForeign = false;
+    for (const auto& entry : platform::dir_entries(probeDir)) {
+        if (examined >= 8) break;
+        std::error_code fec;
+        if (!fs::is_regular_file(entry.path(), fec)) continue;
+        const auto fmt = executable_format_(entry.path());
+        if (fmt.empty()) continue;   // script, data, unrecognized
+        ++examined;
+        if (fmt == host_platform_tag()) return PayloadPlatform::Host;
+        sawForeign = true;
+    }
+    return sawForeign ? PayloadPlatform::Foreign : PayloadPlatform::Unknown;
+}
+
+PayloadPlatform classify_payload_platform(const std::filesystem::path& dir) {
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    if (!fs::is_directory(dir, ec)) return PayloadPlatform::Unknown;
+
+    // The stamp is authoritative when present.
+    if (auto stamp = dir / std::filesystem::path(kPayloadStampFile);
+        fs::is_regular_file(stamp, ec)) {
+        // Read as text rather than through the JSON parser: this function is
+        // the first thing in the module and instantiating the parser here
+        // trips a GCC 16 modules failure ("failed to load pendings for
+        // 'std::map'") whose error message names an unrelated module. The
+        // stamp is written by write_payload_stamp below and has exactly one
+        // shape, so a scan for the field is sufficient and total.
+        auto content = platform::read_file_to_string(stamp.string());
+        if (auto key = content.find("\"os\""); key != std::string::npos) {
+            auto colon = content.find(':', key);
+            auto open = colon == std::string::npos
+                ? std::string::npos : content.find('"', colon);
+            auto close = open == std::string::npos
+                ? std::string::npos : content.find('"', open + 1);
+            if (close != std::string::npos) {
+                const auto recorded =
+                    content.substr(open + 1, close - open - 1);
+                return recorded == host_platform_tag()
+                    ? PayloadPlatform::Host : PayloadPlatform::Foreign;
+            }
+        }
+        {
+            // Unreadable stamp: fall through to the heuristic rather than
+            // treating an unparseable file as a verdict.
+        }
+    }
+
+    // No stamp: sample the payload. Deliberately biased toward Unknown --
+    // a false Foreign costs a needless reinstall of a working package, so
+    // ONE file of the host's own format is enough to settle it, and a
+    // payload of scripts settles nothing.
+    return classify_payload_content(dir);
+}
+
+// Record what this platform installed, so the next run does not have to guess.
+void write_payload_stamp(const std::filesystem::path& dir,
+                         std::string_view version) {
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    if (!fs::is_directory(dir, ec)) return;
+    // An empty install dir belongs to a wrapper package whose real payload
+    // lives elsewhere. Writing here would make it look non-empty, which is
+    // the very signal the installed-probe reads.
+    if (fs::is_empty(dir, ec) || ec) return;
+    // Written by hand for the same reason classify_payload_platform reads by
+    // hand (see there). Three string fields, no user input in any of them.
+    const auto text = std::format(
+        "{{\n  \"os\": \"{}\",\n  \"version\": \"{}\",\n"
+        "  \"xlings_version\": \"{}\"\n}}\n",
+        host_platform_tag(), version, Info::VERSION);
+    platform::write_string_to_file(
+        (dir / std::filesystem::path(kPayloadStampFile)).string(), text);
+}
+
+}  // namespace xlings::xim

--- a/src/core/xself/doctor.cppm
+++ b/src/core/xself/doctor.cppm
@@ -68,6 +68,11 @@ namespace fs = std::filesystem;
 //     remove-and-reinstall, then -- when the entry is provably dead and the
 //     ladder could not revive it -- prune the registration.
 //   - alias warning  → not auto-fixed (could be intentional external).
+//   - baked subos path in an alias/env → rewritten to the active subos.
+//     This is NOT the exception above: `alias unresolved` might be a system
+//     command someone meant to call, so guessing is wrong. A baked subos path
+//     has one correct value, computed by the same resolution point the shim
+//     uses, so there is nothing to guess.
 //   - corrupt binding metadata → --reset-metadata only. Why: it is the one
 //     repair that loses information (the release, its members and its header
 //     assets are discarded), so it must be asked for, not inherited from
@@ -90,6 +95,18 @@ enum class FindingKind {
     // name exists purely to anchor the release its libraries belong to.
     ReleaseAnchor,
     AliasUnresolved,
+    // An alias or env value that recorded the ABSOLUTE path of whichever
+    // subos was active when the package was installed. The shim re-points it
+    // at the active subos when it executes, so this is stale bookkeeping
+    // rather than a live breakage -- but the DB still says something untrue,
+    // and it is the only trace left of the homes that shipped with it.
+    SubosPathBaked,
+    // A symlink in the subos sysroot whose target no longer exists. It fails
+    // every `[ -e ]` test, which is exactly why it survived: code that asked
+    // "does it exist" read a dangling link as "already cleaned up", and the
+    // compiler that follows it reports a missing header from a directory the
+    // user can see in the error message.
+    SysrootDangling,
     BindingState,
     OtherSubos,
 };
@@ -494,6 +511,44 @@ Scan detect_(const DoctorState& st, const CoordinateProbe& probe) {
                 continue;
             }
 
+            // An install-time subos path recorded in the alias or an env
+            // value. Detected before the alias/no-alias split because envs
+            // carry it too, and a package with no alias at all still can.
+            if (const auto activeSubos =
+                    Config::xvm_artifact_subos_dir().string();
+                !activeSubos.empty()) {
+                std::vector<std::string> baked;
+                const auto note_if_baked = [&](std::string_view what,
+                                               const std::string& value) {
+                    if (xvm::normalize_subos_paths(value, st.homeStr,
+                                                   activeSubos) != value) {
+                        baked.push_back(std::format("{} '{}'", what, value));
+                    }
+                };
+                if (!vdata.alias.empty()) note_if_baked("alias", vdata.alias[0]);
+                for (const auto& [key, value] : vdata.envs) {
+                    note_if_baked(std::format("env {}", key), value);
+                }
+                if (!baked.empty()) {
+                    std::string list;
+                    for (const auto& b : baked) {
+                        if (!list.empty()) list += ", ";
+                        list += b;
+                    }
+                    add({
+                        .kind    = FindingKind::SubosPathBaked,
+                        .level   = FindingLevel::Warning,
+                        .target  = name,
+                        .version = version,
+                        .detail  = std::format(
+                            "{} records an install-time subos path: {} — "
+                            "execution already follows the active subos; "
+                            "`--fix` rewrites the record",
+                            xvm::display_coordinate(name, version), list),
+                    });
+                }
+            }
+
             const bool aliasMode =
                 !vdata.alias.empty() && !vdata.alias[0].empty();
             if (!aliasMode) {
@@ -588,6 +643,42 @@ Scan detect_(const DoctorState& st, const CoordinateProbe& probe) {
             }
             entries.push_back(std::move(entry));
         }
+        // Dangling links, scanned rather than derived from the workspace.
+        //
+        // The loop above only visits destinations the ACTIVE selection
+        // declares, and the links that matter here are precisely the ones
+        // nothing declares any more: the package was removed, or was
+        // installed by a run whose payload store is gone. Scanning is cheap
+        // (the header farm is one link per top-level entry) and it is the
+        // only way to see them at all.
+        for (const auto& sub : {"usr/include", "usr/lib", "usr/lib64",
+                                "usr/bin"}) {
+            const auto dir = p.subosDir / sub;
+            std::error_code dec;
+            if (!fs::is_directory(dir, dec)) continue;
+            for (const auto& entry : platform::dir_entries(dir)) {
+                std::error_code lec;
+                // Both halves are required. A dangling link IS a symlink and
+                // is NOT `exists()`; testing only existence reads it as
+                // "already gone" -- the mistake that let #423's test pass
+                // while the links were still on disk.
+                if (!fs::is_symlink(entry.path(), lec)) continue;
+                if (fs::exists(entry.path(), lec)) continue;
+                auto target = fs::read_symlink(entry.path(), lec);
+                add({
+                    .kind    = FindingKind::SysrootDangling,
+                    .level   = FindingLevel::Warning,
+                    .detail  = std::format(
+                        "{} points at {}, which does not exist",
+                        Config::display_path(entry.path()),
+                        lec ? std::string("(unreadable)")
+                            : Config::display_path(target)),
+                    .remedy  = "xlings self doctor --fix",
+                    .shimPath = entry.path(),
+                });
+            }
+        }
+
         auto ownership = xvm::inspect_sysroot_ownership(
             st.db, st.ws, entries, (p.dataDir / "xpkgs").string());
         bindingFindings.insert(bindingFindings.end(),
@@ -735,6 +826,20 @@ void repair_local_(const DoctorState& st, const Scan& scan,
                     "could not recreate {}",
                     Config::display_path(f.shimPath)));
             }
+        } else if (f.kind == FindingKind::SysrootDangling) {
+            std::error_code ec;
+            // remove(), not remove_all(): the link is being deleted, and if
+            // it were somehow followable, remove_all would delete the
+            // package payload behind it.
+            fs::remove(f.shimPath, ec);
+            if (!ec) {
+                note(glyph::mark(glyph::bullet, "dangling link removed"),
+                     Config::display_path(f.shimPath));
+            } else {
+                note(glyph::mark(glyph::failed, "sysroot repair failed"),
+                     std::format("could not remove {}",
+                                 Config::display_path(f.shimPath)));
+            }
         } else if (f.kind == FindingKind::OrphanShim
                 || f.kind == FindingKind::LegacyAliasShim) {
             std::error_code ec;
@@ -779,6 +884,69 @@ void repair_state_(RepairReport& out) {
                         xvm::display_coordinate(e.target, e.version),
                         xvm::display_coordinate(e.peerTarget, e.peerVersion)));
                 }
+            }
+        }
+    }
+
+    // Baked subos paths. Rewritten to the subos this run resolves to -- the
+    // same value the shim would substitute at exec time, so the record stops
+    // disagreeing with the behaviour.
+    {
+        const auto homeStr = Config::paths().homeDir.string();
+        const auto activeSubos = Config::xvm_artifact_subos_dir().string();
+        const auto has_baked = [&](const xvm::VersionDB& src) {
+            if (activeSubos.empty()) return false;
+            for (const auto& [name, vinfo] : src) {
+                for (const auto& [version, vdata] : vinfo.versions) {
+                    if (!vdata.alias.empty()
+                        && xvm::normalize_subos_paths(vdata.alias[0], homeStr,
+                                                      activeSubos)
+                               != vdata.alias[0]) {
+                        return true;
+                    }
+                    for (const auto& [k, v] : vdata.envs) {
+                        if (xvm::normalize_subos_paths(v, homeStr, activeSubos)
+                            != v) {
+                            return true;
+                        }
+                    }
+                }
+            }
+            return false;
+        };
+        if (has_baked(Config::versions())) {
+            auto lock = xvm::acquire_state_lock(Config::paths().homeDir);
+            if (!lock) {
+                note(glyph::mark(glyph::failed, "subos path"), std::format(
+                    "cannot rewrite install-time subos paths: {}",
+                    lock.error()));
+            } else {
+                Config::reload_state();
+                auto& mutableDb = Config::versions_mut();
+                std::size_t rewritten = 0;
+                for (auto& [name, vinfo] : mutableDb) {
+                    for (auto& [version, vdata] : vinfo.versions) {
+                        bool touched = false;
+                        for (auto& a : vdata.alias) {
+                            auto fixed = xvm::normalize_subos_paths(
+                                a, homeStr, activeSubos);
+                            if (fixed != a) { a = std::move(fixed); touched = true; }
+                        }
+                        for (auto& [k, v] : vdata.envs) {
+                            auto fixed = xvm::normalize_subos_paths(
+                                v, homeStr, activeSubos);
+                            if (fixed != v) { v = std::move(fixed); touched = true; }
+                        }
+                        if (touched) {
+                            ++rewritten;
+                            note(glyph::mark(glyph::bullet, "subos path"),
+                                 std::format(
+                                     "{} now records the active subos",
+                                     xvm::display_coordinate(name, version)));
+                        }
+                    }
+                }
+                if (rewritten > 0) Config::save_versions();
             }
         }
     }
@@ -1104,6 +1272,7 @@ struct Counts {
 Counts count_(const Scan& scan) {
     Counts c;
     std::set<std::string> aliasTargets;
+    std::set<std::string> bakedTargets;
     for (const auto& f : scan.findings) {
         switch (f.kind) {
             case FindingKind::MissingShim:     ++c.missing; break;
@@ -1125,6 +1294,11 @@ Counts count_(const Scan& scan) {
                 if (aliasTargets.insert(f.target).second) ++c.warnings;
                 break;
             case FindingKind::ReleaseAnchor:   break;
+            // Per TARGET, matching how they are printed (see render_).
+            case FindingKind::SubosPathBaked:
+                if (bakedTargets.insert(f.target).second) ++c.warnings;
+                break;
+            case FindingKind::SysrootDangling: ++c.warnings; break;
             case FindingKind::BindingState:
                 if (f.level != FindingLevel::Notice) ++c.binding;
                 break;
@@ -1208,8 +1382,11 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
     // Everything else, in a stable order.
     std::set<std::string> aliasTargetsShown;
     std::map<std::string, int> aliasVersionCount;
+    std::set<std::string> bakedTargetsShown;
+    std::map<std::string, int> bakedVersionCount;
     for (const auto& f : scan.findings) {
         if (f.kind == FindingKind::AliasUnresolved) ++aliasVersionCount[f.target];
+        else if (f.kind == FindingKind::SubosPathBaked) ++bakedVersionCount[f.target];
     }
     for (const auto& f : scan.findings) {
         switch (f.kind) {
@@ -1240,6 +1417,25 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
                             aliasVersionCount.at(f.target) > 1
                                 ? std::format("  (+{} other version(s))",
                                               aliasVersionCount.at(f.target) - 1)
+                                : std::string{}));
+                }
+                break;
+            case FindingKind::SysrootDangling:
+                add(glyph::mark(glyph::warn, "dangling sysroot link"), f.detail);
+                break;
+            case FindingKind::SubosPathBaked:
+                // One line per TARGET. A single gcc install bakes the path
+                // into fourteen registrations (gcc, g++, cc, c++ and the
+                // triple-prefixed spellings, times two versions), and
+                // fourteen identical lines bury everything else -- the same
+                // reason `alias unresolved` collapses.
+                if (verbose || bakedTargetsShown.insert(f.target).second) {
+                    add(glyph::mark(glyph::warn, "subos path"), verbose
+                        ? f.detail
+                        : std::format("{}{}", f.detail,
+                            bakedVersionCount.at(f.target) > 1
+                                ? std::format("  (+{} other registration(s))",
+                                              bakedVersionCount.at(f.target) - 1)
                                 : std::string{}));
                 }
                 break;

--- a/src/core/xvm/commands.cppm
+++ b/src/core/xvm/commands.cppm
@@ -65,12 +65,53 @@ fs::path header_destination_(const HeaderAsset& asset,
         : sysroot_include / fs::path(asset.destinationPrefix);
 }
 
+// Whether a payload directory may be linked into a sysroot.
+//
+// Everything xlings materializes lives in the home it materializes into --
+// under `data/`, or elsewhere inside the home. A source outside both means the
+// run's payload store and its sysroot belong to DIFFERENT homes, and the link
+// it would leave behind outlives the run that made it: the measured case is an
+// isolated run whose store was a temp dir and whose sysroot was the user's
+// real `~/.xlings/subos/dev-hello`, leaving three header links pointing into a
+// `/tmp` path that no longer exists. Every later `remove` and `install` of the
+// package repaired the OTHER subos and reported success, because nothing was
+// ever wrong there.
+bool sysroot_source_is_local_(const fs::path& src) {
+    std::error_code ec;
+    const auto canon = fs::weakly_canonical(src, ec);
+    const auto& probe = ec ? src : canon;
+    const auto under = [&](const fs::path& root) {
+        if (root.empty()) return false;
+        std::error_code rec;
+        auto canonRoot = fs::weakly_canonical(root, rec);
+        const auto& r = rec ? root : canonRoot;
+        auto a = probe.string(), b = r.string();
+        return a == b || a.starts_with(b + static_cast<char>(fs::path::preferred_separator))
+            || a.starts_with(b + "/");
+    };
+    const auto& p = Config::paths();
+    return under(p.dataDir) || under(p.homeDir);
+}
+
 // Install header symlinks from source includedir into sysroot include/
 void install_headers(const std::string& includedir, const fs::path& sysroot_include) {
     fs::create_directories(sysroot_include);
     std::error_code ec;
     fs::path src(includedir);
     if (!fs::exists(src, ec)) return;
+    if (!sysroot_source_is_local_(src)) {
+        // Warned, not refused. A recipe may legitimately expose headers from
+        // outside the store (a wrapper around system headers is the obvious
+        // one), and refusing would break packages that work today. What is
+        // NOT legitimate is the run that produced the measured damage, and
+        // this is the moment it becomes visible instead of surfacing weeks
+        // later as a missing header from a subos the user is not even in.
+        log::warn("[xvm] linking headers from outside this home: {}",
+                  Config::display_path(src));
+        log::warn("  into sysroot: {}", Config::display_path(sysroot_include));
+        log::warn("  these links outlive the run that made them; "
+                  "`xlings self doctor --fix` removes them once they dangle");
+    }
     for (auto& entry : platform::dir_entries(src)) {
         auto target = sysroot_include / entry.path().filename();
         // Already pointing at this exact source: leave it alone.

--- a/src/core/xvm/db.cppm
+++ b/src/core/xvm/db.cppm
@@ -478,6 +478,123 @@ std::string get_binding(const VersionDB& db,
     return vit->second;
 }
 
+// ── subos-relative alias/env normalization ───────────────────────────
+//
+// `gcc.lua` bakes `--sysroot=<subos_sysrootdir()>` -- the ABSOLUTE path of
+// whichever subos was active at install time -- into the alias. The versions
+// DB is shared by the entire home and `subos use` rewrites nothing, so that
+// path outlives every switch: the user switches to `default` and their g++
+// keeps compiling against `dev-hello`, against a sysroot that may not even
+// exist any more. Re-point such paths at the subos THIS process resolves to,
+// at the moment the alias is executed. Doing it here rather than at install
+// time is what makes existing homes correct without a reinstall.
+//
+// Only provably-ours paths are touched: the segment before /subos/ must be the
+// home itself, or end in `.xlings` (which is how a PROJECT subos --
+// <projectDir>/.xlings/subos/<name>, not under homeDir at all -- is caught).
+// A user's own /opt/subos/foo, the flags around the path, and all quoting come
+// through byte-identical.
+std::string normalize_subos_paths(const std::string& text,
+                                  const std::string& xlings_home,
+                                  const std::string& active_subos_dir) {
+    if (active_subos_dir.empty() || text.empty()) return text;
+
+    static constexpr std::string_view kPosix = "/subos/";
+    static constexpr std::string_view kWin   = "\\subos\\";
+
+    auto is_sep = [](char c) { return c == '/' || c == '\\'; };
+    // Where a path token can start: whitespace, plus the punctuation that
+    // glues a path onto a flag (`--sysroot=`, `PATH=a:b`, quotes).
+    auto is_boundary = [](char c) {
+        return c == ' ' || c == '\t' || c == '=' || c == ':' || c == ';'
+            || c == ',' || c == '"' || c == '\'';
+    };
+    auto is_alpha = [](char c) {
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+    };
+    auto path_equal = [](std::string_view a, std::string_view b) {
+#if defined(_WIN32)
+        // Windows compares paths case-insensitively and treats / and \ alike.
+        if (a.size() != b.size()) return false;
+        auto fold = [](char c) -> char {
+            if (c == '\\') return '/';
+            if (c >= 'A' && c <= 'Z') return static_cast<char>(c - 'A' + 'a');
+            return c;
+        };
+        for (std::size_t i = 0; i < a.size(); ++i) {
+            if (fold(a[i]) != fold(b[i])) return false;
+        }
+        return true;
+#else
+        return a == b;
+#endif
+    };
+
+    std::string out;
+    out.reserve(text.size());
+    std::size_t cursor = 0;
+
+    while (cursor < text.size()) {
+        auto p1 = text.find(kPosix, cursor);
+        auto p2 = text.find(kWin, cursor);
+        auto hit = std::min(p1, p2);   // npos is max, so min() picks the real one
+        if (hit == std::string::npos) break;
+
+        // Widen left to the start of the path token.
+        std::size_t start = hit;
+        while (start > cursor && !is_boundary(text[start - 1])) --start;
+        // ':' is a boundary (PATH=a:b), which would cut the drive letter off
+        // `--sysroot=C:\Users\...`: the prefix becomes `\Users\u\.xlings` and
+        // the replacement splices a second drive spec onto the surviving `C:`.
+        // Step back over a drive letter that is itself token-initial.
+        if (start >= cursor + 2 && text[start - 1] == ':'
+            && is_alpha(text[start - 2])
+            && (start < cursor + 3 || is_boundary(text[start - 3]))) {
+            start -= 2;
+        }
+        // A flag can sit flush against the path with no boundary between them
+        // (`-B/h/.xlings/subos/a`), and the walk above happily swallows it.
+        // Skip forward to where the path actually begins -- a separator, or a
+        // drive letter -- so the replacement never eats the flag.
+        const bool drive =
+            start + 1 < hit && is_alpha(text[start]) && text[start + 1] == ':';
+        if (!drive) {
+            while (start < hit && !is_sep(text[start])) {
+                if (start + 1 < hit && is_alpha(text[start])
+                    && text[start + 1] == ':') {
+                    break;   // `-BC:\...`
+                }
+                ++start;
+            }
+        }
+        std::string_view prefix(text.data() + start, hit - start);
+
+        // Right: the subos NAME segment only. Everything after it (`/usr/
+        // include`, …) is the caller's business and is preserved.
+        std::size_t nameStart = hit + kPosix.size();
+        std::size_t nameEnd = nameStart;
+        while (nameEnd < text.size()
+               && !is_sep(text[nameEnd]) && !is_boundary(text[nameEnd])) {
+            ++nameEnd;
+        }
+
+        const bool ours =
+            path_equal(prefix, xlings_home)
+            || (prefix.size() >= 7
+                && path_equal(prefix.substr(prefix.size() - 7), ".xlings"));
+
+        if (!ours || nameEnd == nameStart) {
+            out.append(text, cursor, nameEnd - cursor);   // passthrough
+        } else {
+            out.append(text, cursor, start - cursor);
+            out.append(active_subos_dir);
+        }
+        cursor = nameEnd;
+    }
+    out.append(text, cursor, std::string::npos);
+    return out;
+}
+
 // Expand ${XLINGS_HOME} in a path string
 std::string expand_path(const std::string& path, const std::string& xlings_home) {
     std::string result = path;

--- a/src/core/xvm/shim.cppm
+++ b/src/core/xvm/shim.cppm
@@ -294,10 +294,14 @@ std::optional<std::string> merge_shim_env_value(const std::string& expanded,
 // Set environment variables for a program before exec
 void setup_envs(const VData& vdata,
                 const std::string& resolved_path,
-                const std::string& xlings_home) {
+                const std::string& xlings_home,
+                const std::string& active_subos_dir) {
     // Set envs from VData
     for (auto& [key, value] : vdata.envs) {
-        auto expanded = expand_path(value, xlings_home);
+        // Same hazard as the alias: an env value recorded at install time can
+        // name that install's subos. Re-point it at the active one.
+        auto expanded = normalize_subos_paths(
+            expand_path(value, xlings_home), xlings_home, active_subos_dir);
         auto existing = std::string(std::getenv(key.c_str()) ? std::getenv(key.c_str()) : "");
         if (auto merged = merge_shim_env_value(expanded, existing))
             platform::set_env_variable(key, *merged);
@@ -339,6 +343,9 @@ int shim_dispatch(const std::string& program_name, int argc, char* argv[]) {
 
     auto& cfg = Config::paths();
     auto xlings_home = cfg.homeDir.string();
+    // The one resolution point that is correct in all three selection modes
+    // (project subos > XLINGS_ACTIVE_SUBOS > the home's activeSubos field).
+    auto active_subos_dir = Config::xvm_artifact_subos_dir().string();
 
     // Get effective workspace (project > subos > global)
     auto workspace = Config::effective_workspace();
@@ -438,9 +445,14 @@ int shim_dispatch(const std::string& program_name, int argc, char* argv[]) {
         platform::set_env_variable("PATH", new_path);
 
         // Setup custom envs
-        setup_envs(*vdata, "", xlings_home);
+        setup_envs(*vdata, "", xlings_home, active_subos_dir);
 
-        std::string alias_cmd = vdata->alias[0];
+        // The alias may carry the absolute path of whatever subos was active
+        // when the package was installed (gcc.lua bakes `--sysroot=<subos>`).
+        // Re-point it at the subos THIS process resolves to -- project, env
+        // and global selection all land on xvm_artifact_subos_dir().
+        std::string alias_cmd = normalize_subos_paths(
+            vdata->alias[0], xlings_home, active_subos_dir);
 
         if (depth >= MAX_SHIM_DEPTH) {
             // Fallback: resolve alias command to full path to break recursion
@@ -488,7 +500,7 @@ int shim_dispatch(const std::string& program_name, int argc, char* argv[]) {
     log::debug("exe path: {}", exe_path.string());
 
     // Setup environment
-    setup_envs(*vdata, exe_path.string(), xlings_home);
+    setup_envs(*vdata, exe_path.string(), xlings_home, active_subos_dir);
 
     // Build argv for execvp
     auto exe_str = exe_path.string();

--- a/tests/e2e/foreign_payload_reinstall_test.sh
+++ b/tests/e2e/foreign_payload_reinstall_test.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# foreign_payload_reinstall_test.sh — a payload that belongs to another
+# platform is not "already installed".
+#
+# `already installed` used to mean "the directory exists and is not empty". A
+# payload left behind by a run that targeted another platform passes that test
+# perfectly, so the install hook -- the only code that unpacks the right
+# tarball -- was skipped, while the CONFIG hook ran and registered whatever was
+# lying there. The measured case: a May-era Windows llvm@20.1.7 in a Linux
+# store, which registered `clang.exe` … `libomp.dll` as programs, warned six
+# times that `cc -> clang` could not be found, and reported success.
+#
+# Refs: .agents/docs/2026-07-30-subos-selection-leak-and-foreign-payload-plan.md
+set -euo pipefail
+
+# shellcheck source=./project_test_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
+
+require_fixture_index
+
+RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/foreign_payload"
+HOME_DIR="$RUNTIME_DIR/home"
+LOCAL_INDEX_DIR="$RUNTIME_DIR/xim-pkgindex"
+
+cleanup() {
+  chmod -R u+w "$RUNTIME_DIR" 2>/dev/null || true
+  rm -rf "$RUNTIME_DIR"
+}
+trap cleanup EXIT
+cleanup
+
+XLINGS_BIN="$(find_xlings_bin)"
+
+RUN() {
+  ( cd /tmp && env -i HOME="$HOME" PATH=/usr/bin:/bin \
+      XLINGS_HOME="$HOME_DIR" XLINGS_ACTIVE_SUBOS=default \
+      "$XLINGS_BIN" "$@" )
+}
+
+mkdir -p "$HOME_DIR/subos/default/bin" "$RUNTIME_DIR"
+cp -r "$FIXTURE_INDEX_DIR" "$LOCAL_INDEX_DIR"
+printf 'xim_indexrepos = {}\n' > "$LOCAL_INDEX_DIR/xim-indexrepos.lua"
+rm -f "$LOCAL_INDEX_DIR/.xlings-index-cache.json"
+mkdir -p "$LOCAL_INDEX_DIR/pkgs/f"
+
+cat > "$LOCAL_INDEX_DIR/pkgs/f/fp-probe.lua" <<'LUA'
+package = {
+    spec = "1", name = "fp-probe",
+    description = "foreign payload fixture",
+    authors = {"xlings-ci"}, licenses = {"MIT"}, type = "package",
+    archs = {"x86_64"}, status = "stable", categories = {"test-fixture"},
+    xpm = {
+        linux   = { ["1.0.0"] = {} },
+        macosx  = { ["1.0.0"] = {} },
+        windows = { ["1.0.0"] = {} },
+    },
+}
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+function install()
+    local bindir = path.join(pkginfo.install_dir(), "bin")
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(bindir)
+    io.writefile(path.join(bindir, "fp-tool"), "#!/bin/sh\necho native\n")
+    return true
+end
+function config()
+    xvm.add("fp-probe", { bindir = path.join(pkginfo.install_dir(), "bin") })
+    return true
+end
+function uninstall() xvm.remove("fp-probe") return true end
+LUA
+
+cp "$XLINGS_BIN" "$HOME_DIR/xlings"
+cat > "$HOME_DIR/.xlings.json" <<JSON
+{ "mirror": "GLOBAL",
+  "index_repos": [{ "name": "xim", "url": "$LOCAL_INDEX_DIR" }] }
+JSON
+
+log "init sandbox"
+RUN self init >/dev/null 2>&1 || fail "self init failed"
+
+log "F1: first install stamps the payload"
+RUN install fp-probe >/dev/null 2>&1 || fail "install failed"
+PAYLOAD="$(dirname "$(find "$HOME_DIR/data/xpkgs" -name fp-tool -type f | head -1)")"
+[[ -n "$PAYLOAD" ]] || fail "F1: payload not installed"
+PKG_DIR="$(dirname "$PAYLOAD")"
+[[ -f "$PKG_DIR/.xpkg-install.json" ]] \
+  || fail "F1: no platform stamp written"
+grep -q '"os"' "$PKG_DIR/.xpkg-install.json" \
+  || fail "F1: stamp has no os field"
+
+# ── F2: a foreign payload is reinstalled ─────────────────────────────
+#
+# Replace the payload with something from another platform and drop the
+# stamp, exactly as a store carried over from another machine would look.
+log "F2: a foreign payload is not 'already installed'"
+rm -f "$PKG_DIR/.xpkg-install.json"
+rm -f "$PAYLOAD/fp-tool"
+printf 'MZ\220\0\0\0\0\0\0\0\0\0\0\0\0\0' > "$PAYLOAD/fp-tool.exe"
+
+out="$(RUN install fp-probe 2>&1 || true)"
+grep -qi "not for" <<<"$out" \
+  || fail "F2: no warning about the foreign payload; got:\n$out"
+[[ -f "$PAYLOAD/fp-tool" ]] \
+  || fail "F2: install hook did not re-run (native binary still missing)"
+[[ ! -f "$PAYLOAD/fp-tool.exe" ]] \
+  || fail "F2: the foreign payload survived the reinstall"
+[[ -f "$PKG_DIR/.xpkg-install.json" ]] \
+  || fail "F2: the reinstall left no stamp"
+
+# ── F3: a stamped native payload takes the fast path ─────────────────
+#
+# The check must not turn every repeat install into a reinstall: that would
+# trade one silent wrong answer for a loud slow one.
+log "F3: a stamped payload is still 'already installed'"
+printf 'sentinel\n' > "$PAYLOAD/keep-me"
+out="$(RUN install fp-probe 2>&1 || true)"
+grep -q "already installed" <<<"$out" \
+  || fail "F3: a stamped native payload should short-circuit; got:\n$out"
+[[ -f "$PAYLOAD/keep-me" ]] \
+  || fail "F3: the install hook re-ran and wiped the payload"
+
+log "PASS: foreign_payload_reinstall"

--- a/tests/e2e/run_all.sh
+++ b/tests/e2e/run_all.sh
@@ -95,6 +95,8 @@ TESTS=(
     "E2E-43 |declared_programs_verified_test.sh||"
     "E2E-44 |tui_output_contract_test.sh||"
     "E2E-45 |self_doctor_anchor_shim_test.sh||"
+    "E2E-46 |subos_alias_sysroot_test.sh||"
+    "E2E-47 |foreign_payload_reinstall_test.sh||"
 )
 
 PASS=0; FAIL=0; SOFTFAIL=0

--- a/tests/e2e/subos_alias_sysroot_test.sh
+++ b/tests/e2e/subos_alias_sysroot_test.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# subos_alias_sysroot_test.sh — an alias that baked a subos path at install
+# time must follow the ACTIVE subos at execution time.
+#
+# `gcc.lua` writes `g++ --sysroot=<system.subos_sysrootdir()>` into the xvm
+# alias: the absolute path of whichever subos was active when gcc was
+# installed. The versions DB is shared by the whole home and `subos use`
+# rewrites nothing, so that path outlives every switch -- the user switches to
+# `default` and their g++ keeps compiling against `dev`'s sysroot, which may
+# not even exist any more. Nothing in doctor sees it either: the alias's
+# PROGRAM resolves fine, only its --sysroot argument points somewhere stale.
+#
+# The fixture reproduces exactly that shape (bake at install, execute later
+# from another subos) with a probe that prints the arguments it was handed.
+#
+# Refs: .agents/docs/2026-07-30-subos-selection-leak-and-foreign-payload-plan.md
+set -euo pipefail
+
+# shellcheck source=./project_test_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
+
+require_fixture_index
+
+RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/subos_alias_sysroot"
+HOME_DIR="$RUNTIME_DIR/home"
+LOCAL_INDEX_DIR="$RUNTIME_DIR/xim-pkgindex"
+
+cleanup() {
+  # The copied index carries read-only git objects; make them removable.
+  chmod -R u+w "$RUNTIME_DIR" 2>/dev/null || true
+  rm -rf "$RUNTIME_DIR"
+}
+trap cleanup EXIT
+cleanup
+
+XLINGS_BIN="$(find_xlings_bin)"
+
+# Every command names the subos it runs in: this test is entirely about which
+# subos a thing happens in, so there is no default form.
+RUN_IN() {
+  local subos="$1"; shift
+  ( cd /tmp && env -i HOME="$HOME" PATH=/usr/bin:/bin \
+      XLINGS_HOME="$HOME_DIR" XLINGS_ACTIVE_SUBOS="$subos" \
+      "$XLINGS_BIN" "$@" )
+}
+
+# Execute a shim (not the CLI) with a named active subos. `""` means "no
+# XLINGS_ACTIVE_SUBOS at all", i.e. selection falls to the persisted field.
+RUN_SHIM() {
+  local subos="$1" shim="$2"; shift 2
+  if [[ -n "$subos" ]]; then
+    ( cd /tmp && env -i HOME="$HOME" PATH=/usr/bin:/bin \
+        XLINGS_HOME="$HOME_DIR" XLINGS_ACTIVE_SUBOS="$subos" "$shim" "$@" )
+  else
+    ( cd /tmp && env -i HOME="$HOME" PATH=/usr/bin:/bin \
+        XLINGS_HOME="$HOME_DIR" "$shim" "$@" )
+  fi
+}
+
+mkdir -p "$HOME_DIR/subos/default/bin" "$RUNTIME_DIR"
+cp -r "$FIXTURE_INDEX_DIR" "$LOCAL_INDEX_DIR"
+printf 'xim_indexrepos = {}\n' > "$LOCAL_INDEX_DIR/xim-indexrepos.lua"
+rm -f "$LOCAL_INDEX_DIR/.xlings-index-cache.json"
+mkdir -p "$LOCAL_INDEX_DIR/pkgs/s"
+
+# sr-probe registers an alias onto a DIFFERENT real binary (sr-real) so the
+# shim is not recursive, and bakes the install-time sysroot into it -- byte
+# for byte what gcc.lua does.
+cat > "$LOCAL_INDEX_DIR/pkgs/s/sr-probe.lua" <<'LUA'
+package = {
+    spec = "1", name = "sr-probe",
+    description = "alias sysroot normalization fixture",
+    authors = {"xlings-ci"}, licenses = {"MIT"}, type = "package",
+    archs = {"x86_64"}, status = "stable", categories = {"test-fixture"},
+    xpm = {
+        linux   = { ["1.0.0"] = {} },
+        macosx  = { ["1.0.0"] = {} },
+        windows = { ["1.0.0"] = {} },
+    },
+}
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.system")
+import("xim.libxpkg.xvm")
+function install()
+    local bindir = path.join(pkginfo.install_dir(), "bin")
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(bindir)
+    io.writefile(path.join(bindir, "sr-real"),
+                 "#!/bin/sh\necho \"probe-args: $*\"\n")
+    return true
+end
+function config()
+    local bindir = path.join(pkginfo.install_dir(), "bin")
+    xvm.add("sr-probe", {
+        bindir = bindir,
+        alias  = "sr-real --sysroot=" .. system.subos_sysrootdir(),
+    })
+    return true
+end
+function uninstall()
+    xvm.remove("sr-probe")
+    return true
+end
+LUA
+
+cp "$XLINGS_BIN" "$HOME_DIR/xlings"
+cat > "$HOME_DIR/.xlings.json" <<JSON
+{ "mirror": "GLOBAL",
+  "index_repos": [{ "name": "xim", "url": "$LOCAL_INDEX_DIR" }] }
+JSON
+
+log "init sandbox"
+RUN_IN default self init >/dev/null 2>&1 || fail "self init failed"
+RUN_IN default subos new dev >/dev/null 2>&1 || fail "subos new dev failed"
+
+# ── the real-world sequence ──────────────────────────────────────────
+#
+#   1. install in `default`      → alias bakes default, default's workspace
+#                                  and shim exist
+#   2. install in `dev`          → payload already there, but the CONFIG hook
+#                                  re-runs and rewrites the SHARED alias to
+#                                  dev; dev gets its own workspace + shim
+#   3. work in `default` again   → default's shim runs, and used to hand the
+#                                  compiler dev's sysroot
+log "install sr-probe in 'default', then in 'dev'"
+RUN_IN default install sr-probe >/dev/null 2>&1 || fail "install in default failed"
+RUN_IN dev install sr-probe >/dev/null 2>&1 || fail "install in dev failed"
+
+PAYLOAD_BIN="$(find "$HOME_DIR/data/xpkgs" -name sr-real -type f | head -1)"
+[[ -n "$PAYLOAD_BIN" ]] || fail "payload not installed"
+chmod +x "$PAYLOAD_BIN"
+
+# Precondition. Without this the test is unfalsifiable: if the recipe ever
+# stops baking the path, every assertion below passes for the wrong reason.
+grep -q '/subos/dev' "$HOME_DIR/.xlings.json" \
+  || fail "precondition lost: the alias no longer bakes the install-time subos"
+
+# ── A1: run from 'dev' — the baseline, must target dev ───────────────
+log "A1: executing under 'dev' targets dev's sysroot"
+out="$(RUN_SHIM dev "$HOME_DIR/subos/dev/bin/sr-probe" 2>&1 || true)"
+grep -q "$HOME_DIR/subos/dev" <<<"$out" \
+  || fail "A1: running in its own subos must target it; got:\n$out"
+
+# ── A2: THE ASSERTION — the same shim under a different active subos ─
+#
+# Same DB entry, same baked alias, different active subos. Which shim FILE is
+# invoked is irrelevant: dispatch resolves the program by name out of the
+# home-wide DB, so this is the same code path a user hits after switching.
+# Before the exec-time normalization this printed dev's sysroot regardless.
+log "A2: executing under 'default' must target default's sysroot"
+[[ -x "$HOME_DIR/subos/default/bin/sr-probe" ]] || fail "A2: no shim in default"
+out="$(RUN_SHIM default "$HOME_DIR/subos/default/bin/sr-probe" 2>&1 || true)"
+grep -q "$HOME_DIR/subos/default" <<<"$out" \
+  || fail "A2: shim still targets the install-time subos; got:\n$out"
+if grep -q "$HOME_DIR/subos/dev/" <<<"$out"; then
+  fail "A2: the install-time subos leaked into execution; got:\n$out"
+fi
+
+# ── A2b: the same, selected by the persisted field instead of the env ─
+#
+# XLINGS_ACTIVE_SUBOS and the home config's activeSubos are two different
+# selection modes and only one of them is set in A2. `subos use --global`
+# exercises the other, with no env var in sight.
+log "A2b: selection via the persisted activeSubos field"
+RUN_IN default subos use --global default >/dev/null 2>&1 \
+  || fail "subos use --global default failed"
+out="$(RUN_SHIM "" "$HOME_DIR/subos/default/bin/sr-probe" 2>&1 || true)"
+grep -q "$HOME_DIR/subos/default" <<<"$out" \
+  || fail "A2b: persisted selection ignored; got:\n$out"
+
+# ── A3: the DB is not rewritten ──────────────────────────────────────
+#
+# Normalization is an exec-time read, not a migration. The recorded alias
+# stays as installed -- that is what makes this correct for a home whose
+# subos selection differs per shell (XLINGS_ACTIVE_SUBOS) or per project.
+log "A3: the stored alias is untouched"
+grep -q '/subos/dev' "$HOME_DIR/.xlings.json" \
+  || fail "A3: exec-time normalization must not rewrite the DB"
+
+# ── A4: doctor sees it ───────────────────────────────────────────────
+#
+# Until now this state was invisible to every diagnostic: the alias's PROGRAM
+# resolves, so `alias unresolved` never fired, and nothing else looked at the
+# arguments at all.
+log "A4: doctor reports the baked path"
+out="$(RUN_IN default self doctor 2>&1 || true)"
+grep -q "subos path" <<<"$out" \
+  || fail "A4: doctor is silent about the baked subos path; got:\n$out"
+
+# It is a warning, not an error: execution is already correct.
+RUN_IN default self doctor >/dev/null 2>&1 \
+  || fail "A4: a baked path must not fail the doctor run"
+
+# ── A5: --fix rewrites it, and is idempotent ─────────────────────────
+log "A5: doctor --fix rewrites the record"
+RUN_IN default self doctor --fix >/dev/null 2>&1 \
+  || fail "A5: doctor --fix failed"
+if grep -q "/subos/dev\"" "$HOME_DIR/.xlings.json"; then
+  fail "A5: --fix left the baked path in the DB"
+fi
+out="$(RUN_IN default self doctor 2>&1 || true)"
+if grep -q "subos path" <<<"$out"; then
+  fail "A5: the finding survived --fix; got:\n$out"
+fi
+
+# The probe must still work after the rewrite.
+out="$(RUN_SHIM default "$HOME_DIR/subos/default/bin/sr-probe" 2>&1 || true)"
+grep -q "$HOME_DIR/subos/default" <<<"$out" \
+  || fail "A5: the rewritten alias no longer targets the active subos:\n$out"
+
+# ── A6: a dangling sysroot link is seen and removed ──────────────────
+#
+# The measured shape: an isolated run materialized header links into the real
+# home's subos and then deleted its own payload store, leaving links into a
+# /tmp path that no longer exists. `[ -e ]` says they are gone; the compiler
+# following them says otherwise.
+log "A6: dangling sysroot links"
+mkdir -p "$HOME_DIR/subos/default/usr/include"
+ln -s "$RUNTIME_DIR/gone/linux" "$HOME_DIR/subos/default/usr/include/linux"
+[[ -L "$HOME_DIR/subos/default/usr/include/linux" ]] \
+  || fail "A6: fixture link not created"
+if [[ -e "$HOME_DIR/subos/default/usr/include/linux" ]]; then
+  fail "A6: fixture link must be dangling"
+fi
+
+out="$(RUN_IN default self doctor 2>&1 || true)"
+grep -q "dangling sysroot link" <<<"$out" \
+  || fail "A6: doctor missed the dangling link; got:\n$out"
+
+RUN_IN default self doctor --fix >/dev/null 2>&1 \
+  || fail "A6: doctor --fix failed"
+# Both halves, again: a link that is still there fails -e too.
+if [[ -L "$HOME_DIR/subos/default/usr/include/linux" ]]; then
+  fail "A6: --fix left the dangling link on disk"
+fi
+
+log "PASS: subos_alias_sysroot"

--- a/tests/unit/test_xim_install.cpp
+++ b/tests/unit/test_xim_install.cpp
@@ -22,6 +22,7 @@ import xlings.core.xim.index;
 import xlings.core.xim.catalog;
 import xlings.core.xim.resolver;
 import xlings.core.xim.downloader;
+import xlings.core.xim.payload;
 import xlings.core.xim.installer;
 import xlings.core.xim.commands;
 import xlings.core.xim.repo;
@@ -631,5 +632,39 @@ TEST(PayloadPlatformTest, StampIsNotWrittenIntoAnEmptyPayload) {
     fs::create_directories(dir);
     pp::write_payload_stamp(dir, "1.0.0");
     EXPECT_TRUE(fs::is_empty(dir));
+    fs::remove_all(dir);
+}
+
+TEST(PayloadPlatformTest, AStampAloneIsNotAPayload) {
+    // The emptiness probe is what lets a broken payload be reinstalled. If a
+    // stamp satisfied it on its own, the record of an install would become
+    // evidence of one -- measured: a hook that began with
+    // os.tryrm(install_dir), found no artifact to unpack, and left a
+    // directory containing nothing but this platform's stamp.
+    auto dir = fs::temp_directory_path() / "xlings-payload-stamp-only";
+    fs::remove_all(dir);
+    fs::create_directories(dir);
+    xlings::platform::write_string_to_file(
+        (dir / ".xpkg-install.json").string(), "{\n  \"os\": \"linux\"\n}\n");
+    EXPECT_FALSE(pp::payload_has_content(dir));
+
+    // The legacy wrapper marker means the opposite and must still count.
+    xlings::platform::write_string_to_file((dir / ".xim-installed").string(), "");
+    EXPECT_TRUE(pp::payload_has_content(dir));
+    fs::remove_all(dir);
+}
+
+TEST(PayloadPlatformTest, ContentClassificationIgnoresTheStamp) {
+    // "Should this payload be stamped" must never be answered by reading the
+    // stamp, or a run that wrote one over a payload it did not install would
+    // confirm its own claim forever.
+    auto dir = make_payload_dir("content-vs-stamp");
+    write_foreign_executable(dir / "bin" / "tool.exe");
+    xlings::platform::write_string_to_file(
+        (dir / ".xpkg-install.json").string(),
+        std::string("{\n  \"os\": \"") + std::string(pp::host_platform_tag())
+            + "\"\n}\n");
+    EXPECT_EQ(pp::classify_payload_platform(dir), pp::PayloadPlatform::Host);
+    EXPECT_EQ(pp::classify_payload_content(dir), pp::PayloadPlatform::Foreign);
     fs::remove_all(dir);
 }

--- a/tests/unit/test_xim_install.cpp
+++ b/tests/unit/test_xim_install.cpp
@@ -508,3 +508,128 @@ TEST(XimAddXpkgTest, FlatPkgsDirNotIndexed) {
 
     fs::remove_all(testDir);
 }
+
+// ── payload platform identity (2026-07-30) ───────────────────────────
+//
+// "Already installed" used to mean "the directory exists and is not empty",
+// which a payload built for another platform passes perfectly. The measured
+// case was a Windows llvm@20.1.7 sitting in a Linux store: the install hook
+// was skipped, the config hook ran anyway, and `libomp.dll` was registered as
+// a program while `cc -> clang` warned six times and the command reported
+// success.
+
+namespace {
+
+namespace pp = xlings::xim;
+namespace fs = std::filesystem;
+
+fs::path make_payload_dir(const std::string& name) {
+    auto dir = fs::temp_directory_path() / ("xlings-payload-" + name);
+    fs::remove_all(dir);
+    fs::create_directories(dir / "bin");
+    return dir;
+}
+
+void write_bytes(const fs::path& file, std::initializer_list<unsigned char> b) {
+    std::ofstream out(file, std::ios::binary);
+    for (auto c : b) out.put(static_cast<char>(c));
+    // Pad so the file is a plausible executable, not a 4-byte curiosity.
+    for (int i = 0; i < 64; ++i) out.put('\0');
+}
+
+// A magic number that is NOT this host's, whatever this host is.
+void write_foreign_executable(const fs::path& file) {
+    if (pp::host_platform_tag() == "windows") {
+        write_bytes(file, {0x7F, 'E', 'L', 'F'});          // an ELF on Windows
+    } else {
+        write_bytes(file, {'M', 'Z', 0x90, 0x00});         // a PE anywhere else
+    }
+}
+
+void write_host_executable(const fs::path& file) {
+    if (pp::host_platform_tag() == "windows") {
+        write_bytes(file, {'M', 'Z', 0x90, 0x00});
+    } else if (pp::host_platform_tag() == "macosx") {
+        write_bytes(file, {0xCF, 0xFA, 0xED, 0xFE});
+    } else {
+        write_bytes(file, {0x7F, 'E', 'L', 'F'});
+    }
+}
+
+}  // namespace
+
+TEST(PayloadPlatformTest, ForeignExecutablesAreDetected) {
+    auto dir = make_payload_dir("foreign");
+    write_foreign_executable(dir / "bin" / "clang.exe");
+    EXPECT_EQ(pp::classify_payload_platform(dir), pp::PayloadPlatform::Foreign);
+    fs::remove_all(dir);
+}
+
+TEST(PayloadPlatformTest, HostExecutablesAreAccepted) {
+    auto dir = make_payload_dir("host");
+    write_host_executable(dir / "bin" / "clang");
+    EXPECT_EQ(pp::classify_payload_platform(dir), pp::PayloadPlatform::Host);
+    fs::remove_all(dir);
+}
+
+TEST(PayloadPlatformTest, OneHostBinaryOutweighsForeignCompanions) {
+    // Cross-compilers legitimately ship the other platform's artifacts. A
+    // false Foreign costs a needless reinstall, so any host-format file
+    // settles it.
+    auto dir = make_payload_dir("mixed");
+    write_foreign_executable(dir / "bin" / "target-tool.exe");
+    write_host_executable(dir / "bin" / "driver");
+    EXPECT_EQ(pp::classify_payload_platform(dir), pp::PayloadPlatform::Host);
+    fs::remove_all(dir);
+}
+
+TEST(PayloadPlatformTest, ScriptsAreInconclusive) {
+    // A payload of shell scripts says nothing about its platform, and must
+    // NOT be reinstalled on that basis.
+    auto dir = make_payload_dir("scripts");
+    xlings::platform::write_string_to_file(
+        (dir / "bin" / "tool").string(), "#!/bin/sh\necho hi\n");
+    EXPECT_EQ(pp::classify_payload_platform(dir), pp::PayloadPlatform::Unknown);
+    fs::remove_all(dir);
+}
+
+TEST(PayloadPlatformTest, MissingDirectoryIsInconclusive) {
+    EXPECT_EQ(pp::classify_payload_platform(
+                  fs::temp_directory_path() / "xlings-payload-absent"),
+              pp::PayloadPlatform::Unknown);
+}
+
+TEST(PayloadPlatformTest, StampBeatsTheHeuristic) {
+    // The stamp is what the payload's own install wrote. A host-format file
+    // that arrived some other way must not overrule it.
+    auto dir = make_payload_dir("stamped-foreign");
+    write_host_executable(dir / "bin" / "tool");
+    xlings::platform::write_string_to_file(
+        (dir / ".xpkg-install.json").string(),
+        "{\n  \"os\": \"plan9\",\n  \"version\": \"1.0.0\"\n}\n");
+    EXPECT_EQ(pp::classify_payload_platform(dir), pp::PayloadPlatform::Foreign);
+    fs::remove_all(dir);
+}
+
+TEST(PayloadPlatformTest, WrittenStampRoundTrips) {
+    auto dir = make_payload_dir("roundtrip");
+    write_foreign_executable(dir / "bin" / "tool.exe");
+    ASSERT_EQ(pp::classify_payload_platform(dir), pp::PayloadPlatform::Foreign);
+    // Self-heal: once this platform installs it, the heuristic is never
+    // consulted again.
+    pp::write_payload_stamp(dir, "1.0.0");
+    EXPECT_EQ(pp::classify_payload_platform(dir), pp::PayloadPlatform::Host);
+    fs::remove_all(dir);
+}
+
+TEST(PayloadPlatformTest, StampIsNotWrittenIntoAnEmptyPayload) {
+    // Wrapper packages (linux-headers, fromsource:* aliases) legitimately
+    // leave install_dir empty; a stamp would make the emptiness probe read
+    // "installed".
+    auto dir = fs::temp_directory_path() / "xlings-payload-empty";
+    fs::remove_all(dir);
+    fs::create_directories(dir);
+    pp::write_payload_stamp(dir, "1.0.0");
+    EXPECT_TRUE(fs::is_empty(dir));
+    fs::remove_all(dir);
+}

--- a/tests/unit/test_xvm_shim.cpp
+++ b/tests/unit/test_xvm_shim.cpp
@@ -690,3 +690,89 @@ TEST_F(ShimCreateTest, CleanupLegacyAliasShimsRemovesOnlyMatchingSymlinks) {
     }
 #endif
 }
+
+// ── subos path normalization (2026-07-30) ────────────────────────────
+//
+// An install-time absolute subos path baked into an alias survives every
+// `subos use`, because the versions DB is shared by the whole home and nothing
+// rewrites it: the user switches to `default` and their g++ keeps compiling
+// against `dev-hello`. These pin the rewrite that happens at exec time.
+
+namespace {
+std::string norm(const std::string& text,
+                 const std::string& home,
+                 const std::string& active) {
+    return xlings::xvm::normalize_subos_paths(text, home, active);
+}
+}  // namespace
+
+TEST(SubosPathNormalizeTest, RewritesBakedSysrootToActiveSubos) {
+    EXPECT_EQ(norm("g++ --sysroot=/home/u/.xlings/subos/dev-hello",
+                   "/home/u/.xlings", "/home/u/.xlings/subos/default"),
+              "g++ --sysroot=/home/u/.xlings/subos/default");
+}
+
+TEST(SubosPathNormalizeTest, KeepsSuffixAfterSubosName) {
+    EXPECT_EQ(norm("cc -I/home/u/.xlings/subos/dev/usr/include -O2",
+                   "/home/u/.xlings", "/home/u/.xlings/subos/default"),
+              "cc -I/home/u/.xlings/subos/default/usr/include -O2");
+}
+
+TEST(SubosPathNormalizeTest, LeavesForeignSubosPathsAlone) {
+    // A user's own /opt/subos/... is not ours. Byte-identical passthrough.
+    const std::string cmd = "tool --root=/opt/subos/foo/bar";
+    EXPECT_EQ(norm(cmd, "/home/u/.xlings", "/home/u/.xlings/subos/default"),
+              cmd);
+}
+
+TEST(SubosPathNormalizeTest, AcceptsProjectSubosByDotXlingsSuffix) {
+    // Project mode bakes <projectDir>/.xlings/subos/<name>, which is not under
+    // homeDir at all -- the `.xlings` suffix rule is what catches it.
+    EXPECT_EQ(norm("g++ --sysroot=/w/proj/.xlings/subos/anon",
+                   "/home/u/.xlings", "/w/proj/.xlings/subos/dev"),
+              "g++ --sysroot=/w/proj/.xlings/subos/dev");
+}
+
+TEST(SubosPathNormalizeTest, IsIdempotent) {
+    const std::string cmd = "g++ --sysroot=/home/u/.xlings/subos/default";
+    auto once = norm(cmd, "/home/u/.xlings", "/home/u/.xlings/subos/default");
+    EXPECT_EQ(once, cmd);
+    EXPECT_EQ(norm(once, "/home/u/.xlings", "/home/u/.xlings/subos/default"),
+              cmd);
+}
+
+TEST(SubosPathNormalizeTest, RewritesEveryOccurrence) {
+    EXPECT_EQ(norm("g++ --sysroot=/h/.xlings/subos/a -B/h/.xlings/subos/a/usr/lib",
+                   "/h/.xlings", "/h/.xlings/subos/b"),
+              "g++ --sysroot=/h/.xlings/subos/b -B/h/.xlings/subos/b/usr/lib");
+}
+
+TEST(SubosPathNormalizeTest, EmptyActiveDirIsNoOp) {
+    // Never rewrite to nothing: an unresolvable active subos must leave the
+    // alias as it was, so any failure names the real path.
+    const std::string cmd = "g++ --sysroot=/h/.xlings/subos/a";
+    EXPECT_EQ(norm(cmd, "/h/.xlings", ""), cmd);
+}
+
+TEST(SubosPathNormalizeTest, HandlesPathListSeparators) {
+    // A colon-separated list is two tokens, and only the ours-prefixed one
+    // may move.
+    EXPECT_EQ(norm("/h/.xlings/subos/a/bin:/opt/subos/x/bin",
+                   "/h/.xlings", "/h/.xlings/subos/b"),
+              "/h/.xlings/subos/b/bin:/opt/subos/x/bin");
+}
+
+TEST(SubosPathNormalizeTest, HandlesWindowsSeparators) {
+    // The drive letter must survive: ':' is a token boundary, so without the
+    // drive-letter step-back the prefix would be `\Users\u\.xlings` and the
+    // result would splice a second drive spec onto the surviving `C:`.
+    EXPECT_EQ(norm("g++ --sysroot=C:\\Users\\u\\.xlings\\subos\\dev",
+                   "C:\\Users\\u\\.xlings", "C:\\Users\\u\\.xlings\\subos\\default"),
+              "g++ --sysroot=C:\\Users\\u\\.xlings\\subos\\default");
+}
+
+TEST(SubosPathNormalizeTest, LeavesTrailingSubosMarkerAlone) {
+    // A path that ends at the marker has no name segment to replace.
+    const std::string cmd = "tool --dir=/h/.xlings/subos/";
+    EXPECT_EQ(norm(cmd, "/h/.xlings", "/h/.xlings/subos/b"), cmd);
+}


### PR DESCRIPTION
## 现象（来自真实环境）

两个互不相关的缺陷，共同点只有一个：**"什么都没发生"和"成功了"输出完全一致**。

```
$ g++ -std=c++20 -fmodules -c bits/std.cc
/home/speak/.xlings/subos/dev-hello/usr/include/bits/local_lim.h:38:10:
fatal error: linux/limits.h: No such file or directory
$ xlings remove xim:linux-headers     # ✓ removed  (subos: default)
$ xlings install xim:linux-headers    # ✓ 1 package(s) installed
$ g++ ...                             # 一模一样的错误
```

```
$ xlings install llvm@20.1.7
xim:llvm@20.1.7 is already installed
[WARN] skip xvm add alias (not found): cc -> clang      (×6)
$ clang++ --version                   # 还是系统的 18.1.3
```

## A. subos 切换从来没有到达工具链

`gcc.lua` 把 `--sysroot=<system.subos_sysrootdir()>` 写进 xvm alias —— 安装那一刻活动 subos 的**绝对路径**。versions DB 是全 home 共享的，而 `subos use` 不重写任何 alias，于是这个路径活过了每一次切换。实测 home 上 14 条注册指向 `subos/dev-hello`，而 `activeSubos` 是 `default`；每次 `remove/install linux-headers` 修的都是 `default` —— 编译器没在读的那个 —— 然后报告成功。

没有任何诊断能看见它：alias 的**程序名**是可解析的，所以 `alias unresolved` 从不触发，而没有任何检查看过参数。

**修法：在执行期归一化，而不是在安装期。** `normalize_subos_paths` 把任何 `<home 或 *.xlings>/subos/<name>` 前缀重指到 `Config::xvm_artifact_subos_dir()` —— project / `XLINGS_ACTIVE_SUBOS` / 持久化字段三种选择模式唯一都正确的解析点 —— 其余部分（别人的路径、flag、引号）逐字节不变。

放在这里的三个理由：
1. **存量 home 不重装即修好**（安装期方案改不了已经烧死的记录）；
2. **不需要改 recipe，也不需要 libxpkg 版本门**（对比"占位符"方案要做 capability probe）；
3. **三种选择模式都对**（对比"`use` 时重写 DB"：env-spawn 与 project 模式从不写 DB）。

顺带：
- `envs` 同样处理，风险同源；
- doctor 报告这条记录（warning —— 执行已经正确了），`--fix` 重写它。与 `alias unresolved` 不同，它只有一个正确值，没有可猜的成分；
- doctor 检测并清理**悬空 sysroot 符号链接**。断言用 `-L` 和 `-e` 两条：悬空链接 `-e` 为假，正是 #423 的测试把"还在"读成"已清干净"的原因；
- 从 home 之外物化头文件时当场告警，点名那些会活过本次运行的链接。

## B. "already installed" 分不清平台

它的含义是"目录存在且非空" —— 一个为别的平台构建的载荷完美通过。5 月留在 Linux store 里的 Windows `llvm@20.1.7` 因此跳过了 install 钩子（唯一会解压正确 tarball 的地方），而 **config 钩子照跑**，把 `clang.exe` … `libomp.dll` 注册成 program，然后六条 `cc -> clang` 警告，报告成功。

现在载荷会被打上安装平台的戳；**可证明**属于别的平台的载荷会重装。无戳的存量载荷用魔数分类一次，然后补戳，所以启发式对每个包最多跑一次。判定刻意偏向"不确定"：一个本平台格式的文件即可定论，一堆脚本什么都不定论 —— 误判的代价是把能用的包白装一遍。

顺带：`install <pkg>@<ver>` 决定不切换活动版本时会明说，并给出切换命令。以前它打印成功，而用户要的版本仍然不可达。

## 测试

| | 内容 |
|---|---|
| 单测 | `SubosPathNormalizeTest` 10 例（含 Windows 盘符、紧贴 flag、幂等、非我方路径原样透传）、`PayloadPlatformTest` 8 例 |
| e2e | `subos_alias_sysroot_test.sh` (E2E-46)、`foreign_payload_reinstall_test.sh` (E2E-47) |
| 差分 | 两个 e2e 对 `2026.7.29.2` 的二进制运行**都失败**，且失败在各自该失败的断言上 |
| 回归 | 25 个单测文件全绿；另本地跑通 10 个回归敏感的既有 e2e（doctor 多 subos、install 幂等、group/library 切换、project 等） |

## 跨仓

配套的 recipe 侧修复：openxlings/xim-pkgindex#454（`.dll`/`.exe` 判定改为 payload-gated，alias 全 miss 即失败）。两边**无顺序依赖**。libxpkg 不需要改动。

方案文档：`.agents/docs/2026-07-30-subos-selection-leak-and-foreign-payload-plan.md`
Refs: #408, #419, #423, #447
