### PR TITLE
fix(self): silence is not a refusal for an idempotent reinstall (2026.8.22.3)

### DIFF
--- a/src/core/xself/install.cpp
+++ b/src/core/xself/install.cpp
@@ -513,16 +513,31 @@ bool same_dir_(const fs::path& a, const fs::path& b) {
     return ca == cb;
 }
 
-// A y/n on the EventStream, with `self install`'s own answer for "nobody was
-// there": DECLINE and say so.
+// What to do when nobody can answer. Same idea as `xim`'s enum of the same
+// shape, and for the same reason: only the caller knows which way its own
+// question defaults, so only the caller can say what silence means.
 //
-// Deliberately not `xim`'s `confirmed_or_refused_`: that one lives in the
-// package layer and carries a per-caller Proceed/Refuse policy. Every question
-// here is "may I overwrite an existing installation", and the answer to that
-// with nobody watching is no -- there is no direction in which guessing yes is
-// safe, which is exactly what the old `ask_yes_no(question, !downgrade)` did.
+// A first cut gave every question here a blanket Refuse, on the reasoning that
+// "may I overwrite an installation" is never safely guessed as yes. That is
+// true of two of the three and wrong about the third: reinstalling the SAME
+// version is idempotent, and a scripted `xlings self install` means exactly
+// that. The release pipeline's Windows smoke test found it -- it runs
+// `self install` over the running binary to check issue #473, and a refusal
+// leaves it nothing to check.
+//
+// Worth recording what that test was doing BEFORE: `ask_yes_no` returned its
+// `false` default on EOF, so the reinstall was cancelled every single run and
+// the test passed on an exit code from a cancellation. It has never once
+// overwritten a running binary. Proceed is what makes it start.
+enum class IfNobodyAnswers {
+    Proceed,   // affirmative default; doing it unattended is safe
+    Decline,   // negative default for an OPTIONAL extra -- say what was kept
+               // and carry on; the command has not failed
+    Refuse,    // negative default for the command ITSELF -- stop and say why
+};
+
 bool confirm_(EventStream& stream, std::string id, std::string question,
-              std::string defaultValue) {
+              std::string defaultValue, IfNobodyAnswers policy) {
     PromptEvent req;
     req.id = std::move(id);
     req.question = std::format("[xlings:self] {}", question);
@@ -534,6 +549,23 @@ bool confirm_(EventStream& stream, std::string id, std::string question,
         [](EventStream::Chosen&& c) { return c.value == "y"; },
         [](EventStream::Cancelled&&) { return false; },
         [&](EventStream::NobodyToAsk&&) {
+            if (policy == IfNobodyAnswers::Proceed) return true;
+            if (policy == IfNobodyAnswers::Decline) {
+                // NOT an error, and specifically not on stderr: the command is
+                // continuing, having taken the safe side of an optional
+                // question. Reporting it as a failure made PowerShell treat a
+                // successful `self install` as a terminating error -- which is
+                // how the release pipeline found this.
+                diag::emit({
+                    .level   = diag::Level::Note,
+                    .code    = "xself.kept_existing",
+                    .summary = "nobody to ask, so the existing data and subos "
+                               "were left as they are",
+                    .actions = { { "to replace them, run it where you can answer",
+                                   "xlings self install" } },
+                });
+                return false;
+            }
             diag::emit({
                 .code    = "xself.needs_confirmation",
                 .summary = "this would overwrite an installation, and there "
@@ -647,14 +679,19 @@ int cmd_install(EventStream& stream) {
     bool overwriteDataSubos = false;
     if (!fromTempExtract) {
         if (!pkgVersion.empty() && !installedVersion.empty() && pkgVersion == installedVersion) {
+            // Idempotent: the payload is replaced with an identical one.
             if (!confirm_(stream, "self_reinstall",
-                          "same version installed, reinstall?", "n")) {
+                          "same version installed, reinstall?", "n",
+                          IfNobodyAnswers::Proceed)) {
                 std::println("[xlings:self] cancelled\n");
                 return 0;
             }
             if (fs::exists(targetHome / "data") || fs::exists(targetHome / "subos")) {
+                // Destructive and unrecoverable: it discards installed
+                // packages and every subos. Nobody there means no.
                 overwriteDataSubos = confirm_(stream, "self_overwrite_data",
-                                              "overwrite data and subos?", "n");
+                                              "overwrite data and subos?", "n",
+                                              IfNobodyAnswers::Decline);
             }
         } else if (fs::exists(targetHome / "bin") && fs::exists(targetHome / "subos")) {
             // Name both versions, and say which DIRECTION this is.
@@ -684,8 +721,13 @@ int cmd_install(EventStream& stream) {
                 question = std::format("replace v{} with v{}?",
                                        installedVersion, pkgVersion);
             }
+            // The asymmetry the question wording above explains, stated as
+            // policy rather than smuggled in as a default value: an upgrade
+            // proceeds unattended, going BACKWARDS needs somebody to say so.
             if (!confirm_(stream, "self_overwrite", question,
-                          downgrade ? "n" : "y")) {
+                          downgrade ? "n" : "y",
+                          downgrade ? IfNobodyAnswers::Refuse
+                                    : IfNobodyAnswers::Proceed)) {
                 std::println("[xlings:self] cancelled\n");
                 return 0;
             }

--- a/tests/candidate-install/smoke.ps1
+++ b/tests/candidate-install/smoke.ps1
@@ -46,14 +46,23 @@ try {
     Write-Host $selfUpdate
     throw "shim rewrite reported a locked path while replacing the running binary"
   }
-  # Positive evidence that the step ran, not merely that it did not throw.
-  # `self install` onto its own home takes the "already in target dir, fixing
-  # links" path -- which is the one that rewrites the running .exe's shim, and
-  # therefore the one under test. Without this assertion a silent no-op would
-  # look exactly like a pass.
-  if ($selfUpdate -notmatch 'fixing links|install:') {
+  # Positive evidence that the step COMPLETED, not merely that it started.
+  #
+  # This used to accept `install:` -- which is printed BEFORE the reinstall
+  # confirmation, so a cancelled run matched it. And every run was cancelled
+  # until 2026.8.22.3: `ask_yes_no` returned its `false` default on EOF, so
+  # this test passed on the exit code of a cancellation and never once
+  # overwrote a running binary, which is the one thing it exists to check
+  # (issue #473).
+  #
+  # `- ok` is printed only by the path that finished.
+  if ($selfUpdate -notmatch '- ok|fixing links') {
     Write-Host $selfUpdate
-    throw "self install over the running binary produced no evidence it ran"
+    throw "self install over the running binary did not complete"
+  }
+  if ($selfUpdate -match '\[xlings:self\] cancelled') {
+    Write-Host $selfUpdate
+    throw "self install was cancelled, so the running-binary overwrite never happened"
   }
   if (-not (Test-Path $installed)) { throw "the running binary was displaced without a replacement" }
   & $installed --version | Out-Null

--- a/tests/candidate-install/smoke.sh
+++ b/tests/candidate-install/smoke.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# `fail` was USED on line 47 and never defined -- so the one assertion in this
+# file reported "fail: command not found" instead of its message. The test
+# still went red (127), but the CI log said nothing about what was wrong, which
+# on a release-only job is most of the cost.
+fail() {
+  echo "candidate-smoke: $*" >&2
+  exit 1
+}
+
 archive=${1:?archive path required}
 sidecar=${2:?sidecar path required}
 repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
@@ -39,13 +48,24 @@ run_candidate "$installed" self doctor
 # shim path is shared with Windows -- where it did not (issue #473) -- and a
 # contract only one platform checks is one the other can quietly lose.
 self_update_out=$(cd "$package_root" && run_candidate "$installed" self install 2>&1)
-# Positive evidence the step ran: `self install` onto its own home takes the
-# "already in target dir, fixing links" path, which is the one that rewrites
-# the running binary's shim. Without this a silent no-op would look like a pass.
-grep -qE 'fixing links|install:' <<<"$self_update_out" || {
+# Positive evidence the step COMPLETED, not merely that it started.
+#
+# This used to accept `install:` as evidence -- and `install:` is printed
+# before the reinstall confirmation, so a cancelled run matched it. That is
+# what happened on every run until 2026.8.22.3: `ask_yes_no` returned its
+# `false` default on EOF, the reinstall was cancelled, and this test passed on
+# the exit code of a cancellation without ever overwriting a running binary --
+# the one thing it exists to check (issue #473).
+#
+# `- ok` is printed only on the path that finished.
+grep -qE '\- ok|fixing links' <<<"$self_update_out" || {
   echo "$self_update_out"
-  fail "self install over the running binary produced no evidence it ran"
+  fail "self install over the running binary did not complete"
 }
+if grep -qE '^\[xlings:self\] cancelled' <<<"$self_update_out"; then
+  echo "$self_update_out"
+  fail "self install was cancelled, so the running-binary overwrite never happened"
+fi
 test -x "$installed"
 run_candidate "$installed" --version >/dev/null
 


### PR DESCRIPTION
Fixes the `candidate-windows-x86_64` failure that blocked the 2026.8.22.3 release ([run](https://github.com/openxlings/xlings/actions/runs/32551275063/job/96979400820)).

## The regression

#558 gave every confirmation in `self install` a blanket refusal when nobody can answer. That is right for two of the three questions and wrong for the third: **reinstalling the same version is idempotent**, and a scripted `xlings self install` means exactly that.

Policy is now per question, as `xim`'s already is:

| question | nobody answers | why |
|---|---|---|
| same version, reinstall? | **Proceed** | idempotent |
| overwrite data and subos? | **Decline** | optional and destructive — keep them, carry on |
| replace vA with vB? | **Proceed** | upgrade unattended is fine |
| DOWNGRADE vB → vA? | **Refuse** | going backwards needs a person |

`Decline` is a third outcome, not a spelling of `Refuse`. Declining an *optional* extra does not stop the command, so reporting it as an error was wrong twice: it claims a failure that did not happen, and it writes to stderr — where PowerShell turns a native command's output into a terminating error and fails a `self install` that succeeded. It is a Note on stdout now.

## Two older defects this uncovered

**The smoke tests have never tested what they exist to test.** Both sides assert `self install` over the running binary works (issue #473). Both accepted `install:` as evidence — and `install:` prints *before* the reinstall confirmation. Until this release `ask_yes_no` returned its `false` default on EOF, so the reinstall was **cancelled on every run**. The tests passed on the exit code of a cancellation; a running binary was never once overwritten.

Now they require `- ok` (only the finishing path prints it) and fail explicitly on `cancelled`. Checked both directions against real captured output:

| log | old assertion | new |
|---|---|---|
| completed install | PASS | PASS |
| cancelled install | **PASS** | FAIL |

**`fail` was called and never defined** in `smoke.sh`. Had its one assertion fired, the log would have said `fail: command not found` and nothing else — on a job that only runs during a release, where the log is all there is.

## Verified

Built a real package locally with `tools/linux_release.sh` and ran `tests/candidate-install/smoke.sh` against it: passes, and the output now contains `- ok` — the first time the running-binary overwrite has actually happened. Broke the policy back to a blanket refuse and confirmed the smoke test fails with a readable message.

E2E-48 and E2E-61 still pass.