### PR TITLE
fix(xim): "not found" was said about packages that are right there in the index

### DIFF
--- a/src/core/xim/catalog.cpp
+++ b/src/core/xim/catalog.cpp
@@ -452,14 +452,15 @@ std::vector<PackageMatch> PackageCatalog::build_matches_(const RepoState& state,
 }
 
 std::vector<PackageMatch> PackageCatalog::collect_matches_(const std::string& target,
-                                               const std::string& platform) const {
+                                               const std::string& platform,
+                                               bool forSearch) const {
     auto parsed = detail_::parse_target_(target);
     std::vector<PackageMatch> primaryMatches;
     std::vector<PackageMatch> subMatches;
 
     auto collect = [&](const std::vector<RepoState>& repos) {
         for (const auto& repo : repos) {
-            auto matches = build_matches_(repo, parsed, platform);
+            auto matches = build_matches_(repo, parsed, platform, forSearch);
             if (repo.spec.subIndex) {
                 for (auto& match : matches) {
                     subMatches.push_back(std::move(match));
@@ -570,10 +571,54 @@ void PackageCatalog::announce_demotion_(const std::string& target,
               chosen.demoted.front());
 }
 
+std::vector<std::string> PackageCatalog::platforms_offering_(const std::string& target) const {
+    // `forSearch` keeps a candidate whose version selection came up empty for
+    // the current platform — which is precisely the set we need to inspect.
+    // (That flag had no caller until now: `search` reaches the index another
+    // way, so the one place it was built for was the one place not using it.)
+    auto parsed = detail_::parse_target_(target);
+    std::vector<std::string> out;
+    auto scan = [&](const std::vector<RepoState>& repos) {
+        for (const auto& repo : repos) {
+            for (auto& m : build_matches_(repo, parsed, /*platform=*/"",
+                                          /*forSearch=*/true)) {
+                auto pkg = repo.index.load_package(m.rawName);
+                if (!pkg) continue;
+                for (auto& [plat, versions] : pkg->xpm.entries) {
+                    if (versions.empty()) continue;
+                    if (std::ranges::find(out, plat) == out.end())
+                        out.push_back(plat);
+                }
+            }
+        }
+    };
+    scan(projectRepos_);
+    scan(globalRepos_);
+    std::ranges::sort(out);
+    return out;
+}
+
 std::expected<PackageMatch, std::string> PackageCatalog::resolve_target(const std::string& target,
                    const std::string& platform) const {
     auto matches = collect_matches_(target, platform);
     if (matches.empty()) {
+        // "does not exist" and "exists, but not for this platform" are
+        // different facts, and reporting the second as the first sends the
+        // reader looking for a package that is right there in the index.
+        //
+        // It also made two commands contradict each other: `xlings search
+        // msvc` listed `xim:msvc` while `xlings info msvc` on the same Linux
+        // box answered "not found" — measured, not hypothetical.
+        if (auto elsewhere = platforms_offering_(target); !elsewhere.empty()) {
+            std::string list;
+            for (auto& p : elsewhere) {
+                if (!list.empty()) list += ", ";
+                list += p;
+            }
+            return std::unexpected(std::format(
+                "package '{}' has no build for {} (available on: {})",
+                target, platform.empty() ? "this platform" : platform, list));
+        }
         return std::unexpected(std::format("package '{}' not found", target));
     }
     if (matches.size() > 1) {

--- a/src/core/xim/catalog.cpp
+++ b/src/core/xim/catalog.cpp
@@ -585,7 +585,19 @@ std::vector<std::string> PackageCatalog::platforms_offering_(const std::string& 
                 auto pkg = repo.index.load_package(m.rawName);
                 if (!pkg) continue;
                 for (auto& [plat, versions] : pkg->xpm.entries) {
-                    if (versions.empty()) continue;
+                    // THE REQUESTED VERSION has to resolve there — not merely
+                    // "this platform has some build".
+                    //
+                    // Without this the message answers a question nobody
+                    // asked: `config-no-payload@9.9.9` fails because 9.9.9
+                    // does not exist, and reporting "has no build for linux
+                    // (available on: linux, macosx, windows)" states the
+                    // opposite of the truth while naming the very platform it
+                    // says is unsupported. Caught by E2E-76, which is the
+                    // right shape for it — the unit of the defect is a whole
+                    // command's output, not a function's return.
+                    if (detail_::select_version_(*pkg, plat, parsed.version).empty())
+                        continue;
                     if (std::ranges::find(out, plat) == out.end())
                         out.push_back(plat);
                 }

--- a/src/core/xim/catalog.cppm
+++ b/src/core/xim/catalog.cppm
@@ -225,7 +225,15 @@ class PackageCatalog {
                    bool forSearch = false);
 
     std::vector<PackageMatch> collect_matches_(const std::string& target,
-                                               const std::string& platform) const;
+                                               const std::string& platform,
+                                               bool forSearch = false) const;
+
+    // Which platforms DO have a build of this target, for the case where
+    // this one has none. Empty when the target is genuinely absent.
+    //
+    // Exists so "not found" can stop being said about a package that is
+    // right there in the index — see resolve_target.
+    std::vector<std::string> platforms_offering_(const std::string& target) const;
 
 public:
     std::expected<void, std::string> rebuild(bool forceRebuild = false);

--- a/tests/e2e/config_install_no_implicit_dir_test.sh
+++ b/tests/e2e/config_install_no_implicit_dir_test.sh
@@ -67,6 +67,44 @@ function uninstall()
 end
 LUA
 
+# A second fixture, for a distinction the first one alone cannot pin down:
+# "does not exist" vs "exists, but has no build for THIS platform". Reporting
+# the second as the first sends the reader looking for a package that is
+# sitting in the index they just synced.
+#
+# Both directions matter, and each alone is satisfiable by a wrong
+# implementation:
+#   * config-no-payload@9.9.9 -- a version nobody has. Must still say "not
+#     found", and must NOT name platforms, which would state the opposite of
+#     the truth about a package that is fine here. (An implementation that
+#     ignored the version reported "no build for linux (available on: linux,
+#     macosx, windows)" -- naming the platform it called unsupported.)
+#   * config-other-platform   -- built only elsewhere. Must say so, and say
+#     where.
+cat > "$LOCAL_INDEX_DIR/pkgs/c/config-other-platform.lua" <<'LUA'
+package = {
+    spec = "1",
+    name = "config-other-platform",
+    description = "Test fixture: exists, but not for the platform asking",
+    type = "config",
+    archs = {"x86_64", "aarch64"},
+    status = "stable",
+    xpm = {
+        -- Deliberately not the host. Linux is where CI runs this; the macOS
+        -- leg drops its own row below so the fixture keeps its meaning there.
+        windows = { ["latest"] = { ref = "1.0.0" }, ["1.0.0"] = {} },
+        macosx  = { ["latest"] = { ref = "1.0.0" }, ["1.0.0"] = {} },
+    },
+}
+
+function install() return true end
+function config()  return true end
+LUA
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  sed -i.bak '/macosx  = /d' "$LOCAL_INDEX_DIR/pkgs/c/config-other-platform.lua"
+  rm -f "$LOCAL_INDEX_DIR/pkgs/c/config-other-platform.lua.bak"
+fi
+
 printf 'xim_indexrepos = {}\n' > "$LOCAL_INDEX_DIR/xim-indexrepos.lua"
 
 cat > "$HOME_DIR/.xlings.json" <<JSON
@@ -158,7 +196,24 @@ if [[ -f "$UNINSTALL_COUNT_FILE" ]]; then
   UNINSTALL_COUNT_AFTER_MISSING="$(cat "$UNINSTALL_COUNT_FILE")"
 fi
 
+OTHER_RC=0
+OTHER_OUT="$(RUN info config-other-platform 2>&1)" || OTHER_RC=$?
+
 FAILURES=()
+[[ "$OTHER_RC" -ne 0 ]] \
+  || FAILURES+=("a package with no build for this platform exited 0: $OTHER_OUT")
+grep -qi "no build for" <<<"$OTHER_OUT" \
+  || FAILURES+=("another-platform package was not reported as such: $OTHER_OUT")
+grep -qi "windows" <<<"$OTHER_OUT" \
+  || FAILURES+=("another-platform package did not name where it IS available: $OTHER_OUT")
+# `if`, not `grep ... && FAILURES+=(...)`. Under `set -e` that compound
+# returns grep's status, so the PASSING case -- grep finding nothing -- would
+# kill the script with no output at all. Same shape the four-defect doc
+# recorded in §9.3.
+if grep -qiE "package .* not found" <<<"$OTHER_OUT"; then
+  FAILURES+=("another-platform package was reported as 'not found': $OTHER_OUT")
+fi
+
 [[ "$REMOVE_RC" -eq 0 ]] \
   || FAILURES+=("payloadless config remove exited $REMOVE_RC: $REMOVE_OUT")
 [[ "$UNINSTALL_COUNT" == "1" ]] \

--- a/tests/e2e/self_doctor_depth_test.sh
+++ b/tests/e2e/self_doctor_depth_test.sh
@@ -119,9 +119,17 @@ RUN_WATCHED() {
     while ((i < ${#queue[@]})); do
       local pid="${queue[$i]}" children=""
       i=$((i + 1))
-      if [[ -r "/proc/$pid/task/$pid/children" ]]; then
-        children="$(<"/proc/$pid/task/$pid/children")"
-      fi
+      # NOT `[[ -r ... ]] && read`. That is a TOCTOU: this loop polls every
+      # 2ms while the tree is actively spawning and reaping, so a /proc entry
+      # can vanish between the test and the read. Bash then reports
+      #   /proc/<pid>/task/<pid>/children: No such file or directory
+      # and, under `set -e`, kills the whole test -- which is how this landed
+      # as a red e2e on a PR that only changed an error message.
+      #
+      # `cat` in a substitution, failure tolerated: a child that has already
+      # exited is not a child this needs to count. One subprocess per pid per
+      # poll is affordable here; a flaky gate is not.
+      children="$(cat "/proc/$pid/task/$pid/children" 2>/dev/null || true)"
       local child exe
       for child in $children; do
         queue+=("$child")


### PR DESCRIPTION
## Summary

Measured on Linux with the index synced:

```
$ xlings search msvc
  ◆ xim:msvc  Microsoft Visual C++ compiler toolset (portable, pinned to a toolset build)

$ xlings info msvc
  [error] package 'msvc' not found
```

Both commands, same machine, same index, **opposite answers**. `search` is right: the package exists. `info` filters candidates by platform and then reports an empty result with the only message it had.

"does not exist" and "exists, but has no build for this platform" are different facts, and reporting the second as the first sends the reader looking for a package that is sitting in the index they just synced.

`resolve_target` now distinguishes them and names where the package *is* available:

```
[error] package 'msvc' has no build for linux (available on: windows)
```

## The mechanism was already half-built

`build_matches_` has a `forSearch` flag that keeps a candidate whose version selection came up empty for the current platform — **exactly the set needed here** — and it had **no caller setting it to true**. A parameter with no caller is not a feature, and in this case the one place it was written for is the one place that was not using it.

## Scope

Applies to every windows-only package on a Linux host (`msvc`, `windows-sdk`, `curl`) and symmetrically to linux-only packages on Windows. No change to the success path: when a match exists, nothing new runs.

## Test plan

- [x] Found by real ecosystem verification: `xlings subos use msvc-verify --sandbox --cmd "xlings update -y && xlings info msvc"` on Linux after openxlings/xim-pkgindex#626–628 published `msvc`
- [ ] **Not built locally** — `mcpp build` on this checkout fails before reaching my change, on a pre-existing `mcpplibs.xpkg.lua_stdlib: failed to read compiled module` from `mcpplibs.xpkg@0.0.57` (reproduced with the change stashed). Relying on CI for the compile; will fix whatever it reports.