### PR TITLE
docs: what the release pipeline caught, and what I got wrong doing it

### DIFF
--- a/.agents/docs/2026-08-22-release-2026.8.22.3-notes.md
+++ b/.agents/docs/2026-08-22-release-2026.8.22.3-notes.md
@@ -2,7 +2,7 @@
 
 > 设计:`2026-08-22-interaction-theme-and-layout-design.md`
 > 上一轮:`2026-08-22-release-2026.8.22.2-notes.md`
-> PR: openxlings/xlings#558
+> PR: openxlings/xlings#558(主体)· #559(发布管线抓到的回归)
 
 ## 1. 一句话
 
@@ -109,3 +109,40 @@ E2E-48 的 N8 覆盖这两条。它**不能用现成的 `RUN_PTY`** —— 那�
 | `config --lang/--mirror` 不带值时进入选择 | 同上 |
 | `diag` 的 15 个 code 接入 i18n | 机制已就位,接线是下一轮 |
 | `xlings interface` 的 prompt/prompt-reply | 该协议目前是死的(不开启交互且无 auto-responder)。**这在本轮之前就是如此**,不是回归,单独处理 |
+
+## 13. 发布过程本身抓到的东西
+
+第一次发布尝试失败在 `candidate-windows-x86_64`,而这一次失败连着挖出三层:
+
+**其一,我的回归。** `self install` 的所有确认在无人可答时被我一刀切拒绝,但同版本重装是幂等的 —— 脚本化的 `xlings self install` 就是这个意思。改成按问题声明策略,并引入第三种结局:
+
+| 问题 | 无人可答 | 理由 |
+|---|---|---|
+| 同版本重装 | `Proceed` | 幂等 |
+| 覆盖 data/subos | `Decline` | 可选项;拒绝它不终止命令,报 Note 走 stdout |
+| 升级 | `Proceed` | 无人值守也安全 |
+| 降级 | `Refuse` | 往回走要有人明说 |
+
+`Decline` 不是 `Refuse` 的别名。把一个**可选项**的拒绝报成 error 错了两次:声称失败而其实没有,以及写到 stderr —— 而 PowerShell 会把 native 命令的 stderr 转成终止错误,于是一次**成功**的 `self install` 被判为失败。这就是 Windows 红的直接原因。
+
+**其二,candidate smoke 从来没测过它声称要测的东西。** 两侧都断言"覆盖正在运行的二进制"(#473),而"positive evidence"用的是 `install:` —— 那一行在**取消**的输出里同样存在;旧的 `ask_yes_no` 在 EOF 总是取消。所以它一直在为一次取消的退出码鼓掌。用两份真实日志交叉验证:
+
+| 日志 | 旧断言 | 新断言 |
+|---|---|---|
+| 装完了 | PASS | PASS |
+| 取消了 | **PASS** | FAIL |
+
+改用 `- ok`(只有跑完的路径才打印)并显式拒绝 `cancelled`。发布后从 CI 日志确认:`- ok` 出现 1 次、`cancelled` 0 次 —— 这个测试第一次真的执行了。
+
+**其三,`fail` 被调用但从不存在。** `smoke.sh` 里唯一一处断言调用它,真触发只会得到 `command not found`:红是红了,原因全丢 —— 而这是个只在发布时才跑的 job,日志就是全部。已定义。
+
+## 14. 我在这次发布里犯的错
+
+**用 `ls -d build/xlings-* | head -1` 选包,字典序让半年前的 `0.4.40` 排在 `2026.8.22.3` 前面。** 那个旧二进制早于「`self install` 尊重 `XLINGS_HOME`」的修复,于是无视我传的变量,装进了开发者的真实 home,把入口二进制降级并清掉了 `config/themes/`(已恢复;`data/` 与 45 个 subos 未被触碰,因为覆盖它们是另一个默认为否的确认)。
+
+教训有两条,都已写进 `.agents` 之外的长期记忆:
+
+1. **绝不按 glob 顺序选构建产物** —— 不用 `head -1`、不用 `tail -1`、不用 `ls -t`。按版本号拼出确切路径,并在运行前先核对 `--version`。
+2. **验证性 `self install` 要同时重定向 `HOME` 与 `XLINGS_HOME`。** 只设后者等于假设被测二进制尊重它,而这恰恰是陈旧二进制会打破的假设;`HOME` 一并重定向后,`~/.xlings` 的回退也落在 scratch 里。
+
+顺带一提:同一天我在自己的验证脚本里也造了两个"失败与成功产出相同输出"的检查(`grep -c … || echo 0` 产生 `"0\n0"`;把一次瞬时读数当稳定状态)。和本轮在产品里修的三个缺陷是同一形状,区别只在于产品的会误导用户,我的会误导我自己。


### PR DESCRIPTION
Completes the 2026.8.22.3 release notes. Docs only — no code.

The notes referenced #558 but the release also contains #559, and the interesting part of that failure was not the regression itself:

**The first release attempt failed on `candidate-windows-x86_64`, and that one failure had three layers.**

1. **My regression** — a blanket refusal for every `self install` confirmation when nobody can answer. Wrong for the idempotent same-version reinstall, which is what a scripted `self install` means. Now per-question policy, with a third outcome: `Decline` (optional extra, keep going, Note on stdout) is not a spelling of `Refuse` (the command stops). Reporting an optional decline as an error on stderr is what made PowerShell fail a `self install` that had succeeded.

2. **The candidate smoke tests had never tested what they exist to test.** Both assert overwriting the running binary (#473); both accepted `install:` as evidence — printed *before* the reinstall confirmation, which `ask_yes_no` cancelled on EOF every single run. Verified both directions against real captured logs; confirmed from the release CI afterwards that `- ok` now appears once and `cancelled` zero times.

3. **`fail` was called and never defined** in `smoke.sh` — its one assertion would have said `command not found` and nothing about what was wrong, on a job that only runs during a release.

**And §14 records what I got wrong**: I picked a build artifact with `ls -d build/xlings-* | head -1`, where `0.4.40` sorts before `2026.8.22.3`. That six-month-old binary predates `self install` honouring `XLINGS_HOME`, so it installed into the developer's real home. Restored; `data/` and the subos tree were never at risk because overwriting them is a separate confirmation that defaults to no. Two rules written down: never select an artifact by glob order, and redirect `HOME` as well as `XLINGS_HOME` when verifying — setting only the latter assumes the binary honours it, which is exactly what a stale one does not.