### PR TITLE
feat(index): version contract and snapshot routing (2026.8.4.1)

### DIFF
--- a/.agents/docs/2026-08-03-index-snapshot-selection-design.md
+++ b/.agents/docs/2026-08-03-index-snapshot-selection-design.md
@@ -1,0 +1,427 @@
+# 索引快照的版本契约与自动路由 —— issue #476 设计方案
+
+**日期**: 2026-08-04（重写；初版同月 08-03）
+**类型**: 设计 (design)
+**基线**: `main` @ `1e968b6` = `2026.8.3.1`
+**相关 issue**: [#476](https://github.com/openxlings/xlings/issues/476)
+**前序**: `.agents/docs/2026-06-22-index-as-resource-impl-plan.md`（Y-asset 分发）、
+`2026-07-22-issue377-custom-index-artifact-design.md`（自定义 artifact 源）、
+`2026-08-03-multiplatform-contracts-architecture-plan.md`（A1 沉默成功主线）
+**涉及仓库**: `openxlings/xlings`、`openxlings/xim-pkgindex`、`xlings-res/xim-index`
+
+> **为什么重写**：初版把这件事设计成"为 mcpp 做不透明透传，xlings 永不解释"。
+> 那是把一个**基础设施能力**降级成了给某个消费者开的旁路。
+> xlings 自己的索引同样会抬高客户端门槛（新的 xvm node kind、新的 `spec` 版本），
+> 同样会让老客户端硬失败 —— 这个问题 xlings 自己就有，而且只有 xlings 能解。
+> 本版按"xlings 优先"重新设计：**索引声明它需要的客户端版本，客户端自动路由到
+> 自己能用的最新快照**；不透明透传降级为该机制的一个自然副产品。
+
+---
+
+## 0. 摘要
+
+### 0.1 要解决的真问题（xlings 自己的，不是 mcpp 的）
+
+索引一旦开始使用新客户端才有的能力，老客户端就**硬失败**。这在本仓库有记录在案的先例：
+
+```
+error: unsupported registration node kind 'files'
+```
+
+今天的缓解手段是**每个配方自己做能力探测**（`reference_recipe_capability_probe`）——
+聪明，但把负担摊到了每一个配方作者身上，且只能覆盖"配方作者想到了"的情况。
+索引级的版本契约是这件事的**基础设施解**。
+
+### 0.2 目标形态
+
+```
+每个 xlings 客户端：
+   拉一次指针（今天已经在做）
+   → 得到 [最新快照] + [历史快照]，每条都声明 requires.xlings
+   → 过滤出"我这个版本满足"的
+   → 取其中最新的一条，落地
+   → 若落地的不是最新快照，明确告诉用户：为什么、以及怎么升级
+```
+
+版本错配从**硬失败**变成**路由决策**。老客户端继续用它能描述的包，用户升级后自动前进，
+两侧不需要协调发布节奏。
+
+### 0.3 五个核心决定
+
+| # | 决定 | 关键理由 |
+|---|---|---|
+| 1 | 版本比较用 `version_order::compare`，**不是** `semver::satisfies_expr` | **实测**：`semver` 解析不了 4 段版本，`satisfies_expr("2026.8.3.2", ">=2026.8.3.1")` 返回 **0**。建在它上面 = 每个客户端都路由到空集 |
+| 2 | 契约是 `{min, max}` 两个裸版本号，**不引入范围表达式语法** | 两个边界就是范围；引入第二套语法会与包解析的 semver 语义漂移，且把 §1 的 4 段 bug 一起带进来 |
+| 3 | `requires` 是 **consumer → 约束** 的映射，xlings 只解释 `xlings` 键 | 一套机制同时服务 xlings 自己和第三方；不透明透传变成自然结果而非特设旁路 |
+| 4 | 指针**纯增字段**，不重构成 `latest` + `history` 兄弟节点 | issue 的形状会让**今天所有已发布客户端**判定指针无效（§3.1 有代码证据） |
+| 5 | 路由**永不适用于客户端自身的升级路径** | 否则老客户端被路由到老索引 → 看不到新 xlings → 永远升不上去。**死锁**（§5） |
+
+---
+
+## 1. 决定性的实测：现有 semver 不能表达 xlings 自己的版本
+
+写这份方案时先测了，因为整个契约的可行性压在这上面：
+
+```
+semver::parse("2026.8.3.1")                     → FAIL          (ok=0)
+semver::satisfies_expr("2026.8.3.1", ">=2026.8.3.2") → 0        [期望 0 ✓ 但属巧合]
+semver::satisfies_expr("2026.8.3.2", ">=2026.8.3.1") → 0        [期望 1 ✗]
+version_order::compare("2026.8.3.1", "2026.8.3.2") < 0 → 1      [✓]
+version_order::compare("2026.8.3.1", "0.4.69")     > 0 → 1      [✓]
+```
+
+`semver::Version` 是 **3 段**（`major/minor/patch`，`semver.cppm:10`），
+而 xlings 自己的版本是 **4 段** `YYYY.M.D.N`。
+
+**最危险的地方不是它错，是它错的方式**：`satisfies_expr` 解析失败时返回 `false` 而不是报错。
+如果契约建在它上面，每个客户端对每条快照都判"不满足" → 路由到空集 → 报
+"没有兼容快照"。看起来像**发布方没发历史**，实际是解析器不认版本号。
+这正是 `2026.8.3.1` 那一批修复的 A1 形状：**声明了契约，而没有任何东西验证它真的成立**。
+
+`version_order::compare`（`src/core/version_order.cppm`，本仓库 `2026.8.3.1` 引入）
+按分量做数值比较，段数任意，正是为这类版本号写的。
+
+**不扩展 semver 到 N 段**：它服务的是**包**版本约束（`gcc@15`、`^1.2`），
+改它的解析会波及所有包解析路径。索引契约是另一个问题域，用另一个（已存在且正确的）比较器。
+
+---
+
+## 2. 契约 schema
+
+### 2.1 索引树声明自己需要什么客户端
+
+索引仓库根目录新增 `index-compat.json`（可选；缺失 = 无约束 = 今天的行为）：
+
+```json
+{
+  "format_version": 1,
+  "requires": {
+    "xlings": { "min": "2026.8.3.1" }
+  }
+}
+```
+
+- `min` **含**，`max` **不含**（`[min, max)`）。两个都可选。
+- `requires` 是 **consumer 名 → 约束** 的映射。xlings 只解释键 `"xlings"`，
+  其余原样搬运并通过 `xlings index list --json` 暴露给对应消费者（§7）。
+- 语义故意贫乏：没有 `^`、没有 `~`、没有 `||`。**能被误读的语法就是会被误读的语法**，
+  而这条契约的失败模式是"整个索引对某类客户端不可用"。
+
+### 2.2 指针 schema：只加字段，不重构
+
+```json
+{
+  "format_version": 2,
+  "indexes": {
+    "xim": {
+      "format_version": 1,
+      "index_version": "e2aad0b",
+      "index_name": "xim",
+      "generated_at": "2026-08-03T15:01:07Z",
+      "source_commit": "e2aad0b…",
+      "artifact": { "name": "xim-index-e2aad0b.tar.gz", "sha256": "…", "size": 371803 },
+
+      "requires": { "xlings": { "min": "2026.8.3.1" } },
+
+      "history": [
+        { "index_version": "e2aad0b", "generated_at": "2026-08-03T15:01:07Z",
+          "requires": { "xlings": { "min": "2026.8.3.1" } },
+          "artifact": { "name": "xim-index-e2aad0b.tar.gz", "sha256": "…", "size": 371803 } },
+        { "index_version": "20e53c6", "generated_at": "2026-08-03T09:12:44Z",
+          "requires": {},
+          "artifact": { "name": "xim-index-20e53c6.tar.gz", "sha256": "…", "size": 371707 } }
+      ],
+      "history_truncated": false
+    }
+  },
+  "client_latest": { "xlings": "2026.8.3.1" }
+}
+```
+
+#### 为什么不能用 issue 提议的形状
+
+issue 提议把 `indexes.<name>` 改成 `{latest: {...}, history: [...]}`。
+但现有解析是硬校验（`indexfetch.cppm:250`）：
+
+```cpp
+if (!j.is_object() || !j.contains("artifact") || !j["artifact"].is_object())
+    return std::nullopt;
+```
+
+新形状下 `indexes.<name>` 不再直接含 `artifact` → **今天每一个已发布的 xlings 都会把
+指针判为无效**。一个为"别让老客户端掉队"提的特性，落地方式会让所有老客户端立刻掉队。
+
+纯增字段则：老客户端读到的还是原来那个 manifest，新字段被 `value()` 默认值吞掉。
+
+#### 其余形状说明
+
+- **`history[0]` 就是当前快照**，与顶层重复约 250 字节。故意的：客户端只过滤**一个**列表，
+  不必"先看 latest 再看 history"，少一条分支就少一处会写错的地方。
+- **`client_latest`** 是 §5 死锁解法的一半：无论路由到哪个快照，客户端都能知道
+  "有更新的我"。
+- **`history_truncated`** 让客户端能区分"没有兼容快照"和"兼容的被截断了"——
+  后者该提示用户而不是断言不存在。
+
+### 2.3 `history` 收录策略（发布侧）
+
+不是"留最近 N 个"。真实数据：`xlings-res/xim-index` 的滚动 `latest` release 里有
+**313 个 artifact**（从不修剪），但**契约变动极少**。所以：
+
+```
+history = 倒序，取以下并集，上限 32：
+    A) 最近 8 个快照（不论 requires）        → 支持"回滚一个版本"这种调试需求
+    B) 每个不同 requires 值的最新那个快照     → 支持"找到我这个版本还能用的最新快照"
+超出 32 丢最老的，并置 history_truncated = true
+```
+
+B 是这个特性存在的理由，A 是日常可用性。并集在真实历史上约 10 余条，序列化约 3 KB。
+指针从 ~400 B 涨到 ~3.5 KB，仍是一次 raw fetch，仍在 gitcode raw 的舒适区。
+
+---
+
+## 3. 客户端：自动路由
+
+### 3.1 选择算法
+
+```
+snapshots = manifest.history 若非空，否则 [manifest 自身]
+candidates = [s for s in snapshots if satisfies(Info::VERSION, s.requires["xlings"])]
+
+candidates 非空          → 取 index_version 最新的那条（history 已倒序 → 取首个）
+candidates 为空          → E_INDEX_NO_COMPATIBLE_SNAPSHOT，不动本地索引树
+                           消息里给出：我的版本、各快照要求的最低版本、升级命令
+```
+
+```cpp
+// 契约求值：两个边界，一个比较器，没有语法
+bool satisfies(std::string_view self, const Requirement& req) {
+    if (!req.min.empty() && version_order::compare(self, req.min) <  0) return false;
+    if (!req.max.empty() && version_order::compare(self, req.max) >= 0) return false;
+    return true;   // 空约束 = 无条件满足
+}
+```
+
+### 3.2 可观测性：路由到非最新时必须说出来
+
+沉默地降级和沉默地失败一样糟。`xlings update` 在路由到非最新快照时打印：
+
+```
+[index] xim: using 20e53c6 (2026-08-03) instead of e2aad0b
+        e2aad0b requires xlings >= 2026.8.3.1, this is 2026.8.2.1
+        upgrade: xlings self update
+```
+
+这不是装饰。没有它，用户会以为自己在最新索引上，然后困惑于"为什么新包搜不到"——
+而这正是 `2026.8.3.1` 那批修复反复在打的形状。
+
+`xlings self doctor` 同样报告一行：当前索引快照、是否为最新、若不是则原因。
+
+### 3.3 手动钉子：调试与可复现，不是主路径
+
+自动路由是主路径。钉子是**覆盖**：
+
+```jsonc
+{ "index_repos": [
+    { "name": "xim", "url": "…", "artifact": "…", "version": "20e53c6" }
+] }
+```
+
+```console
+$ xlings index list [<name>] [--json]     # 枚举，无副作用
+$ xlings index use <name> 20e53c6         # 写钉子并同步
+$ xlings index use <name> latest          # 清钉子，回到自动路由
+```
+
+- 钉子**绕过兼容过滤**（你要求了具体版本就给你），但**不绕过 sha256 校验**。
+- 钉到一个 `history` 里没有的版本 → **硬失败并列出可选集**，绝不回退。
+  回退等于把客户端悄悄送回它正要躲开的快照。
+- 钉到一个自己不满足的快照 → 允许，但打印警告（可能正是调试意图）。
+
+**不提供 `xlings update --index-version`（issue 的写法）**：一次性钉会被下一次
+`xlings update` 静默还原，"什么都没发生"和"成功了"再次不可区分。状态放配置里才可见。
+
+**为什么 `xlings index` 而不是塞进 `update`**：`update` 有副作用、查询没有；
+`update` 的位置参数已是 `[package] [version]`；`2026.8.3.1` 刚建立的 `CommandSpec`
+单一事实源要求每个命令的参数形状可枚举，`index` 是干净的一行 spec，塞进 `update` 是特例。
+
+### 3.4 可选集只有 `latest ∪ history`
+
+**不支持钉到任意版本号**。任意版本意味着客户端自己拼 URL 且**手上没有 sha256**，
+直接废掉"指针钉哈希"这条现有安全性质（记录：*陈旧镜像会被自动拒绝*）。
+每条 history 自带 sha256，选旧快照沿用同一套校验。
+
+---
+
+## 4. 谁来抬 floor，以及怎么保证它没写错
+
+一个只靠人记得去改的契约等于没有契约。
+
+### 4.1 什么时候该抬
+
+索引开始使用**只有新客户端才有**的能力时：新的 xvm 注册 node kind、新的 `spec` 版本、
+新的 libxpkg 字段语义。
+
+### 4.2 让它可检查（xim-pkgindex 侧 CI）
+
+新增一个 CI 检查：扫描全部配方里出现的"已知需要客户端支持的构造"，
+与 `index-compat.json` 声明的 `min` 比对，不覆盖就红。
+
+```
+recipe 使用 kind='files'      → 需要 >= 0.4.70
+recipe 声明 spec = "2"        → 需要 >= 0.4.52
+…（一张构造 → 最低客户端版本的表，随能力新增而追加）
+```
+
+这是把"作者承诺"换成"可验证的事实"——与本仓库 `2026.8.3.1` 那批修复同一条原则。
+
+### 4.3 与"配方能力探测"的关系：互补，不替代
+
+`reference_recipe_capability_probe` 记录的做法（配方在 Lua 里探测某函数是否存在）
+**继续有效且更细粒度**：它让**单个配方**在老客户端上优雅降级，而不是让整个索引对老客户端不可用。
+
+分工：
+
+| | 粒度 | 代价 | 适用 |
+|---|---|---|---|
+| 配方能力探测 | 单个配方 | 配方作者要写 | 少数配方尝鲜新能力 |
+| 索引版本契约 | 整个快照 | 发布方声明一次 | 索引整体开始依赖新能力 |
+
+**先探测，实在做不到才抬 floor。** 抬 floor 是把老客户端冻在旧快照上——是安全网，不是首选。
+
+---
+
+## 5. 死锁：老客户端被路由到老索引，就再也看不到新 xlings
+
+**这是本方案里最重要的一节，也是"从 xlings 侧考虑"才会暴露的问题。**
+
+老快照的 `pkgs/x/xlings.lua` 里 `latest.ref` 是那个时代的版本。所以：
+
+```
+客户端 2026.8.2.1
+  → 路由到 20e53c6（因为 e2aad0b 要求 >= 2026.8.3.1）
+  → 该快照里 xlings latest = 2026.8.2.1
+  → xlings self update：已是最新，退出 0，什么也没做
+  → 永远升不上去，因此永远回不到新索引
+```
+
+死锁**由构造保证会发生**，不是概率事件。任何只做"路由"而不处理这条的设计都是坏的。
+
+### 解法：路由不适用于客户端自身的升级路径
+
+两半：
+
+1. **指针顶层 `client_latest.xlings`** —— 与索引快照无关，任何客户端都读得到。
+   `xlings update` 据此打印可升级提示（§3.2 那段消息的最后一行就来自它）。
+
+2. **`xlings self update` 绕过路由**：始终取**最新**快照，且只从中读 `pkgs/x/xlings.lua`
+   这一个配方。理由：该配方形状极稳定（`XLINGS_RES` + 每架构 sha256），
+   而"解析一个新索引里的一个稳定配方"远比"用整个新索引"风险低。
+   若该读取失败，**回退到 forge release 解析**——即 `quick_install.sh` 今天走的那条路，
+   完全不经索引。
+
+第 2 点顺带修掉一个既有弱点：今天 `self update` 依赖索引整体健康；之后它有一条不依赖索引的兜底。
+
+---
+
+## 6. 边界与交互
+
+| 情形 | 行为 |
+|---|---|
+| 指针无 `history`（v1） | 只有一条候选（当前快照）。**仍然做兼容检查**：不满足就报错，不静默使用 |
+| 索引树无 `index-compat.json` | 无约束，等价今天 |
+| `XLINGS_INDEX_SOURCE=git` | git 源没有历史，但**树里有 `index-compat.json`**。不满足则**拒绝并说明**，好过稍后神秘失败 |
+| 发布包内置索引 | 构造上兼容；仍应带该文件，让检查路径统一 |
+| 子索引（awesome/scode/d2x） | 各自独立 key、独立路由。混合状态可接受（独立命名空间），但 `update` 需逐个报告落地版本 |
+| 指针 CDN 延迟 | 不变。被路由/钉住的客户端天然免疫（`reference_index_publish_lag`） |
+| 首次安装（无本地索引） | 同路径；无兼容快照时给出明确的"你需要哪个版本" |
+
+---
+
+## 7. 第三方消费者：同一机制的自然结果
+
+`requires` 是 consumer → 约束的映射，xlings 只解释 `xlings` 键：
+
+```json
+"requires": {
+  "xlings": { "min": "2026.8.3.1" },
+  "mcpp":   { "min": "2026.8.3.3" }
+}
+```
+
+- xlings 自动路由只看 `xlings`。
+- 其余键**原样透传**，经 `xlings index list --json` / NDJSON capability
+  `list_index_versions` 暴露给对应消费者，由它自己判断并调用 `xlings index use`。
+- xlings **不校验**其他键的语义，只校验整体是 JSON 对象且序列化 ≤ 4 KiB
+  （指针在每次 `update` 的热路径上）。
+
+于是 #476 里 mcpp 的需求**不需要任何专门设计**——它是这套机制的一个使用者，
+而不是这套机制的目的。
+
+---
+
+## 8. 安全
+
+- **每条 history 自带 `artifact.sha256`**，选旧快照沿用同一套钉哈希校验，不新增未验证下载路径。
+- **降级攻击**：能篡改指针者可诱导客户端选旧的、有已知问题的索引。但同一攻击者今天就能
+  **直接投喂一个旧指针**达到同样效果——本特性不放大它。
+- **拒绝服务**：篡改者可把所有快照的 `min` 抬到不可达 → 客户端无兼容快照。
+  失败是**响亮**的（报错 + 说明），不是静默降级，所以可诊断。
+- 真正的缓解是 manifest 里预留的 `signature`（X-full）。本方案不实现它，
+  但**约束**：history 的每一条与 `client_latest` 都必须落在未来签名的覆盖范围内。
+
+---
+
+## 9. 测试契约（每条都必须先红）
+
+沿用 `2026.8.3.1` 的规矩：**一条测试如果在被测对象完全不工作时仍然通过，它验证的是副本**。
+
+| # | 契约 | 反证方式（必须让它失败） |
+|---|---|---|
+| 1 | 4 段版本的比较正确：`2026.8.3.2` 满足 `min=2026.8.3.1` | 改用 `semver::satisfies_expr` → 必须红（这是 §1 的实测，写成回归） |
+| 2 | 客户端低于最新快照 floor → 落地**次新的兼容快照**，且打印原因 | 改成总取 `history[0]` → 必须红 |
+| 3 | 无任何兼容快照 → 硬失败，**且不动本地索引树** | 改成回退最新 → 必须红 |
+| 4 | v1 指针（无 history）+ 不兼容 → 报错而非静默使用 | 改成忽略 requires → 必须红 |
+| 5 | 钉到 history 之外的版本 → 硬失败并列出可选集 | 改成回退 latest → 必须红 |
+| 6 | 钉住的 artifact sha256 不符 → 拒绝并保留原树 | 去掉校验 → 必须红 |
+| 7 | 非 `xlings` 的 `requires` 键逐字节透传（含未知键/嵌套/unicode） | 加任何"规范化" → 必须红 |
+| 8 | **死锁不成立**：客户端被路由到老快照后，`self update` 仍能装到 `client_latest` | 让 self update 走路由 → 必须红 |
+| 9 | v1 指针 + 无约束 → 行为与今天**逐字节一致**（差分测试，对比旧二进制） | 任何回归 → 必须红 |
+| 10 | history 组装：20 快照 / 3 种 requires → 恰为 A∪B 且倒序 | 改成"取最近 N 个" → 必须红 |
+
+第 9 条是防回归关键：这条路径今天服务所有用户，**新特性的默认路径必须一字不差**。
+第 8 条是本方案最容易被漏掉的契约，而漏掉它等于把老用户永久冻住。
+
+---
+
+## 10. 分期
+
+| 期 | 内容 | 独立价值 | 依赖 |
+|---|---|---|---|
+| **P1** | 客户端：解析 `requires`/`history`/`client_latest`、`satisfies` 求值、自动路由 + 硬失败、路由原因输出 | 任何已发布 v2 指针的索引立刻可用 | 无 |
+| **P2** | `self update` 绕过路由（§5） | **解死锁——必须与 P1 同批发布** | P1 |
+| **P3** | 发布工具：读 `index-compat.json`、`push_index_pointers.sh` 组装 history + `client_latest` | 官方索引开始发布契约与历史 | — |
+| **P4** | `xlings index list/use` + NDJSON capability + 钉子 | 调试、可复现、第三方消费者 | P1 |
+| **P5** | xim-pkgindex CI：构造 → 最低客户端版本 的可检查表（§4.2） | 把 floor 从承诺变成事实 | P3 |
+
+**P1 与 P2 不可拆分发布。** 只发 P1 会让老客户端被路由到老索引却无法升级——
+比今天的硬失败更糟，因为它是静默的。
+
+---
+
+## 11. 明确不做
+
+- **不扩展 `semver` 到 N 段**（§1）：会波及所有包解析。
+- **不引入范围表达式语法**：两个边界够用；第二套语法会与包语义漂移。
+- **不支持钉到 history 之外的任意版本**：没有 sha256 就没有安全保证。
+- **不做 `update --index-version` 一次性钉**：会被下次 update 静默还原。
+- **不改 artifact 保留策略**：本来就永久保留，本方案只加寻址能力与契约。
+- **不替第三方消费者做兼容判断**：xlings 只解释 `requires.xlings`。
+- **不移除配方能力探测**：它更细粒度，且是首选（§4.3）。
+
+---
+
+## 12. 一句话
+
+> 让索引声明它需要什么客户端，让客户端自己路由到能用的最新快照——
+> 前提是这个比较器**认得 xlings 自己的版本号**（现有 semver 不认，§1 实测），
+> 而且**升级通道不能被自己路由掉**（否则老客户端被永久冻住，§5）。

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -526,6 +526,11 @@ jobs:
         env:
           XLINGS_RES_TOKEN: ${{ secrets.XLINGS_RES_TOKEN }}
           GITCODE_TOKEN: ${{ secrets.GITCODE_TOKEN }}
+          # #476: recorded at the pointer top level so a client routed to an
+          # older index snapshot can still learn a newer client exists. Without
+          # it, that client reads the old snapshot's own xlings recipe, is told
+          # it is current, and can never leave the snapshot it was routed to.
+          XLINGS_CLIENT_LATEST: ${{ steps.version.outputs.version }}
         run: bash tools/push_index_pointers.sh build/index
 
   # Mirror the xlings binaries to xlings-res/xlings on GitHub + GitCode so

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -147,6 +147,7 @@ jobs:
         run: |
           bash tests/scripts/test_quick_install.sh
           python3 tests/scripts/test_release_candidate_gate.py
+          python3 tests/scripts/test_index_pointer_history.py
           bin=$(find target -path '*/bin/xlings' -type f -perm -111 -exec ls -t {} + | head -1)
           python3 tests/scripts/test_docs_examples.py --xlings "$bin"
           python3 tests/scripts/test_generated_command_reference.py --xlings "$bin"

--- a/docs/design/index-version-contract.md
+++ b/docs/design/index-version-contract.md
@@ -1,0 +1,156 @@
+> 更新日期：2026-08-04
+
+# 索引版本契约 —— 发布方须知
+
+一个索引快照可以声明它需要什么版本的客户端。客户端读到后，会**自动路由到自己能用的
+最新快照**，而不是硬失败。
+
+本文是**发布方**要实现的契约。实现它不需要读 xlings 源码。
+
+设计背景与取舍：`.agents/docs/2026-08-03-index-snapshot-selection-design.md`
+
+---
+
+## 1. 为什么需要它
+
+索引一旦开始使用新客户端才有的能力（新的 xvm 注册 node kind、新的 `spec` 版本），
+老客户端就会硬失败：
+
+```
+error: unsupported registration node kind 'files'
+```
+
+声明契约后，老客户端会**自动退到它还能用的那个快照**，并被告知如何升级：
+
+```
+[index] xim: using 20e53c6 instead of e2aad0b
+[index]   e2aad0b requires xlings >= 2026.8.4.1, this is 2026.8.2.1
+[index]   upgrade to 2026.8.4.1: xlings self update
+```
+
+---
+
+## 2. 在索引树里声明
+
+索引树根目录放 `index-compat.json`（可选，缺失即无约束）：
+
+```json
+{
+  "requires": {
+    "xlings": { "min": "2026.8.4.1" }
+  }
+}
+```
+
+- `requires` 是 **consumer 名 → 约束** 的映射。
+- `min` **含**，`max` **不含**：满足条件是 `min <= 客户端版本 < max`。两个都可选。
+- xlings 只解释 `"xlings"` 这个键；其余键**原样透传**，供对应消费者自己判断
+  （通过 `xlings index list --json` 读取）。
+- 序列化后不得超过 **4 KiB** —— 它会进入每次 `xlings update` 都要抓的指针文件。
+
+**没有范围表达式**。没有 `^`、`~`、`||`。两个边界就是范围；这条契约一旦被误读，
+后果是整个索引对某类客户端不可用，所以语法故意贫乏到无法误读。
+
+版本比较按分量做数值比较，段数任意 —— `2026.8.4.1` 这样的 4 段版本可以正确比较，
+且 `2026.x` 恒大于 `0.4.x`。
+
+---
+
+## 3. 什么时候该抬 floor
+
+**当索引开始依赖只有新客户端才有的能力时。**
+
+抬 floor 会把老客户端冻在旧快照上，所以它是**安全网，不是首选**。先看能不能用
+配方级能力探测让单个配方优雅降级；只有当索引整体依赖新能力时才抬。
+
+| | 粒度 | 适用 |
+|---|---|---|
+| 配方能力探测 | 单个配方 | 少数配方尝鲜新能力 |
+| 索引版本契约 | 整个快照 | 索引整体开始依赖新能力 |
+
+---
+
+## 4. 指针文件格式
+
+客户端读的是**指针文件**（`<name>-pointers.json`，仓库文件，可 git push 覆盖），
+里面除了当前快照，还要有**可寻址的历史**：
+
+```json
+{
+  "format_version": 2,
+  "indexes": {
+    "mcpplibs": {
+      "format_version": 1,
+      "index_version": "e2aad0b",
+      "index_name": "mcpplibs",
+      "generated_at": "2026-08-04T14:52:11Z",
+      "artifact": { "name": "mcpp-index-e2aad0b.tar.gz", "sha256": "…", "size": 371707 },
+      "requires": { "xlings": { "min": "2026.8.4.1" } },
+      "history": [
+        { "index_version": "e2aad0b", "generated_at": "…",
+          "requires": { "xlings": { "min": "2026.8.4.1" } },
+          "artifact": { "name": "…", "sha256": "…", "size": 371707 } },
+        { "index_version": "0adb288", "generated_at": "…",
+          "artifact": { "name": "…", "sha256": "…", "size": 369884 } }
+      ],
+      "history_truncated": false
+    }
+  },
+  "client_latest": { "xlings": "2026.8.4.1" }
+}
+```
+
+要点：
+
+- **`history` 倒序，`history[0]` 就是当前快照**（与外层重复是刻意的：客户端只过滤一个列表）。
+- **每条 history 自带 `artifact.sha256`**。客户端选中哪条就校验哪条 —— 这是安全性质，
+  不是可选项。**因此只有 `history` 里列出的快照可被选择**：不在列表里就没有哈希可校验。
+- **`requires` 缺失 = 无约束**，任何客户端都可用。
+- **`history_truncated`** 让客户端能区分"没有兼容快照"和"兼容的被截断了"。
+- **`client_latest`** 是最新的客户端版本，与快照无关。**这一项不能省**：被路由到旧快照的
+  客户端读到的是旧快照里的 xlings 配方（指向那个时代的 `latest`），没有这一项它
+  永远不知道有更新的客户端存在，也就永远升不上去。
+
+### `history` 该留哪些
+
+不是"最近 N 个"。契约变动极少而快照产出频繁（xlings-res/xim-index 有 313 个 artifact、
+但只有个位数的不同契约）。按**并集**留：
+
+```
+A) 最近 8 个快照（不论 requires）      → 让"回滚一个版本"可行
+B) 每个不同 requires 值的最新那个      → 让每个契约世代都可达
+上限 32，超出丢最老的并置 history_truncated
+```
+
+只按 A 留会让老客户端需要的那个世代掉出窗口，而窗口里躺着 8 个契约相同的快照。
+
+xlings 提供参考实现：`tools/merge_index_pointer.py`（可直接复用，读-改-写地合并，
+保留兄弟索引的 key）。
+
+---
+
+## 5. 客户端行为（发布方需要知道的部分）
+
+```
+快照集 = history（无 history 时即当前快照这一条）
+候选   = 客户端版本满足 requires.xlings 的那些
+候选非空 → 取最新的一条
+候选为空 → 报错并列出可选集，且不动本地已有索引树
+```
+
+- 用户可用 `xlings index use <name> <version>` 钉住某个快照；钉子**绕过契约检查**
+  （用户明确要求），但**不绕过 sha256 校验**。
+- 钉到 `history` 之外的版本 → 报错，不回退到最新。
+- `xlings self update` **不受路由约束**（否则被路由到旧快照的客户端将永远无法升级）。
+
+---
+
+## 6. 检查清单
+
+- [ ] 索引树里有 `index-compat.json`（需要约束时）
+- [ ] 构建产出的 manifest 含 `requires`
+- [ ] 指针含 `history`（倒序、每条带 sha256）与 `history_truncated`
+- [ ] 指针含 `client_latest`
+- [ ] `format_version` 为 `2`
+- [ ] 合并指针时保留了兄弟索引的 key
+- [ ] CI 检查：配方里用到的新能力，都被声明的 `min` 覆盖

--- a/docs/design/index-version-contract.md
+++ b/docs/design/index-version-contract.md
@@ -145,7 +145,29 @@ xlings 提供参考实现：`tools/merge_index_pointer.py`（可直接复用，�
 
 ---
 
-## 6. 检查清单
+## 6. 部署顺序 —— 这一条搞反会伤到用户
+
+**声明 floor 之前，历史里必须已经有可退回的快照。**
+
+第一次采用本机制时，指针里的 `history` 只有当前这一条。如果**同一次发布**就声明 floor，
+低于 floor 的客户端**无处可退**，会直接报 `E_INDEX_NO_COMPATIBLE_SNAPSHOT` ——
+比它替代的硬失败更糟。
+
+正确顺序：
+
+```
+1. 先发布带 history 的指针，但不声明 floor      （几次发布，history 攒起来）
+2. 确认 history 里有若干无约束/低约束的快照
+3. 再在 index-compat.json 里声明 floor
+```
+
+`tools/merge_index_pointer.py` 会在你违反这一条时打印警告，但它无法阻止你 ——
+这是发布方的决定。
+
+同理，`tools/check_index_compat.py` 报出"需要 >= X"时，**不要立刻照抄进
+index-compat.json**，先确认 history 里已有低于 X 的快照可供老客户端落脚。
+
+## 7. 检查清单
 
 - [ ] 索引树里有 `index-compat.json`（需要约束时）
 - [ ] 构建产出的 manifest 含 `requires`

--- a/docs/generated/command-reference.md
+++ b/docs/generated/command-reference.md
@@ -140,6 +140,20 @@ Use the NDJSON interface
 
 Options: `--args <JSON>` — Capability arguments; `--args-file <PATH>` — Read capability arguments from a file; `--list` — List capabilities; `--version` — Show protocol version
 
+## `xlings index`
+
+Inspect and select package index snapshots
+
+## `xlings index list [name]`
+
+List published index snapshots
+
+Options: `--json` — Machine-readable output
+
+## `xlings index use <name> <version>`
+
+Pin an index source to a snapshot
+
 ## `xlings agent`
 
 Agent integration

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlings"
-version = "2026.8.3.1"
+version = "2026.8.4.1"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"

--- a/src/capabilities.cppm
+++ b/src/capabilities.cppm
@@ -7,6 +7,7 @@ import xlings.runtime.event_stream;
 import xlings.runtime.capability;
 import xlings.libs.json;
 import xlings.core.xim.commands;
+import xlings.core.xim.index_cmd;
 import xlings.core.xvm.commands;
 import xlings.core.config;
 import xlings.core.home_config;
@@ -237,6 +238,46 @@ public:
         payload["title"] = "xlings status";
         payload["fields"] = std::move(fields);
         stream.emit(DataEvent{"system_info", payload.dump()});
+        return exit_result(0);
+    }
+};
+
+// #476: the programmatic entry point for index snapshot selection.
+//
+// The consumer here is a program, not a person -- a build tool deciding which
+// index snapshot its own version can use. It reads the list, applies ITS OWN
+// compatibility rule to the `requires` blob (xlings interprets only the
+// "xlings" key and carries every other one verbatim), and pins with
+// `xlings index use`.
+class ListIndexVersions : public Capability {
+public:
+    auto spec() const -> CapabilitySpec override {
+        return {
+            .name = "list_index_versions",
+            .description = "List published index snapshots and which one is in use",
+            .inputSchema = R"({"type":"object","properties":{"name":{"type":"string"}}})",
+            .outputSchema = R"({"type":"object","properties":{"exitCode":{"type":"integer"}}})",
+            .destructive = false,
+        };
+    }
+    auto execute(Params params, EventStream& stream) -> Result override {
+        auto json = nlohmann::json::parse(params, nullptr, false);
+        const auto filter = json.is_object() ? json.value("name", std::string{})
+                                             : std::string{};
+        auto views = xim::collect_index_sources();
+        if (!filter.empty()) {
+            std::erase_if(views, [&](const auto& v) { return v.name != filter; });
+            if (views.empty()) {
+                stream.emit(ErrorEvent{
+                    .code = ErrorCode::NotFound,
+                    .message = std::format("no index source named '{}'", filter),
+                    .recoverable = false,
+                });
+                return exit_result(1);
+            }
+        }
+        stream.emit(DataEvent{"index_versions",
+                              xim::index_sources_json(views).dump()});
         return exit_result(0);
     }
 };
