### PR TITLE
fix(build): declare compatibility packages exactly

### DIFF
--- a/mcpp.lock
+++ b/mcpp.lock
@@ -11,11 +11,23 @@ version = "1.0.8"
 source  = "index+compat@1.0.8"
 hash    = "fnv1a:3672c2797c5f2faf"
 
+[package."compat.ftxui"]
+namespace = "compat"
+version = "6.1.9"
+source  = "index+compat@6.1.9"
+hash    = "fnv1a:f4f0f58dc9107814"
+
 [package."compat.libarchive"]
 namespace = "compat"
 version = "3.8.7"
 source  = "index+compat@3.8.7"
 hash    = "fnv1a:e412742c0533bef7"
+
+[package."compat.lua"]
+namespace = "compat"
+version = "5.4.7"
+source  = "index+compat@5.4.7"
+hash    = "fnv1a:6bda787e2c850eac"
 
 [package."compat.lz4"]
 namespace = "compat"
@@ -52,18 +64,6 @@ namespace = "mcpplibs"
 version = "0.0.2"
 source  = "index+mcpplibs@0.0.2"
 hash    = "fnv1a:8ee8a8e51ac69885"
-
-[package."ftxui"]
-namespace = "mcpplibs"
-version = "6.1.9"
-source  = "index+mcpplibs@6.1.9"
-hash    = "fnv1a:b3ae3d5c6e5a7a91"
-
-[package."lua"]
-namespace = "mcpplibs"
-version = "5.4.7"
-source  = "index+mcpplibs@5.4.7"
-hash    = "fnv1a:baac1cce64264c57"
 
 [package."mcpplibs.tinyhttps"]
 namespace = "mcpplibs"

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -31,10 +31,8 @@ linkage = "static"
 [target.aarch64-linux-musl]
 linkage = "static"
 
-[dependencies]
-ftxui = "6.1.9"
-
 [dependencies.compat]
+ftxui = "6.1.9"
 libarchive = "3.8.7"
 
 [dependencies.mcpplibs]
@@ -43,5 +41,5 @@ xpkg = "0.0.54"
 tinyhttps = "0.2.9"
 capi.lua = "0.0.3"
 
-[dev-dependencies]
+[dev-dependencies.compat]
 gtest = "1.15.2"


### PR DESCRIPTION
## 概要

- 把 `ftxui@6.1.9` 精确声明为 `compat.ftxui`
- 把仅测试使用的 `gtest@1.15.2` 精确声明为 `compat.gtest`
- 刷新 `mcpp.lock`，使 FTXUI 和传递 Lua C 库保留 canonical package identity

## 原因

mcpp-community/mcpp#400 的 exact-selector 契约明确规定：省略命名空间只等于 `mcpplibs`，不再按短名称猜测另一个命名空间。xlings 仍使用裸 `ftxui` 和 `gtest`，因此新 mcpp 会正确尝试 `(mcpplibs, ftxui)` / `(mcpplibs, gtest)`，并在进入平台专属验证前停止。

不可变 `mcpplibs.capi.lua@0.0.3` 中的传递裸 Lua 依赖已经由 mcpplibs/mcpp-index#197 用 index-side Form-B bridge 精确声明为 `compat.lua@5.4.7`；该 PR 已正常合并，10/10 CI 通过。

## 验证

- 使用 exact-selector mcpp 分支的隔离构建通过
- dependency trace 使用 `compat.ftxui`、`compat.gtest`、`mcpplibs.capi.lua` 和精确 `compat.lua`
- 终端策略标准化后的 xlings 完整 unit：36/36
- GitHub Actions：Linux build/test、Linux E2E、Linux root、macOS、Windows、aarch64 cross/QEMU 和 native aarch64 contract 共 8/8 通过
- diff 隐私扫描未发现本地用户名、绝对 workspace/home 路径、缓存/临时目录或凭据

## Draft 边界

- 本 PR 保持 Draft，等待用户明确 review
- 不使用 amend/rebase/force-push，不使用 admin/bypass/squash 合并
- review 通过后走普通合并
- 当前已发布的 xlings `2026.8.9.2` 不包含本修复；合并后需要独立 version bump、全平台 release CI 和新稳定 release
- 新 xlings release 完成后，mcpp-community/mcpp#400 需要用独立 commit 更新 pin 并重新跑 latest-head 全矩阵

Fixes #520

Related: mcpp-community/mcpp#400, mcpplibs/mcpp-index#197
