### PR TITLE
feat(graphics): one owner for the loader tag, and two things that now say so (2026.8.10.4)

### DIFF
--- a/mcpp.lock
+++ b/mcpp.lock
@@ -73,9 +73,9 @@ hash    = "fnv1a:3465dd0bd5d7aa20"
 
 [package."mcpplibs.xpkg"]
 namespace = "mcpplibs"
-version = "0.0.56"
-source  = "index+mcpplibs@0.0.56"
-hash    = "fnv1a:1f00ff8945ea9597"
+version = "0.0.57"
+source  = "index+mcpplibs@0.0.57"
+hash    = "fnv1a:91399fb9d7d59ebc"
 
 [package."mcpplibs.capi.lua"]
 namespace = "mcpplibs.capi"

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xlings"
-version = "2026.8.10.3"
+version = "2026.8.10.4"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"
@@ -39,7 +39,7 @@ libarchive = "3.8.7"
 
 [dependencies.mcpplibs]
 cmdline = "0.0.2"
-xpkg = "0.0.56"
+xpkg = "0.0.57"
 tinyhttps = "0.2.9"
 capi.lua = "0.0.3"
 

--- a/src/core/closure_check.cppm
+++ b/src/core/closure_check.cppm
@@ -31,6 +31,12 @@ import xlings.core.elf_same_source;
 //            than the host's glibc recorded at subos creation. Host objects
 //            can always enter a form-X process (dlopen, host-link), and an
 //            older libc cannot serve their symbol versions.
+//   rule E   a form-X EXECUTABLE's search path must be in DT_RPATH, not
+//            DT_RUNPATH. DT_RUNPATH is consulted only for the object carrying
+//            it, so an executable that dlopens two or three levels deep -- any
+//            GL program does -- cannot reach the bottom however correct the
+//            path is. Libraries are deliberately out of scope: the transitive
+//            tag on a LIBRARY is measured harmful (xim-pkgindex#593).
 //
 // Rule B (loader and libc from one payload) is elfcheck's, already enforced
 // hard earlier in the same install loop. This module deliberately does not
@@ -64,11 +70,98 @@ struct VersionFloor {
     std::string interpPayload;
 };
 
+// A form-X executable whose search path is in the non-transitive tag.
+//
+// rule E. DT_RUNPATH is consulted only for the object that carries it;
+// DT_RPATH is consulted for every dlopen anywhere in the process. An
+// executable that dlopens something three levels deep -- which is what any GL
+// program does, since glvnd dlopens a vendor, the vendor dlopens its platform
+// modules, and those dlopen their own dependencies -- cannot reach the bottom
+// through DT_RUNPATH however correct the path itself is.
+//
+// This rule exists for the same reason as rule D, one layer up. Rule D's
+// comment says it: a predicate that is right but "runs in exactly one place --
+// a repository workflow the user's machine never sees". The TAG was in a worse
+// place than that -- it lived in each recipe author's head. Measured on a real
+// home: 1 of 73 installed executables carried DT_RPATH, 68 carried DT_RUNPATH,
+// and 55 of those 68 already carried the correct PATH. The one that was right
+// was right because that package's author found the problem independently and
+// fixed it locally; nothing carried the finding to the other 68.
+struct NonTransitiveTag {
+    std::string elf;
+    std::string rpath;      // the value, which is usually correct
+};
+
+// Which of the two search-path tags an ELF carries.
+//
+// Parsed here rather than shelled out because there is no tool to shell out
+// TO: `patchelf --print-rpath` prints the value of whichever tag exists and
+// does not say which, and `readelf` is not something a payload is guaranteed
+// to have. It is also the right shape for a check that runs over every ELF of
+// every install -- no process per file.
+enum class PathTag { None, Rpath, Runpath };
+
+inline PathTag path_tag_of(const fs::path& file) {
+    std::ifstream f(file, std::ios::binary);
+    if (!f) return PathTag::None;
+    std::string buf((std::istreambuf_iterator<char>(f)), {});
+    if (buf.size() < 64) return PathTag::None;
+    const auto* p = reinterpret_cast<const unsigned char*>(buf.data());
+    if (!(p[0] == 0x7f && p[1] == 'E' && p[2] == 'L' && p[3] == 'F'))
+        return PathTag::None;
+
+    const bool is64 = p[4] == 2;
+    // Little-endian only. Every target this check runs on is LE, and a wrong
+    // guess here would misreport rather than fail loudly, so it declines
+    // instead.
+    if (p[5] != 1) return PathTag::None;
+
+    auto rd = [&](std::size_t off, int width) -> std::uint64_t {
+        if (off + static_cast<std::size_t>(width) > buf.size()) return 0;
+        std::uint64_t v = 0;
+        for (int i = width - 1; i >= 0; --i) v = (v << 8) | p[off + static_cast<std::size_t>(i)];
+        return v;
+    };
+
+    const std::uint64_t phoff     = is64 ? rd(32, 8) : rd(28, 4);
+    const std::uint64_t phentsize = is64 ? rd(54, 2) : rd(42, 2);
+    const std::uint64_t phnum     = is64 ? rd(56, 2) : rd(44, 2);
+    if (phoff == 0 || phentsize == 0) return PathTag::None;
+
+    constexpr std::uint64_t PT_DYNAMIC = 2;
+    constexpr std::uint64_t DT_NULL = 0, DT_RPATH = 15, DT_RUNPATH = 29;
+
+    for (std::uint64_t i = 0; i < phnum; ++i) {
+        const std::uint64_t ph = phoff + i * phentsize;
+        if (rd(ph, 4) != PT_DYNAMIC) continue;
+        const std::uint64_t dynoff = is64 ? rd(ph + 8, 8) : rd(ph + 4, 4);
+        const int w = is64 ? 8 : 4;
+        // The WHOLE dynamic section, not the first hit. When both tags are
+        // present the loader IGNORES DT_RPATH and uses DT_RUNPATH, so an ELF
+        // carrying both behaves as Runpath -- and returning whichever
+        // happened to come first in the table would report the opposite on
+        // half of them.
+        bool sawRpath = false;
+        for (std::uint64_t d = dynoff; d + 2 * static_cast<std::uint64_t>(w) <= buf.size();
+             d += 2 * static_cast<std::uint64_t>(w)) {
+            const std::uint64_t tag = rd(d, w);
+            if (tag == DT_NULL) break;
+            if (tag == DT_RUNPATH) return PathTag::Runpath;
+            if (tag == DT_RPATH)   sawRpath = true;
+        }
+        return sawRpath ? PathTag::Rpath : PathTag::None;
+    }
+    return PathTag::None;
+}
+
 struct Report {
     int scannedElves = 0;
     int formXElves   = 0;
     std::vector<MissingSoname>  missing;   // one entry per (first elf, soname)
     std::optional<VersionFloor> floor;     // one offender is enough to say it
+    // rule E. One offender names the payload: every executable in a payload is
+    // stamped by the same pass, so listing all of them would repeat one fact.
+    std::optional<NonTransitiveTag> nonTransitive;
 };
 
 // ── pure core ───────────────────────────────────────────────────────────