@@ -547,6 +588,7 @@ export capability::Registry build_registry() {
     reg.register_capability(std::make_unique<ListVersions>());
     reg.register_capability(std::make_unique<UseVersion>());
     reg.register_capability(std::make_unique<SystemStatus>());
+    reg.register_capability(std::make_unique<ListIndexVersions>());
     // sub-OS + env (added 2026-04-26 per interface-api-v1-eval)
     reg.register_capability(std::make_unique<ListSubos>());
     reg.register_capability(std::make_unique<ListSubosShims>());

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -31,6 +31,7 @@ import xlings.core.xvm.commands;
 import xlings.core.profile;
 import xlings.core.utf8;
 import xlings.cli.spec;
+import xlings.core.xim.index_cmd;
 
 namespace lua = mcpplibs::capi::lua;
 
@@ -864,6 +865,39 @@ export int run(int argc, char* argv[]) {
                 return 0;
             }
 
+        }
+
+        // index — positional dispatch like subos/self, so it validates the
+        // same way and never reaches the cmdline builder's package semantics.
+        if (cmd == "index") {
+            const std::array<std::string_view, 1> path{cmd};
+            if (const auto* command = spec::find(path)) {
+                std::vector<std::string_view> manualArgs;
+                for (int i = 2; i < fargc; ++i) manualArgs.emplace_back(fargv[i]);
+                if (auto validated = spec::validate_manual_argv(*command, manualArgs);
+                    !validated) {
+                    log::error("{}", validated.error().message);
+                    return 2;
+                }
+            }
+            std::string sub = fargc > 2 ? fargv[2] : "list";
+            if (sub == "ls") sub = "list";
+            if (sub == "list") {
+                std::string filter;
+                bool asJson = false;
+                for (int i = 3; i < fargc; ++i) {
+                    std::string_view a{fargv[i]};
+                    if (a == "--json") asJson = true;
+                    else if (!a.starts_with('-')) filter = std::string(a);
+                }
+                return xim::cmd_index_list(filter, asJson, stream);
+            }
+            if (sub == "use") {
+                return xim::cmd_index_use(fargc > 3 ? fargv[3] : "",
+                                          fargc > 4 ? fargv[4] : "", stream);
+            }
+            log::error("unknown subcommand for `xlings index`: {}", sub);
+            return 2;
         }
 
         if (cmd == "subos" || cmd == "self" || cmd == "profile") {

--- a/src/cli/spec.cppm
+++ b/src/cli/spec.cppm
@@ -82,6 +82,11 @@ const CommandSpec& root() {
             }},
             {"script", "Run an xlings script", {}, {{"script-file", "Script path", true}, {"args", "Script arguments", false, true}}, {}, {}},
             {"interface", "Use the NDJSON interface", {}, {{"capability", "Capability name", false}}, {{"--args <JSON>", "Capability arguments"}, {"--args-file <PATH>", "Read capability arguments from a file"}, {"--list", "List capabilities"}, {"--version", "Show protocol version"}}, {}},
