### PR TITLE
fix(xvm,xself,xim): a foreign claim on one name must not strand its release (2026.8.1.1)

### DIFF
--- a/.agents/docs/2026-08-01-alias-resolution-and-inactive-install-plan.md
+++ b/.agents/docs/2026-08-01-alias-resolution-and-inactive-install-plan.md
@@ -1,0 +1,413 @@
+# alias 解析口径 与「已安装但无 active 版本」优化方案
+
+**日期**: 2026-08-01
+**类型**: 计划（plan）→ **已实现，随 `2026.8.1.1` 发布**
+**基线**: `2026.7.31.3`（已发布）
+**代码**: `src/core/xvm/shim.cppm`、`src/core/xself/doctor.cppm`、
+`src/core/xvm/registration.cppm`、`src/core/xim/commands.cppm`
+**相关**: `.agents/docs/2026-07-29-orphan-shim-inactive-group-root-design.md`、
+`.agents/docs/2026-07-29-doctor-fix-one-shot-design.md`、
+[#452](https://github.com/openxlings/xlings/issues/452)
+
+两项，互不依赖。都来自同一次真实现场：一台用了几个月的 home 上
+`xlings self doctor --fix` 刷出 34 条 `alias unresolved`，而与此同时
+`codex` 报 `/usr/bin/env: 'node': No such file or directory` —— doctor 一条都
+没提。
+
+| # | 问题 | 类型 | 规模 |
+|---|---|---|---|
+| **P1** | doctor 的 alias 解析口径比运行时窄两级，34 条全是误报 | **误报**（掩盖真断裂） | 小 |
+| **P2** | 包已安装、payload 完好、却无 active 版本、无 shim，三个出口全静默 | **真缺陷**（静默成功） | 中 |
+
+两者是一对：P1 制造噪音，P2 制造沉默，合起来的效果是
+**doctor 报了 34 条不该报的，同时漏了唯一该报的那条。**
+
+---
+
+## 现场（真实 home，`2026.7.31.3`）
+
+```
+$ xlings self doctor --fix
+  ⚠ alias unresolved  madd@0.0.1 alias 'mcpp' not resolvable in
+                      @xlings/data/xpkgs/xim-x-mcpp-short-cmd/0.0.1
+                      (may be a system command)
+  … 共 34 条 …
+  warnings            34
+
+$ codex
+/usr/bin/env: 'node': No such file or directory
+```
+
+实测两条事实，后面所有推理都建立在它们上：
+
+```
+$ madd --help          → exit 0，正常打印 mcpp add 用法   ← 34 条警告全是误报
+$ which node npx npm   → node (none) / npx (none) / npm 有 ← doctor 一个字没说
+```
+
+---
+
+## P1. doctor 的 alias 解析口径比运行时窄两级
+
+### 成因
+
+运行时执行 alias 的实际路径（`shim.cppm:425-501`）先拼 PATH 再交给 shell：
+
+```cpp
+// shim.cppm:427-447
+if (!expanded_path.empty() && exists(expanded_path)) new_path = expanded_path;   // ① payload
+if (exists(bin_path))            new_path += … + bin_path;                        // ② payload/bin
+if (!cfg_bin.empty())            new_path += … + cfg_bin;                         // ③ subos binDir
+if (!existing_path.empty())      new_path += … + existing_path;                   // ④ 继承的 PATH
+platform::set_env_variable("PATH", new_path);
+…
+return platform::exec(cmd);
+```
+
+doctor 的判定（`doctor.cppm:614-619`）只走了 `resolve_executable`：
+
+```cpp
+const auto aliasProg = alias_program_(vdata.alias[0], st.homeStr);
+if (fs::path(aliasProg).is_absolute()) continue;
+if (!xvm::resolve_executable(aliasProg, vdata.path, st.homeStr).empty()) continue;
+```
+
+而 `resolve_executable`（`shim.cppm:243-269`）只查 `path/prog` 与
+`path/bin/prog` —— **只覆盖 ①②，完全没有 ③④。**
+
+`xim-x-mcpp-short-cmd/0.0.1/` 里没有任何 payload：
+
+```
+.xim-installed  .xpkg-install.json  .xpkg.lua      ← 只有元数据
+```
+
+这个包的全部职责就是注册 30 个短命令，全部转发给**另一个包**里的 `mcpp`。
+运行时在 ③ subos binDir 里一击命中，doctor 因为不看 ③ 而必然报错。
+`musl-gcc-static → musl-gcc`、`gcc-specs-config → xlings`、
+`xpkg-helper → xlings` 同理。
+
+`doctor.cppm:608-613` 的 TODO 已经承认判据不足，并据此把等级压到 warning。
+压等级缓解的是后果，没有修口径 —— 代价是**真断裂和误报混在同一个等级里，
+34 条噪音之下第 35 条没人看得见**。
+
+### 目标：让 doctor 问的问题和运行时做的事逐级对齐
+
+新增一个返回「在哪一级命中」的解析函数，放进 `xvm/shim.cppm` ——
+和运行时同源，两边不会漂移（沿用 `doctor.cppm:534-537` 已确立的
+"Detection calls the function the repair calls" 原则）：
+
+```cpp
+// xvm/shim.cppm
+enum class AliasOrigin { Payload, SubosBin, SystemPath, Nowhere };
+struct AliasResolution { AliasOrigin origin; std::filesystem::path path; };
+
+AliasResolution resolve_alias_program(const std::string& prog,
+                                      const std::string& payloadPath,
+                                      const std::string& xlingsHome);
+```
+
+查找顺序严格复刻 ①②③④，Windows 下 ③ 要带 `shim_ext_`（`.exe`）重试。
+
+doctor 按命中级别三分：
+
+| 命中位置 | doctor 判定 | 理由 |
+|---|---|---|
+| ① payload / ② payload/bin | **静默** | 今天的 `continue`，不变 |
+| ③ subos binDir | **静默** | 兄弟 shim，xlings 自己管得到 —— `madd → mcpp` 就在这一级 |
+| ④ 系统 PATH | **notice** | 能用，但依赖宿主机；是可移植性信号，不是缺陷 |
+| 哪都没有 | **error** | alias 真的断了，今天被压成 warning 埋掉了 |
+
+预期效果：现场 34 条 → **0**。
+
+### 两个必须写进实现的边界
+
+**1 — ④ 的判定依赖 doctor 自己的 PATH。**
+doctor 进程的 PATH 不等于用户登录 shell 的 PATH。在 CI / 剥离环境里，一个
+alias 到 `bash` 的包可能落到「哪都没有」而误报 error。所以 error 分支必须
+带一句环境说明，且 detail 里打印实际查过的四个位置。
+
+**2 — 「哪都没有」要先问是不是 P2。**
+如果 alias 目标本身是一个已知的 xvm program target、只是**没有 active 版本**，
+那它不是「alias 断了」，而是 P2 那条更精确的发现。此时不报
+`alias unresolved`，改报 P2 的 `no active version`，remedy 指向真正的修法。
+—— 这是 P1 和 P2 唯一的耦合点，也是把两件事放进一份文档的原因。
+
+### 需要一并调整的既有契约
+
+`tests/e2e/self_doctor_test.sh` **S10** 现在删掉 payload 里的 alias 目标后断言
+warning + `exit 0` + `--fix 不得触碰`：
+
+```bash
+# self_doctor_test.sh:376-381
+echo "$out" | grep -q "alias unresolved" || fail …
+[[ $rc -eq 0 ]] || fail "S10: alias warning alone should exit 0; got $rc"
+```
+
+新口径下 `alias-real` 在四级里都找不到 → **error + exit 1**。S10 必须改成断言
+error，并新增两条 fixture 覆盖 ③ 和 ④：
+
+- **S10-a** alias 目标只存在于 subos binDir → 静默、exit 0
+- **S10-b** alias 目标只存在于系统 PATH → notice、exit 0
+- **S10-c** 四级皆无 → error、exit 1（原 S10 改写）
+
+`.agents/tools/doctor-acceptance.sh:75-76` 数的是
+`alias unresolved.*claude` 的条数，新口径下 before/after 都会归零，断言要相应
+放宽或改数 notice。
+
+---
+
+## P2. 已安装、payload 完好、无 active 版本 —— 三个出口全静默
+
+### 现场
+
+```
+subos/default/.xlings.json:
+  node  {"installed": ["23.6.0", "24.15.0"]}                        ← 无 active
+  npx   {"installed": ["node-23.6.0", "node-24.15.0"]}              ← 无 active
+  npm   {"active": "11.2.0", "installed": ["11.2.0", "node-…"]}     ← 有（来自 xim-x-npm）
+```
+
+payload 完好（`xim-x-node/24.15.0/bin/node`，122 MB，在），但没有 active 就
+不生成 shim，`which node` 为空。用户最终看到的是**第三方工具**抛出的
+`/usr/bin/env: 'node': No such file or directory` —— 错误信息里出现的是
+`node` 和 `env`，从头到尾没有 xlings 三个字。
+
+**node 与 npx 同时缺、npm 独存**，这是判定成因的决定性证据（见下）。
+
+### 成因 A（install 侧，根因）
+
+`registration.cppm:921-925`：
+
+```cpp
+const bool anyMemberActive = std::ranges::any_of(
+    group.members, [&](const auto& member) {
+        return candidateWorkspace.contains(member.first);   // ← 只问"这个名字被占了吗"
+    });
+const bool activateGroup = batch.useAfterInstall || !anyMemberActive;
+```
+
+node 组的成员是 `{node, npm, npx}`。`npm` 被**另一个包** `xim-x-npm@11.2.0`
+占着 → `anyMemberActive == true` → `activateGroup == false` →
+**整组都不激活**，包括没有任何人竞争的 `node` 和 `npx`。
+
+`registration.cppm:918-920` 写明的意图是：
+
+> Leaving a name alone when something already owns it is also the right answer
+> across providers: installing gcc must not silently take `cc` away from an
+> active llvm.
+
+意图是**不要抢别人的名字**，实现却升级成了**一个被占的名字否决整组**，
+连没被占的名字一起不激活。结果是刚装好的 node 整个不可达。
+node/npx 缺、npm 在，正是"整组否决、npm 因另有其主而幸存"的指纹。
+
+### 成因 B（remove 侧）
+
+`removal.cppm:346-349` 删掉 active 指针后，`385+` 的 group-coherent 复活只肯
+整组搬迁，否则维持不激活，理由写在 `361-366`：
+
+> Otherwise the group stays inactive and the user re-selects explicitly —
+> **an inactive toolchain is a visible problem**, an incoherent one is not.
+
+两条路径殊途同归，且都押在同一个假设上。
+
+### 这个假设被本次现场证伪了
+
+「inactive 是可见问题」在今天的三个出口上**一个都不成立**：
+
+| 出口 | 代码 | 对 node 说了什么 |
+|---|---|---|
+| `xlings list` | `commands.cppm:852-866` 只读 `workspace_installed()`，**从不查 active** | `◆ xim:node@24.15.0` —— 和正常包一模一样 |
+| `xlings self doctor` | Check 1 遍历 `st.ws`（active 表），无 active 的名字压根不在表里 → 跳过 | 一个字没说 |
+| shim | 没有 active 就不写 shim，binDir 里没有文件 | Check 2 遍历 binDir 也看不到 |
+
+Check 3 遍历 DB，node@24.15.0 是 program、path 有效、`node` 可执行文件解析成功
+→ `continue`，同样静默。**三个检查全过，问题就在中间那条缝里。**
+
+而 doctor 已经把判定所需的数据加载进内存了 —— `DoctorState::wsInstalled`
+（`doctor.cppm:150`）就是 installed 表，只是从来没和 `st.ws` 交叉比对过。
+
+### 目标 A：新增 Check —— `InactiveInstalled`
+
+```cpp
+// FindingKind 新增
+// 该 subos 装了这个包、payload 在、却没有任何 active 版本，因此没有 shim。
+// list 会把它显示成正常安装，doctor 的其余检查全部够不到它：Check 1 遍历
+// active 表，这个名字不在表里；Check 2 遍历 binDir，没有文件可看。
+InactiveInstalled,
+```
+
+判定：对 `st.wsInstalled` 中每个 installed 非空的 name，
+若该 name 有 program kind、且 `st.ws` 中无 active（或为空）→ 报 Error。
+
+必须排除的三类（否则会把正常状态报成缺陷）：
+
+1. **binding root / release anchor** —— `is_binding_root()` 为真，或
+   `payload_has_any_executable_()` 为假。库包本来就不该有 active program，
+   这正是 #452 的教训。
+2. **该 name 的所有已安装版本都不是 program kind**（复用 Check 3 的
+   `effective_kind` 逐版本判定）。
+3. **归属其它 subos 的条目** —— 复用 `xvm::subos_ownership()`，避免在
+   subos A 里把 subos B 的选择报成缺陷（`doctor.cppm:465-481` 已有先例）。
+
+detail 里要同时打印 installed 列表和"无 shim"这个后果，因为后者才是用户
+真正撞上的现象：
+
+```
+✗ no active version  node — installed 23.6.0, 24.15.0; none active, so no
+                     shim exists in this subos (`node` is not on PATH)
+                     fix: xlings use node@24.15.0
+```
+
+### 目标 B：`--fix` 自动激活最高已安装版本
+
+`--fix` 直接把 active 指向最高的已安装版本（沿用 `removal.cppm:390-393` 的
+`version_key_greater` 排序，而不是安装先后）。
+
+这与 `removal.cppm:361-366` 确立的「不替用户猜版本」原则**存在张力，必须正面
+处理**：那条原则的前提是"inactive 可见"，前提已被证伪；在用户看不见的前提下
+拒绝修复，等于把包永久留在不可达状态。`--fix` 是用户显式请求修复的入口，
+在这里做出选择是它的职责。
+
+但自动激活**必须是组一致的**，否则会重新引入 binding-group 模型专门要防的
+混合工具链。约束三条：
+
+1. **不抢已被占用的名字。** 任何已有 active 的 name，`--fix` 一律不碰。
+   node 场景下 `npm` 留在 `xim-x-npm@11.2.0`，只激活 `node` 和 `npx`。
+2. **同 provider 的竞争 → 整组不动，只报告。** 若组内有 name 被
+   **同一 provider 的另一个版本**占着，那是 release 升级决策，只有用户能做
+   （对应 `test_xvm_bindings.cpp:3140-3152` 钉住的 gcc 15→16 场景）。
+3. **虚拟 root 不单独激活。** 若组内可激活的成员全是无可执行文件的
+   binding root，则整组不动 —— 否则 #452 的 orphan shim 原样回来
+   （`test_xvm_bindings.cpp:3166` 钉住这条）。
+
+### 目标 C（根因）：install 侧改成"被占的名字不否决兄弟"
+
+`registration.cppm:921-925` 改为三段式判定：
+
+```
+1. 找出组内所有已被占用的成员名，按"当前占用者的 provider"分类
+   （占用者 provider = db[name].versions[activeVersion].bindingGroup.provider）
+2. 若存在【同 provider】的竞争 → 整组不激活（今天的行为，保留）
+3. 否则 → 激活所有【未被占用】的成员；被占用的留给原主
+   3a. 若可激活的成员全是无可执行文件的 binding root → 整组不激活
+```
+
+**遗留条目的 provider 未知**（如 `node-23.6.0` 只有 `path`，无
+`bindingGroup`）→ 保守按【同 provider】处理，即维持今天的否决行为，
+避免老 home 出现行为回归。
+
+### 四个已知场景的逐条对照
+
+这套规则必须在改之前先过一遍已有的钉子，否则就是拿一个缺陷换另一个：
+
+| 场景 | 竞争的名字 / 占用者 provider | 新规则结果 | 依据 |
+|---|---|---|---|
+| **装 node，npm 已被 xim-x-npm 占** | `npm` / `xim:npm`（异） | 激活 node、npx；npm 留给原主 | 修好本文现场 ✓ |
+| **gcc 16 覆盖已激活的 gcc 15** | `gcc`,`g++` / `xim:gcc`（同） | 整组不激活 | `test_xvm_bindings.cpp:3148-3152` 不破 ✓ |
+| **musl-gcc flavor，gcc 已被 glibc gcc 占** | `gcc` / `xim:gcc`（异）；未占用的只剩虚拟 root `xim-musl-gnu-gcc` | 3a 命中 → 整组不激活 | `test_xvm_bindings.cpp:3166` 不破、#452 不复发 ✓ |
+| **装 gcc，cc/c++ 已被 llvm 占** | `cc`,`c++` / `xim:llvm`（异） | 激活 gcc、g++、cpp、gcov；cc/c++ 留给 llvm | **行为变化**：今天是整组不激活。这正是 `918-920` 注释所声明的意图 ⚠ |
+
+第四行是唯一的行为变化，需要单独一条单测钉住，并在 release notes 里写明。
+
+### 目标 D：`list` 标出未激活
+
+`commands.cppm:886-891` 渲染时查一次 `Config::effective_workspace()`，
+无 active 的条目加标记：
+
+```
+◆ xim:node@24.15.0  (inactive — no shim; `xlings use node@24.15.0`)
+```
+
+这条独立于 A/B/C，可以最先落地：**它是三个静默出口里唯一一个用户会主动去看
+的**，改动也最小。
+
+### 验收 → 新增 E2E `inactive_installed_test.sh`
+
+隔离 home，遵循
+`.agents/docs` 既有的 isolated-home 约定（不预置 `data/`，否则 index 变成
+符号链接、差分不可证伪）：
+
+| # | 构造 | 断言 |
+|---|---|---|
+| **S1** | 装一个 group 包，其中一个成员名先被另一 provider 占住 | 未被占的成员**有** active、**有** shim，能执行 |
+| **S2** | 手工把某 target 的 active 抹掉、保留 installed | `doctor` 报 `no active version`、**exit 1** |
+| **S3** | 承 S2 → `doctor --fix` | active 指向最高已安装版本，shim 出现，命令可执行 |
+| **S4** | 承 S2 → `list` | 该条目带 `inactive` 标记 |
+| **S5** | 虚拟 root（无可执行文件）无 active | **不**报 `no active version`（沿用 release anchor notice） |
+| **S6** | 同 provider 竞争（gcc 15→16 形状） | 整组不激活；`--fix` **不**替用户选版本，只报告 |
+
+S5/S6 是防回归的重点：它们钉的是"**不该**报、"**不该**自动修"，而这两类
+恰恰是 A/B/C 最容易过度触发的方向。
+
+---
+
+## 落地顺序
+
+四步，每步独立可发：
+
+1. **D（list 标记）** —— 最小、无风险、直接减轻现场痛感。
+2. **A（doctor 新增 Check）+ S2/S5** —— 让问题第一次可见。
+3. **P1（alias 四级口径）+ S10 系列改写** —— 噪音归零，且 A 已经就位，
+   「哪都没有」才能正确降级到 P2 的精确发现（P1 的边界 2 依赖 A 先落地，
+   **顺序不能反**）。
+4. **C（install 根因）+ B（--fix）+ S1/S3/S6** —— 改动最大、对照表最长，
+   单独一个 PR，release notes 写明第四行的行为变化。
+
+## 实现时改掉的六处（计划 → 实际）
+
+计划是照着现场写的，实现时被测试和真实数据推翻了六处。记在这里，因为每一处
+都是"看起来对的判据其实分不开两种东西"。
+
+**1 — `is_binding_root` 不能用来排除虚拟锚点。**
+计划里的排除条件写的是"binding root 或无可执行文件"。实测 `node@24.15.0`
+**就是**自己那个 release 的 root（npm/npx 都 bind 到它），所以这个判据会把
+本次要修的那个包第一个排除掉 —— 加上去之后 doctor 对 node 一言不发。
+真正的判据只有 payload：**只问可执行文件，和 Check 3 同序**。
+
+**2 — 虚拟锚点也有 `path`，`kind` 也可能是 `program`。**
+install 侧本来打算用 `path.empty()` 认虚拟 root。实测 `xim-musl-gnu-gcc`
+记的是 musl-gcc 自己的目录；#452 fixture 里那个明确"不写 bindir"的
+`xim-anchor-root`，libxpkg 仍然给它填上了包的 install_dir，`kind` 也照样
+默认成 `program`，`sourceName` 照样从 target 推出来 —— **和 `node` 的记录逐字段
+相同**。E2E-45 直接把这条打了回来（`S1 precondition: the root was activated`）。
+最终解法：registration 层按设计不碰文件系统，所以由**装完 payload 的那一层
+回答**，新增 `RegistrationNode::runnable`，默认 `true`，只在跨 provider 那一
+条路径上读。
+
+**3 — `contested.empty()` 必须单独短路。**
+锚点守卫写成合取项之后，一个"只有一个虚拟 root、且无人竞争"的批次也不再激活，
+`VirtualGroupRetainsEmptyPayloadAndNoSelfEdge` 当场变红。守卫只该守跨 provider
+这一扇新开的门，无人竞争的 release 走的还是老路。
+
+**4 — INV-2 也得同样地认 provider（计划里没有）。**
+install 侧放行之后，`self doctor` 的 Check 4 立刻把新状态判成
+`xvm-active-group-incoherent` —— 即 install 造出一个 doctor 判定为坏的状态。
+两边对"什么算一个 release"必须用同一条规则：`inspect.cppm` 的 INV-2 现在同样
+跳过被**其它 provider** 持有的名字。同 provider 的分裂仍然报。
+
+**5 — `--fix` 走 `use`，会带走被占的名字；办法是先说，不是不做。**
+计划的约束 1 是"`--fix` 不抢已被占用的名字"。实现时发现 `use` 天然是
+release 级操作：`xlings use node@24.15.0` 一定会把 `npm` 一起搬走，
+所以"`--fix` 做得比它自己打印的 remedy 更窄"会变成第三种行为。
+最终：`--fix` 就执行打印的那条 remedy，但 finding 里**提前列出会被搬动的名字**
+（`—  activating it also moves npm (11.2.0 → node-24.15.0)`）。
+静默地改变用户的选择才是这一族缺陷的本体，改变本身不是。
+
+**6 — finding 按 release 聚合（计划里是按 target）。**
+真实 home 上按 target 报是 **50 行**（llvm 37、binutils 11、node 2），每行带一条
+一模一样的 remedy —— 正是 broken payload 的 `groupKey` 当初要解决的掩埋问题，
+而且 `node` 就埋在中间。改成按 release 聚合后是 **3 行**。
+
+## 不做什么
+
+- **不**让 doctor 去理解 alias 目标的 shebang。`codex` 是
+  `#!/usr/bin/env node` 的 JS 脚本，本次现场的直接触发点是它 —— 但
+  「解释器缺失」是包依赖问题，属于 recipe 的 `deps`，不是 doctor 的职责。
+  P2 修好之后 `node` 自然在 PATH 上，这条现场就消失了。
+- **不**动 `resolve_executable` 现有的两级语义。运行时的 ①② 是对的，
+  P1 是在它之上**补** ③④，不是改它 —— `shim.cppm:504` 的非 alias 路径仍然
+  只该看 payload。
+- **不**顺手清理用户 `.bashrc` 里那条指向已删除 dev build 的 node PATH。
+  那是本次现场"为什么是突然"的答案（`build/xlings/data/xim/runtimedir/…`
+  已随 build 树重建而消失，它此前一直在替 xlings 兜底），属于用户环境，
+  记录在此备查，不进代码。

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlings"
-version = "2026.7.31.3"
+version = "2026.8.1.1"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"

--- a/src/agent/text_renderer.cppm
+++ b/src/agent/text_renderer.cppm
@@ -113,10 +113,16 @@ export void render_data_event(const DataEvent& e) {
             bool numbered = json.value("numbered", false);
             for (auto& item : json["items"]) {
                 if (item.is_array() && item.size() >= 2) {
+                    // The status qualifier goes next to the name, not at the
+                    // end of the line: an agent reading this transcript must
+                    // not be able to attribute `inactive` to the description.
+                    std::string status = item.size() >= 3
+                        ? item[2].get<std::string>() : std::string{};
+                    if (!status.empty()) status = " [" + status + "]";
                     if (numbered) {
-                        std::println("  {}. {} {}", idx++, item[0].get<std::string>(), item[1].get<std::string>());
+                        std::println("  {}. {}{} {}", idx++, item[0].get<std::string>(), status, item[1].get<std::string>());
                     } else {
-                        std::println("  {} {}", item[0].get<std::string>(), item[1].get<std::string>());
+                        std::println("  {}{} {}", item[0].get<std::string>(), status, item[1].get<std::string>());
                     }
                 } else if (item.is_string()) {
                     if (numbered) {

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -98,13 +98,18 @@ static void dispatch_data_event(const DataEvent& e) {
     else if (e.kind == "styled_list") {
         std::string title = json.value("title", "");
         bool numbered = json.value("numbered", false);
-        std::vector<std::pair<std::string, std::string>> items;
+        std::vector<ui::ListRow> items;
         if (json.contains("items") && json["items"].is_array()) {
             for (auto& item : json["items"]) {
                 if (item.is_array() && item.size() >= 2) {
-                    items.emplace_back(item[0].get<std::string>(), item[1].get<std::string>());
+                    items.push_back({
+                        item[0].get<std::string>(),
+                        item[1].get<std::string>(),
+                        item.size() >= 3 ? item[2].get<std::string>()
+                                         : std::string{},
+                    });
                 } else if (item.is_string()) {
-                    items.emplace_back(item.get<std::string>(), "");
+                    items.push_back({item.get<std::string>(), "", ""});
                 }
             }
         }

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "2026.7.31.3";
+    static constexpr std::string_view VERSION = "2026.8.1.1";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/xim/commands.cppm
+++ b/src/core/xim/commands.cppm
@@ -883,11 +883,39 @@ int cmd_list(const std::string& filter, EventStream& stream, bool all = false) {
         return 0;
     }
 
+    // Installed is not the same question as usable.
+    //
+    // `installed[]` and the active selection are two different tables, and a
+    // package can sit in the first without appearing in the second — a group
+    // whose activation was withheld at install time, or a `remove` that took
+    // out the active version and found no coherent replacement. Such a package
+    // has no shim, so its commands are not on PATH, and until now this list
+    // rendered it identically to a working one. The user then meets the
+    // failure through whatever tried to run it, in an error message that names
+    // the missing command and never names xlings.
+    const auto& ws = Config::effective_workspace();
+    const auto has_active = [&](std::string_view name) {
+        auto it = ws.find(std::string(name));
+        return it != ws.end() && !it->second.empty();
+    };
+
     nlohmann::json listItems = nlohmann::json::array();
     for (auto& match : installed) {
         auto pkg = catalog.load_package(match);
         std::string desc = pkg ? std::string(pkg->description) : std::string{};
-        listItems.push_back({match.canonicalName + "@" + match.version, desc});
+        // Asked of the programs the recipe declares, not of the package name:
+        // the package is `mcpp-short-cmd`, the xvm targets are `madd`,
+        // `mbuild`, … and the package name is never one of them. A package
+        // that declares nothing runnable (a library, a release anchor) has no
+        // active version to lack, so it is never flagged — the same
+        // `package.programs` promise installer.cppm:1847 verifies.
+        std::string status;
+        if (pkg && !pkg->programs.empty()
+            && std::ranges::none_of(pkg->programs, has_active)) {
+            status = "inactive";
+        }
+        listItems.push_back({match.canonicalName + "@" + match.version,
+                             desc, status});
     }
     nlohmann::json listPayload;
     listPayload["title"] = all ? "Installed packages (all subos):"

--- a/src/core/xim/commands.cppm
+++ b/src/core/xim/commands.cppm
@@ -894,9 +894,28 @@ int cmd_list(const std::string& filter, EventStream& stream, bool all = false) {
     // failure through whatever tried to run it, in an error message that names
     // the missing command and never names xlings.
     const auto& ws = Config::effective_workspace();
-    const auto has_active = [&](std::string_view name) {
-        auto it = ws.find(std::string(name));
-        return it != ws.end() && !it->second.empty();
+    const auto& db = Config::versions();
+
+    // Does this ROW's version serve the name, or does some other version?
+    //
+    // A row is a (package, version) pair, so "is the name active" is the wrong
+    // question whenever more than one version is installed: llvm 20.1.7 and
+    // 22.1.8 both register `llvm`, and asking only whether `llvm` is active
+    // leaves the 22.1.8 row looking exactly like the 20.1.7 one that is
+    // actually serving. Compare against the release the active version belongs
+    // to, not against the member version, because a member of a release
+    // carries its own version string (node's `npm` is at `node-24.15.0`).
+    const auto served_by_this_row = [&](std::string_view program,
+                                        const std::string& rowVersion) {
+        const auto it = ws.find(std::string(program));
+        if (it == ws.end() || it->second.empty()) return false;
+        std::string release = it->second;
+        if (const auto* vd = xvm::get_vdata(db, std::string(program), release);
+            vd && vd->bindingGroup) {
+            release = vd->bindingGroup->rootVersion;
+        }
+        return release == rowVersion
+            || xvm::strip_namespace(release) == rowVersion;
     };
 
     nlohmann::json listItems = nlohmann::json::array();
@@ -909,9 +928,20 @@ int cmd_list(const std::string& filter, EventStream& stream, bool all = false) {
         // that declares nothing runnable (a library, a release anchor) has no
         // active version to lack, so it is never flagged — the same
         // `package.programs` promise installer.cppm:1847 verifies.
+        //
+        // LIMIT: a recipe that declares no `programs` is never marked, because
+        // nothing records which xvm targets a package version registered —
+        // that mapping exists only in the recipe. Measured: `binutils` and
+        // `gcc` declare theirs and are marked; `llvm` declares none and is
+        // not, though `self doctor` reports it by release. This is a floor,
+        // not full coverage, and the fix is in the recipe.
         std::string status;
         if (pkg && !pkg->programs.empty()
-            && std::ranges::none_of(pkg->programs, has_active)) {
+            && std::ranges::none_of(pkg->programs,
+                                    [&](std::string_view program) {
+                                        return served_by_this_row(
+                                            program, match.version);
+                                    })) {
             status = "inactive";
         }
         listItems.push_back({match.canonicalName + "@" + match.version,

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -373,6 +373,28 @@ normalize_xpkg_registration_plan(
             return std::unexpected(std::move(exactVersion.error()));
         }
         registrationNode.version = std::move(*exactVersion);
+        // Is there a command behind this name, or is it a pure anchor?
+        //
+        // The registration layer cannot ask -- it never touches the
+        // filesystem -- and nothing else in the record distinguishes the two:
+        // an anchor registered with no bindir still gets the package install
+        // dir as its `path`, still defaults to kind "program", and still has a
+        // sourceName derived from its own target. The payload has run by the
+        // time config() does, so the file either is there or it is not, and
+        // this is the layer that can look.
+        //
+        // Same helper the shim dispatches through, so "registration thinks
+        // there is a program here" and "the shim finds one" cannot disagree.
+        // An alias-mode entry runs something else by definition and is
+        // runnable regardless.
+        // `operation.alias`, not `registrationNode.alias`: the latter is
+        // filled in further down and is still empty here.
+        if (kind == "program" && operation.alias.empty()) {
+            registrationNode.runnable = !xvm::resolve_executable(
+                sourceName.empty() ? operation.name : sourceName,
+                registrationNode.path,
+                Config::paths().homeDir.string()).empty();
+        }
         // Stored verbatim. The core does not rewrite what a recipe wrote --
         // it only expands its OWN marker at execution time
         // (kSubosPlaceholder). A recipe that needs the active subos writes

--- a/src/core/xself/doctor.cppm
+++ b/src/core/xself/doctor.cppm
@@ -95,6 +95,23 @@ enum class FindingKind {
     // name exists purely to anchor the release its libraries belong to.
     ReleaseAnchor,
     AliasUnresolved,
+    // Installed in this subos, payload intact, and no version of it active --
+    // so no shim was ever written and none of its programs are on PATH.
+    //
+    // Every other check is structurally blind to this. Check 1 walks the
+    // ACTIVE workspace, and the name is not in it. Check 2 walks binDir, and
+    // there is no file to find. Check 3 walks the DB and finds a payload that
+    // resolves perfectly, because it does. `xlings list` reported it as
+    // installed like any other package.
+    //
+    // The state is produced by both halves of the lifecycle: registration
+    // withholding activation from a whole release (registration.cppm), and a
+    // `remove` that took out the active version and found no coherent
+    // replacement (removal.cppm). Both were written believing an inactive
+    // package is a visible problem. It is not: the user meets it through
+    // whatever tried to run the missing command, in an error message that
+    // never mentions xlings.
+    InactiveInstalled,
     // An alias or env value that recorded the ABSOLUTE path of whichever
     // subos was active when the package was installed. The shim re-points it
     // at the active subos when it executes, so this is stale bookkeeping
@@ -297,6 +314,17 @@ Scan detect_(const DoctorState& st, const CoordinateProbe& probe) {
     Scan scan;
     const auto add = [&](Finding f) { scan.findings.push_back(std::move(f)); };
 
+    // The PATH an aliased command would inherit. Read once, and read from
+    // THIS process: doctor is normally started from the user's shell, so this
+    // is the same PATH the shim would get. It is not guaranteed to be -- a
+    // stripped environment sees fewer host commands than the user does -- so
+    // it can only ever downgrade a finding from "satisfied by the host" to
+    // "resolves to nothing", never the reverse. That direction is the safe
+    // one to be wrong in: it over-reports in a sandbox instead of staying
+    // silent on a real break.
+    const std::string hostPath =
+        std::getenv("PATH") ? std::getenv("PATH") : std::string{};
+
     // Check 1: every workspace program has its shim.
     for (const auto& [name, version] : st.ws) {
         if (version.empty()) continue;
@@ -400,6 +428,157 @@ Scan detect_(const DoctorState& st, const CoordinateProbe& probe) {
                 .shimPath = path,
             });
         }
+    }
+
+    // Check 2.7: installed here, and nothing active.
+    //
+    // The gap between Check 1 and Check 2. Check 1 asks "does every ACTIVE
+    // program have a shim" and never sees a name with no active version;
+    // Check 2 asks "does every shim have an active version" and never sees a
+    // name with no shim. A package that is installed and inactive is missing
+    // from both tables at once, so both loops skip it and the payload loop
+    // below finds it perfectly healthy -- which it is. What is broken is the
+    // selection, and until now nothing looked at the selection.
+    //
+    // Reported per RELEASE, not per program.
+    //
+    // Activation is a release-level act -- `use` moves a whole binding group
+    // at once -- so one inactive release is one problem no matter how many
+    // names it registers. On the measured home the per-program shape printed
+    // fifty lines for three releases: `clang`, `clang++`, `clang-22`,
+    // `llvm-ar` … each with its own identical remedy. That is the same burial
+    // the broken-payload grouping exists to prevent (see Finding::groupKey),
+    // and it would have hidden `node` in the middle of it.
+    struct InactiveRelease {
+        std::string rootTarget;
+        std::string rootVersion;
+        std::vector<std::string> members;
+    };
+    std::map<std::string, InactiveRelease> inactiveReleases;
+
+    for (const auto& [name, versions] : st.wsInstalled) {
+        if (versions.empty()) continue;
+        if (auto wit = st.ws.find(name);
+            wit != st.ws.end() && !wit->second.empty()) continue;
+
+        const auto* vi = xvm::get_vinfo(st.db, name);
+        if (!vi || !xvm::has_program_kind(st.db, name)) continue;
+
+        // Only versions this subos actually has, highest first: the same
+        // ordering removal.cppm:390-393 uses to pick a replacement release,
+        // so doctor's remedy and remove's automatic choice cannot disagree.
+        std::vector<std::string> candidates;
+        for (const auto& version : versions) {
+            if (!vi->versions.contains(version)) continue;
+            if (xvm::effective_kind_of(st.db, name, version) != "program")
+                continue;
+            candidates.push_back(version);
+        }
+        if (candidates.empty()) continue;
+        std::ranges::sort(candidates, xvm::version_key_greater);
+
+        // Would activating it actually produce a working command?
+        //
+        // This is the whole filter, and `is_binding_root` deliberately is not
+        // part of it. A name that exists only to anchor a release has no
+        // executable and drops out here -- activating one is issue #452 in the
+        // other direction, where the shim can only ever print "no active
+        // version". But asking `is_binding_root` first would have thrown out
+        // the real cases too: a group's root is usually its main program.
+        // `node` roots the release that owns `npm` and `npx`, so it answers
+        // true to that question while being exactly the program the user is
+        // missing. Only the payload can tell the two apart, so only the
+        // payload is asked -- the same order Check 3 uses.
+        //
+        // A version whose payload is gone is skipped as well: Check 3 already
+        // reports that as a broken payload with an install remedy, and
+        // offering `xlings use` on top of it would name a command that cannot
+        // succeed.
+        const auto usable = std::ranges::find_if(
+            candidates, [&](const std::string& version) {
+                const auto* vd = xvm::get_vdata(st.db, name, version);
+                if (!vd || vd->path.empty()) return false;
+                if (!vd->alias.empty() && !vd->alias[0].empty()) return true;
+                return !xvm::resolve_executable(name, vd->path, st.homeStr)
+                            .empty();
+            });
+        if (usable == candidates.end()) continue;
+
+        // The release this program belongs to, which is what `use` takes as
+        // an argument. A legacy entry carries no group and is its own root --
+        // that is not a fallback, it is what a single-program package is.
+        const auto* vd = xvm::get_vdata(st.db, name, *usable);
+        const std::string rootTarget =
+            vd && vd->bindingGroup ? vd->bindingGroup->rootTarget : name;
+        const std::string rootVersion =
+            vd && vd->bindingGroup ? vd->bindingGroup->rootVersion : *usable;
+
+        auto& release = inactiveReleases[std::format("{}@{}", rootTarget,
+                                                     rootVersion)];
+        release.rootTarget  = rootTarget;
+        release.rootVersion = rootVersion;
+        release.members.push_back(name);
+    }
+
+    for (const auto& [key, release] : inactiveReleases) {
+        // Names, not a count. "30 programs" tells the user nothing they can
+        // check; `clang, clang++, ld.lld …` is how they recognise what they
+        // have been missing. The list is capped because a release with thirty
+        // members would otherwise take the terminal apart -- `--all` prints it
+        // whole.
+        constexpr std::size_t kShown = 6;
+        std::string names;
+        for (std::size_t i = 0; i < release.members.size() && i < kShown; ++i) {
+            if (!names.empty()) names += ", ";
+            names += release.members[i];
+        }
+        if (release.members.size() > kShown) {
+            names += std::format(", … (+{})", release.members.size() - kShown);
+        }
+
+        // What the repair will ALSO do.
+        //
+        // The remedy is `use`, and `use` moves a whole release. A name that
+        // another package currently owns -- node's release registers `npm`,
+        // and a standalone npm package may hold it -- changes hands when the
+        // release is activated. That is correct for `use` and it is what the
+        // user gets whether they run the command themselves or let `--fix`
+        // run it, but it must not be something they discover afterwards:
+        // finding out later that a selection moved is the same silent-change
+        // shape this whole check exists to end.
+        std::string alsoMoves;
+        if (const auto selection = xvm::resolve_binding_selection(
+                st.db, release.rootTarget, release.rootVersion)) {
+            for (const auto& [memberTarget, memberVersion]
+                     : selection->members) {
+                const auto activeIt = st.ws.find(memberTarget);
+                if (activeIt == st.ws.end() || activeIt->second.empty()) continue;
+                if (activeIt->second == memberVersion) continue;
+                if (!alsoMoves.empty()) alsoMoves += ", ";
+                alsoMoves += std::format("{} ({} → {})", memberTarget,
+                                         activeIt->second, memberVersion);
+            }
+        }
+
+        add({
+            .kind    = FindingKind::InactiveInstalled,
+            .level   = FindingLevel::Error,
+            .target  = release.rootTarget,
+            .version = release.rootVersion,
+            .detail  = std::format(
+                "{} is installed in this subos but no version is active, so no "
+                "shim was written and {} program(s) are not on PATH: {}{}",
+                xvm::display_coordinate(release.rootTarget,
+                                        release.rootVersion),
+                release.members.size(), names,
+                alsoMoves.empty() ? std::string{}
+                                  : std::format(
+                                        "  —  activating it also moves {}",
+                                        alsoMoves)),
+            .remedy  = std::format("xlings use {}@{}", release.rootTarget,
+                                   release.rootVersion),
+            .groupKey = key,
+        });
     }
 
     // Check 2.6: shim ownership anchoring (0.4.48). Warning-only: the usual
@@ -600,33 +779,84 @@ Scan detect_(const DoctorState& st, const CoordinateProbe& probe) {
                 continue;
             }
 
-            // Alias mode: best-effort coverage. Absolute-path aliases are
-            // intentionally external and skipped; relative aliases that don't
-            // resolve locally are downgraded to a warning because they MIGHT
-            // be system commands found via the runtime PATH.
+            // Alias mode: ask the question the runtime answers.
             //
-            // TODO(self-doctor): only alias[0] is inspected (matches runtime
-            // today; if multi-element fallback chains ever land they should be
-            // covered too), and "intentional system command" vs
-            // "misconfiguration" still cannot be told apart from inside
-            // doctor. Bounded by warning severity: no error, no exit-1,
-            // --fix doesn't touch it.
+            // This used to call resolve_executable, which searches the
+            // package's own payload and nothing else, and report every miss as
+            // one warning. But the alias branch of shim_dispatch prepends the
+            // payload, the payload's bin, AND the subos bin dir to PATH before
+            // handing the command to a shell, so two whole tiers of the real
+            // search were invisible here. A package whose only job is to give
+            // thirty short names to a sibling package's `mcpp` resolves on
+            // every invocation and was reported broken on every doctor run --
+            // thirty-four such warnings on one measured home, all of them
+            // false, and one warning level for "runs fine via a sibling",
+            // "runs fine via the host" and "nothing to exec at all".
+            //
+            // resolve_alias_program lives next to the dispatcher so the two
+            // cannot drift, the same reason the baked-path check calls the
+            // function its repair calls.
+            //
+            // TODO(self-doctor): only alias[0] is inspected — matches the
+            // runtime today; if multi-element fallback chains ever land they
+            // should be covered too.
             const auto aliasProg = alias_program_(vdata.alias[0], st.homeStr);
-            if (fs::path(aliasProg).is_absolute()) continue;
-            if (!xvm::resolve_executable(aliasProg, vdata.path, st.homeStr)
-                     .empty()) {
+            const auto resolution = xvm::resolve_alias_program(
+                aliasProg, vdata.path, st.homeStr, p.binDir, hostPath);
+            // Its own payload, a sibling shim in this subos, or a full path
+            // that is there. Nothing to report.
+            //
+            // The absolute case used to be skipped BEFORE anything was
+            // checked, so an absolute alias pointing at a path that no longer
+            // existed was the one alias shape doctor could never report. It
+            // is checked now, and only its absence is a finding.
+            if (resolution.origin == xvm::AliasOrigin::Absolute
+                || resolution.origin == xvm::AliasOrigin::Payload
+                || resolution.origin == xvm::AliasOrigin::SubosBin) {
+                continue;
+            }
+            if (resolution.origin == xvm::AliasOrigin::SystemPath) {
+                // Works, and is allowed to: a recipe may deliberately wrap a
+                // host tool. Worth saying once because it is the difference
+                // between a home that is portable and one that is not, but it
+                // is not a defect and must not touch the exit code.
+                add({
+                    .kind    = FindingKind::AliasUnresolved,
+                    .level   = FindingLevel::Notice,
+                    .target  = name,
+                    .version = version,
+                    .detail  = std::format(
+                        "{} alias '{}' is satisfied by a host command ({}), "
+                        "not by anything xlings installed",
+                        xvm::display_coordinate(name, version), aliasProg,
+                        resolution.path.string()),
+                });
+                continue;
+            }
+
+            // Nothing to exec, anywhere the runtime would look.
+            //
+            // Now an error, because it now means what it says. If the alias
+            // names a target xlings knows about, the honest finding is that
+            // the target has no active version -- Check 2.7 already reported
+            // it against the release, with a remedy that fixes both -- and
+            // repeating it here as an alias defect would send the user after
+            // the wrong thing.
+            if (const auto* aliasVi = xvm::get_vinfo(st.db, aliasProg);
+                aliasVi && xvm::has_program_kind(st.db, aliasProg)) {
                 continue;
             }
             add({
                 .kind    = FindingKind::AliasUnresolved,
-                .level   = FindingLevel::Warning,
+                .level   = FindingLevel::Error,
                 .target  = name,
                 .version = version,
                 .detail  = std::format(
-                    "{} alias '{}' not resolvable in {} (may be a system "
-                    "command)",
+                    "{} alias '{}' resolves to nothing — not in {}, not a "
+                    "sibling command in {}, not on PATH",
                     xvm::display_coordinate(name, version), aliasProg,
-                    Config::display_path(expanded)),
+                    Config::display_path(expanded),
+                    Config::display_path(p.binDir)),
             });
         }
     }
@@ -1215,6 +1445,57 @@ void repair_payloads_(const DoctorState& st, const Scan& scan,
     }
 }
 
+// Activate what is installed and inactive, by running `use`.
+//
+// Deliberately a subprocess and deliberately the exact command the finding
+// prints. Activating a release is not a workspace write: it places the
+// release's libraries and headers in the sysroot and writes a shim per
+// member, and xvm's `use` path is the only code that does all of it. Setting
+// `workspace[name]` here would activate the name and leave the sysroot
+// holding whatever the previous release put there -- the half-switched state
+// plan_use_switch was written to make impossible.
+//
+// `use` moves the WHOLE release, which can take a name from another provider:
+// node's release owns `npm`, and a separately installed npm package may hold
+// that name today. That is not a side effect this hides -- it is what the
+// printed remedy does when the user runs it by hand, and a `--fix` that did
+// something narrower than the command it advertises would be a third
+// behaviour to reason about. The install path is where "do not take a name
+// from another provider" belongs, and that is where it now lives
+// (registration.cppm); by the time doctor is looking at the wreckage, the
+// user has asked for repair.
+void repair_inactive_(const Scan& scan, const std::string& client,
+                      const CommandRunner& run, bool dryRun,
+                      RepairReport& out) {
+    for (const auto& f : scan.findings) {
+        if (f.kind != FindingKind::InactiveInstalled) continue;
+        if (!is_shell_safe_token(f.target) || !is_shell_safe_token(f.version)) {
+            out.notes.emplace_back(
+                glyph::mark(glyph::failed, "activation skipped"),
+                std::format("{} — name or version is not a safe shell token",
+                            xvm::display_coordinate(f.target, f.version)));
+            continue;
+        }
+        const auto cmd = std::format("{} use {}@{}", client, f.target,
+                                     f.version);
+        if (dryRun) {
+            out.planned.push_back(cmd);
+            continue;
+        }
+        if (run(cmd + quiet_suffix()) == 0) {
+            out.notes.emplace_back(glyph::mark(glyph::bullet, "activated"),
+                                   std::format("{}@{}", f.target, f.version));
+        } else {
+            out.failedEntries.emplace_back(f.target, f.version);
+            out.notes.emplace_back(
+                glyph::mark(glyph::failed, "activation failed"),
+                std::format("{} — run `{}` to see why",
+                            xvm::display_coordinate(f.target, f.version),
+                            f.remedy));
+        }
+    }
+}
+
 // The last rung: drop a registration that is provably dead.
 //
 // Runs after the ladder and after a reload, on findings that SURVIVED it. That
@@ -1333,12 +1614,14 @@ struct Counts {
     int orphans { 0 };
     int broken  { 0 };
     int binding { 0 };
+    int inactive { 0 };
+    int aliasBroken { 0 };
     int warnings { 0 };
     int foreignPayloads { 0 };
     int otherSubos { 0 };
 
     [[nodiscard]] int issues() const {
-        return missing + orphans + broken + binding;
+        return missing + orphans + broken + binding + inactive + aliasBroken;
     }
 };
 
@@ -1363,10 +1646,16 @@ Counts count_(const Scan& scan) {
             // count that does not match the list is the shape the old summary
             // had -- "broken payloads 1" with nothing in the list to explain
             // it -- and it sends people looking for a line that is not there.
+            // An alias that a host command satisfies is a Notice and counts
+            // as nothing; one that resolves nowhere is an Error and counts as
+            // an issue. They used to be the same warning, which is how a real
+            // break stayed invisible inside thirty-four false ones.
             case FindingKind::AliasUnresolved:
-                if (aliasTargets.insert(f.target).second) ++c.warnings;
+                if (f.level != FindingLevel::Error) break;
+                if (aliasTargets.insert(f.target).second) ++c.aliasBroken;
                 break;
             case FindingKind::ReleaseAnchor:   break;
+            case FindingKind::InactiveInstalled: ++c.inactive; break;
             // Per TARGET, matching how they are printed (see render_).
             case FindingKind::SubosPathBaked:
                 if (bakedTargets.insert(f.target).second) ++c.warnings;
@@ -1458,7 +1747,11 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
     std::set<std::string> bakedTargetsShown;
     std::map<std::string, int> bakedVersionCount;
     for (const auto& f : scan.findings) {
-        if (f.kind == FindingKind::AliasUnresolved) ++aliasVersionCount[f.target];
+        // Errors only: the "+N other version(s)" suffix is printed on an
+        // error line, so counting notices into it would inflate a number the
+        // user cannot see the rest of.
+        if (f.kind == FindingKind::AliasUnresolved
+            && f.level == FindingLevel::Error) ++aliasVersionCount[f.target];
         else if (f.kind == FindingKind::SubosPathBaked) ++bakedVersionCount[f.target];
     }
     for (const auto& f : scan.findings) {
@@ -1474,6 +1767,10 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
                 break;
             case FindingKind::LegacyAliasShim:
                 add(glyph::mark(glyph::failed, "legacy alias shim"), f.detail); break;
+            case FindingKind::InactiveInstalled:
+                add(glyph::mark(glyph::failed, "no active version"), f.detail);
+                add("  " + glyph::mark(glyph::remedy, "run"), f.remedy);
+                break;
             case FindingKind::ShimAnchor:
                 add(glyph::mark(glyph::warn, "shim anchor"), f.detail); break;
             case FindingKind::AliasUnresolved:
@@ -1484,8 +1781,22 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
                 // the repeats is the fix; hiding the category is not, because
                 // a genuinely missing alias binary is the only signal there
                 // is.
+                //
+                // The Notice level is "a host command answers this", which is
+                // a portability fact rather than a defect. It is summarised
+                // like the other notices and printed only under `--all`, so
+                // the Error level -- an alias with nothing to exec anywhere --
+                // is the only thing this category shows by default. That is
+                // the whole point of splitting it: the error used to be one
+                // line among thirty-four identical-looking warnings.
+                if (f.level == FindingLevel::Notice) {
+                    if (verbose) {
+                        add(glyph::mark(glyph::note, "host alias"), f.detail);
+                    }
+                    break;
+                }
                 if (verbose || aliasTargetsShown.insert(f.target).second) {
-                    add(glyph::mark(glyph::warn, "alias unresolved"), verbose ? f.detail
+                    add(glyph::mark(glyph::failed, "alias unresolved"), verbose ? f.detail
                         : std::format("{}{}", f.detail,
                             aliasVersionCount.at(f.target) > 1
                                 ? std::format("  (+{} other version(s))",
@@ -1545,6 +1856,9 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
     // four lines that matter got lost.
     if (!verbose) {
         int anchors = 0, anchorShims = 0, bindingNotices = 0, subosNotices = 0;
+        // Per TARGET, like the warning line it replaced: one package's alias
+        // is one fact however many versions of it are registered.
+        std::set<std::string> hostAliasTargets;
         for (const auto& f : scan.findings) {
             if (f.kind == FindingKind::ReleaseAnchor) ++anchors;
             else if (f.kind == FindingKind::OrphanShim
@@ -1553,6 +1867,10 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
                      && f.level == FindingLevel::Notice) ++bindingNotices;
             else if (f.kind == FindingKind::OtherSubos
                      && f.level == FindingLevel::Notice) ++subosNotices;
+            else if (f.kind == FindingKind::AliasUnresolved
+                     && f.level == FindingLevel::Notice) {
+                hostAliasTargets.insert(f.target);
+            }
         }
         std::string summary;
         const auto part = [&](int n, std::string_view what) {
@@ -1561,6 +1879,7 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
             summary += std::format("{} {}", n, what);
         };
         part(anchors, "release anchor");
+        part(static_cast<int>(hostAliasTargets.size()), "host alias");
         part(anchorShims, "anchor shim");
         part(bindingNotices, "binding notice");
         part(subosNotices, "other-subos notice");
@@ -1590,6 +1909,10 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
             add("broken payloads", std::to_string(counts.broken));
         if (counts.binding > 0)
             add("binding state", std::to_string(counts.binding));
+        if (counts.inactive > 0)
+            add("no active version", std::to_string(counts.inactive));
+        if (counts.aliasBroken > 0)
+            add("unresolvable aliases", std::to_string(counts.aliasBroken));
         if (counts.warnings > 0)
             add("warnings", std::to_string(counts.warnings));
         // Reported apart from the counts above because they are apart from the
@@ -1710,8 +2033,13 @@ export int cmd_doctor(EventStream& stream, bool fix,
 
     const int before = count_(scan).issues();
 
+    const CommandRunner run = [](const std::string& cmd) {
+        return platform::exec(cmd);
+    };
+
     if (dryRun) {
         repair_payloads_(state, scan, probe, /*dryRun=*/true, repair);
+        repair_inactive_(scan, client, run, /*dryRun=*/true, repair);
         render_(scan, repair, fix, dryRun, verbose, stream);
             return count_(scan).issues() == 0 ? 0 : 1;
     }
@@ -1744,6 +2072,16 @@ export int cmd_doctor(EventStream& stream, bool fix,
 
     // Phase 2: the payload ladder.
     repair_payloads_(state, scan, probe, /*dryRun=*/false, repair);
+    refresh();
+
+    // Phase 2.5: activate what is installed and inactive.
+    //
+    // After the ladder, not before: a package whose payload was missing is
+    // both broken AND inactive, and `use` on a payload that is not there fails
+    // for a reason the user cannot act on. The ladder reinstalls it first, and
+    // re-registration may activate it on its own -- in which case `refresh()`
+    // has already dropped the finding and there is nothing left to do here.
+    repair_inactive_(scan, client, run, /*dryRun=*/false, repair);
     refresh();
 
     // Phase 3: the cheap repairs again, on what the ladder left behind.

--- a/src/core/xvm/inspect.cppm
+++ b/src/core/xvm/inspect.cppm
@@ -276,6 +276,32 @@ std::vector<BindingFinding> inspect_binding_state(
             const bool coherent = activeIt != workspace.end()
                 && activeIt->second == memberVersion;
             if (coherent) continue;
+
+            // A name another PROVIDER owns is not this release breaking step.
+            //
+            // Two packages can register the same program name -- node's
+            // release registers `npm`, and a standalone npm package registers
+            // it too. Whichever is active, the other release's member is
+            // "wrong" by version alone, and calling that incoherent asks the
+            // user to run a `use` that would take the name away from the
+            // package they chose. Registration applies the same rule from the
+            // other side: a foreign claim does not veto its siblings, and a
+            // foreign claim is not a defect afterwards either. A contest with
+            // the SAME provider is a genuinely split release and still
+            // reported.
+            if (activeIt != workspace.end()) {
+                const auto holderIt = db.find(memberTarget);
+                if (holderIt != db.end()) {
+                    const auto heldIt =
+                        holderIt->second.versions.find(activeIt->second);
+                    if (heldIt != holderIt->second.versions.end()
+                        && heldIt->second.bindingGroup
+                        && heldIt->second.bindingGroup->provider
+                               != dataIt->second.bindingGroup->provider) {
+                        continue;
+                    }
+                }
+            }
             const auto key = dataIt->second.bindingGroup->provider + "@"
                 + dataIt->second.bindingGroup->providerVersion + "/"
                 + memberTarget;

--- a/src/core/xvm/registration.cppm
+++ b/src/core/xvm/registration.cppm
@@ -26,6 +26,22 @@ struct RegistrationNode {
     std::vector<std::string> alias;
     std::map<std::string, std::string> envs;
     std::optional<RegistrationBinding> binding;
+    // Is there actually a command behind this name?
+    //
+    // A virtual root -- registered only so a release has something to bind to
+    // -- is indistinguishable from a real program in this struct and in the
+    // database: `path` is filled in from the package's install dir either way,
+    // `kind` defaults to "program", and `sourceName`/`destinationName` are
+    // auto-derived from the target. The measured #452 anchor
+    // (`xim-anchor-root`, registered with no bindir at all) carries exactly
+    // the same fields as `node`. Only the payload can tell them apart, and
+    // this module does not touch the filesystem by design -- so the caller
+    // that materialised the payload answers the question and passes it here.
+    //
+    // Defaults to true, which is what every existing caller and test means:
+    // "assume there is a command". It is read on ONE path, where being wrong
+    // in the optimistic direction would resurrect #452.
+    bool runnable { true };
 };
 
 struct RegistrationHeader {
@@ -918,11 +934,101 @@ apply_registration_batch(
         // Leaving a name alone when something already owns it is also the
         // right answer across providers: installing gcc must not silently
         // take `cc` away from an active llvm.
-        const bool anyMemberActive = std::ranges::any_of(
+        //
+        // But leaving the name alone is all that was ever intended, and this
+        // used to do much more than that: ANY member name being active vetoed
+        // the WHOLE group, including members nobody was contesting. Installing
+        // node while a standalone npm package held `npm` therefore activated
+        // nothing at all -- `node` and `npx`, which no other package provides,
+        // came out installed and unreachable, with no shim and no error. The
+        // user met it as `/usr/bin/env: 'node': No such file or directory`
+        // from a tool that had nothing to do with xlings.
+        //
+        // Who holds a contested name decides whether it vetoes:
+        //
+        //   same provider   -- an older release of this same package. Moving
+        //                      part of the workspace to the new release and
+        //                      leaving the rest on the old one is exactly the
+        //                      split the binding-group model exists to
+        //                      prevent, and choosing between two releases of
+        //                      one package is the user's call: `use`. Veto.
+        //   other provider  -- a different package owns that name and keeps
+        //                      it. That is ownership, not incoherence, and it
+        //                      says nothing about this release's other names.
+        //                      No veto; the contested name is skipped below.
+        //   unknown         -- an entry with no group metadata, written before
+        //                      providers were recorded. Treated as the same
+        //                      provider, so old homes keep today's behaviour.
+        const auto contested_by =
+            [&](const std::string& memberTarget)
+            -> std::optional<std::string> {
+            const auto activeIt = candidateWorkspace.find(memberTarget);
+            if (activeIt == candidateWorkspace.end()) return std::nullopt;
+            const auto dbIt = candidateDb.find(memberTarget);
+            if (dbIt == candidateDb.end()) return std::string{};
+            const auto verIt = dbIt->second.versions.find(activeIt->second);
+            if (verIt == dbIt->second.versions.end()) return std::string{};
+            if (!verIt->second.bindingGroup) return std::string{};
+            return verIt->second.bindingGroup->provider;
+        };
+
+        std::set<std::string> contested;
+        bool sameProviderContest = false;
+        for (const auto& member : group.members) {
+            const auto owner = contested_by(member.first);
+            if (!owner) continue;
+            contested.insert(member.first);
+            if (*owner == batch.provider) sameProviderContest = true;
+        }
+
+        // Is there anything left worth activating?
+        //
+        // A virtual root exists only to anchor the release its libraries
+        // belong to; there is no command behind it. Activating one writes a
+        // shim that can only print "no active version", which is issue #452:
+        // `self doctor` called the file an orphan, `--fix` deleted it, and the
+        // next install put it straight back. A group whose only uncontested
+        // members are anchors therefore stays inactive, exactly as before.
+        //
+        // Neither the path nor the kind can answer this on its own. A real
+        // anchor carries a payload path like everything else --
+        // `xim-musl-gnu-gcc` records musl-gcc's own directory, and the #452
+        // fixture's root, registered with no bindir at all, still ends up with
+        // the package install dir -- and `kind` defaults to "program" for both.
+        // So the batch's own answer (RegistrationNode::runnable, set by
+        // whoever materialised the payload) is what decides, with the kind and
+        // path as the cheap checks in front of it.
+        const bool anyRealUncontested = std::ranges::any_of(
             group.members, [&](const auto& member) {
-                return candidateWorkspace.contains(member.first);
+                if (contested.contains(member.first)) return false;
+                const auto dbIt = candidateDb.find(member.first);
+                if (dbIt == candidateDb.end()) return false;
+                const auto verIt = dbIt->second.versions.find(member.second);
+                if (verIt == dbIt->second.versions.end()) return false;
+                if (verIt->second.path.empty()) return false;
+                if (effective_kind(dbIt->second, verIt->second) != "program") {
+                    return false;
+                }
+                const auto nodeIt = std::ranges::find_if(
+                    batch.nodes, [&](const RegistrationNode& n) {
+                        return n.target == member.first
+                            && n.version == member.second;
+                    });
+                return nodeIt == batch.nodes.end() || nodeIt->runnable;
             });
-        const bool activateGroup = batch.useAfterInstall || !anyMemberActive;
+
+        // `contested.empty()` first, and not folded into the clause after it.
+        //
+        // The anchor guard exists to stop #452 coming back through the door
+        // the cross-provider rule opens, so it applies only to that door. A
+        // release nobody is contesting activates exactly as it always has --
+        // including a batch that is nothing but a virtual root, which is how
+        // a library-only package registers and which has to stay activated
+        // for anything to bind to it.
+        const bool activateGroup =
+            batch.useAfterInstall
+            || contested.empty()
+            || (!sameProviderContest && anyRealUncontested);
 
         const BindingGroupRef ref{
             .provider = batch.provider,
@@ -964,7 +1070,12 @@ apply_registration_batch(
             if (!foundVersion) {
                 versions.push_back(version);
             }
-            if (activateGroup) {
+            // A contested name stays with whoever holds it. `useAfterInstall`
+            // is the one exception, and it is not an exception to the rule so
+            // much as a different question: the user typed the switch, so
+            // taking the name is what they asked for.
+            if (activateGroup
+                && (batch.useAfterInstall || !contested.contains(target))) {
                 candidateWorkspace[target] = version;
             }
         }

--- a/src/core/xvm/shim.cppm
+++ b/src/core/xvm/shim.cppm
@@ -268,6 +268,109 @@ std::filesystem::path resolve_executable(const std::string& program_name,
     return {};
 }
 
+// Where an alias's program was found, in the order the runtime looks.
+//
+// The alias path below does not call resolve_executable at all in the normal
+// case: it PREPENDS `<payload>`, `<payload>/bin` and the subos bin dir to
+// PATH and hands the command to a shell (see the alias branch of
+// shim_dispatch). So an alias naming a sibling xlings command -- thirty of
+// mcpp's short commands name `mcpp`, which lives in a different package --
+// resolves at the third position, and one naming a host tool resolves at the
+// fourth.
+//
+// This mattered because `self doctor` was asking resolve_executable, which
+// only knows the first two, and reporting everything past them as
+// unresolvable. Thirty-four such warnings on one measured home, every one of
+// them a command that runs correctly. The point of the enum is that the
+// caller can tell those apart from an alias that really has nothing to run:
+// they were a single warning level before, so a genuine break was
+// indistinguishable from the noise around it.
+enum class AliasOrigin {
+    Absolute,     // the alias named a full path and it is there
+    Payload,      // <payload>/ or <payload>/bin -- the package's own
+    SubosBin,     // a sibling shim in the active subos: still xlings's
+    SystemPath,   // inherited PATH: works, but the host is providing it
+    Nowhere,      // nothing to exec
+};
+
+struct AliasResolution {
+    AliasOrigin origin { AliasOrigin::Nowhere };
+    std::filesystem::path path;
+};
+
+// Resolve an alias program the way the alias branch of shim_dispatch will.
+//
+// `searchPath` is the PATH to search at the fourth position; callers pass the
+// live environment, tests pass their own. Empty means "do not look" -- which
+// is not the same as "found nothing", so a caller that cannot see a
+// representative PATH gets Nowhere and should say so rather than claim the
+// alias is broken.
+AliasResolution resolve_alias_program(const std::string& program_name,
+                                      const std::string& path,
+                                      const std::string& xlings_home,
+                                      const std::filesystem::path& subos_bin,
+                                      std::string_view searchPath) {
+    namespace fs = std::filesystem;
+
+    if (program_name.empty()) return {};
+
+    // An absolute alias is not searched for; it either exists or it does not.
+    // It is NOT a host command -- a recipe that pins a full path into its own
+    // payload store writes one, and calling that "satisfied by the host" gets
+    // the portability question exactly backwards.
+    if (fs::path(program_name).is_absolute()) {
+        std::error_code ec;
+        if (fs::exists(program_name, ec)) {
+            return {AliasOrigin::Absolute, fs::path(program_name)};
+        }
+        return {};
+    }
+
+    if (auto own = resolve_executable(program_name, path, xlings_home);
+        !own.empty()) {
+        return {AliasOrigin::Payload, std::move(own)};
+    }
+
+#if defined(_WIN32)
+    constexpr std::string_view exts[] = {"", ".exe", ".bat", ".cmd"};
+#else
+    constexpr std::string_view exts[] = {""};
+#endif
+
+    const auto probe = [&](const fs::path& dir) -> fs::path {
+        if (dir.empty()) return {};
+        for (auto ext : exts) {
+            auto candidate = dir / (program_name + std::string(ext));
+            std::error_code ec;
+            if (fs::exists(candidate, ec) && !fs::is_directory(candidate, ec)) {
+                return candidate;
+            }
+        }
+        return {};
+    };
+
+    if (auto sibling = probe(subos_bin); !sibling.empty()) {
+        return {AliasOrigin::SubosBin, std::move(sibling)};
+    }
+
+    std::size_t start = 0;
+    while (start <= searchPath.size() && !searchPath.empty()) {
+        auto end = searchPath.find(platform::PATH_SEPARATOR, start);
+        auto part = searchPath.substr(
+            start, end == std::string_view::npos ? std::string_view::npos
+                                                 : end - start);
+        if (!part.empty()) {
+            if (auto hit = probe(fs::path(part)); !hit.empty()) {
+                return {AliasOrigin::SystemPath, std::move(hit)};
+            }
+        }
+        if (end == std::string_view::npos) break;
+        start = end + 1;
+    }
+
+    return {};
+}
+
 // Merge a shim-injected env value into the existing one. PATH-style vars
 // prepend (new first), but a value already present — as the whole value or as
 // one separator-delimited component — must NOT be appended again: the blind

--- a/src/ui/info_panel.cppm
+++ b/src/ui/info_panel.cppm
@@ -13,6 +13,21 @@ import :layout;
 
 export namespace xlings::ui {
 
+// One row of `xlings search` / `xlings list`.
+//
+// `status` is a short qualifier the row cannot be read correctly without —
+// today only `inactive`. It gets a column of its own rather than a place in
+// the description because the description is the column that gets dropped
+// when the terminal is narrow (plan_two_column sets descW to 0 below
+// kMinDescW), and a qualifier that disappears at 80 columns is a qualifier
+// that lies. Empty on every row means no column is reserved at all, so
+// `search` renders exactly as it did before.
+struct ListRow {
+    std::string name;
+    std::string desc;
+    std::string status;
+};
+
 // A key-value row for info panels
 struct InfoField {
     std::string label;
@@ -184,19 +199,24 @@ void print_info_panel(std::string_view title,
 // column the user acts on — it goes into the next `xlings install` — so it is
 // never elided; the description is.
 void print_styled_list(std::string_view title,
-                       std::span<const std::pair<std::string, std::string>> items,
+                       std::span<const ListRow> items,
                        bool show_marker) {
     using namespace ftxui;
 
     constexpr int kMarkerW = 4;   // "  ◆ " or four spaces
     constexpr int kGap = 2;
 
-    int nameMax = 0, descMax = 0;
-    for (auto& [name, desc] : items) {
-        nameMax = std::max(nameMax, layout::display_width(name));
-        descMax = std::max(descMax, layout::display_width(desc));
+    int nameMax = 0, descMax = 0, statusMax = 0;
+    for (auto& row : items) {
+        nameMax = std::max(nameMax, layout::display_width(row.name));
+        descMax = std::max(descMax, layout::display_width(row.desc));
+        statusMax = std::max(statusMax, layout::display_width(row.status));
     }
-    auto P = layout::plan_two_column(kMarkerW, kGap, nameMax, descMax,
+    // The status column is planned as part of the name block, not of the
+    // description, so it is never the thing that gets dropped or truncated.
+    const int statusBlock = statusMax > 0 ? kGap + statusMax : 0;
+    auto P = layout::plan_two_column(kMarkerW, kGap, nameMax + statusBlock,
+                                     descMax,
                                      2 + layout::display_width(title));
 
     Elements rows;
@@ -205,7 +225,9 @@ void print_styled_list(std::string_view title,
         rows.push_back(text(""));
     }
 
-    for (auto& [name, desc] : items) {
+    for (auto& row : items) {
+        const auto& name = row.name;
+        const auto& desc = row.desc;
         auto marker = show_marker
             ? (text("  " + std::string(theme::icon::package) + " ") | color(theme::magenta()))
             : text("    ");
@@ -222,6 +244,15 @@ void print_styled_list(std::string_view title,
                     text(nameLines[i]) | bold | color(theme::magenta()),
                 }));
             }
+            // Its own line, never elided. The stacked branch is where the
+            // terminal is already too narrow for the name, which is exactly
+            // when a dropped qualifier would do the most damage.
+            if (!row.status.empty()) {
+                rows.push_back(hbox({
+                    text(std::string(kMarkerW + kGap, ' ')),
+                    text(row.status) | color(theme::amber()),
+                }));
+            }
             if (P.descW > 0 && !desc.empty()) {
                 rows.push_back(hbox({
                     text(std::string(kMarkerW + kGap, ' ')),
@@ -233,8 +264,13 @@ void print_styled_list(std::string_view title,
 
         Elements cells;
         cells.push_back(marker);
-        cells.push_back(text(layout::pad_to_width(name, P.nameW))
+        cells.push_back(text(layout::pad_to_width(name, nameMax))
                         | bold | color(theme::magenta()));
+        if (statusMax > 0) {
+            cells.push_back(text(std::string(kGap, ' ')));
+            cells.push_back(text(layout::pad_to_width(row.status, statusMax))
+                            | color(theme::amber()));
+        }
         if (P.descW > 0 && !desc.empty()) {
             cells.push_back(text(std::string(kGap, ' ')));
             cells.push_back(text(layout::truncate_to_width(desc, P.descW))

--- a/tests/e2e/inactive_installed_test.sh
+++ b/tests/e2e/inactive_installed_test.sh
@@ -1,0 +1,334 @@
+#!/usr/bin/env bash
+# E2E: a package that is installed and has no active version.
+#
+# The measured break: `codex` failing with
+# `/usr/bin/env: 'node': No such file or directory` on a home where node was
+# installed and its payload intact. node's release registers `node`, `npm` and
+# `npx`; a separately installed npm package held `npm`; the activation vote was
+# "is ANY member name already active", so one contested name suppressed the
+# whole release. `node` — which nothing else provides — came out installed and
+# unreachable.
+#
+# Nothing reported it. `xlings list` reads installed[] and never looks at the
+# active selection. `self doctor`'s shim checks walk the active workspace (a
+# name with no active version is not in it) and binDir (there is no file). The
+# payload check walks the versions DB and finds everything healthy, which it
+# is: what is broken is the selection.
+#
+# Scenarios:
+#   S1  a foreign provider holding one member name does not veto its siblings
+#   S2  active pointer removed by hand   → doctor reports it, exit 1
+#   S3  --fix activates and the command runs
+#   S4  `list` marks it inactive
+#   S5  a virtual anchor with no command is NOT reported
+#   S6  a same-provider contest still stays inactive, and --fix does not
+#       choose a release for the user
+
+set -euo pipefail
+
+# shellcheck source=./project_test_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
+
+require_fixture_index
+
+RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/inactive_installed"
+HOME_DIR="$RUNTIME_DIR/home"
+LOCAL_INDEX_DIR="$RUNTIME_DIR/xim-pkgindex"
+
+cleanup() { rm -rf "$RUNTIME_DIR"; }
+trap cleanup EXIT
+cleanup
+
+XLINGS_BIN="$(find_xlings_bin)"
+
+RUN() {
+  ( cd /tmp && env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@" )
+}
+
+# A shim, invoked the way a user's shell would: through the subos bin dir, with
+# the sandbox home. Running it by absolute path with no XLINGS_HOME makes it
+# dispatch against the real home, which is both wrong and a way for this test
+# to pass or fail for reasons that have nothing to do with it.
+RUNSHIM() {
+  local name="$1"; shift
+  ( cd /tmp && env -i HOME="$HOME" PATH="$BIN_DIR:/usr/bin:/bin" \
+      XLINGS_HOME="$HOME_DIR" "$BIN_DIR/$name" "$@" )
+}
+
+mkdir -p "$HOME_DIR"
+cp -r "$FIXTURE_INDEX_DIR" "$LOCAL_INDEX_DIR"
+printf 'xim_indexrepos = {}\n' > "$LOCAL_INDEX_DIR/xim-indexrepos.lua"
+rm -f "$LOCAL_INDEX_DIR/.xlings-index-cache.json"
+mkdir -p "$LOCAL_INDEX_DIR/pkgs/i"
+
+# ── Fixtures ───────────────────────────────────────────────────────
+#
+# `solo-tool` registers the single name `shared-cmd`. `group-tool` registers a
+# release of three: its own root plus `shared-cmd` and `only-here`. Installing
+# group-tool after solo-tool reproduces the node/npm shape exactly — one
+# contested name, two uncontested ones, two different providers.
+
+cat > "$LOCAL_INDEX_DIR/pkgs/i/solo-tool.lua" <<'LUA'
+package = {
+    spec = "1",
+    name = "solo-tool",
+    description = "Local fixture: owns `shared-cmd` on its own",
+    authors = {"xlings-ci"},
+    licenses = {"MIT"},
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"test-fixture"},
+    programs = {"shared-cmd"},
+    xpm = {
+        linux   = { ["1.0.0"] = {} },
+        macosx  = { ["1.0.0"] = {} },
+        windows = { ["1.0.0"] = {} },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local bindir = path.join(pkginfo.install_dir(), "bin")
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(bindir)
+    io.writefile(path.join(bindir, "shared-cmd"), "#!/bin/sh\necho solo\n")
+    if os.host() ~= "windows" then
+        os.exec("chmod +x " .. path.join(bindir, "shared-cmd"))
+    end
+    return true
+end
+
+function config()
+    xvm.add("shared-cmd", { bindir = path.join(pkginfo.install_dir(), "bin") })
+    return true
+end
+
+function uninstall()
+    xvm.remove("shared-cmd")
+    return true
+end
+LUA
+
+cat > "$LOCAL_INDEX_DIR/pkgs/i/group-tool.lua" <<'LUA'
+package = {
+    spec = "1",
+    name = "group-tool",
+    description = "Local fixture: a release of three names, one contested",
+    authors = {"xlings-ci"},
+    licenses = {"MIT"},
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"test-fixture"},
+    programs = {"group-tool", "only-here"},
+    xpm = {
+        linux   = { ["2.0.0"] = {} },
+        macosx  = { ["2.0.0"] = {} },
+        windows = { ["2.0.0"] = {} },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local bindir = path.join(pkginfo.install_dir(), "bin")
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(bindir)
+    for _, name in ipairs({"group-tool", "shared-cmd", "only-here"}) do
+        io.writefile(path.join(bindir, name), "#!/bin/sh\necho " .. name .. "@2.0.0\n")
+        if os.host() ~= "windows" then
+            os.exec("chmod +x " .. path.join(bindir, name))
+        end
+    end
+    return true
+end
+
+function config()
+    local bindir = path.join(pkginfo.install_dir(), "bin")
+    xvm.add("group-tool", { bindir = bindir })
+    -- `binding` is a "root@version" STRING (libxpkg xvm.lua). A table is
+    -- accepted and ignored, which leaves every member its own singleton
+    -- group -- the fixture then passes for the wrong reason.
+    local root = "group-tool@" .. pkginfo.version()
+    xvm.add("shared-cmd", { bindir = bindir, binding = root })
+    xvm.add("only-here", { bindir = bindir, binding = root })
+    return true
+end
+
+function uninstall()
+    xvm.remove("group-tool")
+    xvm.remove("shared-cmd")
+    xvm.remove("only-here")
+    return true
+end
+LUA
+
+mkdir -p "$HOME_DIR/subos/default/bin"
+cp "$XLINGS_BIN" "$HOME_DIR/xlings"
+cat > "$HOME_DIR/.xlings.json" <<EOF
+{
+  "mirror": "GLOBAL",
+  "index_repos": [
+    { "name": "xim", "url": "$LOCAL_INDEX_DIR" }
+  ]
+}
+EOF
+
+log "Initializing sandbox XLINGS_HOME at $HOME_DIR"
+RUN self init >/dev/null 2>&1 || fail "self init failed"
+mkdir -p "$HOME_DIR/data/xim-index-repos"
+printf '{}\n' > "$HOME_DIR/data/xim-index-repos/xim-indexrepos.json"
+
+BIN_DIR="$HOME_DIR/subos/default/bin"
+
+# ── S1: a foreign claim does not veto the siblings ─────────────────
+log "S1: install solo-tool, then group-tool → uncontested members activate"
+RUN install solo-tool@1.0.0 -y >/dev/null 2>&1 || fail "S1 setup: solo-tool install failed"
+[[ -e "$BIN_DIR/shared-cmd" ]] || fail "S1 setup: shared-cmd shim should exist"
+
+RUN install group-tool@2.0.0 -y >/dev/null 2>&1 || fail "S1 setup: group-tool install failed"
+
+# The contested name stays with the package that already owned it.
+out=$(RUNSHIM shared-cmd 2>&1 || true)
+echo "$out" | grep -q "solo" \
+  || fail "S1: installing group-tool took 'shared-cmd' from solo-tool; got:\n$out"
+
+# ...and the names nobody contests are usable. This is the whole defect:
+# before the fix these two came out installed with no active version and no
+# shim, because one sibling's name was spoken for.
+[[ -e "$BIN_DIR/only-here" ]] \
+  || fail "S1: 'only-here' is uncontested and must be activated — it had no shim, which is the node/npx break"
+[[ -e "$BIN_DIR/group-tool" ]] \
+  || fail "S1: 'group-tool' is uncontested and must be activated"
+RUNSHIM only-here >/dev/null 2>&1 \
+  || fail "S1: the shim exists but does not run"
+
+RUN self doctor >/dev/null 2>&1 \
+  || fail "S1: a home where every installed program is reachable should be clean"
+
+# ── S2: an active pointer removed by hand is reported ──────────────
+#
+# What `remove` leaves behind when it takes out the active version and finds no
+# coherent replacement (removal.cppm), and what registration used to produce on
+# every contested install.
+log "S2: drop the active pointer → doctor reports it, exit 1"
+python3 - "$HOME_DIR" <<'PY' || fail "S2 setup: could not clear the active pointer"
+import json, pathlib, sys
+p = pathlib.Path(sys.argv[1], "subos", "default", ".xlings.json")
+data = json.loads(p.read_text())
+ws = data["workspace"]
+for name in ("group-tool", "only-here"):
+    entry = ws[name]
+    assert "active" in entry, f"S2 setup: {name} should have been active"
+    assert entry.get("installed"), f"S2 setup: {name} should be installed"
+    del entry["active"]
+p.write_text(json.dumps(data, indent=2))
+PY
+rm -f "$BIN_DIR/group-tool" "$BIN_DIR/only-here"
+
+rc=0
+out=$(RUN self doctor 2>&1) || rc=$?
+echo "$out" | grep -q "no active version" \
+  || fail "S2: installed-and-inactive must be reported; got:\n$out"
+echo "$out" | grep -q "group-tool@2.0.0" \
+  || fail "S2: the finding should name the release, not just a program; got:\n$out"
+[[ $rc -eq 1 ]] || fail "S2: an unreachable installed package is an error; expected exit 1, got $rc"
+
+# The repair is `use`, which moves the whole release — including `shared-cmd`,
+# which solo-tool currently owns. The finding has to say so BEFORE --fix runs.
+echo "$out" | grep -q "also moves shared-cmd" \
+  || fail "S2: activating this release will move a name another package owns; the finding must disclose it; got:\n$out"
+
+# One line per RELEASE. Fifty programs across three releases produced fifty
+# identical-looking lines before this was grouped, which is how the one that
+# mattered got buried.
+count=$(echo "$out" | grep -c "✗ no active version" || true)
+[[ "$count" -eq 1 ]] \
+  || fail "S2: the release's programs must collapse onto ONE finding, got $count:\n$out"
+
+# ── S4: `list` says so too ─────────────────────────────────────────
+#
+# Checked before the repair, while the state is still broken. This is the only
+# one of the three silent surfaces a user looks at on purpose.
+log "S4: list marks the inactive package"
+out=$(RUN list 2>&1) || true
+echo "$out" | grep -q "inactive" \
+  || fail "S4: list rendered an unreachable package exactly like a working one; got:\n$out"
+
+# ── S3: --fix activates it ─────────────────────────────────────────
+log "S3: doctor --fix activates the release and the command runs"
+RUN self doctor --fix >/dev/null 2>&1 || true
+[[ -e "$BIN_DIR/only-here" ]] || fail "S3: --fix did not recreate the shim"
+RUNSHIM only-here >/dev/null 2>&1 || fail "S3: the shim exists but does not run"
+RUN self doctor >/dev/null 2>&1 || fail "S3: doctor should be clean after --fix"
+
+# Activating a release moves the whole release, including a name another
+# package held. That is what `use` means and it is what the remedy does when a
+# user runs it by hand, so `--fix` doing it is not the problem -- doing it
+# WITHOUT SAYING SO would be, which is the shape this entire check exists to
+# end. S2 already asserted the disclosure; here we pin the consequence.
+out=$(RUNSHIM shared-cmd 2>&1 || true)
+echo "$out" | grep -q "shared-cmd@2.0.0" \
+  || fail "S3: the release was activated but its contested member did not move with it; got:\n$out"
+
+# ── S5: a virtual anchor is not a missing command ──────────────────
+#
+# A release anchor has no program behind it, so it has no active version to
+# lack. Reporting one would send `--fix` to activate it, which writes a shim
+# that can only print "no active version" — issue #452, reopened from the
+# other side.
+log "S5: a group-kind entry with no command is not reported"
+python3 - "$HOME_DIR" <<'PY' || fail "S5 setup: could not add the anchor"
+import json, pathlib, sys
+home = pathlib.Path(sys.argv[1])
+state = home / ".xlings.json"
+data = json.loads(state.read_text())
+payload = (data["versions"]["group-tool"]["versions"]["2.0.0"])["path"]
+data["versions"]["anchor-only"] = {
+    "filename": "anchor-only",
+    "type": "program",
+    "versions": {"9.9.9": {"kind": "group", "path": payload}},
+}
+state.write_text(json.dumps(data, indent=2))
+
+sub = home / "subos" / "default" / ".xlings.json"
+subdata = json.loads(sub.read_text())
+subdata["workspace"]["anchor-only"] = {"installed": ["9.9.9"]}
+sub.write_text(json.dumps(subdata, indent=2))
+PY
+rc=0
+out=$(RUN self doctor 2>&1) || rc=$?
+echo "$out" | grep -q "anchor-only" \
+  && fail "S5: a release anchor has no command to activate; got:\n$out"
+[[ $rc -eq 0 ]] || fail "S5: nothing is wrong here; expected exit 0, got $rc"
+
+# ── S6: a same-provider contest is the user's call ─────────────────
+#
+# Two releases of ONE package is the mixed-toolchain hazard the binding-group
+# model exists to prevent, and choosing between them is `use`. Install must not
+# move part of the workspace, and `--fix` must not pick either.
+log "S6: reinstalling a second release of the same package changes nothing"
+python3 - "$LOCAL_INDEX_DIR" <<'PY' || fail "S6 setup: could not add the second release"
+import pathlib, sys, re
+p = pathlib.Path(sys.argv[1], "pkgs", "i", "group-tool.lua")
+text = p.read_text()
+text = text.replace('["2.0.0"] = {}', '["2.0.0"] = {}, ["3.0.0"] = {}')
+p.write_text(text)
+PY
+rm -f "$LOCAL_INDEX_DIR/.xlings-index-cache.json"
+RUN install group-tool@3.0.0 -y >/dev/null 2>&1 || fail "S6 setup: install failed"
+
+active=$(python3 - "$HOME_DIR" <<'PY'
+import json, pathlib, sys
+p = pathlib.Path(sys.argv[1], "subos", "default", ".xlings.json")
+print(json.loads(p.read_text())["workspace"]["group-tool"].get("active", ""))
+PY
+)
+[[ "$active" == "2.0.0" ]] \
+  || fail "S6: install moved the workspace to a new release of the same package (active=$active)"
+
+log "all scenarios passed"

--- a/tests/e2e/run_all.sh
+++ b/tests/e2e/run_all.sh
@@ -101,6 +101,7 @@ TESTS=(
     "E2E-49 |group_switch_report_test.sh||"
     "E2E-50 |subos_scope_authority_test.sh||"
     "E2E-51 |install_use_semantics_test.sh||"
+    "E2E-52 |inactive_installed_test.sh||"
 )
 
 PASS=0; FAIL=0; SOFTFAIL=0

--- a/tests/e2e/self_doctor_test.sh
+++ b/tests/e2e/self_doctor_test.sh
@@ -365,27 +365,66 @@ RUN install alias-fixture@1.0.0 -y >/dev/null 2>&1 \
 RUN self doctor >/dev/null 2>&1 \
   || fail "S9: alias resolves correctly, doctor should be OK"
 
-# ── S10: alias's underlying binary missing → warning ───────────────
-log "S10: rm alias target → doctor reports warning (not error)"
+# ── S10: the three tiers below the payload ─────────────────────────
+#
+# The runtime resolves an alias through four places, in order: the payload,
+# the payload's bin, the subos bin dir, and the inherited PATH. doctor used to
+# ask only about the first two and call everything past them one warning, so a
+# package whose aliases name a sibling package's command — thirty of mcpp's
+# short commands do — was reported broken on every run while working
+# perfectly, and a genuinely unresolvable alias was one indistinguishable line
+# among them.
+#
+# RUN() supplies `PATH=/usr/bin:/bin`, so what the host can satisfy is fixed
+# and these three cases are deterministic.
 ALIAS_PAYLOAD="$HOME_DIR/data/xpkgs/xim-x-alias-fixture/1.0.0/bin/alias-real"
+SUBOS_BIN="$HOME_DIR/subos/default/bin"
+
+log "S10a: alias target only in the subos bin dir → silent, exit 0"
 rm -f "$ALIAS_PAYLOAD"
-# Reset rc — it leaks across scenarios via the `cmd || rc=$?` pattern, so a
-# successful exit here would otherwise still see the previous run's value.
+printf '#!/bin/sh\necho sibling\n' > "$SUBOS_BIN/alias-real"
+chmod +x "$SUBOS_BIN/alias-real"
 rc=0
 out=$(RUN self doctor 2>&1) || rc=$?
 echo "$out" | grep -q "alias unresolved" \
-  || fail "S10: should report 'alias unresolved' warning; got:\n$out"
-# Warning-level → exit 0 (no errors; could be intentional system command)
-[[ $rc -eq 0 ]] || fail "S10: alias warning alone should exit 0; got $rc"
-# --fix MUST NOT touch warning-level findings
-RUN self doctor --fix >/dev/null 2>&1
-python3 - "$HOME_DIR" <<'PY' || fail "S10: --fix should not touch alias warning"
-import json, sys, pathlib
-home = sys.argv[1]
-data = json.loads(pathlib.Path(home, ".xlings.json").read_text())
-vers = (data.get("versions") or {}).get("alias-fixture", {}).get("versions", {})
-assert "1.0.0" in vers, "S10: alias-fixture@1.0.0 should remain registered (warning is non-actionable)"
+  && fail "S10a: a sibling command in the subos bin dir resolves at runtime; got:\n$out"
+[[ $rc -eq 0 ]] || fail "S10a: nothing is wrong, expected exit 0; got $rc"
+rm -f "$SUBOS_BIN/alias-real"
+
+log "S10b: alias target only on the host PATH → notice, exit 0"
+# `sh` is on /bin in every environment RUN() constructs.
+python3 - "$HOME_DIR" <<'PY' || fail "S10b setup: could not repoint the alias"
+import json, pathlib, sys
+p = pathlib.Path(sys.argv[1], ".xlings.json")
+data = json.loads(p.read_text())
+data["versions"]["alias-fixture"]["versions"]["1.0.0"]["alias"] = ["sh"]
+p.write_text(json.dumps(data, indent=2))
 PY
+rc=0
+out=$(RUN self doctor 2>&1) || rc=$?
+echo "$out" | grep -q "alias unresolved" \
+  && fail "S10b: a host command satisfies the alias; that is a notice, not a defect; got:\n$out"
+[[ $rc -eq 0 ]] || fail "S10b: a host-satisfied alias must not set the exit code; got $rc"
+RUN self doctor --all 2>&1 | grep -q "host alias" \
+  || fail "S10b: --all should name the alias the host is satisfying"
+
+log "S10c: alias target nowhere at all → error, exit 1"
+python3 - "$HOME_DIR" <<'PY' || fail "S10c setup: could not repoint the alias"
+import json, pathlib, sys
+p = pathlib.Path(sys.argv[1], ".xlings.json")
+data = json.loads(p.read_text())
+data["versions"]["alias-fixture"]["versions"]["1.0.0"]["alias"] = ["alias-real"]
+p.write_text(json.dumps(data, indent=2))
+PY
+rc=0
+out=$(RUN self doctor 2>&1) || rc=$?
+echo "$out" | grep -q "alias unresolved" \
+  || fail "S10c: an alias with nothing to exec must be reported; got:\n$out"
+echo "$out" | grep -q "resolves to nothing" \
+  || fail "S10c: the finding should say what was searched; got:\n$out"
+# The behaviour change this scenario exists to pin: it used to be a warning
+# that exited 0, which is how it stayed invisible among the false ones.
+[[ $rc -eq 1 ]] || fail "S10c: an unresolvable alias is an error; expected exit 1, got $rc"
 
 # ── S11: repairing an alias-mode entry is reported as repaired ─────
 #

--- a/tests/unit/test_xvm_bindings.cpp
+++ b/tests/unit/test_xvm_bindings.cpp
@@ -3198,6 +3198,171 @@ TEST(XvmRegistrationTest, AnUncontestedRootStillLosesWithItsGroup) {
         db, "xim-musl-gnu-gcc", "15.1.0-musl"));
 }
 
+// The measured break: `codex` reporting
+// `/usr/bin/env: 'node': No such file or directory` on a home where node was
+// installed, its payload intact, and its shim never written.
+//
+// node's release registers `node`, `npm` and `npx`. A separately installed
+// npm package held `npm`. The activation vote was "is ANY member name already
+// active", so one contested name suppressed the whole release and `node` --
+// which nothing else on the machine provides -- came out installed and
+// unreachable. Nothing reported it: `xlings list` showed the package as
+// installed, and `self doctor` had no check that looked at the selection.
+TEST(XvmRegistrationTest, AForeignProvidersClaimDoesNotVetoItsSiblings) {
+    xlings::xvm::VersionDB db;
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+
+    // A standalone npm package takes the `npm` name first.
+    auto standaloneNpm = make_registration_node("npm", "11.2.0");
+    auto npmBatch = make_registration_batch({standaloneNpm});
+    npmBatch.provider = "xim:npm";
+    auto first = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, npmBatch);
+    ASSERT_TRUE(first.has_value()) << first.error().message;
+    ASSERT_EQ(workspace.at("npm"), "11.2.0");
+
+    // Then the node release arrives, which also registers `npm`.
+    auto nodeRoot = make_registration_node("node", "24.15.0");
+    auto nodeNpm = make_registration_node("npm", "node-24.15.0");
+    nodeNpm.binding = make_registration_binding("node", "24.15.0", "node");
+    auto nodeNpx = make_registration_node("npx", "node-24.15.0");
+    nodeNpx.binding = make_registration_binding("node", "24.15.0", "node");
+    auto nodeBatch = make_registration_batch({nodeRoot, nodeNpm, nodeNpx});
+    nodeBatch.provider = "xim:node";
+
+    auto second = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, nodeBatch);
+    ASSERT_TRUE(second.has_value()) << second.error().message;
+
+    EXPECT_EQ(workspace.at("npm"), "11.2.0")
+        << "installing node took a name another provider owns";
+    ASSERT_TRUE(workspace.contains("node"))
+        << "node is installed and unreachable: no active version, so no shim";
+    EXPECT_EQ(workspace.at("node"), "24.15.0");
+    ASSERT_TRUE(workspace.contains("npx"))
+        << "npx is uncontested too and lost the same vote";
+    EXPECT_EQ(workspace.at("npx"), "node-24.15.0");
+}
+
+// The other side of the same rule. A contest with the SAME provider is an
+// older release of this very package, and moving some names to the new one
+// while the rest stay behind is the split the binding-group model exists to
+// prevent. Choosing between two releases of one package is `use`, not
+// install.
+TEST(XvmRegistrationTest, TheSameProvidersOlderReleaseStillVetoesTheGroup) {
+    xlings::xvm::VersionDB db;
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+
+    auto oldGcc = make_registration_node("gcc", "15.1.0");
+    auto oldCxx = make_registration_node("g++", "15.1.0");
+    oldCxx.binding = xlings::xvm::RegistrationBinding{
+        .rootTarget = "gcc", .rootVersion = "15.1.0"};
+    auto firstBatch = make_registration_batch({oldGcc, oldCxx});
+    firstBatch.provider = "xim:gcc";
+    firstBatch.providerVersion = "15.1.0";
+    auto first = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, firstBatch);
+    ASSERT_TRUE(first.has_value()) << first.error().message;
+    ASSERT_EQ(workspace.at("gcc"), "15.1.0");
+
+    // 16.1.0 from the same provider, and it adds a name 15.1.0 did not have.
+    auto newGcc = make_registration_node("gcc", "16.1.0");
+    auto newCxx = make_registration_node("g++", "16.1.0");
+    newCxx.binding = xlings::xvm::RegistrationBinding{
+        .rootTarget = "gcc", .rootVersion = "16.1.0"};
+    auto newAr = make_registration_node("gcc-ar", "16.1.0");
+    newAr.binding = xlings::xvm::RegistrationBinding{
+        .rootTarget = "gcc", .rootVersion = "16.1.0"};
+    auto secondBatch = make_registration_batch({newGcc, newCxx, newAr});
+    secondBatch.provider = "xim:gcc";
+    secondBatch.providerVersion = "16.1.0";
+
+    auto second = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, secondBatch);
+    ASSERT_TRUE(second.has_value()) << second.error().message;
+
+    EXPECT_EQ(workspace.at("gcc"), "15.1.0");
+    EXPECT_EQ(workspace.at("g++"), "15.1.0");
+    EXPECT_FALSE(workspace.contains("gcc-ar"))
+        << "an uncontested NEW member of a same-provider release was "
+           "activated on its own — the workspace now spans two releases";
+}
+
+// #452 must not come back through the new door.
+//
+// A flavor release anchors itself on a virtual root: a `group` entry with no
+// command behind it. When the contest is cross-provider the veto no longer
+// fires, so the only thing standing between this group and activation is the
+// kind check -- and activating the root would write a shim that can only
+// print "no active version", which `--fix` then deletes and the next install
+// recreates.
+TEST(XvmRegistrationTest, AGroupWhoseOnlyFreeMemberIsAnAnchorStaysInactive) {
+    xlings::xvm::VersionDB db;
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+
+    auto glibcGcc = make_registration_node("gcc", "15.1.0");
+    auto glibcBatch = make_registration_batch({glibcGcc});
+    glibcBatch.provider = "xim:gcc";
+    auto first = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, glibcBatch);
+    ASSERT_TRUE(first.has_value()) << first.error().message;
+    ASSERT_EQ(workspace.at("gcc"), "15.1.0");
+
+    // musl-gcc: a DIFFERENT provider, so `gcc` does not veto. Its only other
+    // member is the anchor.
+    auto root = make_registration_node("xim-musl-gnu-gcc", "15.1.0-musl",
+                                       "group");
+    root.sourceName.clear();
+    root.destinationName.clear();
+    auto flavorGcc = make_registration_node("gcc", "15.1.0-musl");
+    flavorGcc.binding = make_registration_binding(
+        "xim-musl-gnu-gcc", "15.1.0-musl", "gcc-flavor");
+    auto flavorBatch = make_registration_batch({root, flavorGcc});
+    flavorBatch.provider = "xim:musl-gcc";
+
+    auto second = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, flavorBatch);
+    ASSERT_TRUE(second.has_value()) << second.error().message;
+
+    EXPECT_EQ(workspace.at("gcc"), "15.1.0")
+        << "the flavor took a name the glibc release still owns";
+    EXPECT_FALSE(workspace.contains("xim-musl-gnu-gcc"))
+        << "a virtual anchor was activated on its own — issue #452, whose "
+           "shim can only ever print \"no active version\"";
+}
+
+// `install --use` says the user typed the switch. Taking a contested name is
+// then not a surprise, it is the request.
+TEST(XvmRegistrationTest, UseAfterInstallStillTakesAContestedName) {
+    xlings::xvm::VersionDB db;
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+
+    auto standaloneNpm = make_registration_node("npm", "11.2.0");
+    auto npmBatch = make_registration_batch({standaloneNpm});
+    npmBatch.provider = "xim:npm";
+    ASSERT_TRUE(xlings::xvm::apply_registration_batch(
+        db, workspace, installed, npmBatch).has_value());
+
+    auto nodeRoot = make_registration_node("node", "24.15.0");
+    auto nodeNpm = make_registration_node("npm", "node-24.15.0");
+    nodeNpm.binding = make_registration_binding("node", "24.15.0", "node");
+    auto nodeBatch = make_registration_batch({nodeRoot, nodeNpm});
+    nodeBatch.provider = "xim:node";
+    nodeBatch.useAfterInstall = true;
+
+    auto second = xlings::xvm::apply_registration_batch(
+        db, workspace, installed, nodeBatch);
+    ASSERT_TRUE(second.has_value()) << second.error().message;
+
+    EXPECT_EQ(workspace.at("npm"), "node-24.15.0")
+        << "--use was ignored for a contested name";
+    EXPECT_EQ(workspace.at("node"), "24.15.0");
+}
+
 TEST(XvmRegistrationHeaderTest, UngroupedHeaderFallsBackToThePrimaryTarget) {
     auto program = make_registration_node("openssl", "repo:3.1.5");
     auto library = make_registration_node("libssl", "repo:3.1.5");

--- a/tests/unit/test_xvm_shim.cpp
+++ b/tests/unit/test_xvm_shim.cpp
@@ -241,6 +241,142 @@ TEST(XvmShimTest, ResolveAliasDirectPath) {
 }
 
 // ============================================================
+// alias resolution — the four tiers the runtime actually searches
+// ============================================================
+//
+// The alias branch of shim_dispatch prepends `<payload>`, `<payload>/bin` and
+// the subos bin dir to PATH and hands the command to a shell, so an alias can
+// legitimately resolve at any of four places. `self doctor` used to ask
+// resolve_executable, which knows only the first two, and reported the other
+// two as broken — thirty-four false warnings on one measured home, with a
+// genuinely unresolvable alias indistinguishable among them.
+
+namespace {
+
+struct AliasFixture {
+    std::filesystem::path root;
+    std::filesystem::path payload;
+    std::filesystem::path subosBin;
+    std::filesystem::path hostBin;
+
+    explicit AliasFixture(std::string_view name) {
+        namespace fs = std::filesystem;
+        root = fs::temp_directory_path() / name;
+        fs::remove_all(root);
+        payload  = root / "payload";
+        subosBin = root / "subos" / "bin";
+        hostBin  = root / "host" / "bin";
+        fs::create_directories(payload / "bin");
+        fs::create_directories(subosBin);
+        fs::create_directories(hostBin);
+    }
+    ~AliasFixture() {
+        std::error_code ec;
+        std::filesystem::remove_all(root, ec);
+    }
+
+    void put(const std::filesystem::path& dir, std::string_view name) const {
+        xlings::platform::write_string_to_file(
+            (dir / name).string(), "#!/bin/sh\n");
+    }
+};
+
+}  // namespace
+
+TEST(AliasResolutionTest, ItsOwnPayloadWins) {
+    AliasFixture fx{"xlings_alias_tier_payload"};
+    fx.put(fx.payload / "bin", "tool");
+    fx.put(fx.subosBin, "tool");
+
+    const auto r = xlings::xvm::resolve_alias_program(
+        "tool", fx.payload.string(), "", fx.subosBin, fx.hostBin.string());
+    EXPECT_EQ(r.origin, xlings::xvm::AliasOrigin::Payload);
+    EXPECT_EQ(r.path, fx.payload / "bin" / "tool");
+}
+
+// The `madd` → `mcpp` case, and the reason thirty of the measured warnings
+// existed: the package that registers the short commands ships no payload at
+// all, and every one of its aliases names a program another package
+// installed.
+TEST(AliasResolutionTest, ASiblingShimInTheSubosResolves) {
+    AliasFixture fx{"xlings_alias_tier_sibling"};
+    fx.put(fx.subosBin, "mcpp");
+
+    const auto r = xlings::xvm::resolve_alias_program(
+        "mcpp", fx.payload.string(), "", fx.subosBin, fx.hostBin.string());
+    EXPECT_EQ(r.origin, xlings::xvm::AliasOrigin::SubosBin);
+    EXPECT_EQ(r.path, fx.subosBin / "mcpp");
+}
+
+TEST(AliasResolutionTest, AHostCommandIsFoundAndNamedAsSuch) {
+    AliasFixture fx{"xlings_alias_tier_host"};
+    fx.put(fx.hostBin, "sh");
+
+    const auto r = xlings::xvm::resolve_alias_program(
+        "sh", fx.payload.string(), "", fx.subosBin, fx.hostBin.string());
+    EXPECT_EQ(r.origin, xlings::xvm::AliasOrigin::SystemPath);
+    EXPECT_EQ(r.path, fx.hostBin / "sh");
+}
+
+TEST(AliasResolutionTest, TheSubosComesBeforeTheHost) {
+    // Order matters: the runtime PREPENDS the subos bin dir, so a name that
+    // exists in both is xlings's, not the host's. Getting this backwards
+    // would report a working sibling command as a portability problem.
+    AliasFixture fx{"xlings_alias_tier_order"};
+    fx.put(fx.subosBin, "git");
+    fx.put(fx.hostBin, "git");
+
+    const auto r = xlings::xvm::resolve_alias_program(
+        "git", fx.payload.string(), "", fx.subosBin, fx.hostBin.string());
+    EXPECT_EQ(r.origin, xlings::xvm::AliasOrigin::SubosBin);
+}
+
+TEST(AliasResolutionTest, NothingAnywhereIsNowhere) {
+    AliasFixture fx{"xlings_alias_tier_nowhere"};
+
+    const auto r = xlings::xvm::resolve_alias_program(
+        "absent", fx.payload.string(), "", fx.subosBin, fx.hostBin.string());
+    EXPECT_EQ(r.origin, xlings::xvm::AliasOrigin::Nowhere);
+    EXPECT_TRUE(r.path.empty());
+}
+
+// An absolute alias is a pinned path, not a host command. The measured home
+// had five `claude` entries whose alias is a full path into xlings's own
+// payload store; calling those "satisfied by the host" inverts the
+// portability fact they represent.
+TEST(AliasResolutionTest, AnAbsolutePathThatExistsIsItsOwnAnswer) {
+    AliasFixture fx{"xlings_alias_tier_abs"};
+    fx.put(fx.payload, "pinned");
+
+    const auto r = xlings::xvm::resolve_alias_program(
+        (fx.payload / "pinned").string(), fx.payload.string(), "",
+        fx.subosBin, fx.hostBin.string());
+    EXPECT_EQ(r.origin, xlings::xvm::AliasOrigin::Absolute);
+}
+
+// ...and the shape doctor could never report before, because it skipped
+// absolute aliases without looking at them.
+TEST(AliasResolutionTest, AnAbsolutePathThatIsGoneIsNowhere) {
+    AliasFixture fx{"xlings_alias_tier_abs_gone"};
+
+    const auto r = xlings::xvm::resolve_alias_program(
+        (fx.payload / "vanished").string(), fx.payload.string(), "",
+        fx.subosBin, fx.hostBin.string());
+    EXPECT_EQ(r.origin, xlings::xvm::AliasOrigin::Nowhere);
+}
+
+// A caller that cannot see a representative PATH must not conclude the alias
+// is broken on the strength of its own stripped environment.
+TEST(AliasResolutionTest, AnEmptySearchPathIsNotSearched) {
+    AliasFixture fx{"xlings_alias_tier_nopath"};
+    fx.put(fx.hostBin, "tool");
+
+    const auto r = xlings::xvm::resolve_alias_program(
+        "tool", fx.payload.string(), "", fx.subosBin, "");
+    EXPECT_EQ(r.origin, xlings::xvm::AliasOrigin::Nowhere);
+}
+
+// ============================================================
 // xvm config integration tests (filesystem-based)
 // ============================================================
 


### PR DESCRIPTION
## The report

```
$ codex
/usr/bin/env: 'node': No such file or directory

$ xlings self doctor --fix
  ⚠ alias unresolved  madd@0.0.1 alias 'mcpp' not resolvable in …
  … 34 of them …
  warnings            34
```

Two problems, and between them the whole output was wrong in both directions:
34 warnings that were all false, and the one real failure reported nowhere.

Design doc: `.agents/docs/2026-08-01-alias-resolution-and-inactive-install-plan.md`

## P2 — installed, intact, unreachable

node's release registers `node`, `npm` and `npx`. A separately installed npm
package held `npm`. `registration.cppm`'s activation vote was *is ANY member
name already active*:

```cpp
const bool anyMemberActive = std::ranges::any_of(
    group.members, [&](const auto& m) { return candidateWorkspace.contains(m.first); });
const bool activateGroup = batch.useAfterInstall || !anyMemberActive;
```

One contested name suppressed the whole release. `node` and `npx` — which
nothing else provides — came out installed with no active version and so no
shim. The comment right above states the intent as *"installing gcc must not
silently take `cc` away from an active llvm"*; the implementation escalated
**not taking one name** into **not activating anything**.

**node and npx both missing while npm survived** is the fingerprint: npm lived
only because another package held it.

Nothing reported it. `list` reads `installed[]` and never consults the active
selection; doctor's Check 1 walks the active workspace (the name isn't in it),
Check 2 walks binDir (no file), Check 3 walks the DB and finds the payload
healthy — because it is. What was broken was the selection.

`removal.cppm:361-366` bets on this being visible: *"an inactive toolchain is a
visible problem"*. This home is the counter-example — the failure surfaced from
a third-party tool, in a message that never says `xlings`.

## P1 — 34 false alias warnings

The runtime resolves an alias through four places (`shim.cppm:427-447`):
payload → payload/bin → **subos bin dir** → **inherited PATH**. doctor asked
`resolve_executable`, which knows the first two. The package that gives thirty
short names to a sibling's `mcpp` resolves at tier 3 every time and was
reported broken every time — and one warning level covered "works via a
sibling", "works via the host" and "nothing to exec at all".

## What changed

- **registration**: *who* holds a contested name decides whether it vetoes.
  Same provider → older release of this package, still vetoes. Other provider
  → ownership, not incoherence; the siblings activate.
- **`RegistrationNode::runnable`**: an anchor and a real program are identical
  in the DB — same auto-filled `path`, same defaulted `kind`, same derived
  `sourceName`. Only the payload separates them and registration is pure, so
  the installer answers. This is what guards #452; E2E-45 caught its absence.
- **`inspect` INV-2**: same provider rule, so install no longer produces a
  state doctor calls incoherent.
- **doctor**: new `no active version` check, **per release** (50 lines → 3 on
  the measured home), repaired by running the remedy it prints — and the
  finding names the siblings that repair will move *before* it moves them.
- **doctor aliases**: silent / notice / error. An absolute alias is now checked
  for existence rather than skipped — the one shape doctor could never report.
- **list**: an installed package with no active version says `inactive`.

## Measured, before → after

```
34 warnings, 0 errors, exit 0     →     0 warnings, 3 releases named, exit 1

✗ no active version  node@24.15.0 … 2 program(s) are not on PATH: node, npx
  → run              xlings use node@24.15.0
```

## Tests

12 new unit cases (4 activation, 8 alias tiers) · new **E2E-52** covering the
foreign-claim install, the report, `--fix`, `list`, the anchor exclusion and
the same-provider refusal · `self_doctor` S10 split into its three tiers.

Local: **25/25 unit suites**, **55/55 e2e**.