@@ -210,6 +303,21 @@ inline Report scan_payload(const fs::path& payloadDir,
             }
         }
 
+        // rule E -- the same set rule A uses: this ELF has PT_INTERP (it is
+        // an executable, not a library) and that interpreter is a payload
+        // (form X). Libraries are deliberately out of scope: forcing the
+        // transitive tag on a LIBRARY is measured harmful, because
+        // transitivity runs downward too and the library's path then enters
+        // every lookup beneath it (xim-pkgindex#593).
+        if (!rep.nonTransitive
+            && path_tag_of(path) == PathTag::Runpath) {
+            const auto rp = run_lines(std::format("--print-rpath \"{}\"", path));
+            rep.nonTransitive = NonTransitiveTag{
+                .elf = path,
+                .rpath = rp.empty() ? std::string{} : rp.back(),
+            };
+        }
+
         // rule D
         if (!store) store = store_sonames(xpkgsRoot, payloadDir);
         const auto needed = run_lines(std::format("--print-needed \"{}\"", path));
@@ -235,6 +343,25 @@ inline std::string describe_missing(const MissingSoname& m) {
         "enter through a *-host-link package, everything else belongs in the "
         "index. (rule D, warn-only)",
         fs::path(m.elf).filename().string(), m.soname);
+}
+
+// Names the file, the tag, and the consequence -- because the consequence is
+// the part nobody would guess. The path is usually right, so a message that
+// only said "wrong tag" would read as pedantry rather than as the reason GL
+// renders in software.
+inline std::string describe_non_transitive(const NonTransitiveTag& t) {
+    return std::format(
+        "non-transitive search path: {} carries DT_RUNPATH, not DT_RPATH.\n"
+        "  Its path ({}) is consulted for this binary's own libraries and for "
+        "NOTHING it dlopens. A GL program reaches its driver through three "
+        "levels of dlopen -- glvnd opens a vendor, the vendor opens its "
+        "platform modules, those open their own dependencies -- so with this "
+        "tag it silently renders in software however correct the path is. "
+        "elfpatch stamps DT_RPATH on executables since libxpkg 0.0.57; a "
+        "payload installed before that keeps the old tag until it is "
+        "reinstalled. (rule E, warn-only)",
+        fs::path(t.elf).filename().string(),
+        t.rpath.empty() ? "empty" : t.rpath);
 }
 
 inline std::string describe_floor(const VersionFloor& v) {

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -13,7 +13,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "2026.8.10.3";
+    static constexpr std::string_view VERSION = "2026.8.10.4";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/subos.cppm
+++ b/src/core/subos.cppm
@@ -1272,6 +1272,45 @@ int use_global(const std::string& name, EventStream& stream) {
 // was created with image/tmpfs storage so the user understands the
 // attribute is dormant in this entry. Writes to stderr (not stdout)
 // so the --shell <kind> path stays eval-safe.
+// `--sandbox` without `--gpu` on a machine that has one, for a subos that does
+// graphics: say so, once, before entering.
+//
+// bwrap's `--dev` builds a fresh /dev from a hard-coded whitelist that does not
+// include /dev/nvidia*, /dev/dri or /dev/dxg, so a sandbox without `--gpu` is a
+// software-rendering environment by construction. That default is CORRECT --
+// device passthrough should be a decision someone takes, not something a tool
+// does quietly -- and `--gpu` genuinely restores it: measured, GLX and Vulkan
+// come back byte-identical to the unsandboxed subos.
+//
+// So the gap is not capability, it is silence. Without the flag the user gets
+// "runs, draws a window, exits 0", indistinguishable from the GPU case except
+// in frame rate. That is this stack's whole failure mode: succeeding at the
+// wrong thing without saying so.
+//
+// THREE conditions, and the narrowness is the point. `warn_storage_dormant_on_
+// shell_` a few lines below is a hint that fired on every entry of its kind,
+// became noise, and is now commented out -- a hint that cannot be acted on is
+// worse than none. This one can only fire where acting on it changes the
+// outcome:
+//
+//   * the subos has a GL dispatch -- a subos that does no graphics is not
+//     missing anything (read, not probed: same state file `subos info` reads)
+//   * the host actually has GPU device nodes -- on a machine with no GPU,
+//     `--gpu` would expose nothing and the advice would be false
+//   * `--gpu` was not passed -- the user who asked does not need telling
+void warn_sandbox_without_gpu_(const std::string& name, bool gpu,
+                               EventStream& stream) {
+    if (gpu) return;
+    auto w = xlings::subos::graphics::read_graphics_wiring(Config::subos_dir(name));
+    if (!w.has_dispatch()) return;
+    if (!xlings::subos::gpu::host_has_gpu_devices()) return;
+    stream.emit(DataEvent{"tip", nlohmann::json{
+        {"message",
+         "this subos has a GL stack but the sandbox exposes no GPU device; "
+         "GL will render in software. Add --gpu to pass the host's GPU through."}
+    }.dump()});
+}
+
 void warn_storage_dormant_on_shell_(const std::string& name) {
     auto& p = Config::paths();
     auto storage = sandbox::read_storage_mode_(p.homeDir / "subos" / name);
@@ -1433,6 +1472,7 @@ int use_spawn_shell(const std::string& name, EventStream& stream,
         // both sides of the boundary.
         if (auto rc = use_detail_::validate_subos_(name, stream); rc != 0) return rc;
         use_detail_::apply_subos_env_(name);
+        warn_sandbox_without_gpu_(name, gpu, stream);
         return sandbox::enter(name, stream, sandbox_backend, gpu, cmd);
     }
     warn_storage_dormant_on_shell_(name);
@@ -1674,6 +1714,24 @@ nlohmann::json graphics_fields_(const fs::path& subosDir) {
         return out;
     default:
         break;
+    }
+
+    // The one part of this stack we do not own is the host's NVIDIA driver,
+    // and it moves: a distribution update replaces it, the versioned SONAMEs
+    // our payload links to change, and the wiring below describes a driver
+    // that is no longer there. The detector already existed and worked
+    // (`xlings-gl-doctor`); what it lacked was a way to reach the user without
+    // being remembered. Reported before the per-vendor rows because when it
+    // fires, every row under it is about the old driver.
+    if (auto d = gfx::read_driver_stamp(w.dispatchDir / "lib" /
+                                        std::string(gfx::kVendorSubdir));
+        d.drifted()) {
+        row("host driver",
+            "CHANGED — this stack was wired for " + d.builtFor +
+            " and the host is now running " + d.hostNow +
+            ". Re-run 'xlings install graphics'; until then the states below "
+            "describe a driver that is no longer loaded.",
+            true);
     }
 
     if (w.dispatchMismatch) {

--- a/src/core/subos/gpu.cppm
+++ b/src/core/subos/gpu.cppm
@@ -83,4 +83,27 @@ inline std::vector<std::string> passthrough_args() {
     });
 }
 
+// Does this host have a GPU that `--gpu` would actually expose?
+//
+// Derived from `passthrough_args` rather than from a second list of device
+// paths. A separate list is a second answerer to a question this function
+// already answers, and the two would drift the first time a platform's node
+// is added to one of them — /dev/dxg was added to the list above precisely
+// because a platform whose node is missing reports "no GPU" identically to a
+// machine that has none.
+//
+// The `--ro-bind /sys` triple is unconditional, so the presence of any
+// `--dev-bind` is exactly "at least one GPU character device exists".
+inline bool host_has_gpu_devices(std::function<bool(const std::string&)> exists_fn) {
+    auto args = passthrough_args(std::move(exists_fn));
+    return std::find(args.begin(), args.end(), "--dev-bind") != args.end();
+}
+
+inline bool host_has_gpu_devices() {
+    return host_has_gpu_devices([](const std::string& p) {
+        std::error_code ec;
+        return std::filesystem::exists(p, ec);
+    });
+}
+
 } // namespace xlings::subos::gpu

--- a/src/core/subos/graphics.cppm
+++ b/src/core/subos/graphics.cppm
@@ -282,6 +282,76 @@ GraphicsWiring read_graphics_wiring(const fs::path& subosDir) {
     return w;
 }
 
+// ─── host driver drift ─────────────────────────────────────────────────────
+//
+// The one piece of this stack we do not own is the NVIDIA userspace driver: it
+// is in lockstep with the host's kernel module (550.144.03 userspace talks to
+// 550.144.03 `nvidia.ko` and to nothing else), so the stack links to the
+// host's files rather than shipping them. That makes the host driver a version
+// that moves under us — a distribution update replaces it, the versioned
+// SONAMEs our payload symlinks to change, and the wiring recorded at install
+// time describes a driver that is no longer there.
+//
+// The detector already exists and works: `xlings-gl-doctor`, shipped by the
+// nvidia-gl-host-link package, compares the version stamped at install against
+// the one the kernel module reports now. What it lacks is a way to reach the
+// user — it has to be remembered and run. This reads the same two files it
+// reads, so `subos info` can say it without anyone remembering.
+//
+// Two plain file reads, no subprocess: the local-query-answers-instantly
+// contract (2026.8.10.1) applies here as much as to the wiring record, and the
+// values are already written down. Re-deriving the driver version by running
+// something would make this the second answerer to a question the installer
+// answered.
+struct DriverStamp {
+    bool known { false };        // the payload recorded a version at install
+    std::string builtFor;        // <nvidia payload>/.host-driver-version
+    std::string hostNow;         // /sys/module/nvidia/version
+    bool drifted() const {
+        // Only a DISAGREEMENT is drift. An unknown on either side is not:
+        // a machine whose module is not loaded right now (`hostNow` empty)
+        // has not changed driver, it has no driver running, and reporting
+        // that as drift would cry wolf on every laptop with the GPU asleep.
+        return known && !builtFor.empty() && !hostNow.empty()
+               && builtFor != hostNow;
+    }
+};
+
+inline std::string read_trimmed_(const fs::path& p) {
+    std::ifstream in(p, std::ios::binary);
+    if (!in) return {};
+    std::string s;
+    std::getline(in, s);
+    while (!s.empty() && (s.back() == '\n' || s.back() == '\r' || s.back() == ' '))
+        s.pop_back();
+    return s;
+}
+
+// `vendorDir` is the dispatch's `glx-vendor/`. The NVIDIA entry there is a
+// symlink into the nvidia payload, so the payload root — and the stamp beside
+// it — is reached the same way everything else here is reached: by following
+// the link the loader would follow, not by searching the store.
+DriverStamp read_driver_stamp(const fs::path& vendorDir) {
+    DriverStamp d;
+    std::error_code ec;
+    for (auto it = fs::directory_iterator(vendorDir, ec);
+         !ec && it != fs::directory_iterator(); it.increment(ec)) {
+        auto name = it->path().filename().string();
+        if (name.find("nvidia") == std::string::npos) continue;
+        auto real = fs::weakly_canonical(it->path(), ec);
+        if (ec) continue;
+        // <payload>/lib/<soname> -> <payload>
+        auto payload = real.parent_path().parent_path();
+        auto stamp = payload / ".host-driver-version";
+        if (!fs::exists(stamp, ec)) continue;
+        d.known = true;
+        d.builtFor = read_trimmed_(stamp);
+        break;
+    }
+    if (d.known) d.hostNow = read_trimmed_("/sys/module/nvidia/version");
+    return d;
+}
+
 // ─── display ───────────────────────────────────────────────────────────────
 //
 // Presentation, not re-derivation: the SONAME is the record's key, and this

--- a/src/core/xim/installer.cppm
+++ b/src/core/xim/installer.cppm
@@ -3063,6 +3063,11 @@ public:
                     log::warn("[{}@{}] {}", node.name, node.version,
                               closurecheck::describe_floor(*rep.floor));
                 }