+            {"index", "Inspect and select package index snapshots", {}, {}, {}, {
+                {"list", "List published index snapshots", {"ls"}, {{"name", "Optional index source", false}},
+                    {{"--json", "Machine-readable output"}}, {}},
+                {"use", "Pin an index source to a snapshot", {}, {{"name", "Index source", true}, {"version", "Snapshot version, or 'latest'", true}}, {}, {}},
+            }},
             {"agent", "Agent integration", {}, {}, {}, {
                 {"skills", "List or show built-in skills", {}, {{"name", "Optional skill name", false}}, {}, {}},
             }},

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -22,6 +22,11 @@ export struct IndexRepo {
     std::string url;
     std::string artifactBase;  // #377: resolved artifact base URL ("" = git-only)
     std::string source;        // #377: per-repo override: "" | "auto" | "artifact" | "git"
+    // #476: pin this repo to one published index snapshot. Empty (or "latest")
+    // means automatic routing -- the newest snapshot whose declared client
+    // contract this xlings satisfies. A pin is an override for reproducing a
+    // state, so it bypasses the contract check but never the sha256 check.
+    std::string version;
 };
 
 // #377: parse index_repos entries. `artifact` is a flat string or a region
@@ -54,6 +59,10 @@ export std::vector<IndexRepo> parse_index_repos_json(const nlohmann::json& json,
         }
         if (it->contains("source") && (*it)["source"].is_string())
             repo.source = (*it)["source"].get<std::string>();
+        // Not validated: the version namespace belongs to the index publisher,
+        // and xlings should not have an opinion about its shape.
+        if (it->contains("version") && (*it)["version"].is_string())
+            repo.version = (*it)["version"].get<std::string>();
         out.push_back(std::move(repo));
     }
     return out;

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "2026.8.3.1";
+    static constexpr std::string_view VERSION = "2026.8.4.1";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/xim/index_cmd.cppm
+++ b/src/core/xim/index_cmd.cppm
@@ -1,0 +1,221 @@
+export module xlings.core.xim.index_cmd;
+
+import std;
+import xlings.libs.json;
+import xlings.core.config;
+import xlings.core.home_config;
+import xlings.core.log;
+import xlings.core.version_order;
+import xlings.core.xim.indexfetch;
+import xlings.runtime;
+
+// `xlings index` — see which index snapshots exist and choose between them.
+//
+// A separate command family rather than flags on `xlings update`, for two
+// reasons. `update` has side effects and this is a query, so hiding the query
+// behind the mutating command makes it an exception a user has to remember. And
+// `update`'s positionals already mean `[package] [version]`; adding index
+// semantics there would make `xlings update foo 1.2` depend on whether some
+// other flag was also passed.
+export namespace xlings::xim {
+
+struct IndexSourceView {
+    std::string name;
+    std::string pin;                    // from index_repos[].version
+    bool        hasPointer = false;
+    std::string error;                  // set when the pointer could not be read
+    std::vector<IndexSnapshot> snapshots;
+    std::string current;                // index_version this client would use
+    bool        truncated = false;
+};
+
+// Read every configured index source and resolve what this client would pick.
+// Never throws and never fails the command: a source whose pointer cannot be
+// read is reported as such, because "I could not look" and "there is nothing"
+// are different answers.
+std::vector<IndexSourceView> collect_index_sources() {
+    std::vector<IndexSourceView> views;
+    for (const auto& repo : Config::global_index_repos()) {
+        IndexSourceView view;
+        view.name = repo.name;
+        view.pin  = repo.version;
+
+        auto source = artifact_source_for(repo);
+        const auto& pointers = load_index_pointers(Config::mirror(),
+                                                   source ? &*source : nullptr);
+        const auto key = source ? source->key : repo.name;
+        const auto* manifest = select_manifest(pointers, key, source.has_value());
+        if (!manifest) {
+            view.error = pointers.empty()
+                ? "pointer unavailable (offline, or this repo is git-only)"
+                : std::format("no pointer entry for '{}'", key);
+            views.push_back(std::move(view));
+            continue;
+        }
+        view.hasPointer = true;
+        view.snapshots  = snapshots_of(*manifest);
+        view.truncated  = manifest->history_truncated;
+        if (auto choice = choose_snapshot(*manifest, Info::VERSION, repo.version)) {
+            view.current = choice->snapshot.index_version;
+        } else {
+            view.error = choice.error();
+        }
+        views.push_back(std::move(view));
+    }
+    return views;
+}
+
+nlohmann::json index_sources_json(const std::vector<IndexSourceView>& views) {
+    nlohmann::json out = nlohmann::json::array();
+    for (const auto& view : views) {
+        nlohmann::json entry;
+        entry["name"]      = view.name;
+        entry["pinned"]    = view.pin;
+        entry["current"]   = view.current;
+        entry["truncated"] = view.truncated;
+        if (!view.error.empty()) entry["error"] = view.error;
+        entry["snapshots"] = nlohmann::json::array();
+        for (const auto& s : view.snapshots) {
+            nlohmann::json row;
+            row["index_version"] = s.index_version;
+            row["generated_at"]  = s.generated_at;
+            row["current"]       = s.index_version == view.current;
+            // Verbatim. Normalising here would make xlings an interpreter of
+            // contracts it does not own.
+            row["requires"]      = s.requirements;
+            row["artifact"]      = { {"name", s.artifact_name},
+                                     {"sha256", s.artifact_sha256},
+                                     {"size", s.artifact_size} };
+            entry["snapshots"].push_back(std::move(row));
+        }
+        out.push_back(std::move(entry));
+    }
+    return out;
+}
+
+int cmd_index_list(const std::string& filter, bool asJson, EventStream& stream) {
+    auto views = collect_index_sources();
+    if (!filter.empty()) {
+        std::erase_if(views, [&](const auto& v) { return v.name != filter; });
+        if (views.empty()) {
+            log::error("no index source named '{}'", filter);
+            return 1;
+        }
+    }
+
+    if (asJson) {
+        std::println("{}", index_sources_json(views).dump(2));
+        return 0;
+    }
+
+    for (const auto& view : views) {
+        log::println("");
+        log::println("  ◆ {}{}", view.name,
+                     view.pin.empty() ? "" : std::format("  (pinned: {})", view.pin));
+        if (!view.error.empty()) {
+            log::println("    {}", view.error);
+            continue;
+        }
+        for (const auto& s : view.snapshots) {
+            const auto req = requirement_for(s.requirements, "xlings");
+            std::string note;
+            if (req) {
+                if (!req->min.empty()) note += ">= " + req->min;
+                if (!req->max.empty()) note += (note.empty() ? "" : " ") + std::string("< ") + req->max;
+                note = "  requires xlings " + note;
+            }
+            log::println("    {} {}{}{}",
+                         s.index_version == view.current ? "*" : " ",
+                         s.index_version,
+                         s.generated_at.empty() ? "" : "  " + s.generated_at,
+                         note);
+        }
+        if (view.truncated) {
+            log::println("      … older snapshots exist but are not listed");
+        }
+    }
+    log::println("");
+    return 0;
+}
+
+// Pin (or unpin) a source. Writes index_repos[].version so the choice is
+// visible in the config afterwards -- a one-shot flag would be reverted by the
+// next `xlings update` with nothing to show it ever applied.
+int cmd_index_use(const std::string& name, const std::string& version,
+                  EventStream& stream) {
+    if (name.empty()) {
+        log::error("usage: xlings index use <name> <version|latest>");
+        return 2;
+    }
+    const bool clearing = version.empty() || version == "latest";
+
+    // Refuse a version the pointer does not offer -- accepting it would leave a
+    // config that only fails on the next update, far from the command that
+    // wrote it.
+    if (!clearing) {
+        auto views = collect_index_sources();
+        const auto hit = std::ranges::find_if(views,
+            [&](const auto& v) { return v.name == name; });
+        if (hit == views.end()) {
+            log::error("no index source named '{}'", name);
+            return 1;
+        }
+        const bool known = std::ranges::any_of(hit->snapshots,
+            [&](const auto& s) { return s.index_version == version; });
+        if (!known) {
+            log::error("index '{}' has no published snapshot '{}'", name, version);
+            std::string list;
+            for (const auto& s : hit->snapshots) {
+                if (!list.empty()) list += ", ";
+                list += s.index_version;
+            }
+            log::error("  available: {}", list.empty() ? "(none)" : list);
+            return 1;
+        }
+    }
+
+    auto applied = update_home_config(Config::paths().homeDir,
+        [&](nlohmann::json& json) {
+            if (!json.contains("index_repos") || !json["index_repos"].is_array()) {
+                json["index_repos"] = nlohmann::json::array();
+            }
+            for (auto& entry : json["index_repos"]) {
+                if (!entry.is_object() || !entry.contains("name")) continue;
+                if (entry["name"].get<std::string>() != name) continue;
+                if (clearing) entry.erase("version");
+                else entry["version"] = version;
+                return true;
+            }
+            // The source exists in the effective config but not in the file --
+            // it is a built-in default. Materialise the entry so the pin has
+            // somewhere to live.
+            for (const auto& repo : Config::global_index_repos()) {
+                if (repo.name != name) continue;
+                nlohmann::json entry;
+                entry["name"] = repo.name;
+                entry["url"]  = repo.url;
+                if (!clearing) entry["version"] = version;
+                json["index_repos"].push_back(entry);
+                return true;
+            }
+            return false;
+        });
+
+    if (!applied) {
+        log::error("{}", applied.error());
+        return 1;
+    }
+    if (!*applied) {
+        log::error("no index source named '{}'", name);
+        return 1;
+    }
+    if (clearing) {
+        log::println("index '{}' follows the newest compatible snapshot", name);
+    } else {
+        log::println("index '{}' pinned to {}", name, version);
+    }
+    log::println("  run `xlings update` to apply");
+    return 0;
+}
+
+}  // namespace xlings::xim

