### PR TITLE
docs: correct issue #500 — the "use writes no shim" symptom was not real

### DIFF
--- a/.agents/docs/2026-08-08-host-loader-migration-and-ecosystem-guards.md
+++ b/.agents/docs/2026-08-08-host-loader-migration-and-ecosystem-guards.md
@@ -371,9 +371,24 @@ doctor 对两个 glibc 都报 `✓ nss resolution`。
 ### V.1 顺带挖出来的两个既有缺陷(已提 issue)
 
 `xlings#500` —— 在没有 subos 的 home 里执行 install,会**副作用地造出半个 subos**:
-`subos list` 能看见它,`subos use` 说 not found;而且此时
-`xlings use <pkg> <ver>` **打印成功但没有写任何 shim**(压根没有 `bin/` 目录)。
-同一个根因:`list` 读目录,`use` 读注册表,两边不一致。上面那次假通过就是它造成的。
+`subos list` 能看见它(读目录),`subos use` 说 not found(读注册表),两边不一致。
+
+> **我在这条 issue 里多报了一个并不存在的症状,已更正。**原文还说
+> `xlings use <pkg> <ver>` 打印成功但不写 shim。**是错的** —— 真实 home 里
+> `subos new tmp-python` → `xlings use python 3` → `which python` 明明白白指向
+> `subos/tmp-python/bin/python`。
+>
+> 我实际撞上的是**嵌套 home**:我的 `XLINGS_HOME` 是真实 home 底下的一个临时目录,
+> 而真实 home 已经占着这些 shim 名字,xlings 于是拒绝写入**并且明确告诉了我**:
+>
+> ```
+> [warn] shim 'python3' owned by /home/speak/.xlings is also resolvable in
+>        XLINGS_HOME=…; using the owner home
+> ```
+>
+> 这是有意为之的行为。我把 xlings 已经印出来的一条警告,当成了 `use` 的缺陷上报,
+> 而且**没跑那个唯一能区分两者的对照**:一个非嵌套 home 里的正常 subos。
+> 上面那次沙箱假通过,也是这条 decline 造成的,不是 `use` 坏了。
 
 `configure-project-installer` 的 macOS 段 `ref = "linux"` 连 deps 一起继承了,
 而 `make`/`gcc` 在索引里**没有 macosx 段**。裸名字解析不到时被容忍,所以这条声明

--- a/.agents/docs/2026-08-08-release-2026.8.8.1-notes.md
+++ b/.agents/docs/2026-08-08-release-2026.8.8.1-notes.md
@@ -98,7 +98,10 @@ llvm-tools 的 RPATH 恰好等于声明的闭包;沙箱内 clangd/clang-format/c
 ## 顺带提的两个 issue
 
 - `xlings#500` —— 在没有 subos 的 home 里 install,会副作用地造出半个 subos:
-  `list` 看得见、`use` 说不存在,且 `xlings use <pkg>` 报成功但不写 shim。
+  `list` 读目录看得见,`use` 读注册表说不存在。
+  (原文还报了"`use` 报成功但不写 shim",**那条是错的,已更正**:真实 home 里
+  `use` 写得好好的,我撞上的是嵌套 home 的 shim 归属拒绝 —— 而 xlings 当时就
+  打了警告说明这一点。沙箱那次假通过也是这个原因,不是 `use` 坏了。)
 - `configure-project-installer` 的 macOS 段 `ref = "linux"` 连 deps 一起继承,
   而 `make`/`gcc` 没有 macosx 段。裸名字解析不到被容忍,所以这条声明一直是**空的**
   而不是对的;加前缀让它第一次可见。**不是回归,是守卫起作用了。**


### PR DESCRIPTION
Follow-up to #499. The correction landed after that PR was already merged.

I reported that `xlings use <pkg> <ver>` prints success and writes no shim. **It was not real** — disproved on a real home:

```
$ xlings subos new tmp-python && xlings subos use tmp-python
[xsubos:tmp-python] $ xlings use python 3
[xlings] python -> 3.13.12
[xsubos:tmp-python] $ which python
/home/speak/.xlings/subos/tmp-python/bin/python
```

What I hit was **nested homes**: my `XLINGS_HOME` was a scratch dir under a real home that already owns those shim names, and xlings declines — and says so at install time:

```
[warn] shim 'python3' owned by /home/speak/.xlings is also resolvable in
       XLINGS_HOME=…; using the owner home
```

That is deliberate behaviour. I attributed a warning xlings had already printed to a defect in `use`, without running the one control that separates them.

Same cause for the sandbox false-pass described in the plan doc: the isolated home never received shims, so PATH fell through to `/usr/bin/python3`.

**The other half of #500 still reproduces** and is unchanged: an install into a subos-less home creates `subos/default/` with no `bin/` and no registry entry, so `list` and `use` disagree about whether it exists.

Docs only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)