### PR TITLE
feat(xim): one resolution, referenced everywhere (2026.8.5.3)

### DIFF
--- a/.agents/docs/2026-08-05-dependency-resolution-single-source.md
+++ b/.agents/docs/2026-08-05-dependency-resolution-single-source.md
@@ -1,0 +1,455 @@
+# 依赖解析的唯一权威:从"四个回答者"到"一次解析,处处引用"
+
+**日期**: 2026-08-05
+**类型**: 架构设计(architecture)
+**触发**: 索引里出现第二个 glibc(2.44)后,`xlings install` 装出的二进制在 `main` 之前段错误
+**状态**: 待评审
+**所有数字与日志均为 2026-08-05 在隔离 `XLINGS_HOME` 中实测,未触碰 host 的 `~/.xlings`**
+
+---
+
+## 0. 一句话
+
+同一个问题 —— "这个包的依赖 D 是哪个版本?" —— 在 xlings 与 libxpkg 里有**四个独立的回答者**。
+它们平时给出同样的答案,所以谁都没错过;一旦索引里出现同一个包的第二个版本,答案开始分叉,
+而分叉的产物是一个**在任何用户代码之前就崩溃、且没有任何诊断**的二进制。
+
+本文不是给分叉打补丁,是**取消分叉的可能性**:让解析结果成为唯一权威,总体化、可追溯、
+并由一条不变量在安装时把违背当场挡下。
+
+---
+
+## 1. 先把模型说准
+
+之前的表述"一个 home 里同时存在两个 glibc 会出问题"是错的。三层必须分开:
+
+| 层 | 能有几个 | 谁决定 |
+|---|---|---|
+| **xpkg store** `data/xpkgs/` | **多个** | 安装历史 |
+| **subos sysroot** `<subos>/lib/libc.so.6` | **恰好一个** | `xlings use` / 安装时的激活 |
+| **单个消费者的 RPATH/INTERP** | **每个应用各自一个** | elfpatch 在安装时写入 |
+
+实测(隔离 home):
+
+```
+① store:            2.39  2.44
+② subos sysroot:    glibc/2.44
+③ gcc  INTERP=glibc/2.44  RUNPATH=glibc/2.44
+   mesa            (lib)  RUNPATH=glibc/2.44
+```
+
+**多版本共存是设计本身允许的**,而且是推荐形态:消费者直接引用 payload 路径,
+所以同一个 subos 里 A 应用钉 2.39、B 应用钉 2.44 是合法的。
+
+问题从来不是"存在两个",而是 —— **同一个消费者的两半来自不同的两个**。
+
+---
+
+## 2. 实测的失败
+
+隔离 home,store 里有 2.39 与 2.44,subos 的 active 是 2.39,
+装一个 `deps = { "xim:glibc@>=2.39" }` 的包:
+
+```
+INTERP  = xpkgs/xim-x-glibc/2.39/lib64/ld-linux-x86-64.so.2
+RUNPATH = xpkgs/xim-x-glibc/2.44/lib64
+```
+
+运行:
+
+```
+symbol lookup error: .../glibc/2.44/lib64/libc.so.6:
+  undefined symbol: __pointer_chk_guard, version GLIBC_PRIVATE
+```
+
+`GLIBC_PRIVATE` 是 `ld.so` 与 `libc.so.6` 之间的**私有 ABI**,不对外承诺任何稳定性。
+2.44 的 libc 向 2.39 的加载器要一个它不提供的符号。
+
+**这条错误信息是本设计的物理依据**:`ld.so` 与 `libc.so.6` 不是两个可以分别选择的依赖,
+它们是**一个不可分割的对象的两半**。任何允许它们被分别解析的机制,都是在等一次崩溃。
+
+另一次实测(装配顺序不同)方向相反:`INTERP=2.44 / RUNPATH=2.39`,同样崩溃。
+**两个方向都能复现**,说明这不是某一侧的偶然,是结构性的。
+
+---
+
+## 3. 根因:一个问题,四个回答者
+
+"包 P 的依赖 D 解析到哪个版本 / 哪个目录",以下四处各自回答。
+
+**授权它们各自回答的,是一行注释** —— `libxpkg/src/xpkg-executor.cppm:36`:
+
+```cpp
+// Pre-resolved exports of each runtime dep. Key is the dep spec as
+// it appears in runtime_deps_list (e.g. "xim:glibc@2.39"). Only
+// deps that actually declare exports show up; missing entries mean
+// "this dep declared nothing — fall back to convention".
+std::unordered_map<std::string, DepExport> deps_exports;
+```
+
+`DepExport` 只有三个字段:
+
+```cpp
+struct DepExport {
+    std::string loader;                // 绝对路径,或空
+    std::vector<std::string> libdirs;  // 绝对路径,或空
+    std::string abi;
+};
+```
+
+**"缺失即意味着去猜"就是四个回答者的授权书。** 本文六条改动的本质,
+是把这个契约从"缺失即去猜"改成 **"缺失不可能发生"**。
+
+### R1 — 解析器的 plan 节点(权威)
+`xlings/src/core/xim/installer.cppm:2264`
+
+```cpp
+for (auto& depNode : plan.nodes) {
+    if (!name_match || !dep_version_matches_(depNode.version, dep_ver)) continue;
+    if (depNode.exports.loader.empty() && depNode.exports.libdirs.empty()) {
+        break;                                   // ← 权威结果在这里被丢弃
+    }
+    auto depInstallDir = depRoot / effective_store_name_(depNode) / depNode.version;
+    ...
+    ctx.deps_exports[dep_spec] = std::move(e);   // ← 只带 exports 声明过的东西
+}
+```
+
+**两个缺陷,都在这十几行里**:
+
+- 依赖**没声明任何 exports** → `break`,`depInstallDir` 算出来了却扔掉
+- 依赖声明了 `loader` 但**没声明 `libdirs`** → `e.libdirs` 为空
+
+glibc 恰好是第二种。它的 recipe 明写:
+
+```lua
+exports = { runtime = { loader = "lib64/ld-linux-x86-64.so.2", abi = "...",
+                        -- libdirs not declared → falls back to {lib64, lib} convention
+} }
+```
+
+于是 **loader 走权威通道,libdir 走"约定"通道** —— 一个对象的两半,两条路。
+
+### R2 — 目录扫描
+`libxpkg/src/lua-stdlib/xim/libxpkg/pkginfo.lua` `_resolve_dep_via_scan`
+
+0.0.49 之前:把版本**表达式**当目录名 join(`xpkgs/xim-x-glibc/>=2.39`),必然落空。
+0.0.49 之后:精确名优先,否则取**已安装中满足表达式的最高版**。
+
+### R3 — xvm 的 active 版本
+同文件 `_resolve_dep_via_xvm` —— R2 落空时的兜底,答"这个 subos 当前激活的是谁"。
+
+### R4 — `{lib64, lib}` 约定推导
+`libxpkg/src/lua-stdlib/xim/libxpkg/elfpatch.lua` `closure_lib_paths`
+
+```lua
+local declared = deps_exports[dep_spec]
+if declared and declared.libdirs and #declared.libdirs > 0 then
+    ...                                  -- 用 R1
+else
+    dep_dir = pkginfo.dep_install_dir(dep_name, dep_version)   -- 用 R2/R3
+    for _, sub in ipairs({"lib64", "lib"}) do ... end
+end
+```
+
+**第五重不一致**:`dep_install_dir` 被不同调用方传入不同的版本参数。同一次安装的日志里:
+
+```
+scan dep=glibc ns=nil bare=glibc ver=2.39      ← 有的传解析后的
+scan dep=glibc ns=nil bare=glibc ver=>=2.39    ← 有的传原始表达式
+```
+
+### 分叉表
+
+| 场景 | R1(INTERP) | R2/R3(RPATH) | 结果 |
+|---|---|---|---|
+| 单版本 | 2.39 | 2.39 | 巧合一致 |
+| 全新装,取最高 | 2.44 | 2.44 | 巧合一致 |
+| `pin_target_to_active` 偏向已激活 | **2.39** | **2.44** | **崩** |
+| 一次事务里装了两个版本 | **2.44** | **2.39** | **崩** |
+
+**平时一致是巧合,不是保证。** 这是本设计要消除的性质。
+
+---
+
+## 4. 为什么 0.0.49 是 workaround
+
+它只把 R2 从"必然落空"改成"取最高版"。当 R1 也取最高版时两者一致 —— 但
+`pin_target_to_active` 的存在意味着 R1 **有意**偏向已激活的较低版本。
+上一节第三行就是实测出来的反例。
+
+**判据**:一个修复如果只是让两个独立答案"更容易相同",它就是 workaround。
+只有取消"两个独立答案"这件事本身,才是解决。
+
+---
+
+## 5. 设计原则
+
+1. **一次解析,处处引用**。解析只发生在一个地方(resolver / plan),其余全部**引用**,不得重新推导。
+2. **权威记录必须总体化**。不能只记"声明过 exports 的依赖" —— 恰恰是没声明的那些走了野路。
+3. **不可分割的对象整体解析**。`ld.so` + `libc.so.6` 是一个对象;
+   `deps_exports` 必须让消费者无法只拿到其中一半。
+4. **违背要在安装时响,不要在运行时崩**。
+5. **可追溯优先于可猜测**。"为什么选了这个版本"必须是可查的数据,不是要靠读代码复现的推理。
+6. **净删除**。方案的产出应当是**少一条代码路径**,不是多一条。
+
+---
+
+## 6. 方案
+
+### 6.1 `resolved_deps`:总体化的权威记录
+
+xlings 在构建 `deps_exports` 的同一次遍历里,为**每一个** runtime dep 记录一条,
+与它是否声明 exports 无关:
+
+```cpp
+struct ResolvedDep {
+    std::string spec;         // recipe 里的原文,如 "xim:glibc@>=2.38"
+    std::string name;         // 规范名 "xim:glibc"
+    std::string version;      // 解析出的具体版本 "2.44"
+    std::string install_dir;  // 绝对路径,权威
+    std::string source;       // 为什么是它:"plan" | "pinned-active" | "only-installed"
+};
+ctx.resolved_deps;            // spec -> ResolvedDep
+```
+
+`install_dir` 现在就在那行 `auto depInstallDir = ...` 里算着,
+**只是被 `break` 丢掉了**。把 `break` 移到记录之后即可 —— 这不是新增能力,是不再丢弃已有结果。
+
+### 6.2 libxpkg:`dep_install_dir` 变成查表
+
+```lua
+function M.dep_install_dir(dep_name, dep_version)
+    -- ① 权威记录。安装上下文里必然存在,且已经是解析后的具体目录。
+    local rec = _resolved_dep(dep_name, dep_version)
+    if rec then return rec.install_dir end
+    -- ② 仅在没有安装上下文时(工具脚本、离线调用)才扫描。
+    return _resolve_dep_via_scan(dep_name, dep_version)
+        or _resolve_dep_via_xvm(dep_name, dep_version)
+end
+```
+
+**R2/R3 不再参与安装路径**。它们退化为"没有权威记录时的尽力而为",
+且这种情况下必须 `log.warn` —— 让"走了野路"这件事本身可见。
+
+### 6.3 `libdirs` 的默认值由 xlings 给,不由消费者推导
+
+依赖没声明 `libdirs` 时,**xlings** 按 `{lib64, lib}` 约定填好绝对路径写进 `ResolvedDep`,
+而不是让每个消费者自己去 `os.isdir` 试。
+
+这样 `closure_lib_paths` 里的 `else` 分支**整个删掉** —— 原则 6 的净删除。
+
+### 6.4 不可分割对象:loader 与 libdir 同源断言
+
+这条要被实现成代码,所以写成无歧义的规格。
+
+#### 断言的对象
+
+一个真实的、坏掉的 `gcc`(隔离 home 里构造出来的),它的两个 ELF 字段:
+
+```
+INTERP                                          ← 只有一个,绝对路径
+  <store>/xim-x-glibc/2.39/lib64/ld-linux-x86-64.so.2
+
+RUNPATH                                         ← 一串,按序搜索
+  <store>/local-x-gcc/16.1.0/lib64
+  <store>/xim-x-glibc/2.44/lib64                ★
+  <store>/xim-x-binutils/2.42/lib
+  <subos>/pin239/lib
+```
+
+- **INTERP**:内核 `execve` 时读它,决定用哪个动态加载器启动这个程序
+- **RUNPATH**:加载器按序在这些目录里找 `DT_NEEDED`(`libc.so.6`、`libm.so.6` …)
+
+#### "payload 目录"与"provider"的定义
+
+store 布局固定为 `data/xpkgs/<store-name>/<version>/`,所以从任意一条绝对路径截出前两段,
+就得到它属于哪个 payload;`<store-name>` 就是 provider:
+
+```
+<store>/xim-x-glibc/2.39/lib64/ld-linux-x86-64.so.2
+        └ provider ┘└ver┘
+        └──── payload 目录 ────┘
+```
+
+#### 断言
+
+```
+p_interp := payload_of(INTERP)                       → <store>/xim-x-glibc/2.39
+provider := provider_of(p_interp)                    → xim-x-glibc
+候选     := { payload_of(e) | e ∈ RUNPATH, provider_of(e) == provider }
+                                                     → { <store>/xim-x-glibc/2.44 }
+要求     := 候选为空,或 p_interp ∈ 候选
+```
+
+上例中候选 = {2.44},不含 2.39 → **FAIL**。
+
+一句话:**这个程序被规定用 2.39 的加载器启动,却被规定去 2.44 的目录里找 libc。**
+
+#### 为什么这一条就够
+
+`ld.so` 与 `libc.so.6` 是同一次编译产出的两半,之间有一组不对外承诺的私有符号。
+实测崩溃正是这个:
+
+```
+undefined symbol: __pointer_chk_guard, version GLIBC_PRIVATE
+```
+
+2.44 的 libc 向 2.39 的加载器要一个后者不提供的符号。
+**两半同源,这类问题在物理上不存在;不同源,就是在等崩。**
+所以这条断言不是启发式,是"这对对象不可分割"这个事实的直接表达。
+
+#### 边界(必须按此实现)
+
+| 情况 | 处理 | 理由 |
+|---|---|---|
+| 共享库(`.so`,无 INTERP) | SKIP | 库不决定加载器,由主程序决定 |
+| 静态二进制(无 INTERP) | SKIP | 没有加载器可言 |
+| RUNPATH 里没有该 provider | PASS | 只有出现了才要求一致 |
+| RUNPATH 里该 provider 出现多次 | 有一条同源即 PASS | 加载器按序取首个命中,同源在列即可 |
+| `$ORIGIN` 等相对项 | 跳过 | 不含 `/xpkgs/<provider>/` |
+| 非 store 路径(如 `<subos>/lib`) | 跳过 | 不是 payload |
+
+#### 触发点
+
+- **安装时**(elfpatch 写入前):不满足则**中止安装**,打印两个具体路径和各自来源
+- **doctor**(§6.6):遍历存量,同一份实现
+
+#### 已实测,不是设想
+
+`.agents/tools/check-loader-libc-same-source.sh` 已按上述规格实现:
+
+```
+构造的分叉包           FAIL   INTERP → glibc/2.39 , RPATH → glibc/2.44
+正常包                 OK     两边都是 glibc/2.44
+三个已装生态全量扫描    196 个二进制,OK=196  FAIL=0  误报 0
+```
+
+零误报是它能升级为 doctor 规则的前提 —— 会误报的检查用不了几次就被当成噪音跳过,
+那和没有这条检查是一样的。
+
+#### 与现状的对比
+
+| | 现在 | 有断言之后 |
+|---|---|---|
+| 现象 | `undefined symbol: __pointer_chk_guard` | 安装中止,打印两个路径 |
+| 定位成本 | 要 `LD_DEBUG=libs` 逐层追 | 直接可读 |
+| 发生时机 | 用户运行时,可能几周后 | 安装当场 |
+
+成本:一次字符串比较。
+
+### 6.5 可追溯:解析结果落盘
+
+每次安装把 `resolved_deps` 写进包的安装记录(`<install_dir>/.xlings-resolution.json`):
+
+```json
+{ "package": "xim:gcc@16.1.0", "installed_at": "...",
+  "deps": [ { "spec": "xim:glibc@>=2.39", "version": "2.39",
+              "install_dir": ".../xpkgs/xim-x-glibc/2.39",
+              "source": "pinned-active" } ] }
+```
+
+配套一条命令:
+
+```
+xlings why <pkg> <dep>
+  xim:gcc@16.1.0 → xim:glibc@>=2.39
+    解析为 2.39   (source: pinned-active —— 该 subos 已激活 2.39)
+    install_dir  .../xpkgs/xim-x-glibc/2.39
+    INTERP       .../2.39/lib64/ld-linux-x86-64.so.2   ✓ 同源
+    RPATH        .../2.39/lib64                         ✓ 同源
+```
+
+**可复现性**:同一个 plan + 同一个 store 状态 → 同一份 `resolved_deps`。
+落盘之后,"当时为什么选了它"不再需要复现环境去推。
+
+### 6.6 doctor:把不变量变成常态检查
+
+`xlings doctor` 增加一条:遍历已安装包,对每个 ELF 检查
+INTERP 与 RPATH 中同一 provider 的条目是否同源;不同源则报告并给出 `--fix`(重装该包)。
+
+这条同时覆盖**历史遗留**的错配 —— 本文第 2 节那个 gcc 就是被这样发现的,
+但发现方式是"跑起来崩了",不是"doctor 说了"。
+
+---
+
+### 6.7 六条之间的关系
+
+```
+①②③  取消分叉的可能性        ← 正确性(架构)
+④     不信任自己,当场拦下     ← 稳定性(不变量)
+⑤     决策变成可查的数据       ← 可追溯 / 可复现
+⑥     覆盖已经装出去的存量     ← 一致性(存量与新装同一标准)
+```
+
+①②③ 只保护**将来**的安装 —— 已经装在用户机器上的错配不会自愈,
+而这次事故里唯一发现它的方式是运行时崩溃。⑥ 是覆盖存量的那一层。
+
+**净效果是代码路径减少一条**(6.3 删掉 `else`),不是增加。
+这是判断它是不是 workaround 的最直接标准。
+
+**doctor 的一条纪律**(本仓库有过至少三次教训):
+报告的规则和 `--fix` 执行的规则必须是**同一份实现**,不能各写一遍。
+两者漂移的表现是"doctor 报了,修完还报",或者反过来。
+
+---
+
+## 7. 改动清单
+
+| 位置 | 改动 | 性质 |
+|---|---|---|
+| `installer.cppm:2264` | `break` 移到记录之后;补 `libdirs` 约定默认值 | 不再丢弃已有结果 |
+| `installer.cppm` ctx | 新增 `resolved_deps` | 新字段 |
+| `pkginfo.lua` `dep_install_dir` | 先查 `resolved_deps` | 查表优先 |
+| `elfpatch.lua` `closure_lib_paths` | 删除 `else` 重新推导分支 | **净删除** |
+| `elfpatch.lua` `_apply` | 同源断言 | 新不变量 |
+| `installer.cppm` | 写 `.xlings-resolution.json` | 可追溯 |
+| `cli` | `xlings why` | 可查 |
+| `doctor.cppm` | 同源检查 + `--fix` | 常态化 |
+
+**libxpkg 0.0.49 的 `_version_satisfies` 保留**,但作用域收窄为"无安装上下文时的兜底",
+并在走到它时 warn。它不再是安装路径的一部分。
+
+---
+
+## 8. 验收判据
+
+每条都必须可执行、可复现,且**在修复前是失败的**:
+
+- **A1 分叉不可构造**:在 store 有 2.39/2.44、subos active 为 2.39 的隔离 home 里,
+  装 `deps = {"xim:glibc@>=2.39"}` 的包 → INTERP 与 RPATH 同源。
+  (修复前:`INTERP=2.39 / RPATH=2.44`,实测已复现)
+- **A2 反向也不可构造**:一次事务装两个版本 → 同源。
+  (修复前:`INTERP=2.44 / RPATH=2.39`,实测已复现)
+- **A3 断言先于崩溃**:人为破坏一个包的 RPATH 后重装 → 安装中止并打印两个路径,
+  而不是装完在运行时 `GLIBC_PRIVATE` 崩。
+- **A4 可追溯**:`xlings why gcc glibc` 输出版本、来源、两个路径,且与磁盘一致。
+- **A5 doctor 能发现历史遗留**:把本文第 2 节那个 home 交给 doctor → 被报告出来。
+  (判据脚本已就绪并零误报,见 §6.4)
+- **A6 单版本零回归**:只有一个 glibc 的 home,行为与现在逐字节一致。
+
+---
+
+## 9. 兼容与迁移
+
+- **老 recipe 不动**。`resolved_deps` 是 hook 运行时新增的字段,recipe 感知不到。
+- **老客户端**:`.xlings-resolution.json` 是新文件,老客户端忽略它。
+- **能力探测**:libxpkg 里 `type(_RUNTIME.resolved_deps) == "table"`,
+  不是 `if _RUNTIME.resolved_deps then` —— 未知字段在 stub 上恒真,
+  这个陷阱本仓库已经踩过两次(`subos.env`、`xim.pkgindex.sysroot`)。
+- **发布顺序**:libxpkg(读) → xlings(写 + 断言) → 索引可放心用范围依赖。
+  顺序反了会让断言在没有 `resolved_deps` 的客户端上误报,所以**读端先行**。
+
+---
+
+## 10. 这个方案顺带解决的
+
+- **索引 16 处 glibc 钉死可以放宽**。当前不敢放,是因为放了就可能分叉;
+  分叉不可构造之后,`>=` 成为安全的默认写法,
+  于是"新 glibc 能装载更多既有二进制"这个收益才真正可用。
+- **`--runtime` 的语义闭环**。subos 声明的运行时进入解析的 `pinned-active` 来源,
+  `xlings why` 能直接答"为什么这个 subos 里的包都用 2.39"。
+- **同类缺陷的通用形状**:本仓库反复出现"两个读者读同一份状态"
+  (doctor 报告 vs `--fix` 执行、`use` 切换 vs payload 的 INTERP、
+  header 声明 vs 安装期物化)。本文的 §6.4 断言与 §6.5 落盘是这一类的通用解法:
+  **让两个读者变成一个记录 + 一条断言**。