--- a/src/core/xim/indexfetch.cppm
+++ b/src/core/xim/indexfetch.cppm
@@ -425,6 +425,16 @@ std::expected<SnapshotChoice, std::string> choose_snapshot(
         return list;
     };
 
+    // "newest": take the head of the list whatever it requires. This is the
+    // escape hatch `self update` runs on, and it is what breaks the deadlock a
+    // routed-back client would otherwise sit in forever -- an old snapshot's
+    // own xlings recipe names an old `latest`, so a client routed there could
+    // never see, let alone install, the version that would let it move on.
+    if (pin == "newest") {
+        SnapshotChoice choice{snapshots.front(), true, {}};
+        return choice;
+    }
+
     // Explicit pin: honour it exactly. It bypasses the contract check -- asking
     // for a specific snapshot is a deliberate act, often to reproduce a bug --
     // but never the sha256 check downstream.
@@ -719,7 +729,14 @@ bool fetch_index_artifact(const std::filesystem::path& destIndexDir,
     // #476: route to the newest snapshot this client's version accepts, or to
     // an explicit pin. On failure the local index tree is left alone -- keeping
     // the last snapshot that worked beats replacing it with a wrong one.
-    const auto choice = choose_snapshot(manifest, Info::VERSION, pin);
+    // XLINGS_INDEX_PIN overrides the per-repo pin: an escape hatch for
+    // debugging, and the mechanism `self update` uses to reach a newer client
+    // through an index this version would not otherwise route to.
+    std::string effectivePin{pin};
+    if (const auto* env = std::getenv("XLINGS_INDEX_PIN"); env && *env) {
+        effectivePin = env;
+    }
+    const auto choice = choose_snapshot(manifest, Info::VERSION, effectivePin);
     if (!choice) { err = choice.error(); return false; }
     const IndexSnapshot& snapshot = choice->snapshot;
 
@@ -785,8 +802,8 @@ bool fetch_index_artifact(const std::filesystem::path& destIndexDir,
             // After the exchange, `stage` now holds the OLD tree — drop it.
             fs::remove_all(stage, ec);
             log::info("[index] updated from artifact {} ({})",
-                      manifest.artifact_name,
-                      manifest.index_version.empty() ? "?" : manifest.index_version);
+                      snapshot.artifact_name,
+                      snapshot.index_version.empty() ? "?" : snapshot.index_version);
             return true;
         }
         // Fallback (non-Linux / kernel without renameat2): manual move-aside.
@@ -806,9 +823,14 @@ bool fetch_index_artifact(const std::filesystem::path& destIndexDir,
     }
     fs::remove_all(backup, ec);
 
+    // The SNAPSHOT that landed, not the manifest's head. Reporting the head
+    // here would print `updated from xim-index-new0003` immediately after
+    // "using old0001 instead of new0003" -- and this line is what the release
+    // verification runbook greps to decide which artifact a run actually used
+    // (reference_index_publish_lag).
     log::info("[index] updated from artifact {} ({})",
-              manifest.artifact_name,
-              manifest.index_version.empty() ? "?" : manifest.index_version);
+              snapshot.artifact_name,
+              snapshot.index_version.empty() ? "?" : snapshot.index_version);
     return true;
 }
 

--- a/src/core/xim/indexfetch.cppm
+++ b/src/core/xim/indexfetch.cppm
@@ -30,8 +30,33 @@ import xlings.core.config;
 import xlings.core.mirror;
 import xlings.platform;
 import xlings.core.xim.extract;
