### PR TITLE
docs: fix the broken star history chart in the READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,4 +197,4 @@ Guides, design notes, and specs live in [`docs/`](docs/).
   <img src="https://contrib.rocks/image?repo=openxlings/xlings" />
 </a>
 
-[![Star History Chart](https://api.star-history.com/svg?repos=openxlings/xlings,openxlings/xim-pkgindex&type=Date)](https://star-history.com/#openxlings/xlings&openxlings/xim-pkgindex&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=openxlings/xlings,openxlings/xim-pkgindex&type=Date)](https://star-history.dera.page/#openxlings/xlings&openxlings/xim-pkgindex&Date)

--- a/README.zh.md
+++ b/README.zh.md
@@ -190,4 +190,4 @@ xlings self doctor --fix               # 修复
   <img src="https://contrib.rocks/image?repo=openxlings/xlings" />
 </a>
 
-[![Star History Chart](https://api.star-history.com/svg?repos=openxlings/xlings,openxlings/xim-pkgindex&type=Date)](https://star-history.com/#openxlings/xlings&openxlings/xim-pkgindex&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=openxlings/xlings,openxlings/xim-pkgindex&type=Date)](https://star-history.dera.page/#openxlings/xlings&openxlings/xim-pkgindex&Date)


### PR DESCRIPTION
The star history chart in README.md and README.zh.md is currently broken and no longer renders, so the project can no longer show its stargazer history. This change swaps both the chart image and its surrounding link to a working endpoint used by many other projects, restoring the chart for both the English and Chinese READMEs.