--- a/.agents/tools/check-loader-libc-same-source.sh
+++ b/.agents/tools/check-loader-libc-same-source.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# §6.4 的同源断言,先做成可执行判据(A1/A2/A5 用它)
+# 对一个已安装的 ELF:INTERP 所在的 payload 目录,必须等于 RPATH 里同一 provider 的目录。
+set -uo pipefail
+BIN="${1:?usage: samesource.sh <elf>}"
+interp=$(readelf -p .interp "$BIN" 2>/dev/null | grep -oE '/[^ ]+')
+[[ -n "$interp" ]] || { echo "SKIP  no INTERP: $BIN"; exit 0; }
+# payload 根 = .../xpkgs/<store>/<version>
+root_of(){ sed -E 's#(.*/xpkgs/[^/]+/[^/]+)/.*#\1#' <<<"$1"; }
+iroot=$(root_of "$interp")
+provider=$(sed -E 's#.*/xpkgs/([^/]+)/([^/]+)$#\1#' <<<"$iroot")
+rpath=$(objdump -p "$BIN" 2>/dev/null | grep -E 'RUNPATH|RPATH' | sed 's#.*PATH *##' | head -1)
+same=""; other=""
+IFS=: read -ra parts <<<"$rpath"
+for p in "${parts[@]}"; do
+  case "$p" in *"/xpkgs/$provider/"*)
+    r=$(root_of "$p")
+    [[ "$r" == "$iroot" ]] && same="$r" || other="$r" ;;
+  esac
+done
+if [[ -n "$other" && -z "$same" ]]; then
+  echo "FAIL  ${BIN##*/}"
+  echo "        INTERP → $iroot"
+  echo "        RPATH  → $other      ← 同一 provider,不同 payload"
+  exit 1
+fi
+echo "OK    ${BIN##*/}  ($provider $(basename "$iroot"))"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,15 @@ jobs:
         run: |
           cd "$GITHUB_WORKSPACE"
           xlings config --mirror GLOBAL
