### PR TITLE
fix(release): guard against the version drifting between config.cppm and mcpp.toml

### DIFF
--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -148,6 +148,7 @@ jobs:
           bash tests/scripts/test_quick_install.sh
           python3 tests/scripts/test_release_candidate_gate.py
           python3 tests/scripts/test_index_pointer_history.py
+          python3 tests/scripts/test_version_consistency.py
           bin=$(find target -path '*/bin/xlings' -type f -perm -111 -exec ls -t {} + | head -1)
           python3 tests/scripts/test_docs_examples.py --xlings "$bin"
           python3 tests/scripts/test_generated_command_reference.py --xlings "$bin"

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlings"
-version = "2026.8.4.1"
+version = "2026.8.4.2"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"

--- a/tests/scripts/test_version_consistency.py
+++ b/tests/scripts/test_version_consistency.py
@@ -1,0 +1,63 @@
+"""The version lives in two files and only one of them is ever read.
+
+`src/core/config.cppm` is what the release workflow reads and what the binary
+reports; `mcpp.toml` is the build manifest. Nothing forces them to agree, so a
+bump touches the first and quietly leaves the second behind -- which is how
+2026.8.4.2 shipped with a manifest still saying 2026.8.4.1.
+
+The drift is harmless the moment it happens and confusing forever after: the
+manifest is what a contributor reads to answer "what version is this tree".
+"""
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _config_version() -> str:
+    text = (ROOT / "src/core/config.cppm").read_text(encoding="utf-8")
+    match = re.search(r'VERSION\s*=\s*"([^"]+)"', text)
+    assert match, "no VERSION in src/core/config.cppm"
+    return match.group(1)
+
+
+def _manifest_version() -> str:
+    text = (ROOT / "mcpp.toml").read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    assert match, "no version in mcpp.toml"
+    return match.group(1)
+
+
+def test_manifest_version_tracks_the_released_version():
+    config, manifest = _config_version(), _manifest_version()
+    assert config == manifest, (
+        f"mcpp.toml says {manifest} but src/core/config.cppm says {config}. "
+        f"The release reads config.cppm, so this drift does not break a build "
+        f"-- it just makes the manifest lie about which tree this is. Bump both."
+    )
+
+
+def test_version_has_four_components_starting_at_one():
+    """YYYY.M.D.N, N starting at 1 -- .0 is reserved for milestone releases."""
+    version = _config_version()
+    parts = version.split(".")
+    assert len(parts) == 4, f"expected YYYY.M.D.N, got {version!r}"
+    assert all(p.isdigit() for p in parts), f"non-numeric component in {version!r}"
+    assert int(parts[3]) >= 1, f"N starts at 1; .0 is reserved ({version!r})"
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"ok   {name}")
+            except AssertionError as error:
+                print(f"FAIL {name}: {error}", file=sys.stderr)
+                failures += 1
+    if failures:
+        raise SystemExit(f"{failures} version-consistency contract(s) failed")
+    print("version consistency: ok")


### PR DESCRIPTION
## 起因

`2026.8.4.2` 发布后做发布后验证时发现：`mcpp.toml` 还停在 `2026.8.4.1`。

发布流程只读 `src/core/config.cppm`，所以漂移**不会**让任何构建或发布失败——它只是让构建清单对"这棵树是哪个版本"说了假话。这是记录在案的**反复发生**的疏漏（`project-release-verification-traps`：「`mcpp.toml` carries a version too and drifts… Bump both」），这次又发生了。

## 改动

与其再小心一次，不如加个守卫：

- `tests/scripts/test_version_consistency.py` — 检查两个文件一致，并检查 `YYYY.M.D.N` 形状且 `N >= 1`（`.0` 保留给里程碑版本）
- 接进 `xlings-ci-linux.yml` 已有的 contract 脚本那一步
- 顺带把 `mcpp.toml` 补到 `2026.8.4.2`

## 验证

- **先对漂移验证为红**：`FAIL … mcpp.toml says 2026.8.4.1 but src/core/config.cppm says 2026.8.4.2`，退出码 1
- 按 **CI 的调用方式**（`python3 <file>`，不是 pytest）独立跑通——这点是刻意确认的：本仓库的 scripts 测试都是直接执行，写成纯 pytest 风格会一条都不收集然后静默通过

不涉及版本号变更（`config.cppm` 保持 `2026.8.4.2`），因此不需要新的 release。