### PR TITLE
fix(xself,xvm): --fix must not undo its own repairs (2026.8.1.2)

### DIFF
--- a/.agents/docs/2026-08-01-alias-resolution-and-inactive-install-plan.md
+++ b/.agents/docs/2026-08-01-alias-resolution-and-inactive-install-plan.md
@@ -386,6 +386,12 @@ install 侧放行之后，`self doctor` 的 Check 4 立刻把新状态判成
 跳过被**其它 provider** 持有的名字。同 provider 的分裂仍然报。
 
 **5 — `--fix` 走 `use`，会带走被占的名字；办法是先说，不是不做。**
+> ⚠️ **本条判断有误，已被
+> `.agents/docs/2026-08-01-doctor-fix-nonconvergence-postmortem.md` 取代。**
+> 披露解决了"用户不知情"，没解决"搬走名字之后原 release 失去连贯性，
+> 会被同一次 `--fix` 里的 `plan_incoherent_deactivation` 立刻拆掉"。
+> 结果是 `--fix` 不收敛，在真实 home 上抹掉了 `gcc`/`ld` 的 active。
+
 计划的约束 1 是"`--fix` 不抢已被占用的名字"。实现时发现 `use` 天然是
 release 级操作：`xlings use node@24.15.0` 一定会把 `npm` 一起搬走，
 所以"`--fix` 做得比它自己打印的 remedy 更窄"会变成第三种行为。