+                if (rep.nonTransitive) {
+                    log::warn("[{}@{}] {}", node.name, node.version,
+                              closurecheck::describe_non_transitive(
+                                  *rep.nonTransitive));
+                }
             }
 
             if (catalog_) {

--- a/tests/e2e/closure_guard_differential_test.sh
+++ b/tests/e2e/closure_guard_differential_test.sh
@@ -17,6 +17,10 @@
 #   2. warn names libnothere.so.9     (rule D fires on the real gap)
 #   3. warn does NOT name libc.so.6   (a provided soname is not a gap)
 #   4. version-floor warn names 1.0 vs the recorded host glibc (rule A)
+#   4b. warn says the search path is non-transitive (rule E) -- the rig carries
+#      DT_RUNPATH, which is what elfpatch wrote before libxpkg 0.0.57. This is
+#      the ONLY way to observe rule E firing: installing anything today
+#      produces DT_RPATH executables, because the writer is now consistent.
 #   5. dep-closure-check.sh on the same payload also fails, also names
 #      libnothere.so.9, and also does not call libc.so.6 host-only
 #
@@ -63,6 +67,15 @@ patchelf --set-interpreter "$FAKE_GLIBC/lib64/ld-linux-x86-64.so.2" "$RIG_DIR/ri
   || fail "patchelf --set-interpreter failed"
 patchelf --add-needed libnothere.so.9 "$RIG_DIR/rigged" \
   || fail "patchelf --add-needed failed"
+# rule E's rig, on the same executable. `--set-rpath` without `--force-rpath`
+# is exactly what elfpatch did before libxpkg 0.0.57, so this reproduces a
+# payload arriving from an older client — the case rule E exists to catch and
+# the one that cannot be produced by installing anything today, because the
+# writer is now consistent.
+patchelf --set-rpath "$FAKE_GLIBC/lib64" "$RIG_DIR/rigged" \
+  || fail "patchelf --set-rpath failed"
+[ -n "$(readelf -d "$RIG_DIR/rigged" | grep -o '(RUNPATH)')" ] \
+  || fail "the rig was meant to carry DT_RUNPATH; patchelf wrote something else"
 
 # ── the fixture recipe that carries it into a payload ───────────────────
 cat > "$LOCAL_INDEX_DIR/pkgs/c/closurefix.lua" <<LUA
@@ -163,6 +176,17 @@ echo "$OUT" | strip_ansi | grep "version floor" | grep -q "1\.0.*$HOST_GLIBC\|$H
   || fail "4: rule A did not report glibc 1.0 vs host $HOST_GLIBC:
 $OUT"
 log "  ✓ 4: rule A reports the version floor (1.0 < host $HOST_GLIBC)"
+
+# rule E. The message has to carry the CONSEQUENCE, not just the tag name:
+# the path in a DT_RUNPATH executable is usually correct, so "wrong tag" alone
+# reads as pedantry rather than as the reason a GL program renders in software.
+echo "$OUT" | strip_ansi | grep -q "non-transitive search path" \
+  || fail "4b: rule E did not report the DT_RUNPATH executable:
+$OUT"
+echo "$OUT" | strip_ansi | grep -q "dlopen" \
+  || fail "4b: rule E fired but did not say what it costs (no mention of dlopen):
+$OUT"
+log "  ✓ 4b: rule E reports the non-transitive tag, and says what it costs"
 
 # ── side 2: the index CI's script, same tree ────────────────────────────
 # -print -quit, not `| head -1`: the shared lib sets -e and this file sets

--- a/tests/unit/test_closure_check.cpp
+++ b/tests/unit/test_closure_check.cpp
@@ -106,3 +106,133 @@ TEST_F(ClosureCheckStore, PayloadSonamesSeesItsOwnOffering) {
     EXPECT_TRUE(self.contains("libfoo.so"));
     EXPECT_FALSE(self.contains("not-a-library"));
 }
+
+
+// ── rule E: which tag the search path is in ────────────────────────────────
+//
+// DT_RUNPATH is consulted only for the object carrying it; DT_RPATH is
+// consulted for every dlopen anywhere in the process. A GL program reaches its
+// driver through three levels of dlopen, so the tag -- not the path -- decides
+// whether it renders on the GPU. Measured on a real home: 1 of 73 installed
+// executables carried DT_RPATH while 55 of the other 68 already carried the
+// correct PATH.
+//
+// Synthetic ELFs rather than real ones: the parser is the thing under test,
+// and a real binary would make these cases depend on whichever toolchain built
+// the fixture.
+namespace {
+
+// A minimal 64-bit LE ELF with one PT_DYNAMIC segment holding the given
+// (tag, value) pairs. Only the fields path_tag_of reads are filled in.
+std::string synth_elf(const std::vector<std::pair<std::uint64_t, std::uint64_t>>& dyn,
+                      bool is64 = true) {
+    const std::size_t ehsize   = is64 ? 64u : 52u;
+    const std::size_t phentsz  = is64 ? 56u : 32u;
+    const std::size_t phoff    = ehsize;
+    const std::size_t dynoff   = phoff + phentsz;
+    const std::size_t w        = is64 ? 8u : 4u;
+    std::string b(dynoff + (dyn.size() + 1) * 2 * w, '\0');
+
+    auto put = [&](std::size_t off, std::uint64_t v, int width) {
+        for (int i = 0; i < width; ++i)
+            b[off + static_cast<std::size_t>(i)] =
+                static_cast<char>((v >> (8 * i)) & 0xff);
+    };
+
+    b[0] = '\x7f'; b[1] = 'E'; b[2] = 'L'; b[3] = 'F';
+    b[4] = is64 ? 2 : 1;   // class
+    b[5] = 1;              // little-endian
+    if (is64) {
+        put(32, phoff, 8); put(54, phentsz, 2); put(56, 1, 2);
+        put(phoff, 2, 4);            // p_type = PT_DYNAMIC
+        put(phoff + 8, dynoff, 8);   // p_offset
+    } else {
+        put(28, phoff, 4); put(42, phentsz, 2); put(44, 1, 2);
+        put(phoff, 2, 4);
+        put(phoff + 4, dynoff, 4);
+    }
+    std::size_t at = dynoff;
+    for (auto& [tag, val] : dyn) {
+        put(at, tag, static_cast<int>(w));
+        put(at + w, val, static_cast<int>(w));
+        at += 2 * w;
+    }
+    return b;   // trailing zeros are the DT_NULL terminator
+}
+
+fs::path write_synth(const fs::path& dir, const std::string& name,
+                     const std::string& bytes) {
+    fs::create_directories(dir);
+    auto p = dir / name;
+    std::ofstream(p, std::ios::binary).write(bytes.data(),
+                                             static_cast<std::streamsize>(bytes.size()));
+    return p;
+}
+
+constexpr std::uint64_t DT_NEEDED = 1, DT_RPATH = 15, DT_RUNPATH = 29;
+
+} // namespace
+
+TEST(ClosureCheckTag, RunpathIsReportedAsNonTransitive) {
+    const auto dir = fs::temp_directory_path() / "xlings-tagtest-runpath";
+    fs::remove_all(dir);
+    auto f = write_synth(dir, "a.elf", synth_elf({{DT_NEEDED, 1}, {DT_RUNPATH, 2}}));
+    EXPECT_EQ(cc::path_tag_of(f), cc::PathTag::Runpath);
+    fs::remove_all(dir);
+}
+
+TEST(ClosureCheckTag, RpathIsTheTransitiveOne) {
+    const auto dir = fs::temp_directory_path() / "xlings-tagtest-rpath";
+    fs::remove_all(dir);
+    auto f = write_synth(dir, "a.elf", synth_elf({{DT_RPATH, 2}, {DT_NEEDED, 1}}));
+    EXPECT_EQ(cc::path_tag_of(f), cc::PathTag::Rpath);
+    fs::remove_all(dir);
+}
+
+// When both tags are present the loader IGNORES DT_RPATH and uses DT_RUNPATH,
+// so the ELF behaves as Runpath. Reading whichever came first in the table
+// would report the opposite on half of them -- and DT_RPATH first is the
+// common layout, so the wrong reading would look right in casual testing.
+TEST(ClosureCheckTag, BothTagsBehaveAsRunpathWhicheverComesFirst) {
+    const auto dir = fs::temp_directory_path() / "xlings-tagtest-both";
+    fs::remove_all(dir);
+    auto a = write_synth(dir, "rpath-first.elf",
+                         synth_elf({{DT_RPATH, 2}, {DT_RUNPATH, 3}}));
+    auto b = write_synth(dir, "runpath-first.elf",
+                         synth_elf({{DT_RUNPATH, 3}, {DT_RPATH, 2}}));
+    EXPECT_EQ(cc::path_tag_of(a), cc::PathTag::Runpath);
+    EXPECT_EQ(cc::path_tag_of(b), cc::PathTag::Runpath);
+    fs::remove_all(dir);
+}
+
+TEST(ClosureCheckTag, NoSearchPathIsNeitherTag) {
+    const auto dir = fs::temp_directory_path() / "xlings-tagtest-none";
+    fs::remove_all(dir);
+    auto f = write_synth(dir, "a.elf", synth_elf({{DT_NEEDED, 1}}));
+    EXPECT_EQ(cc::path_tag_of(f), cc::PathTag::None);
+    fs::remove_all(dir);
+}
+
+TEST(ClosureCheckTag, ThirtyTwoBitElfIsParsedToo) {
+    const auto dir = fs::temp_directory_path() / "xlings-tagtest-32";
+    fs::remove_all(dir);
+    auto f = write_synth(dir, "a.elf", synth_elf({{DT_RUNPATH, 2}}, /*is64=*/false));
+    EXPECT_EQ(cc::path_tag_of(f), cc::PathTag::Runpath);
+    fs::remove_all(dir);
+}
+
+// Anything that is not a little-endian ELF declines rather than guesses. A
+// wrong guess here would MISREPORT -- a payload called out for a tag it does
+// not have -- which is worse than saying nothing.
+TEST(ClosureCheckTag, NonElfAndBigEndianDecline) {
+    const auto dir = fs::temp_directory_path() / "xlings-tagtest-junk";
+    fs::remove_all(dir);
+    auto junk = write_synth(dir, "junk", std::string(200, 'x'));
+    EXPECT_EQ(cc::path_tag_of(junk), cc::PathTag::None);
+
+    auto be = synth_elf({{DT_RUNPATH, 2}});
+    be[5] = 2;   // big-endian
+    auto bef = write_synth(dir, "be.elf", be);
+    EXPECT_EQ(cc::path_tag_of(bef), cc::PathTag::None);
+    fs::remove_all(dir);
+}

--- a/tests/unit/test_subos_graphics.cpp
+++ b/tests/unit/test_subos_graphics.cpp
@@ -67,6 +67,21 @@ struct Tree {
         fs::create_directories(vendorDir);
         std::ofstream(vendorDir / std::string(soname)) << "vendor";
     }
+    // The nvidia payload records the host driver version it was wired for.
+    // The vendor entry is a symlink into that payload, so the stamp is reached
+    // by following the link the loader would follow — the same discipline the
+    // rest of this module uses instead of searching the store.
+    void stamp_driver(std::string_view version) {
+        fs::create_directories(vendorDir);
+        auto nv = root / "store" / "nvidia";
+        fs::create_directories(nv / "lib");
+        std::ofstream(nv / "lib" / "libGLX_nvidia.so.0") << "vendor";
+        std::ofstream(nv / ".host-driver-version") << version << "\n";
+        std::error_code ec;
+        fs::remove(vendorDir / "libGLX_nvidia.so.0", ec);
+        fs::create_symlink(nv / "lib" / "libGLX_nvidia.so.0",
+                           vendorDir / "libGLX_nvidia.so.0", ec);
+    }
     void write_record(std::string_view text) {
         fs::create_directories(vendorDir);
         std::ofstream(vendorDir / ".wiring") << text;
@@ -313,6 +328,55 @@ TEST(SubosGraphics, AnUnknownStateSaysThisClientCannotReadIt) {
     EXPECT_NE(d.find("quarantined"), std::string::npos);
     EXPECT_NE(d.find("newer than this xlings"), std::string::npos);
     EXPECT_NE(d.find("unassessed"), std::string::npos);
+}
+
+// ─── host driver drift ─────────────────────────────────────────────────────
+//
+// The NVIDIA userspace driver is the one part of this stack we do not own: it
+// is in lockstep with the host's kernel module, so we link to the host's files
+// rather than shipping them, and a distribution update moves it under us. The
+// wiring recorded at install then describes a driver that is no longer there.
+
+TEST(SubosGraphics, AgreeingDriverVersionsAreNotDrift) {
+    Tree t("drift-same");
+    WIRE_OR_SKIP(t);
+    t.add_vendor("libGLX_nvidia.so.0");
+    t.stamp_driver("550.144.03");
+    auto d = gfx::read_driver_stamp(t.vendorDir);
+    EXPECT_TRUE(d.known);
+    EXPECT_EQ(d.builtFor, "550.144.03");
+}
+
+// An unknown on either side is NOT drift. A machine whose kernel module is not
+// loaded right now has not changed driver — it has no driver running — and
+// reporting that as a change would cry wolf on every laptop with the GPU
+// asleep, which is how the previous generation of hints in this codebase
+// became noise and got commented out.
+TEST(SubosGraphics, AnUnreadableSideIsNotDrift) {
+    Tree t("drift-unknown");
+    WIRE_OR_SKIP(t);
+    t.add_vendor("libGLX_nvidia.so.0");
+    t.stamp_driver("550.144.03");
+    auto d = gfx::read_driver_stamp(t.vendorDir);
+    // hostNow comes from /sys and is empty on any machine without the module.
+    gfx::DriverStamp probe{true, "550.144.03", "", };
+    EXPECT_FALSE(probe.drifted());
+    gfx::DriverStamp nostamp{false, "", "560.1", };
+    EXPECT_FALSE(nostamp.drifted());
+    gfx::DriverStamp real{true, "550.144.03", "560.35.03", };
+    EXPECT_TRUE(real.drifted()) << "a genuine version change must be reported";
+    (void)d;
+}
+
+// A stack with no stamp at all (installed by a recipe older than the stamp)
+// must not be reported as drifted — nobody recorded what it was built for.
+TEST(SubosGraphics, NoStampIsNotDrift) {
+    Tree t("drift-nostamp");
+    WIRE_OR_SKIP(t);
+    t.add_vendor("libGLX_nvidia.so.0");
+    auto d = gfx::read_driver_stamp(t.vendorDir);
+    EXPECT_FALSE(d.known);
+    EXPECT_FALSE(d.drifted());
 }
 
 TEST(SubosGraphics, AMissingClosureNamesTheLibraries) {


### PR DESCRIPTION
落地图形栈设计的 E1b / E3a / E3b,建立在 libxpkg 0.0.57(E1a,让 elfpatch 给可执行文件打 DT_RPATH)之上。

## rule E —— 把标签不变式放到载荷真正落地的地方

DT_RUNPATH 只对携带它的对象生效;DT_RPATH 对进程内任意深度的 dlopen 都生效。GL 程序要穿三层 dlopen 才够到驱动,所以**决定它在不在 GPU 上渲染的是标签,不是路径**。

真机实测:73 个已安装可执行文件里 **1 个 DT_RPATH、68 个 DT_RUNPATH,而那 68 个里有 55 个路径本来就是对的**。

`closure_check` 就是为这个动作建的模块 —— 它自己的注释写着:一条正确但"只活在仓库工作流里、用户机器永远看不到"的谓词,应该搬到载荷真正落地的地方。**标签此前的处境比那还差:它活在每个 recipe 作者的脑子里**;唯一做对的那个包,是它的作者独立发现了问题并在自己包里修好,而没有任何机制把这个发现带给另外 68 个。

**标签是原生解析的,不是外部命令** —— 因为没有命令可用:`patchelf --print-rpath` 打印的是"两个标签里存在的那个"的值,**不说是哪个**;`readelf` 不保证载荷里有。

**读整个 dynamic section 而不是第一个命中**,这点是有分量的:两个标签同时存在时加载器**忽略 DT_RPATH**,而 DT_RPATH 在前是常见布局 —— 先到先得的读法会在一半样本上给出相反答案,而且在随手测试时看起来是对的。

warn-only,与 rule A/D 一致。**库不在范围内**:在库上强制传递标签是实测有害的(xim-pkgindex#593),传递性向下也成立。

## 宿主驱动漂移 —— `subos info` 现在会说

NVIDIA 用户态是这套栈里唯一不属于我们的部分,它与宿主内核模块锁步,发行版一升级它就在我们脚下换掉,而记录下来的接线描述的是一个已经不在的驱动。

**检测器早就存在并且有效**(`xlings-gl-doctor`)—— 它缺的是一条不依赖"用户想起来"的通道。两次普通文件读、无子进程,与接线记录同一个即时查询契约。

报在逐 vendor 行**之上**,因为它一旦触发,下面每一行说的都是旧驱动。**任一侧未知都不算漂移**:模块没加载的机器不是"换了驱动",是"没有驱动在跑"。

## 沙箱缺 `--gpu` —— 只在能被采取行动时才说

bwrap 重建的 /dev 不含 GPU 节点,所以不带 `--gpu` 的沙箱按构造就是软件渲染环境。**这个缺省是对的**,`--gpu` 也确实能恢复;缺的是**沉默** —— 用户拿到"能跑、有画面、exit 0",与 GPU 可用时观感完全相同,只差帧率。

**三个条件,窄是要点。** 几行之外的 `warn_storage_dormant_on_shell_` 就是一条"每次都响"的提示,变成噪音后被注释掉了。这条要求:subos 有 GL dispatch、宿主**确实有** GPU 设备节点、且没传 `--gpu`。GPU 判据由 `passthrough_args` 派生而不是另立一份设备清单,**两者无法漂移**。

## 真机验证(每项双向)

```
沙箱提示   不带 --gpu 时响;带 --gpu 时不响;无图形栈的 home 不响
漂移行     版本一致时无;伪造不一致时有;还原后又无
标签解析器 已证伪 —— 改成读第一个命中,both-tags 测试变红
```

37/37 测试二进制全绿。

设计:`.agents/docs/2026-08-10-graphics-stack-design.md` §E1b / §E3a / §E3b
上游:openxlings/libxpkg#41,mcpplibs/mcpp-index#202
关联:#532 #533 #534

---

## 追加:E1a 的端到端验证(此前只验了命令构造)

用本 PR 的二进制(内含 libxpkg 0.0.57)真实安装,**删掉载荷目录强制重装**(仅 `remove` 会留下载荷,重装是空操作 —— 已知陷阱):

```
可执行文件 xkbcli  : (RPATH)     ← 新
库 libxkbcommon.so : (RUNPATH)   ← 未变,正是设计要求的分界
```

新装的 wayland 也是 `(RPATH)`。**打包侧的写入者现在是一致的。**

## 诚实标注一处未观察到的行为

**rule E 的解析器已双向证伪**(合成 ELF:改成读第一个命中,both-tags 用例变红),
**但"它在真实安装中发声"这一幕没有观察到** —— 因为 0.0.57 之后正常安装不再产出
DT_RUNPATH 的可执行文件,这个场景无法按需构造(仓库里每个有 `bin/` 的包都有 `lib/`,
所以 elfpatch 总会打标签)。

有一条**反向的真实文件交叉验证**成立:新装的 wayland / libxkbcommon 可执行文件经
`readelf` 是 RPATH,而 rule E 用**我写的解析器扫同一批文件**时保持沉默 —— 解析器若把
RPATH 误读为 RUNPATH,那次安装就会报警。所以真实文件上的一致性在**否定方向**已验证;
**肯定方向缺一个真实样本**。

rule E 的实际作用面因此是两类:被**更旧的 elfpatch** 打过标签的载荷(用户升级后重装老包时),
以及**自己覆盖标签的 recipe**。两者都不是现在能按需制造的。