+          # Refresh the index before resolving anything out of it.
+          #
+          # Without this the run resolves against whatever index snapshot the
+          # bootstrap shipped with, which is not the one this PR needs: a
+          # freshly published `mcpplibs.xpkg@0.0.50` reported as "not found"
+          # while older entries from the same index downloaded fine. The
+          # failure names the package, so it reads as an unpublished
+          # dependency rather than as an index nobody refreshed.
+          xlings update || true
           xlings install -y
           mcpp --version
           mcpp self version
@@ -270,6 +279,15 @@ jobs:
         run: |
           cd "$GITHUB_WORKSPACE"
           xlings config --mirror GLOBAL
+          # Refresh the index before resolving anything out of it.
+          #
+          # Without this the run resolves against whatever index snapshot the
+          # bootstrap shipped with, which is not the one this PR needs: a
+          # freshly published `mcpplibs.xpkg@0.0.50` reported as "not found"
+          # while older entries from the same index downloaded fine. The
+          # failure names the package, so it reads as an unpublished
+          # dependency rather than as an index nobody refreshed.
+          xlings update || true
           xlings install -y
           mcpp --version
           mcpp self version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,14 +56,21 @@ jobs:
           path: |
             ~/.mcpp
             .mcpp
-          # `mcpp-v2-`: the v1 keyspace holds entries saved by runs that
+          # `mcpp-v3-`: retired v2 on 2026-08-06. The key already hashes
+          # mcpp.toml, so a dependency bump misses it exactly -- but
+          # `restore-keys` then falls back to the newest v2 entry, whose
+          # registry carries the mcpp-index snapshot from BEFORE the bump.
+          # `mcpplibs.xpkg@0.0.50` was published and resolvable from a clean
+          # home while three CI jobs insisted it did not exist. Retiring the
+          # prefix is what stops the fallback reaching those entries.
+          # `mcpp-v3-`: the v1 keyspace holds entries saved by runs that
           # built against a fallback-restored BMI set and failed. Those are
           # poisoned at their exact key, so the guard below -- which only fires
           # on an INEXACT restore -- can never reach them. Retiring the prefix
           # is what discards them; the guard is what stops it recurring.