--- a/.agents/docs/2026-08-01-doctor-fix-nonconvergence-postmortem.md
+++ b/.agents/docs/2026-08-01-doctor-fix-nonconvergence-postmortem.md
@@ -1,0 +1,290 @@
+# `self doctor --fix` 不收敛 —— 2026.8.1.1 回归的复盘与修复方案
+
+**日期**: 2026-08-01
+**类型**: 回归复盘（postmortem）+ 方案（plan）
+**引入版本**: `2026.8.1.1`（PR [#465](https://github.com/openxlings/xlings/pull/465)，commit `10788ce`）
+**代码**: `src/core/xself/doctor.cppm`、`src/core/xvm/inspect.cppm`、
+`src/core/xim/payload.cppm`
+**前序**: `.agents/docs/2026-08-01-alias-resolution-and-inactive-install-plan.md`、
+`.agents/docs/2026-07-29-orphan-shim-inactive-group-root-design.md`（#452）
+
+---
+
+## 现场
+
+`2026.8.1.1` 发布后，在一台装了多版本工具链的真实 home 上：
+
+```
+$ xlings self doctor          → 3 条 no active version
+$ xlings self doctor --fix    → 上百行 `deactivated`，结束时 4 条 no active version
+$ gcc --version
+[error] xlings: no active version of 'gcc' in current subos
+$ ld --version
+[error] xlings: no active version of 'ld' in current subos
+```
+
+**`--fix` 让 home 比之前更坏**：`gcc` / `g++` / `ld` / `xim-gnu-gcc` / `binutils`
+的 active 全被抹掉，shim 还在但无版本可派发。
+
+这是本次工作要消灭的那一族缺陷的镜像：不是"没做事却报成功"，而是
+**"做了事，把事做反了，还报了个更长的清单"**。
+
+---
+
+## 引入点：精确到一行
+
+`repair_inactive_`（`doctor.cppm:1467`，#465 新增）被挂在 phase 2.5：
+
+```
+phase 1    repair_state_        ← 既有
+phase 2    repair_payloads_     ← 既有
+phase 2.5  repair_inactive_     ← 新增：跑 `use <root>@<ver>`
+           refresh()
+phase 3    repair_state_        ← 既有：plan_incoherent_deactivation
+```
+
+`repair_state_` 里的 `plan_incoherent_deactivation`（`inspect.cppm:668`）会把
+不连贯 release 的成员 **erase 掉 active**（`doctor.cppm:1296`
+`mutableWs.erase(target)`）。
+
+于是形成闭环：
+
+```
+repair_inactive_  →  use 激活 release A
+                  →  A 里没有的名字 stranded 在 release B 上
+repair_state_     →  B 不连贯 → erase 掉 B 全体成员的 active
+                  →  这些名字变成"已安装、无 active"
+detect_           →  正好命中新增的 InactiveInstalled 检查
+下一轮 --fix      →  去激活 B → 把 A 拆散 → ……
+```
+
+一个修复要"让它可达"，另一个要"让它连贯"，**在同一次 `--fix` 调用里首尾相接**。
+
+**为什么评审没挡住**：`repair_inactive_` 的注释论证了"`use` 会搬走别的
+provider 持有的名字，所以要先披露"，但只考虑了**被搬走的那个名字**，没考虑
+**被搬走之后原 release 整体失去连贯性**，也没去看同一个函数下面 200 行就有一个
+专门拆除不连贯 release 的修复。E2E-52 的 S1–S6 全是单 release / 双 package 的
+形状，没有一个是"多版本共存 + 跨 release 名字重叠"。
+
+#452 的设计文档原话被引用过又被违反了：
+
+> Every earlier fix in this area made one `--fix` converge; none checked that
+> the next install stayed clean.
+
+---
+
+## 缺陷一：doctor 的报告口径（显示问题）
+
+三个独立的误报，叠在同一条 finding 上。
+
+### 1a. 把"你没选中的另一个版本"当成缺陷
+
+```
+✗ no active version  llvm@20.1.7 …29 program(s) are not on PATH
+  → run              xlings use llvm@20.1.7
+```
+
+`llvm` 装了 `20.1.7` 和 `22.1.8`，用户选了 `22.1.8`。**这是正常状态**，不是缺陷。
+而给出的 remedy 会把用户正在用的 llvm 降级。
+
+`xim-gnu-gcc@15.1.0` 和 `@16.1.0` 同时被报是同一个形状：一个包的两个 release，
+本来就只能激活一个，却被报成两条互相矛盾的 finding。
+
+**漏掉的判据**：release 的 **root target 若已有 active（任意版本）**，这个
+release 就是"未选中的替代品"，不是不可达的安装。
+
+| 场景 | root | root 的 active | 应否报 |
+|---|---|---|---|
+| `llvm@20.1.7` | `llvm` | `22.1.8` | ✗ 不报 |
+| `xim-gnu-gcc@15.1.0` | `xim-gnu-gcc` | 无 | ✓ 报（但见 1d） |
+| `node@24.15.0`（#465 原始案例） | `node` | 无 | ✓ 报 |
+
+这条规则**同时保住原始修复并消掉这批噪音**。
+
+### 1b. 把异平台 payload 的产物算成"不在 PATH 上的程序"
+
+被点名的 29 个是：
+
+```
+clang++.exe  clang-cl.exe  clang.exe  libiomp5md.dll  libomp.dll  …
+```
+
+实测 `data/xpkgs/xim-x-llvm/20.1.7/bin/` 里**只有 Windows 二进制**，且没有
+`.xpkg-install.json` 戳 —— 正是 `payload.cppm:14-20` 记录的那个已知案例：
+
+> The measured case: a May-era Windows llvm@20.1.7 in a Linux store, which
+> registered `clang.exe` … `libomp.dll` as programs …
+
+这些在 Linux 上**永远不可能**出现在 PATH 上。`classify_payload_platform()` /
+`classify_payload_content()`（`payload.cppm:83`/`104`）已经能判定，installer
+已经在用（`installer.cppm:2255`），**只有新增的这个检查没调**。
+
+### 1c. 库被算进"program(s) not on PATH"
+
+`libomp.dll`、`libiomp5md.dll` 出现在程序清单里，是 1b 的下游：异平台 payload
+把 DLL 注册成了 `kind = program`。修好 1b 即消失；不必单独处理。
+
+### 1d. 同一 root 的多个未激活 release 各报一条
+
+`xim-gnu-gcc@15.1.0` 与 `@16.1.0` 都没 active 时，两条 finding 给出两条互斥的
+remedy。应当**按 root 合并成一条**，把版本列出来交给用户选 —— 也就是
+`xlings use xim-gnu-gcc` 那个 picker 的语义。
+
+---
+
+## 缺陷二：`--fix` 的 bug —— 而且**能自动识别**
+
+我在对话里说过要让 `--fix` "退回只报告不动手"。**那个判断是错的**，理由是
+"两个修复相互对冲，自动激活不安全"。事实是：
+
+> 判断"这次激活会不会被另一个修复立刻拆掉"所需要的两个函数，
+> **仓库里都已经有了**，而且都已导出。
+
+- `plan_use_switch(db, ws, target, version)`（`switch_plan.cppm:109`）
+  —— 算出激活后**整个 release 的成员映射**，且已经会报 `stranded`。
+- `plan_incoherent_deactivation(db, ws)`（`inspect.cppm:668`）
+  —— 就是 phase 3 那个拆除动作本身。
+
+所以正确的做法不是退让，而是**预演**：
+
+```
+候选修复 →  把 plan_use_switch 的结果套用到 workspace 的副本上
+        →  对副本跑 plan_incoherent_deactivation
+        →  非空 ⇒ 这次激活会被 phase 3 立刻拆掉 ⇒ 不做，改报冲突
+        →  为空 ⇒ 安全，执行
+```
+
+这是**用另一个修复自己的判据**来决定这个修复该不该动手，两边不可能再漂移 ——
+和 `SubosPathBaked` 那条"detection calls the function the repair calls"
+（`doctor.cppm:534-537`）是同一个原则，我在同一个文件里遵守了一次又忘了第二次。
+
+### 预演规则对四个已知场景的判定
+
+| 场景 | 激活后是否有 release 变不连贯 | 结果 |
+|---|---|---|
+| `node@24.15.0`（原始案例） | 否（`npm` 移走后旧 `xim:npm` 已不在 workspace，不参与判定） | ✓ 自动修复 |
+| `binutils@2.42` | 是 —— `ar`/`nm`/`ranlib`/`strip` 会从 `llvm@22.1.8` 移走，llvm 那个 release 随即不连贯 | ✗ 不动手，报冲突 |
+| `llvm@20.1.7` | 不适用（1a 已把它挡在报告之外） | — |
+| `xim-gnu-gcc@16.1.0` | 是 —— `cc`/`c++` 会从 `llvm@22.1.8` 移走 | ✗ 不动手，报冲突 |
+
+`binutils` 那一行正是用户真正需要看到的话：**两个包都提供 `ar`，只能选一个**。
+比"来回拆家"和"悄悄降级"都强。
+
+### 冲突时该说什么
+
+```
+✗ no active version  binutils@2.42 is installed in this subos but no version is
+                     active — 11 program(s) are not on PATH
+  ▸ conflict         activating it would take ar, nm, ranlib, strip from the
+                     active xim:llvm@22.1.8, leaving that release incoherent —
+                     `--fix` will not choose between them
+  → run              xlings use binutils@2.42   (and accept the llvm split)
+```
+
+### 顺序也要改
+
+即便有了预演，`repair_inactive_` 也应当**移到最后一个 `repair_state_` 之后**：
+让拆除类修复先收敛到稳定状态，激活再在稳定状态上做一次。现在它夹在
+phase 2.5，作用于一个还会被 phase 3 改写的 workspace。
+
+---
+
+## 缺陷三（新增防线）：`--fix` 必须证明自己收敛
+
+上面两条都是具体缺陷。这一条是**为什么这类缺陷能溜过去**的答案：
+`--fix` 从来没有检查过"我做完之后是不是更好了"。
+
+加一条终局断言：`--fix` 结束时，重新检测一次，**issue 数不得高于开始时**。
+高于就把这件事直接说出来：
+
+```
+▸ warning  --fix started with 3 issue(s) and ended with 4 — a repair undid
+           another. Nothing further was attempted; please report this.
+```
+
+这不是修复手段，是**止损与自曝**。它会把今天这个 bug 在第一次运行时就变成一行
+可见的告警，而不是上百行 `deactivated` 里的一个静默恶化。
+
+---
+
+## 方案汇总
+
+| # | 改动 | 文件 | 规模 |
+|---|---|---|---|
+| **F1** | root target 已有 active ⇒ 不报（未选中的替代品） | `doctor.cppm` Check 2.7 | 小 |
+| **F2** | 异平台 payload ⇒ 不报（调 `classify_payload_platform`） | `doctor.cppm` Check 2.7 | 小 |
+| **F3** | 同 root 的多个未激活 release 合并成一条 | `doctor.cppm` Check 2.7 | 小 |
+| **F4** | `repair_inactive_` 预演 + `plan_incoherent_deactivation` 判定，冲突则只报告 | `doctor.cppm` | 中 |
+| **F5** | `repair_inactive_` 移到最后一个 `repair_state_` 之后 | `doctor.cppm` | 小 |
+| **F6** | `--fix` 终局收敛断言 | `doctor.cppm` `cmd_doctor` | 小 |
+| **F7** | 报告方与执行方共用同一个 provider 判据 | `inspect.cppm` | 小 |
+
+F1–F3 是**显示口径**，F4–F5 是 **`--fix` 的 bug**，F6 是**防线**。三组互相独立，
+可分别落地；但 F6 应当**最先落**，这样 F1–F5 的验收有一个客观的收敛判据。
+
+### F7 —— 实现时才挖出来的真正主因
+
+写 E2E-53 的 fixture 时才发现：**报告方和执行方对"不连贯"的定义不一致，而这个
+不一致就是级联的发动机。**
+
+`2026.8.1.1` 给 INV-2（`analyze_bindings`，doctor **报告**用）加了 provider 判据
+——"被另一个 provider 持有的名字不算这个 release 掉队"。但
+`plan_incoherent_deactivation`（`inspect.cppm:668`，**`--fix` 真正执行的拆除**）
+**没有加**。
+
+于是同一个 home 上：
+
+```
+xlings self doctor        →  这里没问题（INV-2 认 provider）
+xlings self doctor --fix  →  把 gcc / ld 拆了（拆除方不认 provider）
+```
+
+node 那个 home 也一样：node 的 release 含 `npm`，而 `npm` 被 `xim:npm@11.2.0`
+持有 → 拆除方判定 node 的 release 不连贯 → 把 `node`、`npx` 一起拆掉。**这正是
+gcc/ld 消失的机制。**
+
+修法不是给拆除方也写一份判据（那只会等下次再漂移一次），而是**把判据提成一个
+函数 `detail_::held_by_another_provider_()`，两边都调它**。
+
+F7 落地后，F4 的预演在跨 provider 场景下不再触发 —— 因为已经没有架可打了。
+F4 仍然必要：它守的是**同 provider 的残留态**（一个 release 被拆了一半、root 没
+active 但某个成员还 active），也就是用户机器当时的状态。
+
+---
+
+## 验收 → E2E-53 `doctor_fix_convergence_test.sh`
+
+必须用**多版本共存 + 跨 release 名字重叠**的 fixture，这正是 E2E-52 缺的形状：
+
+| # | 构造 | 断言 |
+|---|---|---|
+| **S1** | 一个包两个 release（`tool@1.0` / `tool@2.0`），激活 2.0 | `tool@1.0` **不被报告**（F1） |
+| **S2** | 两个包争同一个名字（`shared`），各自另有独占名字 | 报冲突、**不自动激活**（F4） |
+| **S3** | 承 S2 → `--fix` 跑两次 | 第二次 issue 数 **不高于**第一次（F6），且 workspace 逐字节不变 |
+| **S4** | 异平台 payload（写入 PE 魔数的假 `.exe`） | **不被报告**（F2） |
+| **S5** | 同 root 两个 release 都无 active | 报**一条**，列出可选版本（F3） |
+| **S6** | 单一 release、无竞争（#465 的 node 形状） | `--fix` **仍然自动激活**，不得因为这次修复而退化 |
+
+S6 是防回归的关键：F4 的预演不能把 #465 修好的那条路一并关掉。
+
+---
+
+## 需要一并做的事
+
+- **修好的版本发布前，`--fix` 的这个 finding 是危险的。** 已在真实 home 上造成
+  `gcc`/`ld` 不可用。发布说明里要写明恢复命令：
+  `xlings use gcc <ver>` / `xlings use binutils 2.42` —— `use` 本身不 erase，
+  只有 `--fix` 会。
+- `.agents/docs/2026-08-01-alias-resolution-and-inactive-install-plan.md`
+  的"实现时改掉的六处"第 5 条（`--fix` 走 `use`，靠披露而非回避）**判断有误**：
+  披露解决了"用户不知情"，没解决"另一个修复会把它拆掉"。该条需要标注被本文档
+  取代。
+
+## 不做什么
+
+- **不**把 `--fix` 对这类 finding 退回成只报告。那是用能力换安全，而判断安全所
+  需的两个函数仓库里都已存在 —— 退让掩盖的是没去用它们。
+- **不**去动 `plan_incoherent_deactivation` 的拆除语义。它是对的：不连贯的
+  release 必须拆。要改的是**在制造不连贯之前就不要动手**。
+- **不**顺手清理那个 Windows llvm@20.1.7 payload。它是 F2 唯一的真实素材，
+  而且删不删是用户的事；doctor 认出它并闭嘴就够了。

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlings"
-version = "2026.8.1.1"
+version = "2026.8.1.2"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "2026.8.1.1";
+    static constexpr std::string_view VERSION = "2026.8.1.2";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/xself/doctor.cppm
+++ b/src/core/xself/doctor.cppm
@@ -17,9 +17,11 @@ import xlings.core.xvm.bindings;
 import xlings.core.xvm.db;
 import xlings.core.xvm.shim;
 import xlings.core.xvm.inspect;
+import xlings.core.xvm.switch_plan;   // plan_use_switch — the --fix preflight
 import xlings.core.xvm.lock;
 import xlings.core.xvm.owner;
 import xlings.core.xself.repair;
+import xlings.core.xim.payload;   // classify_payload_platform
 import xlings.core.profile;
 
 namespace xlings::xself {
@@ -144,6 +146,14 @@ struct Finding {
     // when no command would help -- which is a fact worth printing, not a
     // reason to print a plausible one. See owning_coordinate().
     std::string  remedy;
+    // Why `--fix` must not run the remedy itself.
+    //
+    // Non-empty means the repair is known IN ADVANCE to be one another repair
+    // would immediately undo -- so running it would not fix the home, it would
+    // start a fight. The remedy stays printed: a human who runs it is making a
+    // choice between two packages, which is exactly the thing `--fix` is not
+    // entitled to make on their behalf.
+    std::string  conflict;
     // Broken payloads that share this key are one problem. A missing payload
     // directory takes out every program registered against it -- nine for the
     // measured llvm, three for the measured virtualbox -- and printing each
@@ -309,6 +319,72 @@ owning_coordinate_(const xvm::VersionDB& db,
     return std::nullopt;
 }
 
+// Would activating this release be undone by the repair that runs next?
+//
+// `--fix` is a sequence of repairs, and two of them want opposite things. The
+// activation repair makes an unreachable release reachable; the deactivation
+// repair (repair_state_ → plan_incoherent_deactivation) takes down releases
+// whose members disagree about which release they are. Activating a release
+// that shares program names with an ACTIVE one produces exactly that
+// disagreement, so the second repair tears down what the first just built --
+// and the wreckage reads as a fresh crop of "installed but inactive" entries,
+// which the next run tries to activate again. Measured on 2026.8.1.1: `--fix`
+// ended with more issues than it started with and left `gcc` and `ld` with no
+// active version at all.
+//
+// The answer does not need new machinery. Both halves already exist and are
+// exported: `plan_use_switch` computes the member map activation would write,
+// and `plan_incoherent_deactivation` IS the teardown. So the question is
+// answered by asking the second repair about the first repair's result --
+// simulate, then consult. Detection calls the function the repair calls, the
+// same rule the baked-subos-path check follows, so the two cannot drift.
+//
+// Returns the reason to refuse, or empty when the activation is safe.
+std::string activation_conflict_(const DoctorState& st,
+                                 const std::string& rootTarget,
+                                 const std::string& rootVersion) {
+    auto plan = xvm::plan_use_switch(st.db, st.ws, rootTarget, rootVersion);
+    if (!plan) {
+        // Unresolvable release: `use` would fail too. Refusing here means the
+        // user gets the finding and the command, rather than `--fix` running
+        // something that cannot work.
+        return "the release does not resolve";
+    }
+
+    auto simulated = st.ws;
+    for (const auto& [target, version] : plan->members) {
+        simulated[target] = version;
+    }
+
+    const auto teardown = xvm::plan_incoherent_deactivation(st.db, simulated);
+    if (teardown.targets.empty()) return {};
+
+    // Name the releases that would come down and a few of the programs they
+    // would take with them -- "there is a conflict" is not actionable, "this
+    // takes `ar` away from llvm" is.
+    std::map<std::string, std::vector<std::string>> byRelease;
+    for (const auto& [target, label] : teardown.targets) {
+        byRelease[label].push_back(target);
+    }
+    std::string reason;
+    for (auto& [label, targets] : byRelease) {
+        std::ranges::sort(targets);
+        std::string names;
+        constexpr std::size_t kShown = 4;
+        for (std::size_t i = 0; i < targets.size() && i < kShown; ++i) {
+            if (!names.empty()) names += ", ";
+            names += targets[i];
+        }
+        if (targets.size() > kShown) {
+            names += std::format(", … (+{})", targets.size() - kShown);
+        }
+        if (!reason.empty()) reason += "; ";
+        reason += std::format("it would take {} from the active {}", names,
+                              label);
+    }
+    return reason;
+}
+
 Scan detect_(const DoctorState& st, const CoordinateProbe& probe) {
     auto& p = Config::paths();
     Scan scan;
@@ -449,10 +525,18 @@ Scan detect_(const DoctorState& st, const CoordinateProbe& probe) {
     // `llvm-ar` … each with its own identical remedy. That is the same burial
     // the broken-payload grouping exists to prevent (see Finding::groupKey),
     // and it would have hidden `node` in the middle of it.
+    // Keyed by ROOT TARGET, not by (root, version).
+    //
+    // F3: a package can have several installed releases with none of them
+    // active, and keying by version produced one finding per release, each
+    // with a remedy contradicting the others -- `xim-gnu-gcc@15.1.0` and
+    // `@16.1.0` side by side, both saying "run me". There is one problem here
+    // ("nothing of this package is selected") and one decision to make, so
+    // there is one finding, and it names the versions to choose from.
     struct InactiveRelease {
         std::string rootTarget;
-        std::string rootVersion;
-        std::vector<std::string> members;
+        std::string rootVersion;   // the one the remedy proposes
+        std::set<std::string> members;
     };
     std::map<std::string, InactiveRelease> inactiveReleases;
 
@@ -513,11 +597,55 @@ Scan detect_(const DoctorState& st, const CoordinateProbe& probe) {
         const std::string rootVersion =
             vd && vd->bindingGroup ? vd->bindingGroup->rootVersion : *usable;
 
-        auto& release = inactiveReleases[std::format("{}@{}", rootTarget,
-                                                     rootVersion)];
-        release.rootTarget  = rootTarget;
-        release.rootVersion = rootVersion;
-        release.members.push_back(name);
+        // Both guards run BEFORE the map is touched: `operator[]` would insert
+        // a default-constructed release and the `continue` would leave it
+        // there, which renders as a finding with an empty name and zero
+        // programs.
+        //
+        // F1 — is this release the one you did not pick, rather than one you
+        // cannot reach?
+        //
+        // `llvm` installed at 20.1.7 and 22.1.8, active at 22.1.8, is a normal
+        // home. But 20.1.7 registers names 22.1.8 does not, and those names
+        // have no active version, so the release came back as a finding whose
+        // remedy -- `xlings use llvm@20.1.7` -- would DOWNGRADE the toolchain
+        // the user is actually using. Two releases of one package were
+        // reported as two mutually contradictory defects.
+        //
+        // The root target answers it. If some version of the root is active,
+        // the user has chosen a release of this package and the others are
+        // alternatives, not breakage. When no version of the root is active,
+        // nothing of the package is reachable -- which is exactly the `node`
+        // case this check was written for.
+        if (const auto rootIt = st.ws.find(rootTarget);
+            rootIt != st.ws.end() && !rootIt->second.empty()) {
+            continue;
+        }
+
+        // F2 — a payload built for another platform has no programs to put on
+        // PATH here, ever.
+        //
+        // The measured home carried a May-era WINDOWS llvm@20.1.7 in a Linux
+        // store; it registered `clang.exe` … `libomp.dll` as programs (the
+        // case payload.cppm's header documents), and this check dutifully
+        // reported 29 of them as "not on PATH". They cannot be. The classifier
+        // that answers this already exists and the installer already uses it
+        // (installer.cppm) -- this check simply never asked.
+        if (vd && !vd->path.empty()
+            && xim::classify_payload_platform(
+                   fs::path(xvm::expand_path(vd->path, st.homeStr)))
+                   == xim::PayloadPlatform::Foreign) {
+            continue;
+        }
+
+        auto& release = inactiveReleases[rootTarget];
+        release.rootTarget = rootTarget;
+        // Highest wins the remedy, by version rather than by iteration order.
+        if (release.rootVersion.empty()
+            || xvm::version_key_greater(rootVersion, release.rootVersion)) {
+            release.rootVersion = rootVersion;
+        }
+        release.members.insert(name);
     }
 
     for (const auto& [key, release] : inactiveReleases) {
@@ -528,12 +656,41 @@ Scan detect_(const DoctorState& st, const CoordinateProbe& probe) {
         // whole.
         constexpr std::size_t kShown = 6;
         std::string names;
-        for (std::size_t i = 0; i < release.members.size() && i < kShown; ++i) {
+        std::size_t shown = 0;
+        for (const auto& member : release.members) {
+            if (shown++ >= kShown) break;
             if (!names.empty()) names += ", ";
-            names += release.members[i];
+            names += member;
         }
         if (release.members.size() > kShown) {
             names += std::format(", … (+{})", release.members.size() - kShown);
+        }
+
+        // When several releases are installed and none chosen, the versions
+        // ARE the decision. Naming only the one the remedy proposes would hide
+        // that there was a choice.
+        //
+        // Read from installed[], not from the versions the members happened to
+        // resolve to: every member picks the same highest release, so
+        // accumulating those yields one version and the choice stays invisible
+        // -- which is what it did until this was measured.
+        std::string otherVersions;
+        if (const auto rootInstalled = st.wsInstalled.find(release.rootTarget);
+            rootInstalled != st.wsInstalled.end()) {
+            std::vector<std::string> others;
+            for (const auto& version : rootInstalled->second) {
+                if (version == release.rootVersion) continue;
+                others.push_back(version);
+            }
+            std::ranges::sort(others, xvm::version_key_greater);
+            for (const auto& version : others) {
+                if (!otherVersions.empty()) otherVersions += ", ";
+                otherVersions += version;
+            }
+            if (!otherVersions.empty()) {
+                otherVersions = std::format("  —  also installed: {}",
+                                            otherVersions);
+            }
         }
 
         // What the repair will ALSO do.
@@ -571,12 +728,16 @@ Scan detect_(const DoctorState& st, const CoordinateProbe& probe) {
                 xvm::display_coordinate(release.rootTarget,
                                         release.rootVersion),
                 release.members.size(), names,
-                alsoMoves.empty() ? std::string{}
-                                  : std::format(
-                                        "  —  activating it also moves {}",
-                                        alsoMoves)),
+                otherVersions
+                    + (alsoMoves.empty()
+                           ? std::string{}
+                           : std::format(
+                                 "  —  activating it also moves {}",
+                                 alsoMoves))),
             .remedy  = std::format("xlings use {}@{}", release.rootTarget,
                                    release.rootVersion),
+            .conflict = activation_conflict_(st, release.rootTarget,
+                                             release.rootVersion),
             .groupKey = key,
         });
     }
@@ -1091,6 +1252,10 @@ struct RepairReport {
     std::vector<std::pair<std::string, std::string>> failedEntries;
     // Commands `--dry-run` would have run.
     std::vector<std::string> planned;
+    // `--fix` ended with more issues than it started with. Sets the exit code
+    // on its own: a run that made the home worse must not be able to report
+    // success, whatever the individual repairs thought they were doing.
+    bool regressed { false };
 };
 
 // Everything below the payload layer: shims and pure state-file edits. All of
@@ -1469,6 +1634,12 @@ void repair_inactive_(const Scan& scan, const std::string& client,
                       RepairReport& out) {
     for (const auto& f : scan.findings) {
         if (f.kind != FindingKind::InactiveInstalled) continue;
+        // Known in advance to be a repair another repair would undo. Not
+        // attempted, and said so out loud: choosing between two packages that
+        // register the same program name is the user's decision, and `--fix`
+        // running `use` here would only start the fight described in
+        // activation_conflict_.
+        if (!f.conflict.empty()) continue;
         if (!is_shell_safe_token(f.target) || !is_shell_safe_token(f.version)) {
             out.notes.emplace_back(
                 glyph::mark(glyph::failed, "activation skipped"),
@@ -1769,6 +1940,14 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
                 add(glyph::mark(glyph::failed, "legacy alias shim"), f.detail); break;
             case FindingKind::InactiveInstalled:
                 add(glyph::mark(glyph::failed, "no active version"), f.detail);
+                // Printed before the remedy, because it changes what the
+                // remedy means: not "run this to fix it" but "run this to
+                // choose this package over that one".
+                if (!f.conflict.empty()) {
+                    add("  " + glyph::mark(glyph::warn, "conflict"),
+                        std::format("{} — `--fix` will not choose between "
+                                    "them", f.conflict));
+                }
                 add("  " + glyph::mark(glyph::remedy, "run"), f.remedy);
                 break;
             case FindingKind::ShimAnchor:
@@ -2074,15 +2253,6 @@ export int cmd_doctor(EventStream& stream, bool fix,
     repair_payloads_(state, scan, probe, /*dryRun=*/false, repair);
     refresh();
 
-    // Phase 2.5: activate what is installed and inactive.
-    //
-    // After the ladder, not before: a package whose payload was missing is
-    // both broken AND inactive, and `use` on a payload that is not there fails
-    // for a reason the user cannot act on. The ladder reinstalls it first, and
-    // re-registration may activate it on its own -- in which case `refresh()`
-    // has already dropped the finding and there is nothing left to do here.
-    repair_inactive_(scan, client, run, /*dryRun=*/false, repair);
-    refresh();
 
     // Phase 3: the cheap repairs again, on what the ladder left behind.
     //
@@ -2094,6 +2264,28 @@ export int cmd_doctor(EventStream& stream, bool fix,
     // findings that a single-pass repair reported as unfixed.
     repair_state_(repair);
     repair_local_(state, scan, repair);
+    refresh();
+
+    // Phase 3.5: activate what is installed and inactive.
+    //
+    // LAST among the repairs that write the workspace, and that placement is
+    // the fix for a real bug rather than a preference. It used to run before
+    // the final `repair_state_`, so it activated a release and the
+    // deactivation repair immediately afterwards took down whatever that
+    // activation had knocked out of step -- the two traded the workspace back
+    // and forth and `--fix` ended with more issues than it began with
+    // (2026.8.1.1, measured: `gcc` and `ld` left with no active version).
+    //
+    // Running last means every teardown has already settled, so this acts on a
+    // workspace nothing else is about to rewrite. The preflight in detection
+    // (activation_conflict_) is what stops it from creating a NEW disagreement
+    // for the next run to trip over; the ordering here is what stops it from
+    // being undone within this one.
+    //
+    // Still after the payload ladder for the original reason: a package whose
+    // payload was missing is both broken AND inactive, and `use` on a payload
+    // that is not there fails for a reason the user cannot act on.
+    repair_inactive_(scan, client, run, /*dryRun=*/false, repair);
     refresh();
 
     // Phase 4: whatever is STILL a broken payload after the ladder had its
@@ -2110,6 +2302,32 @@ export int cmd_doctor(EventStream& stream, bool fix,
 
     const auto after = count_(scan);
     repair.healed = std::max(0, before - after.issues() - repair.pruned);
+
+    // Did `--fix` actually leave the home better than it found it?
+    //
+    // Nothing asked this until 2026.8.1.2, and the release before it shipped a
+    // repair that undid another one: activating a release stranded members of
+    // a second release, the deactivation repair then took those members down,
+    // and the resulting "installed but inactive" entries were reported as new
+    // findings. `--fix` ended with MORE issues than it started with, having
+    // printed a hundred lines of `deactivated`, and the two repairs would go on
+    // trading the workspace back and forth on every subsequent run.
+    //
+    // This does not fix anything. It is the assertion that makes that class of
+    // bug announce itself on its FIRST run instead of hiding inside a long
+    // successful-looking report. Repairs that can conflict are prevented from
+    // conflicting elsewhere (see the preflight in repair_inactive_); this is
+    // the backstop for the next one nobody predicted.
+    if (after.issues() > before) {
+        repair.regressed = true;
+        repair.notes.emplace_back(
+            glyph::mark(glyph::failed, "not converging"),
+            std::format(
+                "--fix started with {} issue(s) and ended with {} — a repair "
+                "undid another. This is a bug in doctor, not in the home; "
+                "please report it with the output above.",
+                before, after.issues()));
+    }
 
     // A ladder failure only still counts if the entry it covered is still a
     // finding somewhere. An entry that was pruned, or that a later phase
@@ -2147,7 +2365,8 @@ export int cmd_doctor(EventStream& stream, bool fix,
         Config::record_client_version(std::string(Info::VERSION));
     }
 
-    return (after.issues() == 0 && outstanding == 0) ? 0 : 1;
+    return (after.issues() == 0 && outstanding == 0 && !repair.regressed)
+        ? 0 : 1;
 }
 
 } // namespace xlings::xself

--- a/src/core/xvm/inspect.cppm
+++ b/src/core/xvm/inspect.cppm
@@ -42,6 +42,39 @@ bool release_declares_file_assets_(const VersionDB& db,
     return false;
 }
 
+// Is this member's name currently held by a DIFFERENT provider?
+//
+// Two packages can register the same program name: node's release registers
+// `npm`, and a standalone npm package registers it too. Whichever is active,
+// the other release's member is "wrong" by version alone -- and treating that
+// as a broken release is wrong twice over. As a report it tells the user to
+// run a `use` that would take the name away from the package they chose; as a
+// REPAIR it tears down a release that is working. A contest with the SAME
+// provider is a genuinely split release and is neither.
+//
+// Extracted because the reporter and the repairer disagreed about it and that
+// disagreement shipped. `analyze_bindings` (INV-2) learned this rule in
+// 2026.8.1.1; `plan_incoherent_deactivation` -- which is what `self doctor
+// --fix` actually executes -- did not. So doctor said "this home is fine" and
+// `--fix`, on the same home, took `gcc` and `ld` down. One predicate, both
+// callers: the two cannot drift again.
+bool held_by_another_provider_(const VersionDB& db,
+                               const Workspace& workspace,
+                               const std::string& memberTarget,
+                               const std::string& releaseProvider) {
+    const auto activeIt = workspace.find(memberTarget);
+    if (activeIt == workspace.end()) return false;
+    const auto holderIt = db.find(memberTarget);
+    if (holderIt == db.end()) return false;
+    const auto heldIt = holderIt->second.versions.find(activeIt->second);
+    if (heldIt == holderIt->second.versions.end()) return false;
+    // No group metadata means an entry written before providers were
+    // recorded. Treated as the same provider, so old homes keep the older,
+    // stricter behaviour rather than silently losing a coherence check.
+    if (!heldIt->second.bindingGroup) return false;
+    return heldIt->second.bindingGroup->provider != releaseProvider;
+}
+
 }  // namespace xlings::xvm::detail_
 
 export namespace xlings::xvm {
@@ -277,30 +310,10 @@ std::vector<BindingFinding> inspect_binding_state(
                 && activeIt->second == memberVersion;
             if (coherent) continue;
 
-            // A name another PROVIDER owns is not this release breaking step.
-            //
-            // Two packages can register the same program name -- node's
-            // release registers `npm`, and a standalone npm package registers
-            // it too. Whichever is active, the other release's member is
-            // "wrong" by version alone, and calling that incoherent asks the
-            // user to run a `use` that would take the name away from the
-            // package they chose. Registration applies the same rule from the
-            // other side: a foreign claim does not veto its siblings, and a
-            // foreign claim is not a defect afterwards either. A contest with
-            // the SAME provider is a genuinely split release and still
-            // reported.
-            if (activeIt != workspace.end()) {
-                const auto holderIt = db.find(memberTarget);
-                if (holderIt != db.end()) {
-                    const auto heldIt =
-                        holderIt->second.versions.find(activeIt->second);
-                    if (heldIt != holderIt->second.versions.end()
-                        && heldIt->second.bindingGroup
-                        && heldIt->second.bindingGroup->provider
-                               != dataIt->second.bindingGroup->provider) {
-                        continue;
-                    }
-                }
+            if (detail_::held_by_another_provider_(
+                    db, workspace, memberTarget,
+                    dataIt->second.bindingGroup->provider)) {
+                continue;
             }
             const auto key = dataIt->second.bindingGroup->provider + "@"
                 + dataIt->second.bindingGroup->providerVersion + "/"
@@ -677,15 +690,25 @@ DeactivationPlan plan_incoherent_deactivation(const VersionDB& db,
         auto selection = resolve_binding_selection(db, target, version);
         if (!selection) continue;  // unresolvable is a different problem
 
+        const auto& ref = *dataIt->second.bindingGroup;
+
+        // Exactly the predicate INV-2 reports with. A member whose name is
+        // held by another provider is not this release breaking step, so it
+        // must not put this release on the teardown list either -- which it
+        // did until 2026.8.1.2, making `--fix` demolish releases `self doctor`
+        // had just called healthy.
         const bool coherent = std::ranges::all_of(
             selection->members, [&](const auto& member) {
                 auto activeIt = workspace.find(member.first);
-                return activeIt != workspace.end()
-                    && activeIt->second == member.second;
+                if (activeIt != workspace.end()
+                    && activeIt->second == member.second) {
+                    return true;
+                }
+                return detail_::held_by_another_provider_(
+                    db, workspace, member.first, ref.provider);
             });
         if (coherent) continue;
 
-        const auto& ref = *dataIt->second.bindingGroup;
         const auto label =
             std::format("{}@{}", ref.provider, ref.providerVersion);
         // Take down every member of this release that is active, not just

--- a/tests/e2e/doctor_fix_convergence_test.sh
+++ b/tests/e2e/doctor_fix_convergence_test.sh
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+# E2E: `xlings self doctor --fix` must leave the home better than it found it.
+#
+# The 2026.8.1.1 regression: the activation repair added in that release ran
+# `use` on an unreachable release; that stranded members of a SECOND release;
+# the deactivation repair (plan_incoherent_deactivation) then took those
+# members down; and the resulting "installed but inactive" entries came back as
+# new findings for the next run to activate again. `--fix` ended with MORE
+# issues than it started with, having printed a hundred lines of `deactivated`,
+# and it left `gcc` and `ld` with no active version on a real machine.
+#
+# E2E-52 could not catch it: every one of its scenarios is a single release or
+# two packages with one shared name. The shape that breaks is MULTI-VERSION
+# plus CROSS-RELEASE NAME OVERLAP, which is what this fixture builds.
+#
+# Scenarios:
+#   S1  a second installed release of an ACTIVE package is not a finding
+#   S2  a release that cannot be activated without breaking an active one is
+#       reported as a conflict and NOT auto-activated
+#   S3  --fix twice: issues must not grow and the workspace must stop moving
+#   S4  a foreign-platform payload is not reported as "programs not on PATH"
+#   S5  several inactive releases of one root collapse into ONE finding
+#   S6  the plain unreachable release (#465's node shape) is still auto-fixed
+
+set -euo pipefail
+
+# shellcheck source=./project_test_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
+
+require_fixture_index
+
+RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/doctor_fix_convergence"
+HOME_DIR="$RUNTIME_DIR/home"
+LOCAL_INDEX_DIR="$RUNTIME_DIR/xim-pkgindex"
+
+cleanup() { rm -rf "$RUNTIME_DIR"; }
+trap cleanup EXIT
+cleanup
+
+XLINGS_BIN="$(find_xlings_bin)"
+
+RUN() {
+  ( cd /tmp && env -i HOME="$HOME" PATH=/usr/bin:/bin XLINGS_HOME="$HOME_DIR" "$XLINGS_BIN" "$@" )
+}
+
+issue_count() { RUN self doctor 2>&1 | grep -c '✗' || true; }
+
+ws_digest() {
+  python3 - "$HOME_DIR" <<'PY'
+import hashlib, json, pathlib, sys
+p = pathlib.Path(sys.argv[1], "subos", "default", ".xlings.json")
+ws = json.loads(p.read_text())["workspace"]
+active = {k: v.get("active") for k, v in sorted(ws.items())}
+print(hashlib.sha256(json.dumps(active, sort_keys=True).encode()).hexdigest())
+PY
+}
+
+mkdir -p "$HOME_DIR"
+cp -r "$FIXTURE_INDEX_DIR" "$LOCAL_INDEX_DIR"
+printf 'xim_indexrepos = {}\n' > "$LOCAL_INDEX_DIR/xim-indexrepos.lua"
+rm -f "$LOCAL_INDEX_DIR/.xlings-index-cache.json"
+mkdir -p "$LOCAL_INDEX_DIR/pkgs/c"
+
+# ── Fixtures ───────────────────────────────────────────────────────
+#
+# `alpha` ships two releases, each registering `alpha`, `overlap` and
+# `alpha-only`. `beta` ships one release registering `beta`, `overlap` and
+# `beta-only`. `overlap` is the crossing name — the `ar`/`nm` of the measured
+# home, where binutils and llvm both provide it.
+
+emit_pkg() {
+  local name="$1" versions="$2" extra="$3"
+  cat > "$LOCAL_INDEX_DIR/pkgs/c/$name.lua" <<LUA
+package = {
+    spec = "1",
+    name = "$name",
+    description = "Local fixture for doctor_fix_convergence_test.sh",
+    authors = {"xlings-ci"},
+    licenses = {"MIT"},
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"test-fixture"},
+    programs = {"$name", "overlap", "$extra"},
+    xpm = {
+        linux   = { $versions },
+        macosx  = { $versions },
+        windows = { $versions },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local bindir = path.join(pkginfo.install_dir(), "bin")
+    os.tryrm(pkginfo.install_dir())
+    os.mkdir(bindir)
+    for _, n in ipairs({"$name", "overlap", "$extra"}) do
+        io.writefile(path.join(bindir, n),
+                     "#!/bin/sh\necho " .. n .. "@" .. pkginfo.version() .. "\n")
+        if os.host() ~= "windows" then
+            os.exec("chmod +x " .. path.join(bindir, n))
+        end
+    end
+    return true
+end
+
+function config()
+    local bindir = path.join(pkginfo.install_dir(), "bin")
+    local root = "$name@" .. pkginfo.version()
+    xvm.add("$name", { bindir = bindir })
+    xvm.add("overlap", { bindir = bindir, binding = root })
+    xvm.add("$extra", { bindir = bindir, binding = root })
+    return true
+end
+
+function uninstall()
+    xvm.remove("$name")
+    xvm.remove("overlap")
+    xvm.remove("$extra")
+    return true
+end
+LUA
+}
+
+emit_pkg alpha '["1.0.0"] = {}, ["2.0.0"] = {}' alpha-only
+# A version of its own: two providers may not own the same exact
+# (name, version), and both packages register `overlap`.
+emit_pkg beta  '["3.0.0"] = {}'                 beta-only
+
+mkdir -p "$HOME_DIR/subos/default/bin"
+cp "$XLINGS_BIN" "$HOME_DIR/xlings"
+cat > "$HOME_DIR/.xlings.json" <<EOF
+{
+  "mirror": "GLOBAL",
+  "index_repos": [
+    { "name": "xim", "url": "$LOCAL_INDEX_DIR" }
+  ]
+}
+EOF
+
+log "Initializing sandbox XLINGS_HOME at $HOME_DIR"
+RUN self init >/dev/null 2>&1 || fail "self init failed"
+mkdir -p "$HOME_DIR/data/xim-index-repos"
+printf '{}\n' > "$HOME_DIR/data/xim-index-repos/xim-indexrepos.json"
+
+STATE="$HOME_DIR/subos/default/.xlings.json"
+
+# ── S1: the release you did not pick is not a defect ───────────────
+log "S1: two releases of one package, one active → the other is not reported"
+RUN install alpha@1.0.0 -y >/dev/null 2>&1 || fail "S1 setup: alpha@1.0.0 failed"
+RUN install alpha@2.0.0 -y >/dev/null 2>&1 || fail "S1 setup: alpha@2.0.0 failed"
+RUN use alpha 2.0.0 >/dev/null 2>&1 || fail "S1 setup: use alpha 2.0.0 failed"
+
+rc=0
+out=$(RUN self doctor 2>&1) || rc=$?
+echo "$out" | grep -q "alpha@1.0.0" \
+  && fail "S1: alpha@1.0.0 is the release you did NOT pick, not a broken one; got:\n$out"
+[[ $rc -eq 0 ]] || fail "S1: a home with a chosen release is healthy; expected exit 0, got $rc"
+
+# ── S2: a conflicting activation is reported, not performed ────────
+#
+# beta registers `overlap`, which alpha@2.0.0 currently owns. Activating beta
+# would take it, leaving alpha's release incoherent — which is precisely what
+# the deactivation repair would then tear down.
+log "S2: install beta → uncontested members activate, overlap stays with alpha"
+RUN install beta@3.0.0 -y >/dev/null 2>&1 || fail "S2 setup: beta@3.0.0 install failed"
+
+active_of() {
+  python3 - "$STATE" "$1" <<'PY'
+import json, sys
+ws = json.loads(open(sys.argv[1]).read())["workspace"]
+print((ws.get(sys.argv[2]) or {}).get("active", ""))
+PY
+}
+[[ "$(active_of overlap)" == "2.0.0" ]] \
+  || fail "S2: installing beta took 'overlap' from alpha (now $(active_of overlap))"
+[[ -n "$(active_of beta-only)" ]] \
+  || fail "S2: 'beta-only' is uncontested and must be usable"
+
+# Now strand beta's own root so it becomes an unreachable release whose
+# activation WOULD break alpha.
+python3 - "$STATE" <<'PY'
+import json, pathlib, sys
+p = pathlib.Path(sys.argv[1])
+d = json.loads(p.read_text())
+for name in ("beta", "beta-only"):
+    d["workspace"][name].pop("active", None)
+p.write_text(json.dumps(d, indent=2))
+PY
+rm -f "$HOME_DIR/subos/default/bin/beta" "$HOME_DIR/subos/default/bin/beta-only"
+
+rc=0
+out=$(RUN self doctor 2>&1) || rc=$?
+echo "$out" | grep -q "no active version" \
+  || fail "S2: beta is unreachable and must be reported; got:\n$out"
+# Activating beta takes `overlap` from alpha. That is what `use` means, and the
+# finding has to say so before --fix does it.
+echo "$out" | grep -q "also moves overlap" \
+  || fail "S2: the finding must disclose that repair moves a name alpha holds; got:\n$out"
+[[ $rc -eq 1 ]] || fail "S2: an unreachable release is an error; expected exit 1, got $rc"
+
+# THE REGRESSION, directly.
+#
+# --fix activates beta, which moves `overlap` off alpha's release. Before
+# 2026.8.1.2 the deactivation repair then declared alpha incoherent and took
+# `alpha` and `alpha-only` down with it — on the measured home that is how
+# `gcc` and `ld` lost their active versions. A name held by another PROVIDER is
+# not this release breaking step, and the teardown planner now knows that.
+RUN self doctor --fix >/dev/null 2>&1 || true
+[[ -n "$(active_of beta)" ]] \
+  || fail "S2: nothing prevented it, so --fix should have activated beta"
+[[ "$(active_of alpha)" == "2.0.0" ]] \
+  || fail "S2: activating beta demolished alpha's release — alpha is now '$(active_of alpha)'"
+[[ "$(active_of alpha-only)" == "2.0.0" ]] \
+  || fail "S2: alpha-only was collateral of a repair it had nothing to do with"
+
+# ── S3: convergence ────────────────────────────────────────────────
+#
+# The assertion the 2026.8.1.1 regression would have failed on its first run.
+log "S3: --fix twice → issues never grow and the workspace stops moving"
+n1="$(issue_count)"
+RUN self doctor --fix >/dev/null 2>&1 || true
+after1_digest="$(ws_digest)"
+n2="$(issue_count)"
+RUN self doctor --fix >/dev/null 2>&1 || true
+after2_digest="$(ws_digest)"
+n3="$(issue_count)"
+
+[[ "$n2" -le "$n1" ]] \
+  || fail "S3: --fix made it worse — $n1 issue(s) before, $n2 after"
+[[ "$n3" -le "$n2" ]] \
+  || fail "S3: the second --fix made it worse — $n2 issue(s) before, $n3 after"
+[[ "$after1_digest" == "$after2_digest" ]] \
+  || fail "S3: two --fix runs left different workspaces — the repairs are trading state"
+
+# The regression also has to be visible when it happens, not just prevented.
+RUN self doctor --fix 2>&1 | grep -qi "not converging" \
+  && fail "S3: the convergence assertion fired on a converging home"
+
+# ── S4: a foreign-platform payload has no programs to miss ─────────
+log "S4: a Windows payload in a Linux store is not reported"
+FOREIGN="$HOME_DIR/data/xpkgs/xim-x-foreign-fixture/9.9.9"
+mkdir -p "$FOREIGN/bin"
+# PE header: 'MZ' is what classify_payload_content reads.
+printf 'MZ\x90\x00' > "$FOREIGN/bin/winonly.exe"
+chmod +x "$FOREIGN/bin/winonly.exe"
+python3 - "$HOME_DIR" "$FOREIGN" <<'PY'
+import json, pathlib, sys
+home = pathlib.Path(sys.argv[1])
+state = home / ".xlings.json"
+d = json.loads(state.read_text())
+d["versions"]["winonly.exe"] = {
+    "filename": "winonly.exe",
+    "type": "program",
+    "versions": {"9.9.9": {"kind": "program", "path": sys.argv[2] + "/bin"}},
+}
+state.write_text(json.dumps(d, indent=2))
+sub = home / "subos" / "default" / ".xlings.json"
+s = json.loads(sub.read_text())
+s["workspace"]["winonly.exe"] = {"installed": ["9.9.9"]}
+sub.write_text(json.dumps(s, indent=2))
+PY
+out=$(RUN self doctor 2>&1) || true
+echo "$out" | grep -q "winonly" \
+  && fail "S4: a payload built for another platform can never be on PATH here; got:\n$out"
+
+# ── S5: several inactive releases of one root → one finding ────────
+log "S5: two inactive releases of one root collapse into a single finding"
+python3 - "$STATE" <<'PY'
+import json, pathlib, sys
+p = pathlib.Path(sys.argv[1])
+d = json.loads(p.read_text())
+for name in ("alpha", "alpha-only", "overlap"):
+    d["workspace"][name].pop("active", None)
+p.write_text(json.dumps(d, indent=2))
+PY
+rm -f "$HOME_DIR/subos/default/bin/alpha" "$HOME_DIR/subos/default/bin/alpha-only"
+out=$(RUN self doctor 2>&1) || true
+count=$(echo "$out" | grep -c "no active version.*alpha" || true)
+[[ "$count" -eq 1 ]] \
+  || fail "S5: alpha 1.0.0 and 2.0.0 are one decision, not two findings; got $count:\n$out"
+echo "$out" | grep -q "also installed" \
+  || fail "S5: the finding must name the other version so the choice is visible; got:\n$out"
+
+# ── S6: the plain unreachable release is still auto-fixed ──────────
+#
+# The preflight must not have closed the path #465 opened. Nothing contests
+# beta's names once alpha is entirely inactive.
+log "S6: an unreachable release with nothing contesting it is still repaired"
+RUN self doctor --fix >/dev/null 2>&1 || true
+[[ -n "$(active_of alpha)" ]] \
+  || fail "S6: nothing contested alpha and --fix left it unreachable"
+[[ -e "$HOME_DIR/subos/default/bin/alpha" ]] \
+  || fail "S6: --fix activated alpha but wrote no shim"
+
+n_final="$(issue_count)"
+[[ "$n_final" -le "$n1" ]] \
+  || fail "S6: the run ended worse than S3 started ($n1 → $n_final)"
+
+log "all scenarios passed"

--- a/tests/e2e/run_all.sh
+++ b/tests/e2e/run_all.sh
@@ -102,6 +102,7 @@ TESTS=(
     "E2E-50 |subos_scope_authority_test.sh||"
     "E2E-51 |install_use_semantics_test.sh||"
     "E2E-52 |inactive_installed_test.sh||"
+    "E2E-53 |doctor_fix_convergence_test.sh||"
 )
 
 PASS=0; FAIL=0; SOFTFAIL=0


### PR DESCRIPTION
Regression from **2026.8.1.1** (#465), measured on a real home:

```
$ xlings self doctor          → 3 issues
$ xlings self doctor --fix    → ~100 lines of `deactivated`, ends with 4 issues
$ gcc --version
[error] xlings: no active version of 'gcc' in current subos
$ ld --version
[error] xlings: no active version of 'ld' in current subos
```

`--fix` left the home **worse than it found it**. Postmortem:
`.agents/docs/2026-08-01-doctor-fix-nonconvergence-postmortem.md`

## The engine: the reporter and the repairer disagreed

#465 taught **INV-2** (`analyze_bindings` — what doctor *reports*) that a
program name held by another provider is ownership, not incoherence. It did not
teach the same thing to **`plan_incoherent_deactivation`** — which is what
`--fix` actually *executes*.

So on one home:

```
xlings self doctor        → "workspace, shims, and payloads are all consistent"
xlings self doctor --fix  → tears gcc and ld down
```

node's own home has the same shape: node's release registers `npm`, `npm` is
held by `xim:npm@11.2.0`, so the teardown planner called node's release
incoherent and took `node` and `npx` with it. **That is the mechanism.**

The teardown left members installed-and-inactive → the new `InactiveInstalled`
check reported them → the next run activated them → stranding the other release
again. The two repairs traded the workspace back and forth.

## Fixes

**The real one — one predicate, both callers.** `held_by_another_provider_` is
now called by the reporter *and* the teardown planner. Two parallel copies of
the rule is how it drifted the first time.

**`--fix` preflight (F4).** No new machinery was needed and my first instinct —
"make `--fix` report-only here" — was wrong: both halves already existed and
were exported. Simulate `plan_use_switch` onto a workspace copy, ask
`plan_incoherent_deactivation` about the result. Conflicts are reported with the
names they would move, not acted on.

**Ordering (F5).** The activation repair moves to phase 3.5, after every
teardown has settled, instead of being partly undone by phase 3.

**Convergence assertion (F6).** `--fix` now checks that it converged; ending
with more issues than it began with is one visible line and sets the exit code.
This does not fix anything — it makes the *next* unpredicted conflict announce
itself on its first run instead of hiding in a long successful-looking report.

## Report scope — three separate false positives

| | before | after |
|---|---|---|
| `llvm@20.1.7` beside an active `llvm@22.1.8` | reported, remedy would **downgrade** the toolchain | the release you did not pick |
| 29 × `clang.exe` / `libomp.dll` on Linux | "programs not on PATH" | foreign payload, silent (`classify_payload_platform` already existed) |
| `xim-gnu-gcc@15.1.0` + `@16.1.0` | 2 findings, contradictory remedies | 1 finding naming both versions |

## Tests

New **E2E-53** on the shape E2E-52 could not express — **multi-version plus
cross-release name overlap**. S3 asserts `--fix` run twice never grows the issue
count and leaves the workspace byte-identical the second time; S2 asserts it
does not demolish a release it merely borrowed a name from; S6 asserts the plain
unreachable release from #465 is still auto-fixed.

Local: **25/25 unit suites**, **55/56 e2e**.

### The one red test, and why it is not this branch

`E2E-05 project_e2e_test.sh` fails locally. It **fails identically on the
released 2026.8.1.1 binary**, i.e. on `main` without this branch. It asserts a
project shim errors when `XLINGS_PROJECT_DIR` is unset — which stopped being
true on my machine once `node` became resolvable in the real home (the very bug
#465 fixed). CI runs on a clean home, so it is green there and has been all
along. Filing separately rather than widening this PR: a project shim answering
from the real home while `XLINGS_HOME` points elsewhere deserves its own look.