### PR TITLE
fix(xim): the index marker and `index list` must name the tree on disk (2026.8.4.2)

### DIFF
--- a/docs/design/index-version-contract.md
+++ b/docs/design/index-version-contract.md
@@ -138,6 +138,9 @@ xlings 提供参考实现：`tools/merge_index_pointer.py`（可直接复用，�
 候选为空 → 报错并列出可选集，且不动本地已有索引树
 ```
 
+- `xlings index list` 区分两件事：`*` 是**磁盘上的那棵树**（客户端此刻真正在读的），
+  `>` 是**下次 `update` 会取的那个**。指针移动后、`update` 之前二者不同，
+  `--json` 里对应 `installed` 与 `current` 两个字段。排查"我的包怎么没了"时看 `installed`。
 - 用户可用 `xlings index use <name> <version>` 钉住某个快照；钉子**绕过契约检查**
   （用户明确要求），但**不绕过 sha256 校验**。
 - 钉到 `history` 之外的版本 → 报错，不回退到最新。

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "2026.8.4.1";
+    static constexpr std::string_view VERSION = "2026.8.4.2";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/xim/index_cmd.cppm
+++ b/src/core/xim/index_cmd.cppm
@@ -7,6 +7,7 @@ import xlings.core.home_config;
 import xlings.core.log;
 import xlings.core.version_order;
 import xlings.core.xim.indexfetch;
+import xlings.platform;
 import xlings.runtime;
 
 // `xlings index` — see which index snapshots exist and choose between them.
@@ -25,9 +26,25 @@ struct IndexSourceView {
     bool        hasPointer = false;
     std::string error;                  // set when the pointer could not be read
     std::vector<IndexSnapshot> snapshots;
-    std::string current;                // index_version this client would use
+    std::string current;                // index_version this client would pick NOW
+    std::string installed;              // index_version actually on disk
     bool        truncated = false;
 };
+
+// What the local index tree says it is, from the marker written at swap time.
+// Empty when the index was never fetched as an artifact (git-managed, or not
+// fetched at all) -- absent is a real answer here, not a failure.
+std::string installed_index_version(const std::filesystem::path& repoDir) {
+    std::error_code ec;
+    auto marker = repoDir / ".xlings-index-version";
+    if (!std::filesystem::exists(marker, ec)) return {};
+    try {
+        auto v = platform::read_file_to_string(marker.string());
+        while (!v.empty() && (v.back() == '\n' || v.back() == '\r' || v.back() == ' '))
+            v.pop_back();
+        return v;
+    } catch (...) { return {}; }
+}
 
 // Read every configured index source and resolve what this client would pick.
 // Never throws and never fails the command: a source whose pointer cannot be
@@ -39,6 +56,7 @@ std::vector<IndexSourceView> collect_index_sources() {
         IndexSourceView view;
         view.name = repo.name;
         view.pin  = repo.version;
+        view.installed = installed_index_version(Config::repo_dir_for(repo, false));
 
         auto source = artifact_source_for(repo);
         const auto& pointers = load_index_pointers(Config::mirror(),
@@ -72,6 +90,10 @@ nlohmann::json index_sources_json(const std::vector<IndexSourceView>& views) {
         entry["name"]      = view.name;
         entry["pinned"]    = view.pin;
         entry["current"]   = view.current;
+        // What is on disk, which is not the same question as what would be
+        // picked: between a pointer moving and the next `update`, the two differ
+        // and only this one describes the tree the client is actually reading.
+        entry["installed"] = view.installed;
         entry["truncated"] = view.truncated;
         if (!view.error.empty()) entry["error"] = view.error;
         entry["snapshots"] = nlohmann::json::array();
@@ -80,6 +102,8 @@ nlohmann::json index_sources_json(const std::vector<IndexSourceView>& views) {
             row["index_version"] = s.index_version;
             row["generated_at"]  = s.generated_at;
             row["current"]       = s.index_version == view.current;
+            row["installed"]     = !view.installed.empty()
+                                   && s.index_version == view.installed;
             // Verbatim. Normalising here would make xlings an interpreter of
             // contracts it does not own.
             row["requires"]      = s.requirements;
@@ -124,14 +148,27 @@ int cmd_index_list(const std::string& filter, bool asJson, EventStream& stream) 
                 if (!req->max.empty()) note += (note.empty() ? "" : " ") + std::string("< ") + req->max;
                 note = "  requires xlings " + note;
             }
+            // `*` is the tree on disk -- the packages this client resolves
+            // against right now. `>` is what the next `update` would fetch.
+            // They differ whenever the pointer moved since the last update, and
+            // reporting only the second would answer a question the user did
+            // not ask while looking like it answered theirs.
+            const bool onDisk = !view.installed.empty()
+                                && s.index_version == view.installed;
             log::println("    {} {}{}{}",
-                         s.index_version == view.current ? "*" : " ",
+                         onDisk ? "*" : (s.index_version == view.current ? ">" : " "),
                          s.index_version,
                          s.generated_at.empty() ? "" : "  " + s.generated_at,
                          note);
         }
         if (view.truncated) {
             log::println("      … older snapshots exist but are not listed");
+        }
+        if (view.installed.empty()) {
+            log::println("      (no index on disk yet — run `xlings update`)");
+        } else if (!view.current.empty() && view.current != view.installed) {
+            log::println("      on disk: {} — run `xlings update` to move to {}",
+                         view.installed, view.current);
         }
     }
     log::println("");

--- a/src/core/xim/indexfetch.cppm
+++ b/src/core/xim/indexfetch.cppm
@@ -784,9 +784,16 @@ bool fetch_index_artifact(const std::filesystem::path& destIndexDir,
     }
 
     // Record the installed version for diagnostics / future ETag-style checks.
+    // This is the version of the snapshot that actually lands, NOT the head of
+    // the pointer -- routing (#476) makes those differ, and both readers care:
+    // a human debugging "where did my package go" reads this file, and
+    // get_repo_head_hash() keys the parsed-index cache on it. Writing the head
+    // here would name a tree that is not on disk, and would change on every
+    // publish for a client that keeps landing on the same old snapshot --
+    // rebuilding that client's cache forever.
     {
         std::ofstream v(stage / ".xlings-index-version", std::ios::binary);
-        v << manifest.index_version;
+        v << snapshot.index_version;
     }
 
     auto backup = fs::path(destIndexDir.string() + ".old." +

--- a/tests/e2e/index_version_contract_test.sh
+++ b/tests/e2e/index_version_contract_test.sh
@@ -86,6 +86,7 @@ run() {
     "$XLINGS_BIN" "$@" 2>&1
 }
 landed() { ls "$HOME_DIR/data/xim-pkgindex/pkgs/m/" 2>/dev/null | head -1; }
+marker() { cat "$HOME_DIR/data/xim-pkgindex/.xlings-index-version" 2>/dev/null; }
 
 # ── A: the newest snapshot is within reach ───────────────────────
 write_pointer "" ""
@@ -103,6 +104,11 @@ out="$(run update)" || fail "B: update failed: $out"
 grep -q "new0003" <<<"$out" || fail "B: did not name the snapshot it skipped: $out"
 grep -q "9999.1.1.1" <<<"$out" || fail "B: did not state the requirement: $out"
 grep -qE "self update|upgrade" <<<"$out" || fail "B: did not say how to fix it: $out"
+# The on-disk marker must name the tree that is on disk, not the pointer head.
+# Two readers depend on it: a human debugging a missing package, and
+# get_repo_head_hash(), which keys the parsed-index cache on it.
+[[ "$(marker)" == "mid0002" ]] \
+  || fail "B: version marker says '$(marker)' but the tree is mid0002"
 pass "B: routes back to the newest compatible snapshot and explains why"
 
 # ── C: nothing compatible -> hard error, tree left alone ─────────
@@ -164,6 +170,11 @@ assert rows["new0003"]["current"] is False
 # it does not own.
 assert rows["new0003"]["requires"] == {"xlings": {"min": "9999.1.1.1"}}, \
     rows["new0003"]["requires"]
+# `installed` is the tree on disk; here it agrees with the selection because
+# `update` just ran. Scenario J drives them apart.
+assert xim["installed"] == "mid0002", xim["installed"]
+assert rows["mid0002"]["installed"] is True
+assert rows["new0003"]["installed"] is False
 PYJ
 pass "G: index list reports the routed snapshot, and --json carries the contract"
 
@@ -181,5 +192,63 @@ run update >/dev/null || fail "H: update after unpin failed"
 [[ "$(landed)" == "marker-mid.lua" ]] \
   || fail "H: unpin did not return to automatic routing, got '$(landed)'"
 pass "H: index use pins, refuses unknown versions, and unpins"
+
+# ── I: the head moves, the client still routes to the same snapshot ──
+#
+# The marker is the parsed-index cache key for an artifact-managed index. If it
+# tracked the pointer head, every publish would change the key for a client that
+# keeps landing on the same old tree -- a full index rescan on every update,
+# forever, for exactly the oldest clients.
+run index use xim latest >/dev/null || fail "I: unpin failed"
+build_snapshot new0004 marker-newer
+python3 - "$SERVE" <<'PY'
+import json, pathlib, sys
+serve = pathlib.Path(sys.argv[1])
+def man(v): return json.load(open(serve / f"xim-index-{v}.manifest.json"))
+def entry(v, req):
+    m = man(v)
+    e = {"index_version": m["index_version"], "generated_at": m.get("generated_at", ""),
+         "artifact": m["artifact"]}
+    if req: e["requires"] = {"xlings": {"min": req}}
+    return e
+head = man("new0004")
+head["requires"] = {"xlings": {"min": "9999.1.1.1"}}
+head["history"] = [entry("new0004", "9999.1.1.1"), entry("new0003", "9999.1.1.1"),
+                   entry("mid0002", ""), entry("old0001", "")]
+head["history_truncated"] = False
+json.dump({"format_version": 2, "indexes": {"xim": head},
+           "client_latest": {"xlings": "9999.1.1.1"}},
+          open(serve / "xim-index-pointers.json", "w"), indent=2)
+PY
+run update >/dev/null || fail "I: update after head moved failed"
+[[ "$(landed)" == "marker-mid.lua" ]] \
+  || fail "I: expected to stay on mid0002, got '$(landed)'"
+[[ "$(marker)" == "mid0002" ]] \
+  || fail "I: marker followed the head ('$(marker)') instead of the landed tree"
+pass "I: a moving head does not churn the cache key of a routed-back client"
+
+# ── J: what is on disk, when it differs from what would be picked ──
+#
+# Between a pointer moving and the next `update`, the tree on disk and the
+# snapshot this client would pick are different snapshots. Reporting only the
+# latter answers a question the user did not ask while looking like it answered
+# the one they did.
+write_pointer "" ""            # newest reachable again; disk still holds mid0002
+[[ "$(marker)" == "mid0002" ]] || fail "J: precondition, disk should hold mid0002"
+out="$(run index list xim)"
+grep -qE '^\s*\*\s*mid0002' <<<"$out" || fail "J: did not mark the tree on disk: $out"
+grep -qE '^\s*>\s*new0003' <<<"$out" || fail "J: did not mark what update would fetch: $out"
+grep -q 'xlings update' <<<"$out" || fail "J: did not say the two differ: $out"
+python3 - "$(run index list xim --json)" <<'PYJ'
+import json, sys
+xim = next(e for e in json.loads(sys.argv[1]) if e["name"] == "xim")
+assert xim["installed"] == "mid0002", xim["installed"]
+assert xim["current"] == "new0003", xim["current"]
+PYJ
+run update >/dev/null || fail "J: update failed"
+out="$(run index list xim)"
+grep -qE '^\s*\*\s*new0003' <<<"$out" || fail "J: disk did not follow after update: $out"
+grep -q 'run `xlings update` to move' <<<"$out" && fail "J: still nagging after update: $out"
+pass "J: index list distinguishes the tree on disk from the next selection"
 
 echo "[test] index version contract: all scenarios passed"


### PR DESCRIPTION
## 起因

验证 #476 的"路由死锁能否真正逃出"时，我构造了一个真死锁（客户端 `2026.8.4.1`，head 快照要求 `>= 9999.1.1.1`）。逃逸本身是好的——`self update` 确实够到了被路由挡住的最新快照。但比对"树在哪"和"记录说在哪"时，两者对不上。

## 两个缺陷，同一个根因

#476 引入路由后，**"指针 head"和"客户端实际落地的快照"变成了两个东西**。有两处代码还在把它们当一个。

### 1. `.xlings-index-version` 写的是 head，不是落地快照

`indexfetch.cppm` 在交换时写入 marker，写的是 `manifest.index_version`。路由之前树恒等于 head，所以一直无害；之后就不是了。

两个读者都被误导：

- **人**：查"我的包怎么没了"，这个文件说他在最新快照上，而磁盘上是个旧的。正是本仓库一直在追的"沉默成功"形态。
- **`get_repo_head_hash()`**：拿它当解析索引缓存的 key。head 每次发布都变，于是**持续回退到同一棵旧树的客户端每次 `update` 后都要全量重扫索引**——`repo.cppm:755` 那条注释专门要避免的开销，且只打击最老的那批客户端。

**不是内容错误**：`.xlings-index-cache.json` 与索引树同目录、随原子交换一起被换掉，所以 key 撞了也不会串到另一棵树的缓存。这点实测确认过，不是推断。

### 2. `xlings index list` 报的是预测，不是实况

`current` 由重跑一遍 `choose_snapshot` 得来——"这个客户端*会*选哪个"。指针移动后、下次 `update` 之前，它和磁盘上那棵树是**两个不同的快照**，而命令把 `*` 打在前者、却宣称在描述后者。用户问"我现在用的哪个索引"，得到的是一个对另一个问题的自信回答。

改为 `*` = 磁盘上的树，`>` = 下次 `update` 会取的，二者不同时明说。`--json` **保留 `current`（语义不变，不破坏既有读者）**，新增 `installed`。

第 2 项能报真话，前提是第 1 项已修——在此之前，"磁盘上是哪个"这个答案本身就是 head。

## 测试

E2E-59 加了三个场景，**全部先对已发布的 `2026.8.4.1` 验证为红**：

| | 断言 | 未修版本表现 |
|---|---|---|
| B（增强） | marker 必须命名路由落地的快照 | `says 'new0003' but the tree is mid0002` |
| I（新增） | head 前进而客户端仍落在原快照时，key 不得变 | 同上，key 跟着 head 走 |
| J（新增） | `index list` 区分磁盘实况与下次选择 | 无 `installed` 键；`*` 打在预测上 |

10 个场景全绿；33 个单测二进制全过。

## 版本

`2026.8.4.2`

## 一个仍然成立的限制

线上**至今没有任何索引声明 floor**（`requires: {}`），路由在生产中从未真正触发。上述死锁与分歧状态都是用合成指针构造的——这是 `docs/design/index-version-contract.md` §6 有意安排的顺序（先攒 history 再抬 floor），本 PR 不改变它。