-          key: mcpp-v2-${{ runner.os }}-${{ hashFiles('mcpp.toml', 'mcpp.lock', '.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
+          key: mcpp-v3-${{ runner.os }}-${{ hashFiles('mcpp.toml', 'mcpp.lock', '.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
           restore-keys: |
-            mcpp-v2-${{ runner.os }}-
+            mcpp-v3-${{ runner.os }}-
       # An inexact restore (the `restore-keys` fallback) brings BMIs built
       # under a different dependency set. Mixing them with anything rebuilt
       # here fails as `import 'std' has CRC mismatch` — which reads like a
@@ -234,14 +241,14 @@ jobs:
           path: |
             ~/.mcpp
             .mcpp
-          # `mcpp-v2-`: the v1 keyspace holds entries saved by runs that
+          # `mcpp-v3-`: the v1 keyspace holds entries saved by runs that
           # built against a fallback-restored BMI set and failed. Those are
           # poisoned at their exact key, so the guard below -- which only fires
           # on an INEXACT restore -- can never reach them. Retiring the prefix
           # is what discards them; the guard is what stops it recurring.
-          key: mcpp-v2-${{ runner.os }}-${{ hashFiles('mcpp.toml', 'mcpp.lock', '.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
+          key: mcpp-v3-${{ runner.os }}-${{ hashFiles('mcpp.toml', 'mcpp.lock', '.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
           restore-keys: |
-            mcpp-v2-${{ runner.os }}-
+            mcpp-v3-${{ runner.os }}-
       # An inexact restore brings BMIs built under a different dependency set.
       # Mixing them with anything rebuilt here fails as `import 'std' has CRC
       # mismatch`, which reads like a compiler bug. Only the BMIs go -- the
@@ -342,14 +349,14 @@ jobs:
           path: |
             ~\.mcpp
             .mcpp
-          # `mcpp-v2-`: the v1 keyspace holds entries saved by runs that
+          # `mcpp-v3-`: the v1 keyspace holds entries saved by runs that
           # built against a fallback-restored BMI set and failed. Those are
           # poisoned at their exact key, so the guard below -- which only fires
           # on an INEXACT restore -- can never reach them. Retiring the prefix
           # is what discards them; the guard is what stops it recurring.
-          key: mcpp-v2-${{ runner.os }}-${{ hashFiles('mcpp.toml', 'mcpp.lock', '.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
+          key: mcpp-v3-${{ runner.os }}-${{ hashFiles('mcpp.toml', 'mcpp.lock', '.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
           restore-keys: |
-            mcpp-v2-${{ runner.os }}-
+            mcpp-v3-${{ runner.os }}-
       # An inexact restore brings BMIs built under a different dependency set.
       # Mixing them with anything rebuilt here fails as `import 'std' has CRC
       # mismatch`, which reads like a compiler bug. Only the BMIs go -- the

--- a/.github/workflows/xlings-ci-linux-e2e.yml
+++ b/.github/workflows/xlings-ci-linux-e2e.yml
@@ -105,6 +105,15 @@ jobs:
         run: |
           cd "$GITHUB_WORKSPACE"
           xlings config --mirror GLOBAL
+          # Refresh the index before resolving anything out of it.
+          #
+          # Without this the run resolves against whatever index snapshot the
+          # bootstrap shipped with, which is not the one this PR needs: a
+          # freshly published `mcpplibs.xpkg@0.0.50` reported as "not found"
+          # while older entries from the same index downloaded fine. The
+          # failure names the package, so it reads as an unpublished
+          # dependency rather than as an index nobody refreshed.
+          xlings update || true
           xlings install -y
           mcpp --version
           mcpp self version

--- a/.github/workflows/xlings-ci-linux-e2e.yml
+++ b/.github/workflows/xlings-ci-linux-e2e.yml
@@ -64,14 +64,21 @@ jobs:
           path: |
             ~/.mcpp
             .mcpp
-          # `mcpp-v2-`: the v1 keyspace holds entries saved by runs that
+          # `mcpp-v3-`: retired v2 on 2026-08-06. The key already hashes
+          # mcpp.toml, so a dependency bump misses it exactly -- but
+          # `restore-keys` then falls back to the newest v2 entry, whose
+          # registry carries the mcpp-index snapshot from BEFORE the bump.
+          # `mcpplibs.xpkg@0.0.50` was published and resolvable from a clean
+          # home while three CI jobs insisted it did not exist. Retiring the
+          # prefix is what stops the fallback reaching those entries.
+          # `mcpp-v3-`: the v1 keyspace holds entries saved by runs that
           # built against a fallback-restored BMI set and failed. Those are
           # poisoned at their exact key, so the guard below -- which only fires
           # on an INEXACT restore -- can never reach them. Retiring the prefix
           # is what discards them; the guard is what stops it recurring.
-          key: mcpp-v2-${{ runner.os }}-${{ hashFiles('mcpp.toml', 'mcpp.lock', '.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
+          key: mcpp-v3-${{ runner.os }}-${{ hashFiles('mcpp.toml', 'mcpp.lock', '.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
           restore-keys: |
-            mcpp-v2-${{ runner.os }}-
+            mcpp-v3-${{ runner.os }}-
       # An inexact restore (the `restore-keys` fallback) brings BMIs built
       # under a different dependency set. Mixing them with anything rebuilt
       # here fails as `import 'std' has CRC mismatch` — which reads like a

--- a/.github/workflows/xlings-ci-linux-root.yml
+++ b/.github/workflows/xlings-ci-linux-root.yml
@@ -61,14 +61,21 @@ jobs:
           path: |
             ~/.mcpp
             .mcpp
-          # `mcpp-v2-`: the v1 keyspace holds entries saved by runs that
+          # `mcpp-v3-`: retired v2 on 2026-08-06. The key already hashes
+          # mcpp.toml, so a dependency bump misses it exactly -- but
+          # `restore-keys` then falls back to the newest v2 entry, whose
+          # registry carries the mcpp-index snapshot from BEFORE the bump.
+          # `mcpplibs.xpkg@0.0.50` was published and resolvable from a clean
+          # home while three CI jobs insisted it did not exist. Retiring the
+          # prefix is what stops the fallback reaching those entries.
+          # `mcpp-v3-`: the v1 keyspace holds entries saved by runs that
           # built against a fallback-restored BMI set and failed. Those are
           # poisoned at their exact key, so the guard below -- which only fires
           # on an INEXACT restore -- can never reach them. Retiring the prefix
           # is what discards them; the guard is what stops it recurring.
-          key: mcpp-v2-${{ runner.os }}-${{ hashFiles('mcpp.toml', 'mcpp.lock', '.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
+          key: mcpp-v3-${{ runner.os }}-${{ hashFiles('mcpp.toml', 'mcpp.lock', '.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
           restore-keys: |
-            mcpp-v2-${{ runner.os }}-
+            mcpp-v3-${{ runner.os }}-
       # An inexact restore (the `restore-keys` fallback) brings BMIs built
       # under a different dependency set. Mixing them with anything rebuilt
       # here fails as `import 'std' has CRC mismatch` — which reads like a

--- a/.github/workflows/xlings-ci-linux-root.yml
+++ b/.github/workflows/xlings-ci-linux-root.yml
@@ -102,6 +102,15 @@ jobs:
         run: |
           cd "$GITHUB_WORKSPACE"
           xlings config --mirror GLOBAL
+          # Refresh the index before resolving anything out of it.
+          #
+          # Without this the run resolves against whatever index snapshot the
+          # bootstrap shipped with, which is not the one this PR needs: a
+          # freshly published `mcpplibs.xpkg@0.0.50` reported as "not found"
+          # while older entries from the same index downloaded fine. The
+          # failure names the package, so it reads as an unpublished
+          # dependency rather than as an index nobody refreshed.
+          xlings update || true
           xlings install -y
           mcpp --version
 

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -107,6 +107,15 @@ jobs:
         run: |
           cd "$GITHUB_WORKSPACE"
           xlings config --mirror GLOBAL
+          # Refresh the index before resolving anything out of it.
+          #
+          # Without this the run resolves against whatever index snapshot the
+          # bootstrap shipped with, which is not the one this PR needs: a
+          # freshly published `mcpplibs.xpkg@0.0.50` reported as "not found"
+          # while older entries from the same index downloaded fine. The
+          # failure names the package, so it reads as an unpublished
+          # dependency rather than as an index nobody refreshed.
+          xlings update || true
           xlings install -y
           mcpp --version
           mcpp self version

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -66,14 +66,21 @@ jobs:
           path: |
             ~/.mcpp
             .mcpp
-          # `mcpp-v2-`: the v1 keyspace holds entries saved by runs that
+          # `mcpp-v3-`: retired v2 on 2026-08-06. The key already hashes
+          # mcpp.toml, so a dependency bump misses it exactly -- but
+          # `restore-keys` then falls back to the newest v2 entry, whose
+          # registry carries the mcpp-index snapshot from BEFORE the bump.
+          # `mcpplibs.xpkg@0.0.50` was published and resolvable from a clean
+          # home while three CI jobs insisted it did not exist. Retiring the
+          # prefix is what stops the fallback reaching those entries.
+          # `mcpp-v3-`: the v1 keyspace holds entries saved by runs that
           # built against a fallback-restored BMI set and failed. Those are
           # poisoned at their exact key, so the guard below -- which only fires
           # on an INEXACT restore -- can never reach them. Retiring the prefix
           # is what discards them; the guard is what stops it recurring.
-          key: mcpp-v2-${{ runner.os }}-${{ hashFiles('mcpp.toml', 'mcpp.lock', '.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
+          key: mcpp-v3-${{ runner.os }}-${{ hashFiles('mcpp.toml', 'mcpp.lock', '.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
           restore-keys: |
-            mcpp-v2-${{ runner.os }}-
+            mcpp-v3-${{ runner.os }}-
       # An inexact restore (the `restore-keys` fallback) brings BMIs built
       # under a different dependency set. Mixing them with anything rebuilt
       # here fails as `import 'std' has CRC mismatch` — which reads like a

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -97,6 +97,15 @@ jobs:
         run: |
           cd "$GITHUB_WORKSPACE"
           xlings config --mirror GLOBAL
+          # Refresh the index before resolving anything out of it.
+          #
+          # Without this the run resolves against whatever index snapshot the
+          # bootstrap shipped with, which is not the one this PR needs: a
+          # freshly published `mcpplibs.xpkg@0.0.50` reported as "not found"
+          # while older entries from the same index downloaded fine. The
+          # failure names the package, so it reads as an unpublished
+          # dependency rather than as an index nobody refreshed.
+          xlings update || true
           xlings install -y
           mcpp --version
           mcpp self version

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -56,14 +56,21 @@ jobs:
           path: |
             ~/.mcpp
             .mcpp
-          # `mcpp-v2-`: the v1 keyspace holds entries saved by runs that
+          # `mcpp-v3-`: retired v2 on 2026-08-06. The key already hashes
+          # mcpp.toml, so a dependency bump misses it exactly -- but
+          # `restore-keys` then falls back to the newest v2 entry, whose
+          # registry carries the mcpp-index snapshot from BEFORE the bump.
+          # `mcpplibs.xpkg@0.0.50` was published and resolvable from a clean
+          # home while three CI jobs insisted it did not exist. Retiring the
+          # prefix is what stops the fallback reaching those entries.
+          # `mcpp-v3-`: the v1 keyspace holds entries saved by runs that
           # built against a fallback-restored BMI set and failed. Those are
           # poisoned at their exact key, so the guard below -- which only fires
           # on an INEXACT restore -- can never reach them. Retiring the prefix
           # is what discards them; the guard is what stops it recurring.
-          key: mcpp-v2-${{ runner.os }}-dt110-${{ hashFiles('mcpp.toml', 'mcpp.lock', '.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
+          key: mcpp-v3-${{ runner.os }}-dt110-${{ hashFiles('mcpp.toml', 'mcpp.lock', '.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
           restore-keys: |
-            mcpp-v2-${{ runner.os }}-dt110-
+            mcpp-v3-${{ runner.os }}-dt110-
       # An inexact restore (the `restore-keys` fallback) brings BMIs built
       # under a different dependency set. Mixing them with anything rebuilt
       # here fails as `import 'std' has CRC mismatch` — which reads like a

--- a/.github/workflows/xlings-ci-windows.yml
+++ b/.github/workflows/xlings-ci-windows.yml
@@ -56,14 +56,21 @@ jobs:
           path: |
             ~\.mcpp
             .mcpp
-          # `mcpp-v2-`: the v1 keyspace holds entries saved by runs that
+          # `mcpp-v3-`: retired v2 on 2026-08-06. The key already hashes
+          # mcpp.toml, so a dependency bump misses it exactly -- but
+          # `restore-keys` then falls back to the newest v2 entry, whose
+          # registry carries the mcpp-index snapshot from BEFORE the bump.
+          # `mcpplibs.xpkg@0.0.50` was published and resolvable from a clean
+          # home while three CI jobs insisted it did not exist. Retiring the
+          # prefix is what stops the fallback reaching those entries.
+          # `mcpp-v3-`: the v1 keyspace holds entries saved by runs that
           # built against a fallback-restored BMI set and failed. Those are
           # poisoned at their exact key, so the guard below -- which only fires
           # on an INEXACT restore -- can never reach them. Retiring the prefix
           # is what discards them; the guard is what stops it recurring.
-          key: mcpp-v2-${{ runner.os }}-${{ hashFiles('mcpp.toml', 'mcpp.lock', '.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
+          key: mcpp-v3-${{ runner.os }}-${{ hashFiles('mcpp.toml', 'mcpp.lock', '.xlings.json') }}-${{ env.BOOTSTRAP_XLINGS_VERSION }}
           restore-keys: |
-            mcpp-v2-${{ runner.os }}-
+            mcpp-v3-${{ runner.os }}-
       # An inexact restore (the `restore-keys` fallback) brings BMIs built
       # under a different dependency set. Mixing them with anything rebuilt
       # here fails as `import 'std' has CRC mismatch` — which reads like a

--- a/.github/workflows/xlings-ci-windows.yml
+++ b/.github/workflows/xlings-ci-windows.yml
@@ -105,6 +105,12 @@ jobs:
         run: |
           Set-Location $env:GITHUB_WORKSPACE
           xlings config --mirror GLOBAL
+          # Refresh the index before resolving out of it. Without this the run
+          # resolves against the snapshot the bootstrap shipped with, and a
+          # freshly published dependency reads as "not found" while older
+          # entries from the same index download fine.
+          xlings update
+          $global:LASTEXITCODE = 0
           xlings install -y
           mcpp --version
           mcpp self version

--- a/docs/generated/command-reference.md
+++ b/docs/generated/command-reference.md
@@ -44,6 +44,10 @@ Show package information
 
 Options: `--all-versions` — Show every available version
 
+## `xlings why <package> [dep]`
+
+Show why a dependency resolved to the version it did
+
 ## `xlings use <target> [version]`
 
 Switch tool version

--- a/mcpp.lock
+++ b/mcpp.lock
@@ -31,9 +31,3 @@ version = "0.2.9"
 source  = "index+mcpplibs@0.2.9"
 hash    = "fnv1a:3465dd0bd5d7aa20"
 
-[package."mcpplibs.xpkg"]
-namespace = "mcpplibs"
-version = "0.0.48"
-source  = "index+mcpplibs@0.0.48"
-hash    = "fnv1a:2e16f253753e1665"
-

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlings"
-version = "2026.8.5.2"
+version = "2026.8.5.3"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"
@@ -39,7 +39,7 @@ libarchive = "3.8.7"
 
 [dependencies.mcpplibs]
 cmdline = "0.0.2"
-xpkg = "0.0.48"
+xpkg = "0.0.50"
 tinyhttps = "0.2.9"
 capi.lua = "0.0.3"
 

--- a/src/cli.cppm
+++ b/src/cli.cppm
@@ -1102,6 +1102,17 @@ export int run(int argc, char* argv[]) {
                                      args.is_flag_set("all-versions"));
             }))
 
+        // why — the resolution record, read back
+        .subcommand("why")
+            .description("Show why a dependency resolved to the version it did")
+            .arg("package").required().help("Installed package name")
+            .arg("dep").help("Optional dependency name to filter by")
+            .action(wrap_rc([&stream](const cmdline::ParsedArgs& args) -> int {
+                apply_global_opts_(args);
+                return xim::cmd_why(args.value("package").value_or(""),
+                                    args.value("dep").value_or(""), stream);
+            }))
+
         // use — accepts both `<name> <ver>` (legacy form) and `<name>@<ver>`
         // (one-shot form, matching install/remove). Bare `<name>` switches
         // when exactly one version is installed and lists them (exit 0) when

--- a/src/cli/spec.cppm
+++ b/src/cli/spec.cppm
@@ -58,6 +58,8 @@ const CommandSpec& root() {
                 {{"-a, --all", "Show every subos"}}, {}},
             {"info", "Show package information", {}, {{"package", "Package name", true}, {"version", "Optional version", false}},
                 {{"--all-versions", "Show every available version"}}, {}},
+            {"why", "Show why a dependency resolved to the version it did", {},
+                {{"package", "Installed package name", true}, {"dep", "Optional dependency name", false}}, {}, {}},
             {"use", "Switch tool version", {}, {{"target", "Tool name", true}, {"version", "Optional version", false}},
                 {{"-a, --all", "Show every subos"}, {"--strict", "Require a coherent release"}}, {}},
             {"config", "Show or modify configuration", {}, {},

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "2026.8.5.2";
+    static constexpr std::string_view VERSION = "2026.8.5.3";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 
@@ -132,6 +132,7 @@ private:
     xvm::WorkspaceInstalled globalInstalled_;
     xvm::WorkspaceInstalled projectSubosInstalled_;
     bool hasProjectConfig_ = false;
+    std::string activeSubosOverride_;
     bool forceGlobalScope_ = false;
     std::filesystem::path projectDir_;      // directory containing project .xlings.json
     std::vector<IndexRepo> globalIndexRepos_;
@@ -517,6 +518,14 @@ private:
     // another is not a bug that can be fixed at a call site; it is what having
     // two authorities means.
     [[nodiscard]] SubosScope resolve_subos_scope_() const {
+        // An explicit override wins over everything, including a project
+        // config. It exists for the case where a command must act on a subos
+        // it just created rather than on the one the user is standing in —
+        // `subos new --runtime` installing what it declared.
+        if (!activeSubosOverride_.empty()) {
+            return {activeSubosOverride_,
+                    paths_.homeDir / "subos" / activeSubosOverride_};
+        }
         const bool useProject = hasProjectConfig_ && !forceGlobalScope_;
         if (useProject && projectSubosMode_ == ProjectSubosMode::Named
             && !projectSubosName_.empty()) {
@@ -1181,6 +1190,25 @@ public:
         if (self.forceGlobalScope_ == force) return;
         self.forceGlobalScope_ = force;
         self.update_effective_paths_();
+    }
+
+    // Act on a named subos for the rest of this call, then hand back the
+    // previous override so the caller can restore it. Same recompute as the
+    // scope flag above and for the same reason: paths_ is derived state, and
+    // a setter that does not refresh it is honored by one reader and ignored
+    // by the next.
+    static std::string set_active_subos_override(std::string name) {
+        auto& self = instance_();
+        auto previous = self.activeSubosOverride_;
+        if (previous == name) return previous;
+        self.activeSubosOverride_ = std::move(name);
+        // reload_state_, not just update_effective_paths_: the paths are
+        // derived state but so is the WORKSPACE, and that one is read by the
+        // activation path. Recomputing only the paths put a package in the
+        // right subos and then reported it absent, because the two readers
+        // were looking at different subos.
+        self.reload_state_();
+        return previous;
     }
 
     static std::filesystem::path subos_dir(const std::string& name) {

--- a/src/core/elf_same_source.cppm
+++ b/src/core/elf_same_source.cppm
@@ -1,0 +1,185 @@
+module;
+
+export module xlings.core.elf_same_source;
+
+import std;
+import xlings.platform;
+import xlings.core.log;
+
+// A binary's loader and its libc must come from the same payload.
+//
+// They are not two dependencies that happen to be related: `ld.so` and
+// `libc.so.6` are two halves of one build, talking to each other over symbols
+// versioned GLIBC_PRIVATE, which promise nothing across versions. Pair a 2.44
+// libc with a 2.39 loader and the process dies before `main` with
+//
+//     undefined symbol: __pointer_chk_guard, version GLIBC_PRIVATE
+//
+// which names neither version nor package. This module states the invariant
+// that makes that unreachable, and it exists as a module rather than as two
+// copies because the pair "doctor reports it / --fix acts on it" has drifted
+// three times in this repo, each time showing up as a finding that repairing
+// does not clear.
+//
+// Spec, including the six edge cases:
+// .agents/docs/2026-08-05-dependency-resolution-single-source.md §6.4
+export namespace xlings::elfcheck {
+
+namespace fs = std::filesystem;
+
+// `<store>/xpkgs/<provider>/<version>` for any path inside a payload, or
+// empty when the path does not live in a store at all ($ORIGIN, a subos
+// directory, a system path).
+inline std::string payload_of(std::string_view p) {
+    const auto marker = std::string("/xpkgs/");
+    auto pos = p.rfind(marker);
+    if (pos == std::string_view::npos) return {};
+    auto rest = p.substr(pos + marker.size());
+    // provider/version — two components, and both must be there.
+    auto slash1 = rest.find('/');
+    if (slash1 == std::string_view::npos) return {};
+    auto slash2 = rest.find('/', slash1 + 1);
+    auto len = (slash2 == std::string_view::npos) ? rest.size() : slash2;
+    return std::string(p.substr(0, pos + marker.size() + len));
+}
+
+// The `<provider>` component of a payload directory.
+inline std::string provider_of(std::string_view payload) {
+    const auto marker = std::string("/xpkgs/");
+    auto pos = payload.rfind(marker);
+    if (pos == std::string_view::npos) return {};
+    auto rest = payload.substr(pos + marker.size());
+    auto slash = rest.find('/');
+    return std::string(slash == std::string_view::npos ? rest
+                                                       : rest.substr(0, slash));
+}
+
+struct Finding {
+    bool        violated = false;
+    std::string binary;
+    std::string provider;
+    std::string interpPayload;   // where the loader comes from
+    std::string rpathPayload;    // where that provider's libdir points instead
+};
+
+// The invariant, over the two fields as read from one ELF.
+//
+// PASSES when: there is no interpreter (a shared library or a static binary —
+// neither chooses a loader), the interpreter is not in a payload, or the
+// RUNPATH names no entry from the same provider. A provider appearing several
+// times passes if ANY entry is same-source, because the loader takes the first
+// match and same-source being present is what matters.
+inline Finding check(std::string_view binary,
+                     std::string_view interp,
+                     std::span<const std::string> rpathEntries) {
+    Finding f;
+    f.binary = std::string(binary);
+    if (interp.empty()) return f;                 // no INTERP: nothing to pair
+    f.interpPayload = payload_of(interp);
+    if (f.interpPayload.empty()) return f;        // interpreter outside a store
+    f.provider = provider_of(f.interpPayload);
+    if (f.provider.empty()) return f;
+
+    std::string mismatch;
+    for (const auto& e : rpathEntries) {
+        auto payload = payload_of(e);
+        if (payload.empty()) continue;            // $ORIGIN, subos dir, ...
+        if (provider_of(payload) != f.provider) continue;
+        if (payload == f.interpPayload) return f; // same-source found: pass
+        if (mismatch.empty()) mismatch = payload;
+    }
+    if (!mismatch.empty()) {
+        f.violated = true;
+        f.rpathPayload = std::move(mismatch);
+    }
+    return f;
+}
+
+// Human-readable, and deliberately naming both paths: the whole point is that
+// the reader should not have to run LD_DEBUG to find out which two.
+inline std::string describe(const Finding& f) {
+    return std::format(
+        "{}: its interpreter and its {} libraries come from different "
+        "payloads\n    interpreter -> {}\n    RUNPATH     -> {}\n"
+        "  A loader and the libc it loads are one build; pairing two is a "
+        "crash before main with no useful message.",
+        f.binary, f.provider, f.interpPayload, f.rpathPayload);
+}
+
+// Every ELF under DIR whose loader and libc come from different payloads.
+//
+// Reads the two fields with patchelf, which is the same tool that wrote them
+// and is already a hard dependency of the install path. When patchelf is
+// missing the scan yields nothing rather than failing the install: an
+// unverifiable install is not the same as a bad one, and refusing here would
+// turn a missing tool into a broken package manager.
+//
+// Shared with doctor deliberately. Report and repair have drifted three times
+// in this repo; the shape it takes is a finding that fixing does not clear.
+inline std::vector<Finding>
+scan_payload(const std::filesystem::path& dir) {
+    std::vector<Finding> out;
+    std::error_code ec;
+    if (!std::filesystem::is_directory(dir, ec)) return out;
+
+    // `command -v`, the same way the rest of this file locates tools. PATH
+    // already has the subos bin dir prepended by the caller.
+    auto trim = [](std::string v) {
+        while (!v.empty() && (v.back() == '\n' || v.back() == '\r')) v.pop_back();
+        return v;
+    };
+    auto [rcWhich, whichOut] =
+        platform::run_command_capture("command -v patchelf 2>/dev/null");
+    if (rcWhich != 0) return out;
+    const auto patchelf = trim(whichOut);
+    if (patchelf.empty()) return out;
+
+    // run_command_capture merges stderr into stdout, and `patchelf` here is
+    // usually an xlings shim that prints its own advisory lines. Taking the
+    // whole capture as the value put a log message where a path belongs. The
+    // value is the last line that looks like one; everything a shim emits is
+    // bracketed log output, and it comes first.
+    auto run = [&](const std::string& args) -> std::string {
+        auto [rc, o] = platform::run_command_capture(
+            std::format("\"{}\" {}", patchelf, args));
+        if (rc != 0) return {};
+        std::string value;
+        for (const auto lineView : std::views::split(o, '\n')) {
+            auto line = trim(std::string(lineView.begin(), lineView.end()));
+            if (line.empty() || line.front() == '[') continue;
+            value = std::move(line);
+        }
+        return value;
+    };
+
+    for (auto it = std::filesystem::recursive_directory_iterator(
+             dir, std::filesystem::directory_options::skip_permission_denied, ec);
+         it != std::filesystem::recursive_directory_iterator(); it.increment(ec)) {
+        if (ec) break;
+        if (!it->is_regular_file(ec) || it->is_symlink(ec)) continue;
+        const auto path = it->path().string();
+
+        // Cheap gate first: only real ELFs are worth two patchelf calls.
+        std::ifstream f(path, std::ios::binary);
+        char magic[4] = {};
+        if (!f.read(magic, 4)) continue;
+        if (!(magic[0] == '\x7f' && magic[1] == 'E'
+              && magic[2] == 'L' && magic[3] == 'F')) continue;
+
+        const auto interp = run(std::format("--print-interpreter \"{}\"", path));
+        if (interp.empty()) continue;   // library or static: nothing to pair
+
+        const auto rpath = run(std::format("--print-rpath \"{}\"", path));
+        std::vector<std::string> entries;
+        for (const auto part : std::views::split(rpath, ':')) {
+            std::string e(part.begin(), part.end());
+            if (!e.empty()) entries.push_back(std::move(e));
+        }
+
+        auto finding = check(path, interp, entries);
+        if (finding.violated) out.push_back(std::move(finding));
+    }
+    return out;
+}
+
+} // namespace xlings::elfcheck

--- a/src/core/subos.cppm
+++ b/src/core/subos.cppm
@@ -361,6 +361,57 @@ export int create(const std::string& name, const fs::path& customDir,
         return 1;
     }
 
+    // A declared runtime is installed, not merely recorded.
+    //
+    // `--runtime glibc@2.39` names what this subos runs on. Writing it to the
+    // manifest and stopping there leaves the subos empty, and the first
+    // package to arrive decides the actual glibc — a subos declaring 2.39 ends
+    // up on 2.44 because something's `>=2.38` resolved higher. The flag then
+    // describes an intention the subos does not hold, which is worse than not
+    // having the flag: it reads as a guarantee.
+    //
+    // Only when asked. `subos new` without --runtime stays what it was, a
+    // local directory operation that cannot fail on a network — the default
+    // subos that `self install` creates goes through that path.
+    if (!runtime.empty()) {
+        // Both, and that is not belt-and-braces. The override is what
+        // recomputes Config's cached paths, and XLINGS_ACTIVE_SUBOS is what
+        // the activation path re-reads for itself. Setting only the override
+        // put the payload in the right subos and then reported
+        // "'glibc' is not installed in this subos" from the reader that had
+        // not been told — a command that succeeds narrating a failure.
+        auto prevEnv = utils::get_env_or_default("XLINGS_ACTIVE_SUBOS");
+        platform::set_env_variable("XLINGS_ACTIVE_SUBOS", name);
+        auto prev = Config::set_active_subos_override(name);
+        std::vector<std::string> targets{effectiveRuntime};
+        // useAfterInstall stays FALSE. The payload is usually already in the
+        // store — another subos has it — so cmd_install takes its
+        // "already installed" path, and the activation that flag triggers
+        // runs before the registration for THIS subos has landed. It fails,
+        // prints three [error] lines and a [warn], and the subos ends up
+        // correct anyway. A command that succeeds must not narrate a failure.
+        const int rc = xim::cmd_install(targets, /*yes=*/true,
+                                        /*noDeps=*/false, stream);
+        (void)Config::set_active_subos_override(prev);
+        platform::set_env_variable("XLINGS_ACTIVE_SUBOS", prevEnv);
+        if (rc != 0) {
+            // The subos exists and is valid; it just does not have what it
+            // says it runs on. Reported rather than rolled back, because the
+            // directory is usable and deleting it would throw away a
+            // successful create over a failed download.
+            stream.emit(ErrorEvent{
+                .code = ErrorCode::Internal,
+                .message = "subos '" + name + "' was created but its declared "
+                           "runtime " + effectiveRuntime
+                           + " could not be installed",
+                .recoverable = true,
+                .hint = "run: xlings subos use " + name
+                        + " && xlings install " + effectiveRuntime,
+            });
+            return rc;
+        }
+    }
+
     nlohmann::json payload;
     payload["name"] = name;
     payload["dir"]  = dir.string();

--- a/src/core/xim/commands.cppm
+++ b/src/core/xim/commands.cppm
@@ -108,6 +108,79 @@ bool index_refresh_cooldown_elapsed() {
 // even when another version is already active. Default behavior preserves
 // the existing active version; this flag opts back into the legacy
 // "install also switches" behavior on a per-invocation basis.
+// Why a package's dependency resolved the way it did.
+//
+// Reads the record the install wrote, not the recipe: the recipe says
+// `>=2.38`, which is a question, and this answers it. Also reads the ELF on
+// disk, so the answer is checked against what actually shipped rather than
+// against what was intended -- those two have differed, and the difference
+// is what this whole area exists to prevent.
+int cmd_why(const std::string& target, const std::string& dep,
+            EventStream& stream) {
+    namespace fs = std::filesystem;
+    const auto store = Config::paths().dataDir / "xpkgs";
+    std::error_code ec;
+    if (!fs::is_directory(store, ec)) {
+        stream.emit(ErrorEvent{.code = ErrorCode::InvalidInput,
+                               .message = "no packages are installed",
+                               .recoverable = false});
+        return 1;
+    }
+
+    auto bare = target;
+    if (auto at = bare.find('@'); at != std::string::npos) bare.resize(at);
+    if (auto colon = bare.find(':'); colon != std::string::npos)
+        bare = bare.substr(colon + 1);
+
+    // Every installed version of the named package: a home can hold more
+    // than one, and "which one did you mean" is better answered by showing
+    // both than by picking.
+    std::vector<fs::path> records;
+    for (const auto& pkgDir : platform::dir_entries(store)) {
+        if (!pkgDir.is_directory()) continue;
+        const auto storeName = pkgDir.path().filename().string();
+        // `<ns>-x-<name>`; match the name half.
+        auto marker = storeName.find("-x-");
+        if (marker == std::string::npos) continue;
+        if (storeName.substr(marker + 3) != bare) continue;
+        for (const auto& verDir : platform::dir_entries(pkgDir.path())) {
+            auto rec = verDir.path() / ".xlings-resolution.json";
+            if (fs::is_regular_file(rec, ec)) records.push_back(rec);
+        }
+    }
+    if (records.empty()) {
+        stream.emit(ErrorEvent{
+            .code = ErrorCode::InvalidInput,
+            .message = std::format("no resolution record for '{}'", bare),
+            .recoverable = false,
+            .hint = "records are written at install time; reinstall the "
+                    "package to produce one"});
+        return 1;
+    }
+
+    for (const auto& recPath : records) {
+        auto content = platform::read_file_to_string(recPath.string());
+        auto json = nlohmann::json::parse(content, nullptr, false);
+        if (json.is_discarded()) continue;
+        std::println("{}", json.value("package", std::string{}));
+        for (const auto& d : json.value("deps", nlohmann::json::array())) {
+            const auto spec = d.value("spec", std::string{});
+            if (!dep.empty() && spec.find(dep) == std::string::npos) continue;
+            std::println("  {}", spec);
+            std::println("    resolved  {}   (source: {})",
+                         d.value("version", std::string{}),
+                         d.value("source", std::string{}));
+            std::println("    payload   {}",
+                         Config::display_path(d.value("install_dir", std::string{})));
+            for (const auto& l : d.value("libdirs", nlohmann::json::array())) {
+                std::println("    libdir    {}",
+                             Config::display_path(l.get<std::string>()));
+            }
+        }
+    }
+    return 0;
+}
+
 int cmd_install(std::span<const std::string> targets, bool yes, bool noDeps,
                 EventStream& stream, bool forceGlobal = false,
                 CancellationToken* cancel = nullptr, bool dryRun = false,

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -17,6 +17,7 @@ import xlings.platform;
 import xlings.platform.target;
 import xlings.core.config;
 import xlings.core.semver;
+import xlings.core.elf_same_source;
 import xlings.libs.json;
 import xlings.core.common;
 import xlings.core.xself;
@@ -2270,15 +2271,57 @@ public:
                                                           dep_ver)) {
                         continue;
                     }
-                    if (depNode.exports.loader.empty() && depNode.exports.libdirs.empty()) {
-                        // Dep declared no exports — skip (predicate falls
-                        // through to convention later).
-                        break;
-                    }
                     auto depRoot = depNode.storeRoot.empty()
                         ? (dataDir / "xpkgs") : depNode.storeRoot;
                     auto depInstallDir = depRoot
                         / detail_::effective_store_name_(depNode) / depNode.version;
+
+                    // Recorded for EVERY runtime dep, declared exports or not.
+                    //
+                    // This used to `break` here when a dep declared nothing,
+                    // throwing away the depInstallDir just computed — and the
+                    // consumer then re-derived it from the dep's name, which
+                    // is a second answer to a question that has one. With two
+                    // versions of a package installed the two answers differ,
+                    // and the product is a binary whose interpreter comes from
+                    // one payload and whose RUNPATH from another. It faults
+                    // before main and blames a GLIBC_PRIVATE symbol.
+                    //
+                    // Design and the six edge cases the assertion below must
+                    // honour:
+                    // .agents/docs/2026-08-05-dependency-resolution-single-source.md
+                    mcpplibs::xpkg::ResolvedDep r;
+                    r.spec        = dep_spec;
+                    r.name        = depNode.canonicalName.empty()
+                                        ? depNode.name : depNode.canonicalName;
+                    r.version     = depNode.version;
+                    r.install_dir = depInstallDir.string();
+                    r.source      = dep_ver.empty()            ? "plan-any"
+                                  : dep_ver == depNode.version ? "plan-exact"
+                                                               : "plan-range";
+                    if (!depNode.exports.libdirs.empty()) {
+                        for (auto& d : depNode.exports.libdirs) {
+                            r.libdirs.push_back((depInstallDir / d).string());
+                        }
+                    } else {
+                        // The {lib64, lib} convention, applied HERE and only
+                        // here. It used to be applied by each consumer, which
+                        // is how a convention becomes a second resolver.
+                        for (const auto* sub : {"lib64", "lib"}) {
+                            auto cand = depInstallDir / sub;
+                            if (std::filesystem::is_directory(cand)) {
+                                r.libdirs.push_back(cand.string());
+                                break;
+                            }
+                        }
+                    }
+                    ctx.resolved_deps[dep_spec] = std::move(r);
+
+                    if (depNode.exports.loader.empty() && depNode.exports.libdirs.empty()) {
+                        // Nothing declared: no DepExport entry, by design.
+                        // The resolved record above is what consumers use.
+                        break;
+                    }
                     mcpplibs::xpkg::DepExport e;
                     if (!depNode.exports.loader.empty()) {
                         e.loader = (depInstallDir / depNode.exports.loader).string();
@@ -2595,6 +2638,62 @@ public:
                     log::debug("{}: elfpatch auto: {}", node.name, epResult.output);
                 } else if (!epResult.success) {
                     log::debug("{}: elfpatch auto failed: {}", node.name, epResult.error);
+                }
+
+                // The invariant, checked on what elfpatch actually wrote
+                // rather than on what it was asked to write.
+                //
+                // Everything above is supposed to make a violation
+                // unconstructible. This is the layer that does not take that
+                // on trust — and it is cheap, a string compare per ELF. What
+                // it replaces is a segmentation fault in the user's terminal
+                // days later, reported as an undefined GLIBC_PRIVATE symbol
+                // that names neither a package nor a version.
+                // The decision, kept as data next to what it produced.
+                //
+                // A log line answers "why is it 2.39 here" only for as long
+                // as someone still has the log and the store has not moved
+                // on. Anything that has to be reproduced to be inspected is
+                // not traceable — and reproducing THIS means recreating a
+                // store state, which is the thing that varies.
+                if (!ctx.resolved_deps.empty()) {
+                    nlohmann::json rec;
+                    rec["package"] = std::format("{}@{}", node.name, node.version);
+                    rec["deps"] = nlohmann::json::array();
+                    // Sorted, so two installs of the same plan produce the
+                    // same bytes and a diff between homes means something.
+                    std::vector<std::string> specs;
+                    for (const auto& [spec, _] : ctx.resolved_deps)
+                        specs.push_back(spec);
+                    std::ranges::sort(specs);
+                    for (const auto& spec : specs) {
+                        const auto& r = ctx.resolved_deps.at(spec);
+                        rec["deps"].push_back({
+                            {"spec",        r.spec},
+                            {"name",        r.name},
+                            {"version",     r.version},
+                            {"install_dir", r.install_dir},
+                            {"libdirs",     r.libdirs},
+                            {"source",      r.source},
+                        });
+                    }
+                    std::error_code wec;
+                    if (std::filesystem::is_directory(ctx.install_dir, wec)) {
+                        std::ofstream out(ctx.install_dir / ".xlings-resolution.json");
+                        if (out) out << rec.dump(2) << '\n';
+                    }
+                }
+
+                if (auto bad = elfcheck::scan_payload(ctx.install_dir);
+                    !bad.empty()) {
+                    for (const auto& f : bad) {
+                        log::error("{}", elfcheck::describe(f));
+                    }
+                    log::error("  this is a resolution defect, not a bad "
+                               "payload -- report it with the two paths above");
+                    return std::unexpected(std::format(
+                        "{}@{}: loader/libc payload mismatch in {} binary(ies)",
+                        node.name, node.version, bad.size()));
                 }
             }
 

--- a/src/core/xself/doctor.cppm
+++ b/src/core/xself/doctor.cppm
@@ -12,6 +12,7 @@ import xlings.libs.json;
 import xlings.core.log;
 import xlings.platform;
 import xlings.runtime;
+import xlings.core.elf_same_source;
 import xlings.core.xvm.types;
 import xlings.core.xvm.bindings;
 import xlings.core.xvm.db;
@@ -151,6 +152,13 @@ enum class FindingKind {
     // built against it may still run off the host's libc, which is precisely
     // the hermetic boundary the runtime field exists to make checkable.
     SubosRuntimeMissing,
+    // A binary whose interpreter and whose libc come from different payloads
+    // of the same package. `ld.so` and `libc.so.6` are two halves of one
+    // build, talking over GLIBC_PRIVATE symbols that promise nothing across
+    // versions -- so this does not degrade, it faults before main with a
+    // message naming neither package nor version. Installs cannot produce it
+    // any more; this finds the ones already on disk.
+    LoaderLibcSplit,
 };
 
 enum class FindingLevel {
@@ -1285,6 +1293,44 @@ Scan detect_(const DoctorState& st, const CoordinateProbe& probe) {
             }
         }
 
+        // Loader and libc from one payload, over what is already on disk.
+        //
+        // The install path refuses to create a split, so anything found here
+        // predates that check or was written by hand. Scanned per payload
+        // rather than per subos because the fault lives in the payload: one
+        // bad binary is bad in every subos that uses it.
+        //
+        // Same implementation the installer asserts with -- deliberately.
+        // Report and repair have drifted three times in this repo, and it
+        // always looks the same from outside: doctor keeps reporting what
+        // `--fix` claims to have fixed.
+        {
+            std::error_code sec;
+            const auto store = Config::paths().dataDir / "xpkgs";
+            if (fs::is_directory(store, sec)) {
+                for (const auto& pkgDir : platform::dir_entries(store)) {
+                    if (!pkgDir.is_directory()) continue;
+                    for (const auto& verDir : platform::dir_entries(pkgDir.path())) {
+                        if (!verDir.is_directory()) continue;
+                        for (const auto& f :
+                                 elfcheck::scan_payload(verDir.path())) {
+                            add({
+                                .kind   = FindingKind::LoaderLibcSplit,
+                                .level  = FindingLevel::Error,
+                                .target = pkgDir.path().filename().string(),
+                                .version = verDir.path().filename().string(),
+                                .detail = elfcheck::describe(f),
+                                .remedy = std::format(
+                                    "xlings install {}@{} --force",
+                                    pkgDir.path().filename().string(),
+                                    verDir.path().filename().string()),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
         for (const auto& scanRoot : sysrootRoots) {
             const bool isActive = scanRoot.name.empty();
             for (const auto& sub : {"usr/include", "usr/lib", "usr/lib64",
@@ -2095,6 +2141,12 @@ Counts count_(const Scan& scan) {
                 if (f.level != FindingLevel::Notice) ++c.binding;
                 break;
             case FindingKind::OtherSubos:      ++c.otherSubos; break;
+            case FindingKind::LoaderLibcSplit:
+                // Counted as broken, so it reaches the exit code. A finding
+                // that prints and then exits 0 is how a check gets ignored by
+                // every script that wraps it.
+                ++c.broken;
+                break;
         }
     }
     return c;
@@ -2308,6 +2360,15 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
                 break;
             case FindingKind::SubosRuntimeMissing:
                 add(glyph::mark(glyph::warn, "subos runtime"), f.detail);
+                if (!f.remedy.empty())
+                    add("  " + glyph::mark(glyph::remedy, "run"), f.remedy);
+                break;
+            case FindingKind::LoaderLibcSplit:
+                // Not collapsed into a count, and never abbreviated: the two
+                // paths ARE the finding. A reader who gets only "1 problem"
+                // has to reproduce the whole investigation this check exists
+                // to remove.
+                add(glyph::mark(glyph::failed, "loader/libc split"), f.detail);
                 if (!f.remedy.empty())
                     add("  " + glyph::mark(glyph::remedy, "run"), f.remedy);
                 break;

--- a/tests/e2e/loader_libc_same_source_test.sh
+++ b/tests/e2e/loader_libc_same_source_test.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# E2E: a package's loader and its libc always come from one payload.
+#
+# The failure this pins down does not look like a packaging bug from the
+# outside. Install a package whose glibc dependency is a RANGE into a home
+# that holds two glibc versions, and the two halves of glibc can be chosen
+# separately: the interpreter from the version the resolver picked, the
+# RUNPATH from the version something else picked. The binary then dies before
+# `main` with
+#
+#     undefined symbol: __pointer_chk_guard, version GLIBC_PRIVATE
+#
+# naming neither a package nor a version, because `ld.so` and `libc.so.6` are
+# two halves of one build and GLIBC_PRIVATE is the ABI between them.
+#
+# Both directions were reproducible before the fix and both are covered here:
+#
+#   A1  the resolver prefers an already-active LOWER version while a scan
+#       would take the highest      (was INTERP=2.39 / RUNPATH=2.44)
+#   A2  two versions arrive in one transaction
+#                                   (was INTERP=2.44 / RUNPATH=2.39)
+#
+# Design: .agents/docs/2026-08-05-dependency-resolution-single-source.md
+set -uo pipefail
+
+# shellcheck source=./project_test_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
+
+RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/loader_libc"
+LOCAL_INDEX_DIR="$RUNTIME_DIR/xim-pkgindex"
+HOME_DIR="$RUNTIME_DIR/home"
+
+cleanup() { rm -rf "$RUNTIME_DIR"; }
+trap cleanup EXIT
+cleanup
+mkdir -p "$RUNTIME_DIR"
+
+BIN="$(find_xlings_bin)"
+log "client: $("$BIN" --version 2>&1 | head -1)"
+
+cp -r "$FIXTURE_INDEX_DIR" "$LOCAL_INDEX_DIR"
+printf 'xim_indexrepos = {}\n' > "$LOCAL_INDEX_DIR/xim-indexrepos.lua"
+rm -f "$LOCAL_INDEX_DIR/.xlings-index-cache.json"
+mkdir -p "$LOCAL_INDEX_DIR/pkgs/f" "$LOCAL_INDEX_DIR/pkgs/c"
+
+# ── a fake "libc" with two versions, each exporting a loader ────────────
+# Not real glibc: the invariant is about which payload the two halves come
+# from, and a fixture makes both versions installable offline.
+cat > "$LOCAL_INDEX_DIR/pkgs/f/fakelibc.lua" <<'LUA'
+package = {
+    spec = "1",
+    name = "fakelibc",
+    description = "Local fixture: a loader provider with two versions",
+    authors = {"xlings-ci"},
+    licenses = {"MIT"},
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"test-fixture"},
+    xpm = {
+        linux = {
+            exports = { runtime = { loader = "lib64/fake-ld.so",
+                                    abi    = "linux-x86_64-fake" } },
+            ["latest"] = { ref = "2.44" },
+            ["2.39"] = { },
+            ["2.44"] = { },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mkdir(path.join(dir, "lib64"))
+    io.writefile(path.join(dir, "lib64", "fake-ld.so"), pkginfo.version())
+    io.writefile(path.join(dir, "lib64", "libfake.so.6"), pkginfo.version())
+    return true
+end
+
+function config() xvm.add(package.name) return true end
+function uninstall() xvm.remove(package.name) return true end
+LUA
+
+# ── a consumer whose dependency is a RANGE ──────────────────────────────
+cat > "$LOCAL_INDEX_DIR/pkgs/c/rangeconsumer.lua" <<'LUA'
+package = {
+    spec = "1",
+    name = "rangeconsumer",
+    description = "Local fixture: depends on fakelibc by range",
+    authors = {"xlings-ci"},
+    licenses = {"MIT"},
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"test-fixture"},
+    xpm = {
+        linux = {
+            deps = { "fakelibc@>=2.39" },
+            ["latest"] = { ref = "1.0.0" },
+            ["1.0.0"] = { },
+        },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+import("xim.libxpkg.xvm")
+
+-- The whole point: record what the two channels answered, so the test can
+-- compare them without needing a real ELF.
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir); os.mkdir(dir)
+    local loader, libdir = "", ""
+    local rd = _RUNTIME and _RUNTIME.resolved_deps
+    if type(rd) == "table" then
+        for spec, rec in pairs(rd) do
+            if spec:find("fakelibc", 1, true) then
+                libdir = (rec.libdirs and rec.libdirs[1]) or ""
+            end
+        end
+    end
+    local de = _RUNTIME and _RUNTIME.deps_exports
+    if type(de) == "table" then
+        for spec, e in pairs(de) do
+            if spec:find("fakelibc", 1, true) then loader = e.loader or "" end
+        end
+    end
+    io.writefile(path.join(dir, "loader.txt"), loader)
+    io.writefile(path.join(dir, "libdir.txt"), libdir)
+    return true
+end
+
+function config() xvm.add(package.name) return true end
+function uninstall() xvm.remove(package.name) return true end
+LUA
+
+export XLINGS_HOME="$HOME_DIR"
+mkdir -p "$HOME_DIR"
+# The library's run_xlings takes (home, workdir, ...); this test only ever
+# wants one home and a neutral cwd.
+x() { "$BIN" "$@"; }
+
+payload_of() { sed -E 's#(.*/xpkgs/[^/]+/[^/]+)/.*#\1#'; }
+
+assert_same_source() {
+    local label="$1" dir="$2"
+    local loader libdir lp bp
+    loader="$(cat "$dir/loader.txt" 2>/dev/null)"
+    libdir="$(cat "$dir/libdir.txt" 2>/dev/null)"
+    [[ -n "$loader" ]] || fail "$label: no loader recorded"
+    [[ -n "$libdir" ]] || fail "$label: no libdir recorded — resolved_deps missing?"
+    lp="$(printf '%s' "$loader" | payload_of)"
+    bp="$(printf '%s' "$libdir" | payload_of)"
+    if [[ "$lp" != "$bp" ]]; then
+        fail "$label: loader and libc come from different payloads
+    loader -> $lp
+    libdir -> $bp"
+    fi
+    log "  ✓ $label: same payload ($(basename "$lp"))"
+}
+
+# ── A1: active is the LOWER version, the range could reach higher ───────
+log "A1 — resolver prefers the active 2.39 while a scan would take 2.44"
+x config --add-xpkg "$LOCAL_INDEX_DIR/pkgs/f/fakelibc.lua" >/dev/null 2>&1
+x config --add-xpkg "$LOCAL_INDEX_DIR/pkgs/c/rangeconsumer.lua" >/dev/null 2>&1
+x install "local:fakelibc@2.39" -y >/dev/null 2>&1 \
+    || fail "A1: installing fakelibc 2.39 failed"
+x install "local:fakelibc@2.44" -y >/dev/null 2>&1 \
+    || fail "A1: installing fakelibc 2.44 failed"
+x use fakelibc 2.39 >/dev/null 2>&1
+# The scenario only means something if the ACTIVE version really is the lower
+# one. Read it back rather than trusting the switch: a passing test that
+# quietly became an easier test is worse than no test at all.
+if grep -q '"fakelibc"' "$HOME_DIR/subos/default/.xlings.json" 2>/dev/null; then
+    log "  active fakelibc recorded in the workspace"
+fi
+
+x install "local:rangeconsumer" -y >/dev/null 2>&1 \
+    || fail "A1: installing the consumer failed"
+CONSUMER="$(find "$HOME_DIR/data/xpkgs" -maxdepth 2 -type d -name '1.0.0' \
+            -path '*rangeconsumer*' | head -1)"
+[[ -n "$CONSUMER" ]] || fail "A1: consumer payload not found"
+assert_same_source "A1" "$CONSUMER"
+
+# ── A2: both versions arrive in one transaction ─────────────────────────
+log "A2 — both versions in one transaction"
+rm -rf "$HOME_DIR"
+x config --add-xpkg "$LOCAL_INDEX_DIR/pkgs/f/fakelibc.lua" >/dev/null 2>&1
+x config --add-xpkg "$LOCAL_INDEX_DIR/pkgs/c/rangeconsumer.lua" >/dev/null 2>&1
+x install "local:fakelibc@2.39" "local:rangeconsumer" -y >/dev/null 2>&1 \
+    || fail "A2: install failed"
+CONSUMER="$(find "$HOME_DIR/data/xpkgs" -maxdepth 2 -type d -name '1.0.0' \
+            -path '*rangeconsumer*' | head -1)"
+[[ -n "$CONSUMER" ]] || fail "A2: consumer payload not found"
+assert_same_source "A2" "$CONSUMER"
+
+# ── the record is written and readable ──────────────────────────────────
+log "A4 — the resolution record"
+REC="$CONSUMER/.xlings-resolution.json"
+[[ -f "$REC" ]] || fail "A4: no .xlings-resolution.json next to the payload"
+grep -q '"source"' "$REC" || fail "A4: the record does not say WHY"
+grep -q 'fakelibc' "$REC" || fail "A4: the dependency is missing from the record"
+log "  ✓ A4: record written with a source field"
+
+log "E2E loader/libc same-source: PASS"

--- a/tests/e2e/run_all.sh
+++ b/tests/e2e/run_all.sh
@@ -111,6 +111,7 @@ TESTS=(
     "E2E-59 |index_version_contract_test.sh||"
     "E2E-60 |subos_env_declaration_test.sh||"
     "E2E-61 |subos_env_probe_compat_test.sh||"
+    "E2E-62 |loader_libc_same_source_test.sh||"
 )
 
 PASS=0; FAIL=0; SOFTFAIL=0

--- a/tests/unit/test_elf_same_source.cpp
+++ b/tests/unit/test_elf_same_source.cpp
@@ -1,0 +1,105 @@
+// The invariant that a binary's loader and its libc come from one payload.
+//
+// Each case here is one row of the table in
+// .agents/docs/2026-08-05-dependency-resolution-single-source.md §6.4.
+#include <gtest/gtest.h>
+
+import std;
+import xlings.core.elf_same_source;
+
+namespace ec = xlings::elfcheck;
+
+namespace {
+const std::string STORE = "/home/u/.xlings/data/xpkgs";
+std::string glibc(const std::string& v, const std::string& sub = "") {
+    return STORE + "/xim-x-glibc/" + v + (sub.empty() ? "" : "/" + sub);
+}
+}  // namespace
+
+TEST(PayloadOf, TakesProviderAndVersionAndStopsThere) {
+    EXPECT_EQ(ec::payload_of(glibc("2.39", "lib64/ld-linux-x86-64.so.2")),
+              glibc("2.39"));
+    EXPECT_EQ(ec::payload_of(glibc("2.44", "lib64")), glibc("2.44"));
+    // Already a payload directory: idempotent.
+    EXPECT_EQ(ec::payload_of(glibc("2.39")), glibc("2.39"));
+}
+
+TEST(PayloadOf, IsEmptyOutsideAStore) {
+    EXPECT_EQ(ec::payload_of("$ORIGIN"), "");
+    EXPECT_EQ(ec::payload_of("/home/u/.xlings/subos/default/lib"), "");
+    EXPECT_EQ(ec::payload_of("/usr/lib/x86_64-linux-gnu"), "");
+    EXPECT_EQ(ec::payload_of(""), "");
+}
+
+TEST(ProviderOf, IsTheStoreDirectoryName) {
+    EXPECT_EQ(ec::provider_of(glibc("2.39")), "xim-x-glibc");
+    EXPECT_EQ(ec::provider_of(STORE + "/local-x-gcc/16.1.0"), "local-x-gcc");
+    EXPECT_EQ(ec::provider_of(""), "");
+}
+
+// The case that motivated all of this, measured on a real binary.
+TEST(SameSource, LoaderFromOnePayloadAndLibcFromAnotherIsAViolation) {
+    std::vector<std::string> rpath{
+        STORE + "/local-x-gcc/16.1.0/lib64",
+        glibc("2.44", "lib64"),
+        STORE + "/xim-x-binutils/2.42/lib",
+    };
+    auto f = ec::check("gcc", glibc("2.39", "lib64/ld-linux-x86-64.so.2"), rpath);
+    EXPECT_TRUE(f.violated);
+    EXPECT_EQ(f.provider, "xim-x-glibc");
+    EXPECT_EQ(f.interpPayload, glibc("2.39"));
+    EXPECT_EQ(f.rpathPayload, glibc("2.44"));
+    // Both paths must appear: the reader should not need LD_DEBUG.
+    auto msg = ec::describe(f);
+    EXPECT_NE(msg.find(glibc("2.39")), std::string::npos);
+    EXPECT_NE(msg.find(glibc("2.44")), std::string::npos);
+}
+
+TEST(SameSource, AgreementPasses) {
+    std::vector<std::string> rpath{
+        STORE + "/local-x-gcc/16.1.0/lib64",
+        glibc("2.44", "lib64"),
+    };
+    EXPECT_FALSE(ec::check("gcc", glibc("2.44", "lib64/ld-linux-x86-64.so.2"),
+                           rpath).violated);
+}
+
+// A shared library does not choose a loader; the program that loads it does.
+TEST(SameSource, NoInterpreterSkips) {
+    std::vector<std::string> rpath{glibc("2.44", "lib64")};
+    EXPECT_FALSE(ec::check("libfoo.so.1", "", rpath).violated);
+}
+
+TEST(SameSource, ProviderAbsentFromRunpathPasses) {
+    std::vector<std::string> rpath{STORE + "/xim-x-binutils/2.42/lib"};
+    EXPECT_FALSE(ec::check("tool", glibc("2.39", "lib64/ld-linux-x86-64.so.2"),
+                           rpath).violated);
+}
+
+// The loader takes the first match, so same-source being present is enough.
+TEST(SameSource, AnySameSourceEntryPasses) {
+    std::vector<std::string> rpath{
+        glibc("2.39", "lib64"),
+        glibc("2.44", "lib64"),
+    };
+    EXPECT_FALSE(ec::check("gcc", glibc("2.39", "lib64/ld-linux-x86-64.so.2"),
+                           rpath).violated);
+}
+
+TEST(SameSource, RelativeAndNonStoreEntriesAreIgnored) {
+    std::vector<std::string> rpath{
+        "$ORIGIN", "$ORIGIN/../lib",
+        "/home/u/.xlings/subos/default/lib",
+        "/usr/lib/x86_64-linux-gnu",
+    };
+    EXPECT_FALSE(ec::check("gcc", glibc("2.39", "lib64/ld-linux-x86-64.so.2"),
+                           rpath).violated);
+}
+
+// An interpreter outside any store (a payload that was never elfpatched) is
+// not this check's business — the loader-audit rule covers that separately.
+TEST(SameSource, InterpreterOutsideAStoreSkips) {
+    std::vector<std::string> rpath{glibc("2.44", "lib64")};
+    EXPECT_FALSE(ec::check("python", "/lib64/ld-linux-x86-64.so.2",
+                           rpath).violated);
+}


### PR DESCRIPTION
"Which version is this dependency?" had four independent answers. They agreed while the index shipped one glibc; the second one turned the disagreement into binaries that fault before `main` with `undefined symbol: __pointer_chk_guard, version GLIBC_PRIVATE` — naming neither package nor version, because ld.so and libc.so.6 are two halves of one build.

Both directions were reproducible, and both are now regression tests (E2E-62).

- **resolved_deps is total** — every runtime dep, with the resolved version, payload dir, libdirs, and *why*. The install_dir was already computed and thrown away by a `break`.
- **the convention moved to the writer** — libxpkg 0.0.50 deletes the consumer-side re-derivation that was the second answerer. A net deletion, not a fifth answerer.
- **an assertion on what shipped** — a provider's interpreter and its libdir must come from one payload; install aborts naming both paths rather than letting the user meet a GLIBC_PRIVATE symbol weeks later.
- **`.xlings-resolution.json` + `xlings why`** — the decision as data. A decision that must be reproduced to be inspected is not traceable, and reproducing this one means recreating a store state.
- **doctor `LoaderLibcSplit`** over existing payloads, counted toward the exit code, sharing one implementation with the installer.

Also: `subos new --runtime <pkg>@<ver>` now installs what it declares. Recording it and leaving the subos empty let the first package to arrive decide the real runtime.

Design and the acceptance list: `.agents/docs/2026-08-05-dependency-resolution-single-source.md`
