### PR TITLE
fix(catalog): no version, no `@` in the demotion notice

### DIFF
--- a/.agents/docs/2026-08-11-release-2026.8.11.2-notes.md
+++ b/.agents/docs/2026-08-11-release-2026.8.11.2-notes.md
@@ -321,6 +321,51 @@ xlings install xim:xlings@latest -y && xlings use xlings latest
 
 绝大多数 home 没有 `local:xlings`,不受影响。
 
+## 5.6 发布后真机验证(用**发布出来的**二进制)
+
+升级走的正是 §5.5 那条门 —— 这台机器同时有 `local:xlings`,所以 `self update`
+在旧入口上仍然拒绝,实测输出已固定为证据:
+
+```
+入口 2026.8.11.1:  xlings info xlings  → [error] package 'xlings' is ambiguous
+                                          1. local:xlings@2026.8.10.4
+                                          2. xim:xlings@2026.8.11.1
+                   xlings info xim:xlings → ◆ xim:xlings  2026.8.11.1   ← 门是通的
+```
+
+`xlings install xim:xlings@latest -y && xlings use xlings 2026.8.11.2` 之后:
+
+| 项 | before | after |
+|---|---|---|
+| 入口二进制 | 2026.8.11.1 | **2026.8.11.2** |
+| `xlings` 绑定 | `local:0.4.51`(活着的分叉) | **2026.8.11.2** |
+| doctor `entry binary` | **报** | 不报 |
+| 裸名 `xlings` | ambiguous,拒绝 | 解析成功 + 一行降权提示 |
+| shim 导出 `XLINGS_SUBOS_LIB` | (unset) | `…/subos/default/lib` |
+| 普通 shell `gcc -lGL` | 链接失败 | **rc=0,有产物** |
+| 沙箱 `gcc -lGL` | 链接失败 | **rc=0,有产物** |
+| `.wiring` 带 `payload=` 的行 | 0 | **6** |
+
+`./p_z` 仍然 rc=127(`libz.so.1` 找不到)—— **运行期那一半,本轮明确不做**。
+`matrix.sh` 现在把这个状态说得比我准确:
+
+> build a GL program (gcc -lGL): **links, but the binary CANNOT RUN**
+> (its RUNPATH names only the glibc and gcc payloads)
+
+### 而这次验证抓到了第八个缺陷 —— 我自己的
+
+降权提示在**没有版本**的解析路径上打印成:
+
+```
+'binutils' also provided by local:binutils@; selected xim:binutils@ by namespace priority
+```
+
+**一个尾随的 `@`**。identity-only 路径(`resolve_local_identity`,inventory 走它)
+不选版本,而我无条件地格式化了 `{}@{}`。更糟的是第二行:
+`use its full name, e.g. local:binutils@` —— 一条**复制下来跑不通的命令**。
+
+这行字存在的全部意义就是「读者可以相信它说的」。已修:没有版本就不带 `@`。
+
 ## 6. 已知边界
 
 * **一台机器,一种硬件**(NVIDIA / X11 / x86_64)。

--- a/src/core/xim/catalog.cppm
+++ b/src/core/xim/catalog.cppm
@@ -304,8 +304,13 @@ NamespaceRankResult_ prefer_namespace_rank_(
         if (namespace_rank_(match.namespaceName) == best) {
             out.kept.push_back(match);
         } else {
+            // Same rule as announce_demotion_: no version, no `@`. This string
+            // is printed as a command the user can copy, and
+            // `xlings install local:binutils@` is not one.
             out.demoted.push_back(
-                std::format("{}@{}", match.canonicalName, match.version));
+                match.version.empty()
+                    ? match.canonicalName
+                    : std::format("{}@{}", match.canonicalName, match.version));
         }
     }
     return out;
@@ -698,9 +703,21 @@ public:
         }
         auto key = target + "\x1f" + chosen.canonicalName + "\x1f" + losers;
         if (!demotionsAnnounced_.insert(key).second) return;
-        log::warn("'{}' also provided by {}; selected {}@{} by namespace "
+        // `@version` only when there IS one. The identity-only path
+        // (resolve_local_identity, used by inventory) does not select a
+        // version, so unconditional formatting printed `local:binutils@` --
+        // measured on a real home right after the release. A trailing `@`
+        // reads as a version that failed to render, which is worse than not
+        // showing one: the whole purpose of this line is that the reader can
+        // trust what it says.
+        const auto withVersion = [](const std::string& name,
+                                    const std::string& version) {
+            return version.empty() ? name : name + "@" + version;
+        };
+        log::warn("'{}' also provided by {}; selected {} by namespace "
                   "priority (local ranks last)",
-                  target, losers, chosen.canonicalName, chosen.version);
+                  target, losers,
+                  withVersion(chosen.canonicalName, chosen.version));
         log::warn("  to pick the other: use its full name, e.g. `{}`",
                   chosen.demoted.front());
     }


### PR DESCRIPTION
Found by the post-release verification of 2026.8.11.2, on a real home.

The identity-only resolution path (`resolve_local_identity`, used by inventory) does not select a version, and the notice formatted `{}@{}` unconditionally:

```
'binutils' also provided by local:binutils@; selected xim:binutils@ by namespace priority (local ranks last)
  to pick the other: use its full name, e.g. `local:binutils@`
```

A trailing `@` reads as a version that failed to render — and the second line is worse than cosmetic, because it is **a command, and that one does not run**.

The whole reason the namespace priority was acceptable instead of a refusal is that **the loser gets named**. A notice the reader cannot trust gives that back.

Also records the post-release verification in the release notes, including the before/after table and the evidence — captured *before* upgrading, since it cannot be reproduced afterwards — that this home's old entry refused the bare name and accepted the qualified one.