### PR TITLE
fix(xvm,doctor): make effective_kind the only reader of an entry's kind

### DIFF
--- a/src/core/xself/doctor.cppm
+++ b/src/core/xself/doctor.cppm
@@ -301,7 +301,8 @@ Scan detect_(const DoctorState& st, const CoordinateProbe& probe) {
     for (const auto& [name, version] : st.ws) {
         if (version.empty()) continue;
         const auto* vi = xvm::get_vinfo(st.db, name);
-        if (!vi || vi->type != "program") continue;
+        if (!vi || xvm::effective_kind_of(st.db, name, version) != "program")
+            continue;
 
         auto shimPath = p.binDir / shim_filename_(name);
         if (fs::exists(shimPath) || fs::is_symlink(shimPath)) continue;
@@ -345,8 +346,10 @@ Scan detect_(const DoctorState& st, const CoordinateProbe& probe) {
             if (!shim_ext_.empty() && base.ends_with(shim_ext_)) {
                 base = base.substr(0, base.size() - shim_ext_.size());
             }
+            // Only a shim file name is in hand here, so the question is
+            // widened to "any version of this name is a program".
             const auto* vi = xvm::get_vinfo(st.db, base);
-            if (!vi || vi->type != "program") continue;
+            if (!vi || !xvm::has_program_kind(st.db, base)) continue;
 
             auto wit = st.ws.find(base);
             if (wit != st.ws.end() && !wit->second.empty()) continue;
@@ -421,8 +424,7 @@ Scan detect_(const DoctorState& st, const CoordinateProbe& probe) {
                 base = base.substr(0, base.size() - shim_ext_.size());
             }
             if (xvm::is_xlings_binary(base)) continue;
-            const auto* vi = xvm::get_vinfo(st.db, base);
-            if (!vi || vi->type != "program") continue;
+            if (!xvm::has_program_kind(st.db, base)) continue;
 
             auto owner = xvm::resolve_owner_home(entry.path());
             std::error_code oec;
@@ -495,8 +497,11 @@ Scan detect_(const DoctorState& st, const CoordinateProbe& probe) {
     };
 
     for (const auto& [name, vinfo] : st.db) {
-        if (vinfo.type != "program") continue;
         for (const auto& [version, vdata] : vinfo.versions) {
+            // Per version, not per target: one target can hold versions of
+            // different kinds, and skipping the whole target on the
+            // target-level fallback discards the ones that are programs.
+            if (xvm::effective_kind(vinfo, vdata) != "program") continue;
             if (vdata.path.empty()) continue;  // type-only stub
 
             auto expanded = xvm::expand_path(vdata.path, st.homeStr);

--- a/src/core/xvm/commands.cppm
+++ b/src/core/xvm/commands.cppm
@@ -484,7 +484,9 @@ int cmd_use(const std::string& target, const std::string& version,
         fs::create_directories(p.binDir);
         for (auto& [name, ver] : to_switch) {
             auto vinfo = get_vinfo(db, name);
-            if (!vinfo || vinfo->type != "program") continue;
+            // effective_kind_of, not vinfo->type: the per-version kind is the
+            // authority and the target-level type is only its fallback.
+            if (!vinfo || effective_kind_of(db, name, ver) != "program") continue;
             std::string shim_name = (!vinfo->filename.empty()) ? vinfo->filename : name;
             if (!shim_ext.empty() && !shim_name.ends_with(shim_ext))
                 shim_name += shim_ext;

--- a/src/core/xvm/types.cppm
+++ b/src/core/xvm/types.cppm
@@ -191,6 +191,41 @@ std::string effective_destination_name(const std::string& target,
     return std::string(sourceName);
 }
 
+// effective_kind for a (target, version) resolved out of the database.
+//
+// Several call sites that decide "does this name own a shim" read
+// `VInfo::type` directly. That is the FALLBACK, not the authority: a
+// per-version `kind` overrides it, and entries written before 0.4.70 have no
+// per-version kind at all -- which is why the fallback exists and why reading
+// it where the authority is available gets the answer wrong in exactly the
+// cases the two disagree. A `lib` or `files` entry could be handed a shim it
+// can never dispatch, and a `program` could be denied one.
+std::string effective_kind_of(const VersionDB& db,
+                              const std::string& target,
+                              const std::string& version) {
+    auto it = db.find(target);
+    if (it == db.end()) return {};
+    auto vit = it->second.versions.find(version);
+    if (vit == it->second.versions.end()) return it->second.type;
+    return effective_kind(it->second, vit->second);
+}
+
+// Whether ANY version of this target materializes as a program.
+//
+// For the checks that start from a shim FILE and have no version in hand. A
+// shim belongs to whichever version is active, and widening to "any version"
+// is the conservative direction here: it can only make a check report fewer
+// orphans, never fabricate one.
+bool has_program_kind(const VersionDB& db, const std::string& target) {
+    auto it = db.find(target);
+    if (it == db.end()) return false;
+    if (it->second.versions.empty()) return it->second.type == "program";
+    for (const auto& [version, data] : it->second.versions) {
+        if (effective_kind(it->second, data) == "program") return true;
+    }
+    return false;
+}
+
 } // namespace xlings::xvm
 
 #if !defined(_MSC_VER)

--- a/tests/unit/test_xvm_switch.cpp
+++ b/tests/unit/test_xvm_switch.cpp
@@ -176,6 +176,77 @@ void switch_group_(xlings::xvm::VersionDB& db,
 
 }  // namespace
 
+// ── One authority for "what kind is this entry" ─────────────────────
+//
+// `effective_kind` exists because the per-version `kind` is the authority and
+// the target-level `VInfo::type` is only its fallback -- entries written
+// before 0.4.70 have no per-version kind at all, so on a real installation the
+// fallback was the ONLY thing typing 372 of them.
+//
+// Several call sites read `type` directly anyway, including the line in
+// `cmd_use` that decides whether to write a shim. Where the two disagree, that
+// hands a shim to an entry that can never dispatch one, or denies one to an
+// entry that needs it.
+
+TEST(EffectiveKindAuthority, ThePerVersionKindWins) {
+    xlings::xvm::VersionDB db;
+    auto& info = db["libfoo"];
+    info.type = "program";                       // stale target-level fallback
+    info.versions["1.0.0"].kind = "lib";         // the authority
+    info.versions["1.0.0"].path = "/pkg/libfoo/1.0.0";
+
+    EXPECT_EQ(xlings::xvm::effective_kind_of(db, "libfoo", "1.0.0"), "lib");
+    EXPECT_NE(info.type, "lib") << "the fixture must actually disagree";
+}
+
+TEST(EffectiveKindAuthority, TheTargetTypeIsUsedWhenTheVersionHasNoKind) {
+    // Pre-0.4.70 state: no per-version kind anywhere.
+    xlings::xvm::VersionDB db;
+    auto& info = db["gcc"];
+    info.type = "program";
+    info.versions["15.1.0"].path = "/pkg/gcc/15.1.0";
+
+    EXPECT_EQ(xlings::xvm::effective_kind_of(db, "gcc", "15.1.0"), "program");
+}
+
+TEST(EffectiveKindAuthority, OneTargetCanHoldVersionsOfDifferentKinds) {
+    // Which is why a check that skips the whole target on the target-level
+    // type discards the versions that ARE programs.
+    xlings::xvm::VersionDB db;
+    auto& info = db["mixed"];
+    info.type = "lib";
+    info.versions["1.0.0"].kind = "lib";
+    info.versions["2.0.0"].kind = "program";
+
+    EXPECT_EQ(xlings::xvm::effective_kind_of(db, "mixed", "1.0.0"), "lib");
+    EXPECT_EQ(xlings::xvm::effective_kind_of(db, "mixed", "2.0.0"), "program");
+    EXPECT_TRUE(xlings::xvm::has_program_kind(db, "mixed"));
+}
+
+TEST(EffectiveKindAuthority, AGroupRootIsNotAProgram) {
+    xlings::xvm::VersionDB db;
+    auto& info = db["xim-gnu-gcc"];
+    info.type = "program";                       // the default it gets when unset
+    info.versions["15.1.0"].kind = "group";
+
+    EXPECT_EQ(xlings::xvm::effective_kind_of(db, "xim-gnu-gcc", "15.1.0"),
+              "group");
+    EXPECT_FALSE(xlings::xvm::has_program_kind(db, "xim-gnu-gcc"))
+        << "a group root names a release; nothing dispatches it";
+}
+
+TEST(EffectiveKindAuthority, AnUnknownTargetOrVersionDoesNotInventAKind) {
+    xlings::xvm::VersionDB db;
+    db["gcc"].type = "program";
+    db["gcc"].versions["15.1.0"].kind = "program";
+
+    EXPECT_TRUE(xlings::xvm::effective_kind_of(db, "clang", "1.0.0").empty());
+    // An unknown VERSION of a known target falls back to the target's type --
+    // that is the same widening the pre-0.4.70 state relies on.
+    EXPECT_EQ(xlings::xvm::effective_kind_of(db, "gcc", "9.9.9"), "program");
+    EXPECT_FALSE(xlings::xvm::has_program_kind(db, "clang"));
+}
+
 TEST(XvmSwitchPlan, PlansEveryMemberNotJustTheEntryPoint) {
     xlings::xvm::VersionDB db;
     switch_group_(db, "15.1.0", {"gcc", "g++", "libstdc++"}, "15.1.0");


### PR DESCRIPTION
> **请勿合入 / DO NOT MERGE** — 供 review。独立于 #460 / #461。

`effective_kind(info, data)` 存在的理由是：**per-version 的 `kind` 是权威，target 级的 `VInfo::type` 只是它的回落** —— 0.4.70 之前写的记录根本没有 per-version kind，真实安装上 372 条全靠回落值定型。

**但有 5 处直接读 `type`**，其中包括**决定要不要建 shim 的那一行**：

```cpp
// xvm/commands.cppm:487  —— cmd_use 里
if (!vinfo || vinfo->type != "program") continue;   // 读的是回落值
```

两者不一致时：`lib` / `files` / `group` 条目可能拿到一个**永远无法 dispatch 的 shim**，而 `program` 可能被拒绝。

还有一处更糟 —— `doctor.cppm:498`：

```cpp
for (const auto& [name, vinfo] : st.db) {
    if (vinfo.type != "program") continue;      // 按 target 跳过
    for (const auto& [version, vdata] : vinfo.versions) {   // 然后才逐版本
```

**按 target 级回落值跳过整个 target，把其中确实是 program 的版本一起丢掉。**

## 改法

两个 helper，把"放宽"这件事写明而不是即兴发挥：

| helper | 用于 |
|---|---|
| `effective_kind_of(db, target, version)` | 两者都有的站点 |
| `has_program_kind(db, target)` | 从 **shim 文件名**出发、手上没有版本的两处检查。"任一版本是 program"是这里的保守方向 —— 只会让检查少报 orphan，不会凭空造一个 |

`db.cppm:77` **不动**：那读的是写入时传进来的 `type` 参数，是权威，不是陈旧回落值。

## 测试

5 个单测，双向都钉住：per-version 覆盖陈旧 target type / 版本没有 kind 时用 target type / 一个 target 可以持有不同 kind 的版本 / group root 不是 program / 未知 target 不会被凭空赋予 kind。

25 单测套件 + 10 个 e2e 套件全绿（doctor ×3、group/library switch、files probe、declared-programs、shim ownership、alias sysroot、group switch report）。

## 定位

评估报告 §3。这是那份报告里**唯一一条"应该做"而非"必要"**的条目 —— 它修的是**潜在**缺陷（两者不一致时才发作），不像 #460 那两条有可复现的现场。