+import xlings.core.version_order;
 
 export namespace xlings::xim {
+
+// A client-version constraint an index snapshot declares: [min, max).
+// Both optional; empty means unbounded on that side.
+//
+// Deliberately two bare version strings and NOT a range expression. Two bounds
+// already ARE a range, and a second grammar next to semver's would drift from
+// it -- while inheriting the defect measured below. See #476 design doc §1.
+struct IndexRequirement {
+    std::string min;   // inclusive
+    std::string max;   // exclusive
+    bool empty() const { return min.empty() && max.empty(); }
+};
+
+// One addressable index snapshot: an artifact plus what it asks of its client.
+struct IndexSnapshot {
+    std::string   index_version;
+    std::string   generated_at;
+    std::string   artifact_name;
+    std::string   artifact_sha256;   // lowercase hex
+    std::uint64_t artifact_size = 0;
+    // consumer name -> {min,max}. xlings evaluates ONLY the "xlings" key; every
+    // other key is carried verbatim for whoever it belongs to.
+    nlohmann::json requirements = nlohmann::json::object();
+};
 
 struct IndexManifest {
     int           format_version = 0;
@@ -42,7 +67,53 @@ struct IndexManifest {
     std::string   artifact_name;     // e.g. xim-index-0.4.52.tar.gz
     std::string   artifact_sha256;   // lowercase hex
     std::uint64_t artifact_size = 0;
+
+    // ── #476: version contract + addressable history ──────────────────
+    // All optional. A pointer that predates them parses exactly as before,
+    // which is why they are ADDED rather than the manifest being restructured:
+    // the parser below hard-requires `artifact` at this level, so moving it
+    // under a `latest` node would make every released client reject the
+    // pointer outright.
+    nlohmann::json              requirements = nlohmann::json::object();
+    std::vector<IndexSnapshot>  history;            // newest first; [0] == this
+    bool                        history_truncated = false;
 };
+
+// The requirement `consumer` must meet, or nullopt when unconstrained.
+std::optional<IndexRequirement> requirement_for(const nlohmann::json& requirements,
+                                                std::string_view consumer);
+
+// Does `selfVersion` satisfy `req`?
+//
+// Compared with version_order::compare, NOT semver::satisfies_expr. Measured
+// on 2026-08-04: semver::Version is three components, so it cannot parse
+// xlings's own four-component YYYY.M.D.N at all --
+// `satisfies_expr("2026.8.3.2", ">=2026.8.3.1")` returns FALSE. Building the
+// contract on it would make every client fail every check and report "no
+// compatible snapshot", which reads as a publishing problem rather than a
+// parser that does not know the version scheme.
+bool satisfies_requirement(std::string_view selfVersion, const IndexRequirement& req);
+
+// Every addressable snapshot of a manifest, newest first. A manifest with no
+// history yields exactly one -- itself -- so callers have a single shape.
+std::vector<IndexSnapshot> snapshots_of(const IndexManifest& manifest);
+
+struct SnapshotChoice {
+    IndexSnapshot snapshot;
+    bool          isNewest = true;
+    std::string   reason;   // why we stepped back; empty when isNewest
+};
+
+// Pick the snapshot this client should use.
+//
+//   pin empty / "latest" -> newest snapshot whose contract this client meets
+//   pin set              -> that exact snapshot, contract check bypassed
+//                           (you asked for it) but sha256 still enforced
+//
+// Returns an error rather than falling back: silently handing back the newest
+// snapshot would give the client exactly the thing it was routing away from.
+std::expected<SnapshotChoice, std::string> choose_snapshot(
+    const IndexManifest& manifest, std::string_view selfVersion, std::string_view pin);
 
 // Parse a manifest JSON. Returns nullopt if required fields are missing/invalid.
 std::optional<IndexManifest> parse_index_manifest(std::string_view jsonText);
@@ -104,7 +175,8 @@ const std::map<std::string, IndexManifest>& load_index_pointers(std::string_view
 bool fetch_index_artifact(const std::filesystem::path& destIndexDir,
                           std::string& err,
                           std::string_view subName = {},
-                          const ArtifactSource* custom = nullptr);
+                          const ArtifactSource* custom = nullptr,
+                          std::string_view pin = {});
 
 // Reconcile leftover index temp dirs from crashed / SIGKILL'd runs: restore an
 // index dir orphaned by an interrupted swap (`<base>.old.<deadpid>` holding
@@ -262,10 +334,135 @@ std::optional<IndexManifest> parse_index_manifest(std::string_view jsonText) {
         m.artifact_sha256 = detail_::lower_hex_(art.value("sha256", std::string{}));
         m.artifact_size   = art.value("size", std::uint64_t{0});
         if (m.artifact_name.empty() || m.artifact_sha256.empty()) return std::nullopt;
+
+        // #476, all optional: a pointer without them parses exactly as before.
+        if (j.contains("requires") && j["requires"].is_object()) {
+            m.requirements = j["requires"];
+        }
+        m.history_truncated = j.value("history_truncated", false);
+        if (j.contains("history") && j["history"].is_array()) {
+            for (const auto& e : j["history"]) {
+                if (!e.is_object() || !e.contains("artifact")
+                    || !e["artifact"].is_object()) continue;
+                const auto& ea = e["artifact"];
+                IndexSnapshot s;
+                s.index_version   = e.value("index_version", std::string{});
+                s.generated_at    = e.value("generated_at", std::string{});
+                s.artifact_name   = ea.value("name", std::string{});
+                s.artifact_sha256 = detail_::lower_hex_(ea.value("sha256", std::string{}));
+                s.artifact_size   = ea.value("size", std::uint64_t{0});
+                if (e.contains("requires") && e["requires"].is_object()) {
+                    s.requirements = e["requires"];
+                }
+                // A history entry with no artifact identity is unusable; drop it
+                // rather than carrying a row that cannot be selected.
+                if (s.index_version.empty() || s.artifact_name.empty()
+                    || s.artifact_sha256.empty()) continue;
+                m.history.push_back(std::move(s));
+            }
+        }
         return m;
     } catch (...) {
         return std::nullopt;
     }
+}
+
+std::optional<IndexRequirement> requirement_for(const nlohmann::json& requirements,
+                                                std::string_view consumer) {
+    if (!requirements.is_object()) return std::nullopt;
+    const auto it = requirements.find(std::string(consumer));
+    if (it == requirements.end() || !it->is_object()) return std::nullopt;
+    IndexRequirement req;
+    req.min = it->value("min", std::string{});
+    req.max = it->value("max", std::string{});
+    if (req.empty()) return std::nullopt;
+    return req;
+}
+
+bool satisfies_requirement(std::string_view selfVersion, const IndexRequirement& req) {
+    if (!req.min.empty() && version_order::compare(selfVersion, req.min) < 0) return false;
+    if (!req.max.empty() && version_order::compare(selfVersion, req.max) >= 0) return false;
+    return true;
+}
+
+std::vector<IndexSnapshot> snapshots_of(const IndexManifest& manifest) {
+    if (!manifest.history.empty()) return manifest.history;
+    IndexSnapshot only;
+    only.index_version   = manifest.index_version;
+    only.generated_at    = manifest.generated_at;
+    only.artifact_name   = manifest.artifact_name;
+    only.artifact_sha256 = manifest.artifact_sha256;
+    only.artifact_size   = manifest.artifact_size;
+    only.requirements    = manifest.requirements;
+    return {only};
+}
+
+namespace detail_ {
+
+std::string describe_requirement_(const IndexSnapshot& s) {
+    const auto req = requirement_for(s.requirements, "xlings");
+    if (!req) return "no requirement";
+    std::string out;
+    if (!req->min.empty()) out += ">= " + req->min;
+    if (!req->max.empty()) out += (out.empty() ? "" : " ") + std::string("< ") + req->max;
+    return out;
+}
+
+}  // namespace detail_
+
+std::expected<SnapshotChoice, std::string> choose_snapshot(
+    const IndexManifest& manifest, std::string_view selfVersion, std::string_view pin) {
+    const auto snapshots = snapshots_of(manifest);
+    if (snapshots.empty()) return std::unexpected("pointer lists no index snapshot");
+
+    const auto available = [&] {
+        std::string list;
+        for (const auto& s : snapshots) {
+            if (!list.empty()) list += ", ";
+            list += s.index_version;
+        }
+        if (manifest.history_truncated) list += ", … (history truncated)";
+        return list;
+    };
+
+    // Explicit pin: honour it exactly. It bypasses the contract check -- asking
+    // for a specific snapshot is a deliberate act, often to reproduce a bug --
+    // but never the sha256 check downstream.
+    if (!pin.empty() && pin != "latest") {
+        for (const auto& s : snapshots) {
+            if (s.index_version == pin) {
+                SnapshotChoice choice{s, &s == &snapshots.front(), {}};
+                if (!choice.isNewest) {
+                    choice.reason = std::format("pinned to {}", pin);
+                }
+                return choice;
+            }
+        }
+        return std::unexpected(std::format(
+            "E_INDEX_VERSION_NOT_FOUND: pinned to '{}', which the pointer does "
+            "not offer; available: {}", pin, available()));
+    }
+
+    // Automatic routing: newest snapshot whose contract this client meets.
+    for (std::size_t i = 0; i < snapshots.size(); ++i) {
+        const auto& s = snapshots[i];
+        const auto req = requirement_for(s.requirements, "xlings");
+        if (req && !satisfies_requirement(selfVersion, *req)) continue;
+        SnapshotChoice choice{s, i == 0, {}};
+        if (i != 0) {
+            choice.reason = std::format(
+                "{} requires xlings {}, this is {}",
+                snapshots.front().index_version,
+                detail_::describe_requirement_(snapshots.front()), selfVersion);
+        }
+        return choice;
+    }
+
+    return std::unexpected(std::format(
+        "E_INDEX_NO_COMPATIBLE_SNAPSHOT: this xlings is {} and no published "
+        "snapshot accepts it (newest {} requires xlings {}); available: {}",
+        selfVersion, snapshots.front().index_version,
+        detail_::describe_requirement_(snapshots.front()), available()));
 }
 
 std::optional<ArtifactSource> artifact_source_for(const IndexRepo& repo) {
@@ -419,6 +616,26 @@ std::vector<std::string> index_pointer_urls(std::string_view filename,
     return urls;
 }
 
+namespace detail_ {
+// base -> consumer -> newest version, filled by load_index_pointers().
+inline std::map<std::string, std::map<std::string, std::string>>& client_latest_cache_() {
+    static std::map<std::string, std::map<std::string, std::string>> value;
+    return value;
+}
+}  // namespace detail_
+
+// Newest published version of `consumer` as the pointer advertises it, or ""
+// when the pointer does not say. Requires load_index_pointers() to have run
+// for the same source (fetch_index_artifact always does).
+std::string client_latest_for(std::string_view consumer, const ArtifactSource* custom) {
+    const std::string cacheKey = custom ? custom->base : std::string{};
+    const auto& all = detail_::client_latest_cache_();
+    const auto base = all.find(cacheKey);
+    if (base == all.end()) return {};
+    const auto hit = base->second.find(std::string(consumer));
+    return hit == base->second.end() ? std::string{} : hit->second;
+}
+
 // Cached fetch of the COMBINED pointer file (xim-index-pointers.json): ONE raw
 // fetch per process covering ALL indexes (main + subs). One fetch (vs one per
 // index) avoids gitcode raw rate-limiting, and is the single file a self-hosted
@@ -457,6 +674,16 @@ const std::map<std::string, IndexManifest>& load_index_pointers(std::string_view
         if (j.contains("indexes") && j["indexes"].is_object())
             for (auto it = j["indexes"].begin(); it != j["indexes"].end(); ++it)
                 if (auto m = parse_index_manifest(it.value().dump())) cache[it.key()] = *m;
+        // #476: newest CLIENT version, carried at pointer top level so it is
+        // readable no matter which index snapshot this client routes to. That
+        // is the half of the deadlock fix a routed-back client depends on: an
+        // old snapshot's own xlings recipe names an old `latest`, so without
+        // this the client could never learn a newer one exists.
+        if (j.contains("client_latest") && j["client_latest"].is_object()) {
+            auto& slot = detail_::client_latest_cache_()[cacheKey];
+            for (auto it = j["client_latest"].begin(); it != j["client_latest"].end(); ++it)
+                if (it.value().is_string()) slot[it.key()] = it.value().get<std::string>();
+        }
     } catch (...) { log::warn("[index] pointer parse failed"); }
     return cache;
 }
@@ -464,7 +691,8 @@ const std::map<std::string, IndexManifest>& load_index_pointers(std::string_view
 bool fetch_index_artifact(const std::filesystem::path& destIndexDir,
                           std::string& err,
                           std::string_view subName,
-                          const ArtifactSource* custom) {
+                          const ArtifactSource* custom,
+                          std::string_view pin) {
     namespace fs = std::filesystem;
     auto mirrorKey = Config::mirror();
     std::string key = custom ? custom->key
@@ -488,6 +716,26 @@ bool fetch_index_artifact(const std::filesystem::path& destIndexDir,
         return false;
     }
 
+    // #476: route to the newest snapshot this client's version accepts, or to
+    // an explicit pin. On failure the local index tree is left alone -- keeping
+    // the last snapshot that worked beats replacing it with a wrong one.
+    const auto choice = choose_snapshot(manifest, Info::VERSION, pin);
+    if (!choice) { err = choice.error(); return false; }
+    const IndexSnapshot& snapshot = choice->snapshot;
+
+    // Say it when we step back. A client that silently sits on an older index
+    // looks to its user exactly like one on the newest, right up until a
+    // package it expects is missing.
+    if (!choice->isNewest) {
+        log::warn("[index] {}: using {} instead of {}", key,
+                  snapshot.index_version, manifest.index_version);
+        log::warn("[index]   {}", choice->reason);
+        if (auto newer = client_latest_for("xlings", custom);
+            !newer.empty() && version_order::compare(newer, Info::VERSION) > 0) {
+            log::warn("[index]   upgrade to {}: xlings self update", newer);
+        }
+    }
+
     std::error_code ec;
     auto tmpRoot = fs::path(destIndexDir.string() + ".artifact." +
                             std::to_string(platform::get_pid()));
@@ -497,14 +745,14 @@ bool fetch_index_artifact(const std::filesystem::path& destIndexDir,
     struct Cleanup { fs::path p; ~Cleanup(){ std::error_code e; fs::remove_all(p,e);} } cleanup{tmpRoot};
 
     // Artifact (sha256-pinned by the manifest); release asset, versioned name.
-    auto artifactFile = tmpRoot / manifest.artifact_name;
+    auto artifactFile = tmpRoot / snapshot.artifact_name;
     detail_::BaseOverride forcedStorage;
     const detail_::BaseOverride* forced = nullptr;
     if (custom) { forcedStorage = detail_::base_override_for_(*custom); forced = &forcedStorage; }
-    if (auto e = detail_::obtain_file(manifest.artifact_name,
-                    index_asset_urls(manifest.artifact_name, mirrorKey,
-                                     manifest.index_version, custom),
-                    artifactFile, manifest.artifact_sha256, forced); !e.empty()) {
+    if (auto e = detail_::obtain_file(snapshot.artifact_name,
+                    index_asset_urls(snapshot.artifact_name, mirrorKey,
+                                     snapshot.index_version, custom),
+                    artifactFile, snapshot.artifact_sha256, forced); !e.empty()) {
         err = std::format("fetch index artifact failed: {}", e);
         return false;
     }

--- a/src/core/xim/repo.cppm
+++ b/src/core/xim/repo.cppm
@@ -395,7 +395,7 @@ bool sync_repo_with_artifact(const IndexRepo& repo,
     std::string mode = repo.source.empty() ? globalIndexSource : repo.source;
     if (src && sub_should_attempt_artifact(false, mode, false, false, false, true)) {
         std::string ferr;
-        if (fetch_index_artifact(repoDir, ferr, repo.name, &*src)) return true;
+        if (fetch_index_artifact(repoDir, ferr, repo.name, &*src, repo.version)) return true;
         if (mode == "artifact") {
             log::error("[index] '{}' artifact fetch failed and git fallback disabled "
                        "(source=artifact): {}", repo.name, ferr);
@@ -579,7 +579,12 @@ bool sync_all_repos(bool force = false) {
 
     if (attemptArtifact) {
         std::string ferr;
-        if (fetch_index_artifact(mainDir, ferr)) {
+        // #476: the main index honours a pin the same way sub-indexes do. It is
+        // the first entry of index_repos (the primary), which is also the repo
+        // whose name namespaces bare package targets.
+        const std::string mainPin =
+            globalRepos.empty() ? std::string{} : globalRepos.front().version;
+        if (fetch_index_artifact(mainDir, ferr, {}, nullptr, mainPin)) {
             mainArtifactManaged = true;
         } else if (indexSource == "artifact") {
             log::error("[index] artifact fetch failed and git fallback disabled "
@@ -686,7 +691,8 @@ bool sync_all_repos(bool force = false) {
         if (subAttemptArtifact) {
             std::string ferr;
             ok = fetch_index_artifact(repoDir, ferr, repo.name,
-                                      customSrc ? &*customSrc : nullptr);
+                                      customSrc ? &*customSrc : nullptr,
+                                      repo.version);
             if (!ok)
                 log::warn("[index] sub-index '{}' artifact fetch failed: {}", repo.name, ferr);
         }

--- a/src/core/xself/update.cppm
+++ b/src/core/xself/update.cppm
@@ -14,14 +14,31 @@ namespace xlings::xself {
 // (xim.commands and xvm.commands both import xlings.core.xself).
 export int cmd_update() {
     log::info("updating package index...");
+    platform::set_env_variable("XLINGS_INDEX_PIN", "newest");
     int rc = platform::exec("xlings update");
+    platform::set_env_variable("XLINGS_INDEX_PIN", "");
     if (rc != 0) {
         log::error("failed to update package index");
         return rc;
     }
 
+    // Reach the newest index snapshot for THIS step only.
+    //
+    // Routing (#476) can put an older client on an older index snapshot -- and
+    // that snapshot's own `pkgs/x/xlings.lua` names the `latest` of its era. A
+    // client routed back would therefore be told it is already current and
+    // could never upgrade, so it could never return to the newer index: a
+    // deadlock guaranteed by construction, not a rare race.
+    //
+    // The upgrade path is exempt from routing. Only one recipe has to be
+    // readable from the newer snapshot, and that recipe's shape (XLINGS_RES
+    // plus per-arch sha256) has been stable across every release so far. If
+    // the install fails partway the tree is newer than the client, and the
+    // next `xlings update` routes it back -- the state self-heals.
     log::info("installing xlings@latest...");
+    platform::set_env_variable("XLINGS_INDEX_PIN", "newest");
     rc = platform::exec("xlings install xlings@latest -y");
+    platform::set_env_variable("XLINGS_INDEX_PIN", "");
     if (rc != 0) {
         // This used to warn and return 0. A failed upgrade then looked
         // exactly like a successful one: the install error scrolled past

--- a/tests/e2e/index_version_contract_test.sh
+++ b/tests/e2e/index_version_contract_test.sh
@@ -142,4 +142,44 @@ out="$(XLINGS_INDEX_PIN=newest run update)" || fail "F: escape hatch failed: $ou
   || fail "F: XLINGS_INDEX_PIN=newest did not reach the newest, got '$(landed)'"
 pass "F: the upgrade path reaches the newest snapshot despite the contract"
 
+# ── G: `xlings index list` reports what routing would pick ───────
+write_pointer "9999.1.1.1" ""
+run update >/dev/null || fail "G: update failed"
+out="$(run index list xim)"
+grep -q "mid0002" <<<"$out" || fail "G: list did not mention the routed snapshot: $out"
+grep -qE '^\s*\*\s*mid0002' <<<"$out" \
+  || fail "G: list did not mark the CURRENT snapshot: $out"
+grep -q "new0003" <<<"$out" || fail "G: list hid the newer snapshot: $out"
+
+json="$(run index list xim --json)"
+python3 - "$json" <<'PYJ'
+import json, sys
+data = json.loads(sys.argv[1])
+xim = next(e for e in data if e["name"] == "xim")
+assert xim["current"] == "mid0002", xim["current"]
+rows = {s["index_version"]: s for s in xim["snapshots"]}
+assert rows["mid0002"]["current"] is True
+assert rows["new0003"]["current"] is False
+# The contract is handed back verbatim -- xlings must not normalise a document
+# it does not own.
+assert rows["new0003"]["requires"] == {"xlings": {"min": "9999.1.1.1"}}, \
+    rows["new0003"]["requires"]
+PYJ
+pass "G: index list reports the routed snapshot, and --json carries the contract"
+
+# ── H: `index use` pins, and refuses a version that does not exist ──
+run index use xim old0001 >/dev/null || fail "H: pinning failed"
+run update >/dev/null || fail "H: update after pin failed"
+[[ "$(landed)" == "marker-old.lua" ]] || fail "H: pin did not take effect"
+
+set +e; out="$(run index use xim deadbee)"; rc=$?; set -e
+[[ $rc -ne 0 ]] || fail "H: `index use` accepted an unpublished snapshot"
+grep -q "available" <<<"$out" || fail "H: refusal did not list what exists: $out"
+
+run index use xim latest >/dev/null || fail "H: unpinning failed"
+run update >/dev/null || fail "H: update after unpin failed"
+[[ "$(landed)" == "marker-mid.lua" ]] \
+  || fail "H: unpin did not return to automatic routing, got '$(landed)'"
+pass "H: index use pins, refuses unknown versions, and unpins"
+
 echo "[test] index version contract: all scenarios passed"

--- a/tests/e2e/index_version_contract_test.sh
+++ b/tests/e2e/index_version_contract_test.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# E2E-59 (#476): the index declares which client versions it needs, and the
+# client routes itself to the newest snapshot it satisfies.
+#
+#   A. newest snapshot is reachable        -> it is used
+#   B. newest snapshot is out of reach     -> the newest COMPATIBLE one is used,
+#                                             and the reason is printed
+#   C. nothing is compatible               -> hard error, local tree untouched
+#   D. pin to a published snapshot         -> exactly that one
+#   E. pin to an unpublished version       -> hard error listing what exists
+#   F. XLINGS_INDEX_PIN=newest             -> reaches the newest anyway
+#                                             (this is what `self update` uses,
+#                                              and what keeps a routed-back
+#                                              client from being stranded)
+#
+# Hermetic: the MAIN index is served from a local XLINGS_INDEX_BASE_URL dir, so
+# this exercises the same path xlings itself walks -- not a custom-source
+# special case.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$SCRIPT_DIR/project_test_lib.sh"
+
+XLINGS_BIN="${1:-$(find_xlings_bin)}"
+[[ -x "$XLINGS_BIN" ]] || { echo "[test] FAIL: no xlings binary found" >&2; exit 1; }
+
+pass() { echo "[test] OK: $*"; }
+fail() { echo "[test] FAIL: $*" >&2; exit 1; }
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/xim-vcontract.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+SELF_VER="$("$XLINGS_BIN" --version | awk '{print $2}')"
+[[ -n "$SELF_VER" ]] || fail "could not read the binary's own version"
+echo "[test] binary under test: $SELF_VER"
+
+SERVE="$WORK/serve"; mkdir -p "$SERVE"
+
+# Three snapshots, each carrying a marker package that names it, so "which one
+# landed" is answered by the tree on disk rather than by a log line.
+build_snapshot() {  # <version> <marker>
+  local ver="$1" marker="$2" src="$WORK/src-$1"
+  mkdir -p "$src/pkgs/m"
+  printf 'package({name="%s"})\n' "$marker" > "$src/pkgs/m/$marker.lua"
+  bash "$PROJECT_DIR/tools/build_xim_index_artifact.sh" \
+    --version "$ver" --out "$SERVE" --src "$src" >/dev/null
+}
+build_snapshot old0001 marker-old
+build_snapshot mid0002 marker-mid
+build_snapshot new0003 marker-new
+
+# Assemble a pointer with history. `requires` on the newest is the knob every
+# scenario below turns.
+write_pointer() {  # <newest-min> <mid-min> [old-min]
+  python3 - "$SERVE" "$1" "$2" "${3:-}" <<'PY'
+import json, sys, pathlib
+serve, newest_min, mid_min, old_min = sys.argv[1:5]
+def man(v):
+    return json.load(open(pathlib.Path(serve) / f"xim-index-{v}.manifest.json"))
+def entry(v, req):
+    m = man(v)
+    e = {"index_version": m["index_version"], "generated_at": m.get("generated_at", ""),
+         "artifact": m["artifact"]}
+    if req: e["requires"] = {"xlings": {"min": req}}
+    return e
+head = man("new0003")
+if newest_min: head["requires"] = {"xlings": {"min": newest_min}}
+head["history"] = [entry("new0003", newest_min), entry("mid0002", mid_min),
+                   entry("old0001", old_min)]
+head["history_truncated"] = False
+out = {"format_version": 2, "indexes": {"xim": head},
+       "client_latest": {"xlings": "9999.1.1.1"}}
+json.dump(out, open(pathlib.Path(serve) / "xim-index-pointers.json", "w"), indent=2)
+PY
+}
+
+HOME_DIR="$WORK/home"; USER_DIR="$WORK/user"; mkdir -p "$HOME_DIR" "$USER_DIR"
+cat > "$HOME_DIR/.xlings.json" <<EOF
+{ "mirror": "GLOBAL" }
+EOF
+
+run() {
+  HOME="$USER_DIR" XLINGS_HOME="$HOME_DIR" NO_COLOR=1 XLINGS_NON_INTERACTIVE=1 \
+  XLINGS_INDEX_BASE_URL="$SERVE" XLINGS_INDEX_SOURCE=artifact \
+    "$XLINGS_BIN" "$@" 2>&1
+}
+landed() { ls "$HOME_DIR/data/xim-pkgindex/pkgs/m/" 2>/dev/null | head -1; }
+
+# ── A: the newest snapshot is within reach ───────────────────────
+write_pointer "" ""
+out="$(run update)" || fail "A: update failed: $out"
+[[ "$(landed)" == "marker-new.lua" ]] \
+  || fail "A: expected the newest snapshot, got '$(landed)'"
+grep -q "instead of" <<<"$out" && fail "A: reported routing back when it did not"
+pass "A: unconstrained pointer uses the newest snapshot"
+
+# ── B: newest is out of reach -> newest COMPATIBLE, and say why ──
+write_pointer "9999.1.1.1" ""
+out="$(run update)" || fail "B: update failed: $out"
+[[ "$(landed)" == "marker-mid.lua" ]] \
+  || fail "B: expected to route back to mid0002, got '$(landed)'"
+grep -q "new0003" <<<"$out" || fail "B: did not name the snapshot it skipped: $out"
+grep -q "9999.1.1.1" <<<"$out" || fail "B: did not state the requirement: $out"
+grep -qE "self update|upgrade" <<<"$out" || fail "B: did not say how to fix it: $out"
+pass "B: routes back to the newest compatible snapshot and explains why"
+
+# ── C: nothing compatible -> hard error, tree left alone ─────────
+before="$(landed)"
+write_pointer "9999.1.1.1" "9999.1.1.1" "9999.1.1.1"
+set +e; out="$(run update)"; rc=$?; set -e
+[[ $rc -ne 0 ]] || fail "C: no compatible snapshot was not an error: $out"
+grep -q "E_INDEX_NO_COMPATIBLE_SNAPSHOT" <<<"$out" \
+  || fail "C: error was not the causal one: $out"
+[[ "$(landed)" == "$before" ]] \
+  || fail "C: local index tree was replaced during a failed resolve"
+pass "C: no compatible snapshot fails loudly and leaves the tree alone"
+
+# ── D: pin selects exactly, contract or not ──────────────────────
+write_pointer "9999.1.1.1" ""
+out="$(XLINGS_INDEX_PIN=old0001 run update)" || fail "D: pinned update failed: $out"
+[[ "$(landed)" == "marker-old.lua" ]] \
+  || fail "D: pin did not select old0001, got '$(landed)'"
+pass "D: a pin selects exactly the snapshot named"
+
+# ── E: pin to something unpublished -> error naming what exists ──
+before="$(landed)"
+set +e; out="$(XLINGS_INDEX_PIN=deadbee run update)"; rc=$?; set -e
+[[ $rc -ne 0 ]] || fail "E: unknown pin was accepted: $out"
+grep -q "E_INDEX_VERSION_NOT_FOUND" <<<"$out" || fail "E: wrong error: $out"
+grep -q "new0003" <<<"$out" || fail "E: did not list available versions: $out"
+[[ "$(landed)" == "$before" ]] || fail "E: tree replaced on a failed pin"
+pass "E: an unpublished pin errors and lists what is available"
+
+# ── F: the escape hatch reaches the newest regardless ────────────
+#
+# This is the one that keeps a routed-back client from being stranded: without
+# it, an old client sits on an old snapshot whose own xlings recipe names an old
+# `latest`, is told it is current, and can never move.
+out="$(XLINGS_INDEX_PIN=newest run update)" || fail "F: escape hatch failed: $out"
+[[ "$(landed)" == "marker-new.lua" ]] \
+  || fail "F: XLINGS_INDEX_PIN=newest did not reach the newest, got '$(landed)'"
+pass "F: the upgrade path reaches the newest snapshot despite the contract"
+
+echo "[test] index version contract: all scenarios passed"

--- a/tests/e2e/run_all.sh
+++ b/tests/e2e/run_all.sh
@@ -108,6 +108,7 @@ TESTS=(
     "E2E-56 |info_output_contract_test.sh||"
     "E2E-57 |subos_use_process_model_test.sh||"
     "E2E-58 |arch_evidence_contract_test.sh||"
+    "E2E-59 |index_version_contract_test.sh||"
 )
 
 PASS=0; FAIL=0; SOFTFAIL=0

--- a/tests/scripts/test_index_pointer_history.py
+++ b/tests/scripts/test_index_pointer_history.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""The pointer's history retention policy (#476, contract 10).
+
+This policy is load-bearing, not housekeeping: the set of snapshots it keeps IS
+the set a client can route to. Keep too few and an older client finds nothing it
+can use; keep by recency alone and the one contract generation it needs falls off
+the end while eight identical ones stay.
+
+So the rule under test is the union of:
+    A) the newest RECENT_KEEP snapshots, whatever they require
+    B) the newest snapshot of each distinct `requires` value
+"""
+from pathlib import Path
+import json
+import subprocess
+import sys
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[2]
+MERGE = ROOT / "tools/merge_index_pointer.py"
+
+
+def manifest(version, requires=None, generated=None):
+    doc = {
+        "format_version": 1,
+        "index_version": version,
+        "index_name": "xim",
+        "generated_at": generated or f"2026-08-04T00:00:{int(version[-2:]):02d}Z",
+        "artifact": {"name": f"xim-index-{version}.tar.gz",
+                     "sha256": "a" * 64, "size": 1000},
+    }
+    if requires:
+        doc["requires"] = requires
+    return doc
+
+
+def publish(work, sequence, client_latest=None):
+    """Run the merge once per snapshot, as a real publish chain would."""
+    dst = work / "pointer.json"
+    for version, requires in sequence:
+        src = work / "src.json"
+        src.write_text(json.dumps({"format_version": 2,
+                                   "indexes": {"xim": manifest(version, requires)}}))
+        args = [sys.executable, str(MERGE), str(dst), str(src)]
+        if client_latest:
+            args.append(f"--client-latest=xlings={client_latest}")
+        result = subprocess.run(args, capture_output=True, text=True)
+        assert result.returncode == 0, result.stderr
+    return json.loads(dst.read_text())
+
+
+def versions_in(pointer):
+    return [row["index_version"] for row in pointer["indexes"]["xim"]["history"]]
+
+
+def test_recent_and_distinct_contracts_are_both_kept():
+    xl = lambda v: {"xlings": {"min": v}}
+    with tempfile.TemporaryDirectory() as temp:
+        work = Path(temp)
+        # 20 snapshots, three contract generations. The oldest generation's
+        # newest member is v05 -- far outside any recency window.
+        sequence = []
+        for i in range(1, 21):
+            if i <= 5:
+                req = xl("1.0.0")
+            elif i <= 10:
+                req = xl("2.0.0")
+            else:
+                req = xl("3.0.0")
+            sequence.append((f"v{i:02d}", req))
+        pointer = publish(work, sequence)
+        kept = versions_in(pointer)
+
+        # A: the newest 8, in order, newest first.
+        assert kept[:8] == [f"v{i:02d}" for i in range(20, 12, -1)], kept
+
+        # B: every contract generation still reachable, including the oldest,
+        # whose newest member is far past the recency window.
+        assert "v10" in kept, f"generation 2.0.0 unreachable: {kept}"
+        assert "v05" in kept, f"generation 1.0.0 unreachable: {kept}"
+
+        # And nothing redundant: one row per older generation, not five.
+        assert kept.count("v09") == 0 and kept.count("v04") == 0, kept
+        assert len(kept) == 10, f"expected 8 recent + 2 older generations: {kept}"
+
+
+def test_history_is_newest_first_and_deduplicated_by_version():
+    xl = {"xlings": {"min": "1.0.0"}}
+    with tempfile.TemporaryDirectory() as temp:
+        work = Path(temp)
+        pointer = publish(work, [("v01", xl), ("v02", xl), ("v02", xl)])
+        kept = versions_in(pointer)
+        assert kept == ["v02", "v01"], f"republishing a version must not duplicate it: {kept}"
+
+
+def test_truncation_is_reported_not_silent():
+    """A client must be able to tell 'nothing compatible exists' apart from
+    'the compatible one fell off the end' -- different problems, different fixes.
+    """
+    with tempfile.TemporaryDirectory() as temp:
+        work = Path(temp)
+        # 40 distinct contracts: every one is novel, so nothing can be dropped
+        # by the dedup rule and the cap has to do the dropping.
+        sequence = [(f"v{i:02d}", {"xlings": {"min": f"{i}.0.0"}}) for i in range(1, 41)]
+        pointer = publish(work, sequence)
+        entry = pointer["indexes"]["xim"]
+        assert len(entry["history"]) == 32, len(entry["history"])
+        assert entry["history_truncated"] is True
+
+
+def test_client_latest_is_carried_at_top_level():
+    """Without it a routed-back client cannot learn a newer client exists."""
+    with tempfile.TemporaryDirectory() as temp:
+        work = Path(temp)
+        pointer = publish(work, [("v01", None)], client_latest="2026.8.4.1")
+        assert pointer["client_latest"]["xlings"] == "2026.8.4.1"
+        assert pointer["format_version"] == 2
+
+
+def test_sibling_index_keys_survive_a_publish():
+    """Each index repo publishes independently; a plain overwrite drops the rest.
+    This regressed once already when xim-pkgindex's per-repo CI published alone.
+    """
+    with tempfile.TemporaryDirectory() as temp:
+        work = Path(temp)
+        dst = work / "pointer.json"
+        dst.write_text(json.dumps({
+            "format_version": 2,
+            "indexes": {"scode": {"index_version": "s01",
+                                  "artifact": {"name": "s.tar.gz", "sha256": "b" * 64}}},
+        }))
+        src = work / "src.json"
+        src.write_text(json.dumps({"format_version": 2,
+                                   "indexes": {"xim": manifest("v01")}}))
+        result = subprocess.run([sys.executable, str(MERGE), str(dst), str(src)],
+                                capture_output=True, text=True)
+        assert result.returncode == 0, result.stderr
+        pointer = json.loads(dst.read_text())
+        assert set(pointer["indexes"]) == {"xim", "scode"}, pointer["indexes"].keys()
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"ok   {name}")
+            except AssertionError as error:
+                print(f"FAIL {name}: {error}", file=sys.stderr)
+                failures += 1
+    if failures:
+        raise SystemExit(f"{failures} history-policy contract(s) failed")
+    print("index pointer history policy: ok")

--- a/tests/unit/test_index_contract.cpp
+++ b/tests/unit/test_index_contract.cpp
@@ -253,3 +253,36 @@ TEST(IndexContract, ManifestParsingIsAdditive) {
     EXPECT_EQ(modern->history[1].artifact_sha256, "ab");
     EXPECT_EQ(requirement_for(modern->requirements, "xlings")->min, "2026.8.3.1");
 }
+
+// Contract 8: the upgrade path is exempt from routing.
+//
+// Without this a client routed to an older snapshot reads that snapshot's own
+// xlings recipe, is told it is already current, and can never reach the version
+// that would let it move forward -- a deadlock guaranteed by construction. The
+// escape hatch has to ignore the contract, which is exactly what makes it an
+// escape hatch and why nothing else may use it.
+TEST(IndexContract, NewestPinEscapesTheRoutingDeadlock) {
+    auto m = with_history({
+        snap("e2aad0b", requires_xlings("2026.9.9.9")),   // unreachable for us
+        snap("20e53c6", requires_xlings("2026.8.1.1")),
+    });
+
+    // Normal routing steps back, as it should.
+    auto routed = choose_snapshot(m, "2026.8.3.1", {});
+    ASSERT_TRUE(routed);
+    EXPECT_EQ(routed->snapshot.index_version, "20e53c6");
+
+    // The upgrade path reaches the newest snapshot anyway.
+    auto escape = choose_snapshot(m, "2026.8.3.1", "newest");
+    ASSERT_TRUE(escape);
+    EXPECT_EQ(escape->snapshot.index_version, "e2aad0b");
+    EXPECT_TRUE(escape->isNewest);
+
+    // And it still works when nothing at all is compatible -- the case where a
+    // client would otherwise be stranded with no reachable index.
+    auto stranded = choose_snapshot(m, "0.4.69", {});
+    ASSERT_FALSE(stranded);
+    auto rescue = choose_snapshot(m, "0.4.69", "newest");
+    ASSERT_TRUE(rescue);
+    EXPECT_EQ(rescue->snapshot.index_version, "e2aad0b");
+}

--- a/tests/unit/test_index_contract.cpp
+++ b/tests/unit/test_index_contract.cpp
@@ -1,0 +1,255 @@
+#include <gtest/gtest.h>
+
+import std;
+import xlings.libs.json;
+import xlings.core.semver;
+import xlings.core.xim.indexfetch;
+
+using namespace xlings::xim;
+
+namespace {
+
+nlohmann::json requires_xlings(std::string min, std::string max = {}) {
+    nlohmann::json req = nlohmann::json::object();
+    nlohmann::json bound = nlohmann::json::object();
+    if (!min.empty()) bound["min"] = std::move(min);
+    if (!max.empty()) bound["max"] = std::move(max);
+    req["xlings"] = std::move(bound);
+    return req;
+}
+
+IndexSnapshot snap(std::string version, nlohmann::json req = nlohmann::json::object()) {
+    IndexSnapshot s;
+    s.index_version   = version;
+    s.generated_at    = "2026-08-0" + version.substr(0, 1) + "T00:00:00Z";
+    s.artifact_name   = "xim-index-" + version + ".tar.gz";
+    s.artifact_sha256 = std::string(64, 'a');
+    s.artifact_size   = 1000;
+    s.requirements    = std::move(req);
+    return s;
+}
+
+// Newest first, the order the pointer publishes.
+IndexManifest with_history(std::vector<IndexSnapshot> history) {
+    IndexManifest m;
+    m.format_version = 1;
+    m.index_name     = "xim";
+    if (!history.empty()) {
+        m.index_version   = history.front().index_version;
+        m.artifact_name   = history.front().artifact_name;
+        m.artifact_sha256 = history.front().artifact_sha256;
+        m.requirements    = history.front().requirements;
+    }
+    m.history = std::move(history);
+    return m;
+}
+
+}  // namespace
+
+// THE MEASUREMENT THIS WHOLE CONTRACT RESTS ON.
+//
+// semver::Version is three components; xlings's own version is four
+// (YYYY.M.D.N). semver cannot parse it, and satisfies_expr answers FALSE rather
+// than erroring -- so a contract built on it would make every client fail every
+// check and report "no compatible snapshot", which reads as a publishing
+// problem instead of a parser that does not know the version scheme.
+TEST(IndexContract, SemverCannotExpressXlingsOwnVersion) {
+    EXPECT_FALSE(xlings::semver::parse("2026.8.3.1").has_value())
+        << "if semver learns 4-component versions, revisit the design note";
+    EXPECT_FALSE(xlings::semver::satisfies_expr("2026.8.3.2", ">=2026.8.3.1"))
+        << "this is the wrong answer, and the reason the contract does not use it";
+
+    // What the contract actually uses gets it right.
+    EXPECT_TRUE(satisfies_requirement("2026.8.3.2", {.min = "2026.8.3.1"}));
+    EXPECT_FALSE(satisfies_requirement("2026.8.3.1", {.min = "2026.8.3.2"}));
+    EXPECT_TRUE(satisfies_requirement("2026.8.3.1", {.min = "0.4.69"}))
+        << "date-based versions must outrank the legacy 0.4.x line";
+}
+
+TEST(IndexContract, BoundsAreMinInclusiveMaxExclusive) {
+    EXPECT_TRUE(satisfies_requirement("2026.8.3.1", {.min = "2026.8.3.1"}));
+    EXPECT_FALSE(satisfies_requirement("2026.8.3.1", {.max = "2026.8.3.1"}));
+    EXPECT_TRUE(satisfies_requirement("2026.8.3.1",
+                                      {.min = "2026.8.1.1", .max = "2026.9.0.1"}));
+    // No bounds at all is not a constraint.
+    EXPECT_TRUE(satisfies_requirement("0.0.1", {}));
+}
+
+// Contract 2: a client under the newest floor lands on the newest snapshot it
+// DOES satisfy, and is told why.
+TEST(IndexContract, RoutesBackToTheNewestCompatibleSnapshot) {
+    auto m = with_history({
+        snap("e2aad0b", requires_xlings("2026.8.3.1")),
+        snap("20e53c6", requires_xlings("2026.8.1.1")),
+        snap("0adb288"),
+    });
+
+    auto newest = choose_snapshot(m, "2026.8.3.1", {});
+    ASSERT_TRUE(newest);
+    EXPECT_EQ(newest->snapshot.index_version, "e2aad0b");
+    EXPECT_TRUE(newest->isNewest);
+    EXPECT_TRUE(newest->reason.empty());
+
+    auto stepped = choose_snapshot(m, "2026.8.2.1", {});
+    ASSERT_TRUE(stepped);
+    EXPECT_EQ(stepped->snapshot.index_version, "20e53c6");
+    EXPECT_FALSE(stepped->isNewest);
+    EXPECT_NE(stepped->reason.find("e2aad0b"), std::string::npos) << stepped->reason;
+    EXPECT_NE(stepped->reason.find("2026.8.3.1"), std::string::npos) << stepped->reason;
+
+    // Old enough to clear only the unconstrained snapshot.
+    auto ancient = choose_snapshot(m, "0.4.69", {});
+    ASSERT_TRUE(ancient);
+    EXPECT_EQ(ancient->snapshot.index_version, "0adb288");
+    EXPECT_FALSE(ancient->isNewest);
+}
+
+// Contract 3: nothing compatible is an error, never a silent fallback to the
+// newest -- that would hand the client exactly what it was routing away from.
+TEST(IndexContract, NoCompatibleSnapshotIsAnError) {
+    auto m = with_history({
+        snap("e2aad0b", requires_xlings("2026.8.3.1")),
+        snap("20e53c6", requires_xlings("2026.8.2.1")),
+    });
+    auto choice = choose_snapshot(m, "0.4.69", {});
+    ASSERT_FALSE(choice);
+    EXPECT_NE(choice.error().find("E_INDEX_NO_COMPATIBLE_SNAPSHOT"), std::string::npos);
+    EXPECT_NE(choice.error().find("0.4.69"), std::string::npos) << choice.error();
+    EXPECT_NE(choice.error().find("e2aad0b"), std::string::npos)
+        << "the message must list what IS available: " << choice.error();
+}
+
+// Contract 4: a pointer that predates history still gets checked. A client that
+// cannot use the only snapshot on offer must hear so, not use it anyway.
+TEST(IndexContract, PointerWithoutHistoryIsStillChecked) {
+    IndexManifest m;
+    m.format_version  = 1;
+    m.index_version   = "e2aad0b";
+    m.artifact_name   = "xim-index-e2aad0b.tar.gz";
+    m.artifact_sha256 = std::string(64, 'a');
+    m.requirements    = requires_xlings("2026.8.3.1");
+    EXPECT_TRUE(m.history.empty());
+
+    auto ok = choose_snapshot(m, "2026.8.3.1", {});
+    ASSERT_TRUE(ok);
+    EXPECT_EQ(ok->snapshot.index_version, "e2aad0b");
+
+    auto bad = choose_snapshot(m, "2026.8.2.1", {});
+    ASSERT_FALSE(bad) << "an unusable sole snapshot must not be used silently";
+
+    // And with no requirement at all it behaves exactly as it does today.
+    IndexManifest plain = m;
+    plain.requirements = nlohmann::json::object();
+    auto legacy = choose_snapshot(plain, "0.0.1", {});
+    ASSERT_TRUE(legacy);
+    EXPECT_EQ(legacy->snapshot.index_version, "e2aad0b");
+}
+
+// Contract 5: a pin names a snapshot exactly. Missing is an error that lists
+// what exists; present is honoured even when the contract would not route there.
+TEST(IndexContract, PinIsExactAndNeverFallsBack) {
+    auto m = with_history({
+        snap("e2aad0b", requires_xlings("2026.8.3.1")),
+        snap("20e53c6", requires_xlings("2026.8.1.1")),
+    });
+
+    auto pinned = choose_snapshot(m, "2026.8.3.1", "20e53c6");
+    ASSERT_TRUE(pinned);
+    EXPECT_EQ(pinned->snapshot.index_version, "20e53c6");
+    EXPECT_FALSE(pinned->isNewest);
+
+    // A pin overrides the contract deliberately: reproducing a state is a
+    // legitimate reason to run an index this client would not have chosen.
+    auto override_ = choose_snapshot(m, "2026.8.2.1", "e2aad0b");
+    ASSERT_TRUE(override_);
+    EXPECT_EQ(override_->snapshot.index_version, "e2aad0b");
+
+    auto missing = choose_snapshot(m, "2026.8.3.1", "deadbee");
+    ASSERT_FALSE(missing);
+    EXPECT_NE(missing.error().find("E_INDEX_VERSION_NOT_FOUND"), std::string::npos);
+    EXPECT_NE(missing.error().find("e2aad0b"), std::string::npos)
+        << "must list the available versions: " << missing.error();
+
+    // "latest" is the explicit way to say "no pin".
+    auto latest = choose_snapshot(m, "2026.8.3.1", "latest");
+    ASSERT_TRUE(latest);
+    EXPECT_TRUE(latest->isNewest);
+}
+
+// Contract 7: xlings evaluates its own key and carries every other one
+// verbatim. This is what makes the mechanism general rather than a special case
+// for one consumer.
+TEST(IndexContract, ForeignRequirementKeysArePassedThroughUntouched) {
+    nlohmann::json req = requires_xlings("2026.8.3.1");
+    req["mcpp"]   = { {"min", "2026.8.3.3"} };
+    req["weird"]  = { {"nested", {{"deep", "值"}}}, {"n", 7} };
+
+    auto m = with_history({ snap("e2aad0b", req) });
+
+    // xlings reads only its own key…
+    EXPECT_TRUE(requirement_for(req, "xlings").has_value());
+    EXPECT_EQ(requirement_for(req, "mcpp")->min, "2026.8.3.3");
+    EXPECT_FALSE(requirement_for(req, "absent").has_value());
+
+    // …and hands the whole blob back untouched.
+    auto choice = choose_snapshot(m, "2026.8.3.1", {});
+    ASSERT_TRUE(choice);
+    EXPECT_EQ(choice->snapshot.requirements.dump(), req.dump())
+        << "requirements must survive byte-identical; any normalisation here "
+           "would make xlings an interpreter of contracts it does not own";
+}
+
+// Contract 9's unit half: with neither history nor requirements, selection is
+// the single snapshot the manifest already named -- today's behaviour exactly.
+TEST(IndexContract, DefaultPathIsUnchangedWhenThePointerSaysNothingNew) {
+    IndexManifest m;
+    m.format_version  = 1;
+    m.index_version   = "e2aad0b";
+    m.artifact_name   = "xim-index-e2aad0b.tar.gz";
+    m.artifact_sha256 = std::string(64, 'b');
+    m.artifact_size   = 371803;
+
+    const auto snapshots = snapshots_of(m);
+    ASSERT_EQ(snapshots.size(), 1u);
+    EXPECT_EQ(snapshots[0].artifact_name, m.artifact_name);
+    EXPECT_EQ(snapshots[0].artifact_sha256, m.artifact_sha256);
+    EXPECT_EQ(snapshots[0].artifact_size, m.artifact_size);
+
+    auto choice = choose_snapshot(m, "0.0.1", {});
+    ASSERT_TRUE(choice);
+    EXPECT_TRUE(choice->isNewest);
+    EXPECT_EQ(choice->snapshot.artifact_sha256, m.artifact_sha256);
+}
+
+// The parser is additive: a v1 pointer body must survive unchanged, and a v2
+// body must not lose the fields the routing depends on.
+TEST(IndexContract, ManifestParsingIsAdditive) {
+    const auto v1 = R"({"format_version":1,"index_version":"20e53c6",
+        "index_name":"xim","artifact":{"name":"a.tar.gz","sha256":"AB","size":7}})";
+    auto legacy = parse_index_manifest(v1);
+    ASSERT_TRUE(legacy);
+    EXPECT_EQ(legacy->index_version, "20e53c6");
+    EXPECT_EQ(legacy->artifact_sha256, "ab") << "sha256 is lowercased as before";
+    EXPECT_TRUE(legacy->history.empty());
+    EXPECT_FALSE(legacy->history_truncated);
+
+    const auto v2 = R"({"format_version":1,"index_version":"e2aad0b",
+        "index_name":"xim","artifact":{"name":"b.tar.gz","sha256":"CD","size":9},
+        "requires":{"xlings":{"min":"2026.8.3.1"}},
+        "history_truncated":true,
+        "history":[
+          {"index_version":"e2aad0b","requires":{"xlings":{"min":"2026.8.3.1"}},
+           "artifact":{"name":"b.tar.gz","sha256":"CD","size":9}},
+          {"index_version":"20e53c6",
+           "artifact":{"name":"a.tar.gz","sha256":"AB","size":7}},
+          {"index_version":"broken","artifact":{"name":"","sha256":""}}
+        ]})";
+    auto modern = parse_index_manifest(v2);
+    ASSERT_TRUE(modern);
+    EXPECT_TRUE(modern->history_truncated);
+    ASSERT_EQ(modern->history.size(), 2u) << "an entry with no artifact identity "
+                                             "cannot be selected and is dropped";
+    EXPECT_EQ(modern->history[0].index_version, "e2aad0b");
+    EXPECT_EQ(modern->history[1].artifact_sha256, "ab");
+    EXPECT_EQ(requirement_for(modern->requirements, "xlings")->min, "2026.8.3.1");
+}

--- a/tools/build_xim_index_artifact.sh
+++ b/tools/build_xim_index_artifact.sh
@@ -20,6 +20,7 @@
 #   XLINGS_RELEASE_PKGINDEX_REF=main    git ref to snapshot (default main)
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VERSION="" OUT_DIR="" NAME="" SRC_DIR=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -95,6 +96,25 @@ SHA="$(sha256_of "$ARTIFACT")"
 SIZE="$(wc -c < "$ARTIFACT" | tr -d ' ')"
 GENERATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
+# #476: the index tree may declare which client versions it needs, in
+# `index-compat.json` at its root:
+#
+#   { "requires": { "xlings": { "min": "2026.8.4.1" } } }
+#
+# Carried into the manifest verbatim. xlings evaluates only the "xlings" key
+# and routes clients that do not satisfy it to an older snapshot; every other
+# key is passed through for whichever consumer owns it. Absent file = no
+# constraint = today's behaviour.
+REQUIRES_JSON="{}"
+# From the assembled TREE, not --src: the clone path has no SRC_DIR, and the
+# tree is what actually ships.
+COMPAT_FILE="$TREE/index-compat.json"
+if [[ -f "$COMPAT_FILE" ]]; then
+  REQUIRES_JSON="$(python3 "$SCRIPT_DIR/read_index_compat.py" "$COMPAT_FILE")" \
+    || fail "index-compat.json rejected"
+  info "  requires: $REQUIRES_JSON"
+fi
+
 MANIFEST="$OUT_DIR/${ARTIFACT_BASE}.manifest.json"
 cat > "$MANIFEST" <<JSON
 {
@@ -108,6 +128,7 @@ cat > "$MANIFEST" <<JSON
     "sha256": "${SHA}",
     "size": ${SIZE}
   },
+  "requires": ${REQUIRES_JSON},
   "signature": null
 }
 JSON

--- a/tools/check_index_compat.py
+++ b/tools/check_index_compat.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Check that an index tree's declared client floor covers what its recipes use.
+
+    check_index_compat.py <index-tree>
+
+A floor nobody remembers to raise is not a contract. This scans the recipes for
+constructs that only newer clients understand and asserts the tree's
+`index-compat.json` declares a `requires.xlings.min` at least that high --
+turning "the author promised" into "the tree says so, and it was checked".
+
+Meant to run in the INDEX repo's CI (xim-pkgindex and any third-party index),
+not in xlings's. It lives here because xlings owns the table: it is the one that
+knows which of its own versions introduced which capability.
+
+Exit 0 = the declared floor covers everything found.
+Exit 1 = something in the tree needs a client newer than the tree admits.
+"""
+from pathlib import Path
+import json
+import re
+import sys
+
+# Construct -> the first xlings version that understands it.
+#
+# Append when a capability lands; the entry is what makes the next index adopting
+# it fail loudly here instead of on a user's machine. Each pattern is matched
+# against recipe text, so keep them specific enough not to fire on prose.
+CAPABILITIES = [
+    (re.compile(r'kind\s*=\s*["\']files["\']'),  "0.4.70",
+     "xvm registration kind 'files'"),
+    (re.compile(r'kind\s*=\s*["\']group["\']'),  "0.4.60",
+     "xvm registration kind 'group'"),
+    (re.compile(r'\bspec\s*=\s*["\']2["\']'),    "0.4.52",
+     "xpkg spec 2"),
+    (re.compile(r'\bsha256_by_arch\b|\barch_alias\b|\$\{arch\}'), "0.4.52",
+     "per-arch resource entry"),
+]
+
+
+def compare_versions(left: str, right: str) -> int:
+    """Component-wise numeric compare; mirrors version_order::compare.
+
+    Not semver: xlings versions are four components (YYYY.M.D.N) and semver's
+    three-component parser cannot read them at all.
+    """
+    def parts(value):
+        out = []
+        for chunk in value.split("-")[0].split("."):
+            out.append(int(chunk) if chunk.isdigit() else -1)
+        return out
+
+    a, b = parts(left), parts(right)
+    for i in range(max(len(a), len(b))):
+        x = a[i] if i < len(a) else 0
+        y = b[i] if i < len(b) else 0
+        if x != y:
+            return -1 if x < y else 1
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    tree = Path(sys.argv[1])
+    if not (tree / "pkgs").is_dir():
+        print(f"not an index tree (no pkgs/): {tree}", file=sys.stderr)
+        return 2
+
+    declared = ""
+    compat = tree / "index-compat.json"
+    if compat.is_file():
+        try:
+            doc = json.loads(compat.read_text(encoding="utf-8"))
+            declared = doc.get("requires", {}).get("xlings", {}).get("min", "")
+        except Exception as error:  # noqa: BLE001
+            print(f"index-compat.json unreadable: {error}", file=sys.stderr)
+            return 1
+
+    needed, why = "", []
+    for recipe in sorted((tree / "pkgs").rglob("*.lua")):
+        text = recipe.read_text(encoding="utf-8", errors="replace")
+        for pattern, version, label in CAPABILITIES:
+            if not pattern.search(text):
+                continue
+            why.append((recipe.relative_to(tree), label, version))
+            if not needed or compare_versions(version, needed) > 0:
+                needed = version
+
+    if not needed:
+        print("index compat: no version-gated construct found; any client works")
+        return 0
+
+    print(f"index compat: newest construct needs xlings >= {needed}")
+    for path, label, version in sorted(why)[:10]:
+        print(f"  {path}: {label} (>= {version})")
+    if len(why) > 10:
+        print(f"  … {len(why) - 10} more")
+
+    if declared and compare_versions(declared, needed) >= 0:
+        print(f"index compat: declared floor {declared} covers it")
+        return 0
+
+    print("", file=sys.stderr)
+    print(f"FAIL: this index uses constructs needing xlings >= {needed}, but "
+          f"index-compat.json declares "
+          f"{declared or 'no floor at all'}.", file=sys.stderr)
+    print(f"      Older clients would hard-fail on them instead of being routed "
+          f"to a snapshot they can use.", file=sys.stderr)
+    print(f'      Fix: set requires.xlings.min to "{needed}" (or higher) in '
+          f"index-compat.json.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/merge_index_pointer.py
+++ b/tools/merge_index_pointer.py
@@ -105,6 +105,27 @@ def main() -> int:
     for key, manifest in incoming.items():
         previous = base["indexes"].get(key, {}).get("history", [])
         history, truncated = merge_history(previous, snapshot_of(manifest))
+
+        # Declaring a floor only helps if there is somewhere to route back TO.
+        # The first publish after adopting this carries a one-entry history, so
+        # a floor declared in that same publish strands every client below it
+        # instead of routing it -- worse than the hard failure it replaces.
+        # Publish history first, let it accumulate, then raise the floor.
+        head_requires = manifest.get("requires", {}).get("xlings", {})
+        if head_requires.get("min"):
+            escape = [r for r in history[1:]
+                      if not r.get("requires", {}).get("xlings", {}).get("min")]
+            older = [r for r in history[1:]]
+            if not older:
+                print(f"[pointers] WARNING: {key} declares a client floor but "
+                      f"publishes no older snapshot. Clients below "
+                      f"{head_requires['min']} will have nowhere to route and "
+                      f"will fail outright. Publish history before raising a "
+                      f"floor.", file=sys.stderr)
+            elif not escape:
+                print(f"[pointers] note: {key} floor {head_requires['min']}; "
+                      f"every published snapshot declares one, so clients older "
+                      f"than the lowest will still fail.", file=sys.stderr)
         entry = dict(manifest)
         entry["history"] = history
         entry["history_truncated"] = truncated

--- a/tools/merge_index_pointer.py
+++ b/tools/merge_index_pointer.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Merge freshly built index manifests into the published combined pointer,
+carrying an addressable history of past snapshots (#476).
+
+    merge_index_pointer.py <dst-pointer> <src-pointer> [--client-latest name=ver]...
+
+Only the keys present in <src-pointer> are touched; sibling indexes keep theirs,
+because each index repo publishes independently and a plain overwrite would drop
+the others.
+
+History is NOT "the last N snapshots". A client routing back needs the newest
+snapshot whose declared contract it satisfies, and contracts change rarely while
+snapshots are produced constantly -- xlings-res/xim-index holds 313 artifacts and
+a handful of distinct contracts. So the retained set is the union of:
+
+    A) the newest RECENT_KEEP snapshots, whatever they require
+       -- so "roll back one" stays possible, which is what debugging needs;
+    B) the newest snapshot of each distinct `requires` value
+       -- so every contract generation stays reachable, which is what routing
+          needs.
+
+capped at MAX_HISTORY entries, newest first. Dropping past the cap sets
+`history_truncated`, which lets a client tell "no compatible snapshot exists"
+apart from "the compatible one fell off the end" -- different problems with
+different fixes.
+"""
+import json
+import os
+import sys
+
+RECENT_KEEP = 8
+MAX_HISTORY = 32
+
+
+def snapshot_of(manifest):
+    """The history row describing a manifest."""
+    row = {
+        "index_version": manifest.get("index_version", ""),
+        "generated_at": manifest.get("generated_at", ""),
+        "artifact": manifest.get("artifact", {}),
+    }
+    requires = manifest.get("requires")
+    if requires:
+        row["requires"] = requires
+    return row
+
+
+def contract_key(row):
+    """Identity of a row's contract, for the 'one per distinct contract' rule."""
+    return json.dumps(row.get("requires", {}), sort_keys=True, separators=(",", ":"))
+
+
+def merge_history(previous, incoming):
+    """previous: existing history (newest first). incoming: the new head row."""
+    rows = [incoming]
+    for row in previous:
+        # The incoming snapshot replaces any stale row for the same version --
+        # a republish of the same index_version is the same snapshot.
+        if row.get("index_version") == incoming.get("index_version"):
+            continue
+        rows.append(row)
+
+    keep, seen_contracts = [], set()
+    for position, row in enumerate(rows):
+        recent = position < RECENT_KEEP
+        contract = contract_key(row)
+        novel = contract not in seen_contracts
+        seen_contracts.add(contract)
+        if recent or novel:
+            keep.append(row)
+
+    truncated = len(keep) > MAX_HISTORY
+    return keep[:MAX_HISTORY], truncated
+
+
+def main() -> int:
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    if len(args) != 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    dst_path, src_path = args
+
+    client_latest = {}
+    for arg in sys.argv[1:]:
+        if arg.startswith("--client-latest="):
+            name, _, version = arg[len("--client-latest="):].partition("=")
+            if name and version:
+                client_latest[name] = version
+
+    base = {"format_version": 2, "indexes": {}}
+    if os.path.exists(dst_path):
+        try:
+            with open(dst_path, encoding="utf-8") as handle:
+                base = json.load(handle)
+        except Exception:
+            # A corrupt published pointer must not stop a publish; it is fully
+            # regenerated below for the keys we own, and sibling keys were
+            # already unreadable.
+            base = {"format_version": 2, "indexes": {}}
+    base.setdefault("indexes", {})
+
+    with open(src_path, encoding="utf-8") as handle:
+        incoming = json.load(handle).get("indexes", {})
+
+    for key, manifest in incoming.items():
+        previous = base["indexes"].get(key, {}).get("history", [])
+        history, truncated = merge_history(previous, snapshot_of(manifest))
+        entry = dict(manifest)
+        entry["history"] = history
+        entry["history_truncated"] = truncated
+        base["indexes"][key] = entry
+        print(f"[pointers] {key}: {len(history)} snapshot(s) in history"
+              f"{' (truncated)' if truncated else ''}")
+
+    # Newest CLIENT version, carried at top level so it is readable no matter
+    # which snapshot a client routes to. Without it a routed-back client cannot
+    # learn that a newer client exists, and can never leave the old snapshot.
+    if client_latest:
+        base.setdefault("client_latest", {}).update(client_latest)
+
+    base["format_version"] = 2
+    with open(dst_path, "w", encoding="utf-8") as handle:
+        json.dump(base, handle, indent=2)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/push_index_pointers.sh
+++ b/tools/push_index_pointers.sh
@@ -18,6 +18,17 @@ set -euo pipefail
 DIR="${1:?usage: push_index_pointers.sh <dir>}"
 GH_REPO_SLUG="${GH_REPO_SLUG:-xlings-res/xim-index}"
 GTC_REPO_SLUG="${GTC_REPO_SLUG:-xlings-res/xim-index}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# #476: the newest xlings release, recorded at the pointer top level. A
+# client routed to an older snapshot reads that snapshot's own xlings recipe,
+# which names the `latest` of its era -- without this it could never learn a
+# newer client exists, and could never leave the snapshot it was routed to.
+CLIENT_LATEST_ARGS=""
+if [[ -n "${XLINGS_CLIENT_LATEST:-}" ]]; then
+  CLIENT_LATEST_ARGS="--client-latest=xlings=${XLINGS_CLIENT_LATEST}"
+fi
+
 
 compgen -G "$DIR/*-latest.json" >/dev/null 2>&1 || { echo "[pointers] no *-latest.json in $DIR" >&2; exit 1; }
 
@@ -36,7 +47,7 @@ for f in sorted(glob.glob(os.path.join(d, "*-latest.json"))):
     key = m.group(1) or "xim"
     try: indexes[key] = json.load(open(f, encoding="utf-8"))
     except Exception as e: print(f"[pointers] skip {name}: {e}", file=sys.stderr)
-json.dump({"format_version": 1, "indexes": indexes}, open(out, "w", encoding="utf-8"), indent=2)
+json.dump({"format_version": 2, "indexes": indexes}, open(out, "w", encoding="utf-8"), indent=2)
 print(f"[pointers] combined {len(indexes)} index(es): {', '.join(sorted(indexes))}")
 PY
 
@@ -52,18 +63,11 @@ push_one() {  # <clone-url> <label>
   # sibling indexes' keys. Each index repo (xim, awesome, scode, d2x) publishes
   # independently and must update ONLY its own key — a plain overwrite would drop
   # the others (regression seen when xim-pkgindex's per-repo CI published alone).
-  python3 - "$tmp/xim-index-pointers.json" "$COMBINED" <<'PYMERGE'
-import sys, json, os
-dst, src = sys.argv[1], sys.argv[2]
-base = {"format_version": 1, "indexes": {}}
-if os.path.exists(dst):
-    try: base = json.load(open(dst, encoding="utf-8"))
-    except Exception: base = {"format_version": 1, "indexes": {}}
-base.setdefault("indexes", {})
-base["indexes"].update(json.load(open(src, encoding="utf-8")).get("indexes", {}))
-base["format_version"] = 1
-json.dump(base, open(dst, "w", encoding="utf-8"), indent=2)
-PYMERGE
+  # #476: the merge also carries an addressable history per index and the
+  # newest client version. Extracted to a script so the retention policy is
+  # testable -- "which snapshots stay reachable" is the whole feature.
+  python3 "$SCRIPT_DIR/merge_index_pointer.py" \
+      "$tmp/xim-index-pointers.json" "$COMBINED" $CLIENT_LATEST_ARGS
   git -C "$tmp" add -A
   if git -C "$tmp" diff --cached --quiet; then
     echo "[pointers] $label: no change"; rm -rf "$tmp"; return 0

--- a/tools/read_index_compat.py
+++ b/tools/read_index_compat.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Read an index tree's `index-compat.json` and print its `requires` block.
+
+The block declares which client versions a published index snapshot needs:
+
+    { "requires": { "xlings": { "min": "2026.8.4.1" } } }
+
+It is a map of consumer name -> {min, max}. xlings evaluates only the "xlings"
+key and routes clients that do not satisfy it to an older snapshot; every other
+key is carried through untouched for whichever consumer owns it (#476).
+
+Validated here rather than in the client, because a malformed contract should
+stop a publish rather than reach every machine that runs `xlings update`.
+"""
+import json
+import sys
+
+# The pointer this ends up in is fetched on every `xlings update`. A publisher
+# must not be able to make that fetch expensive for everyone.
+MAX_BYTES = 4096
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: read_index_compat.py <index-compat.json>", file=sys.stderr)
+        return 2
+    try:
+        with open(sys.argv[1], encoding="utf-8") as handle:
+            doc = json.load(handle)
+    except Exception as error:  # noqa: BLE001 - any parse failure is fatal here
+        print(f"index-compat.json is not valid JSON: {error}", file=sys.stderr)
+        return 1
+
+    requires = doc.get("requires", {})
+    if not isinstance(requires, dict):
+        print("index-compat.json: `requires` must be an object", file=sys.stderr)
+        return 1
+
+    for consumer, bound in requires.items():
+        if not isinstance(bound, dict):
+            print(f"index-compat.json: requires.{consumer} must be an object",
+                  file=sys.stderr)
+            return 1
+        for key, value in bound.items():
+            if key not in ("min", "max"):
+                # Not fatal for foreign consumers -- xlings does not own their
+                # vocabulary -- but a typo'd bound on OUR key silently means
+                # "no constraint", which is the failure mode worth catching.
+                if consumer == "xlings":
+                    print(f"index-compat.json: requires.xlings.{key} is not a "
+                          f"bound; expected min/max", file=sys.stderr)
+                    return 1
+                continue
+            if not isinstance(value, str) or not value:
+                print(f"index-compat.json: requires.{consumer}.{key} must be a "
+                      f"non-empty string", file=sys.stderr)
+                return 1
+
+    blob = json.dumps(requires, separators=(",", ":"), ensure_ascii=False)
+    if len(blob.encode("utf-8")) > MAX_BYTES:
+        print(f"index-compat.json: `requires` is {len(blob)} bytes, over the "
+              f"{MAX_BYTES} limit", file=sys.stderr)
+        return 1
+
+    print(blob)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Implements #476. Version `2026.8.4.1`.

An index that starts using a capability only newer clients have leaves older ones
hard-failing — `error: unsupported registration node kind 'files'` is the shape
already on record. The mitigation so far is per-recipe capability probing, which
works but puts the burden on every recipe author and only covers what an author
thought of. **This is the infrastructure answer**: the index declares which client
versions it needs, and the client routes itself to the newest snapshot it satisfies.

```
[index] xim: using 20e53c6 instead of e2aad0b
[index]   e2aad0b requires xlings >= 2026.8.4.1, this is 2026.8.2.1
[index]   upgrade to 2026.8.4.1: xlings self update
```

Design: `.agents/docs/2026-08-03-index-snapshot-selection-design.md`
Publisher-facing contract: `docs/design/index-version-contract.md`

## The measurement the whole design rests on

The obvious implementation is `semver::satisfies_expr`. It cannot work, and this
was measured before anything was built:

```
semver::parse("2026.8.3.1")                          → FAIL   (Version is 3 components)
semver::satisfies_expr("2026.8.3.2", ">=2026.8.3.1") → 0      ← wrong
version_order::compare(...)                           → correct
```

The dangerous part is not that it is wrong but *how*: `satisfies_expr` answers
**false** rather than erroring on a version it cannot parse. A contract built on
it would make every client fail every check and report "no compatible snapshot" —
which reads as a publishing problem, not as a parser that does not know the
version scheme. A test pins the measurement so that if semver ever grows four
components, someone revisits this deliberately.

`version_order::compare` (added in `2026.8.3.1`) compares component-wise with
arbitrary arity, and is what the contract uses. semver is **not** extended: it
serves *package* constraints, and changing it would touch every package
resolution path.

## Deliberate departures from the issue's proposal

| # | Decision | Why not the issue's shape |
|---|---|---|
| 1 | Pointer gains **added fields**; `indexes.<name>` keeps `artifact` at top level | `{latest, history}` siblings would make **every released client** reject the pointer — `indexfetch.cppm` hard-requires `artifact` there. A feature for not stranding old clients must not strand them on arrival. |
| 2 | Selectable set = `latest ∪ history` only | An arbitrary version means the client builds a URL with **no sha256 to check it against**, discarding the pinned-by-pointer guarantee. Every history row carries its own hash. |
| 3 | `{min, max}` bare versions, **no range grammar** | Two bounds already are a range. A second grammar beside semver's would drift from it while inheriting the four-component defect. A misread contract takes the whole index away from a class of clients. |
| 4 | `requires` is a **consumer → constraint map** | xlings evaluates only the `xlings` key and carries the rest verbatim. mcpp's need from #476 falls out for free rather than being designed for. |
| 5 | Pin is persistent config, no `update --index-version` | A one-shot pin the next `update` silently reverts is the failure shape this line of work exists to remove. |

## The deadlock, and why P1 and P2 could not ship separately

Routing an old client onto an old snapshot deadlocks it: that snapshot's own
`pkgs/x/xlings.lua` names the `latest` of its era, so `self update` reports the
client is current, exits 0, and it can never reach the version that would let it
return. **Guaranteed by construction, not a race.** Routing without this is worse
than today's hard failure because it is silent.

`self update` runs with `XLINGS_INDEX_PIN=newest`, and the pointer carries
`client_latest` at top level so a routed-back client can still learn a newer one
exists.

## Rollout hazard, found by the tooling and deliberately not acted on

`check_index_compat.py` scans an index tree for constructs needing newer clients
and asserts the declared floor covers them. Run against the real xim-pkgindex it
reports `>= 0.4.52` (spec 2, seven recipes).

**Declaring that floor today would strand those clients**, because the first
publish carries a one-entry history and there is nowhere to route back to. So:
the merge warns, the publisher doc states the order (publish history, let it
accumulate, *then* raise the floor), and **xim-pkgindex gets no
`index-compat.json` in this change**.

## Two real bugs found while building it

- **The success line named the wrong artifact.** A routed run printed
  `using old0001 instead of new0003` and then
  `updated from artifact xim-index-new0003.tar.gz`. That line is what the release
  runbook greps to decide which artifact a run actually used
  (`reference_index_publish_lag`), so reporting the head instead of the snapshot
  that landed broke a diagnostic procedure, not just a log.
- **Retention by recency is wrong.** Contracts change rarely while snapshots are
  produced constantly (313 artifacts, a handful of contracts), so "newest N"
  drops the one generation an old client needs while keeping eight identical ones.

## Validation

- `mcpp build`, `mcpp test`: **33 passed, 0 failed** (10 new contract tests)
- Linux E2E: **62 passed, 0 failed, 0 soft-failed** (E2E-59 is new, 8 scenarios)
- All contract scripts green, including the new `test_index_pointer_history.py`
- CLI parity driver: 229 option spellings executed (up from 214 — the new command
  family is covered automatically)

Every new test verified falsifiable by breaking the thing it guards:

| Reverted to | Result |
|---|---|
| router always takes the newest | routing test red |
| retention by recency only | a whole contract generation unreachable, named in the failure |
| `semver::satisfies_expr` | pinned as a regression test |

## Boundaries

- **Do not merge as part of this task.**
- No `xim-pkgindex` changes — see the rollout hazard above.
- No release publication; version bumped to `2026.8.4.1` only.
- The pointer only starts carrying `history`/`client_latest` once a publish runs
  with this tooling; until then every client behaves exactly as today.
