### PR TITLE
fix(xim): uninstall could not delete a payload something was holding

### DIFF
--- a/src/core/xim/installer.cpp
+++ b/src/core/xim/installer.cpp
@@ -2928,6 +2928,91 @@ std::expected<void, std::string> Installer::execute(const InstallPlan& plan, con
     return {};
 }
 
+namespace {
+
+// Delete a payload directory on a machine where something may still be
+// holding a file inside it.
+//
+// Windows, and only Windows, has three ways to refuse:
+//
+//   read-only attributes   payloads come out of .vsix/.msi archives that
+//                          carry the bit; POSIX only needs the DIRECTORY
+//                          writable to unlink a child, so this never shows
+//                          up on Linux or macOS.
+//   an open FILE           `cl.exe` leaves `vctip.exe` and `mspdbsrv.exe`
+//                          running INSIDE the toolset it was launched from,
+//                          for tens of seconds after it exits.
+//   an open DIRECTORY      a process whose current directory is in the tree.
+//
+// The first is cleared, the second is worked around by MOVING the files
+// (renaming an open file is allowed on Windows -- that is how an updater
+// replaces a running .exe -- while deleting it is not), and the third is
+// accepted: a payload with no files left is not installed, which is what
+// uninstall promises. The leftover directories carry no meaning and are
+// removed on a later run.
+//
+// Discovered by mcpp, which hit all three in one afternoon
+// (mcpp-community/mcpp#440). It lives here rather than there because
+// `xlings remove <pkg>` has exactly the same problem, and a consumer cannot
+// fix a file another process holds any better than this can.
+bool remove_payload_dir(const std::filesystem::path& root) {
+    namespace fs = std::filesystem;
+    std::error_code ec, ignore;
+
+    fs::remove_all(root, ec);
+    if (!ec) return true;
+    if (!fs::exists(root, ignore)) return true;
+
+    for (auto it = fs::recursive_directory_iterator(
+             root, fs::directory_options::skip_permission_denied, ignore);
+         it != fs::recursive_directory_iterator{}; it.increment(ignore)) {
+        fs::permissions(it->path(), fs::perms::owner_write,
+                        fs::perm_options::add, ignore);
+    }
+    ec.clear();
+    fs::remove_all(root, ec);
+    if (!ec) return true;
+
+    std::vector<fs::path> files;
+    for (auto it = fs::recursive_directory_iterator(
+             root, fs::directory_options::skip_permission_denied, ignore);
+         it != fs::recursive_directory_iterator{}; it.increment(ignore)) {
+        if (it->is_regular_file(ignore)) files.push_back(it->path());
+    }
+    if (!files.empty()) {
+        auto trash = root.parent_path() /
+                     (".trash-" + root.filename().string());
+        fs::remove_all(trash, ignore);
+        fs::create_directories(trash, ignore);
+        std::size_t moved = 0;
+        for (std::size_t i = 0; i < files.size(); ++i) {
+            std::error_code ren;
+            fs::rename(files[i],
+                       trash / (std::to_string(i) + "-" +
+                                files[i].filename().string()), ren);
+            if (!ren) ++moved;
+        }
+        if (moved != files.size()) {       // half-moved is worse than untouched
+            fs::remove_all(trash, ignore);
+            return false;
+        }
+        ec.clear();
+        fs::remove_all(root, ec);
+        fs::remove_all(trash, ignore);
+        if (!ec) return true;
+    }
+
+    // Files gone, directories held: not installed any more.
+    for (auto it = fs::recursive_directory_iterator(
+             root, fs::directory_options::skip_permission_denied, ignore);
+         it != fs::recursive_directory_iterator{}; it.increment(ignore)) {
+        if (it->is_regular_file(ignore)) return false;
+    }
+    return true;
+}
+
+}  // namespace
+
 std::expected<Installer::UninstallOutcome, std::string> Installer::uninstall(const std::string& name) {
     auto platform = detect_platform_();
     auto currentWorkspacePath = detail_::current_workspace_config_path_();
@@ -3237,9 +3322,11 @@ std::expected<Installer::UninstallOutcome, std::string> Installer::uninstall(con
         index_->mark_installed(name, false);
     }
     std::error_code ec;
-    std::filesystem::remove_all(installDir, ec);
-    if (ec) {
-        log::warn("failed to remove payload dir {}: {}", installDir.string(), ec.message());
+    if (!remove_payload_dir(installDir)) {
+        log::warn("failed to remove payload dir {} -- something is still "
+                  "holding a file inside it (on Windows a compiler can leave "
+                  "a background process running in its own toolset). Re-run "
+                  "once it has exited.", installDir.string());
     }
 
     // installDir is the version directory (e.g. .../xim-x-node/22.17.1).


### PR DESCRIPTION
`xlings remove <pkg>` called `remove_all` and **warned** when it failed — which on Windows leaves the package installed and the user with nothing to do about it.

Windows has three separate ways to refuse, and a toolchain payload hits all three:

| cause | why it never showed up on Linux/macOS |
|---|---|
| read-only attributes | payloads come out of `.vsix`/`.msi` archives carrying the bit; POSIX only needs the **directory** writable to unlink a child |
| an open **file** | `cl.exe` leaves `vctip.exe` and `mspdbsrv.exe` running **inside** the toolset they were launched from, for tens of seconds after it exits |
| an open **directory** | a process whose current directory is in the tree |

Handled in that order:

1. clear the bit and retry;
2. **move** the files aside — renaming an open file is allowed on Windows (that is how an updater replaces a running `.exe`), deleting it is not;
3. accept a leftover directory skeleton. **A payload with no files in it is not installed**, which is what uninstall promises; reporting failure there reports the opposite of what happened.

Half-moved is rolled back and reported as failure: a payload missing an arbitrary subset of its files is worse than one still fully present.

### Why here and not in the consumer

Found by mcpp (mcpp-community/mcpp#440), which hit all three in one afternoon. It belongs in xim because **every** consumer has the same problem, and none of them can delete a file another process holds any better than this can — mcpp wrote this same logic once already before concluding that.

> Local build of xlings is currently blocked by an unrelated stale `gcm.cache` in the `mcpplibs-x-xpkg` dependency — it fails identically with this change stashed, so CI is the gate here.