### PR TITLE
docs: 2026.8.26.1 发布后的真实 home 实测

### DIFF
--- a/.agents/docs/2026-08-26-release-2026.8.26.1-notes.md
+++ b/.agents/docs/2026-08-26-release-2026.8.26.1-notes.md
@@ -205,6 +205,34 @@ xlings self doctor --fix
 XLINGS_ACTIVE_SUBOS=<name> xlings self doctor --fix
 ```
 
+## 11.1 发布后在真实 home 上的实测(以及两条只有真实 home 才看得见的事)
+
+```
+self update            2026.8.22.4 → 2026.8.26.1
+沙箱内版本确认          xlings --version → 2026.8.26.1(先确认再动手)
+doctor 报告            5 行,覆盖 112 条泄漏(default 7 / gfxbuild 99 / xkbverify 6)
+                       —— 同一台机器,修复前报 0 条
+doctor --fix           112 → 0,空目录回收,usr/include 保留
+沙箱内编译              zlib / X11 / GL / openssl / glib 全部头文件解析通过
+subos info             GL dispatch、mesa EGL/GLX、nvidia GLX 均 ok —— graphics 栈不变
+GitCode 镜像            16/16 OK;完整下载一份并自算 sha256,与索引记录逐字节一致
+```
+
+**① 索引迁移在已有 home 上,`install` 不够,还要 `use`。**
+`install linux-headers` 解包了目录链接、把**之前就声明过**的叶子放好了,
+但**新声明**的 5 个只注册没激活 —— 而资产只为 active 版本放置,于是 9 个
+`scsi` 头里有 5 个仍然缺。`use linux-headers <ver>` 之后 9/9。
+这条"新成员注册但不激活"是**长期以来的客户端行为**(2026.8.22.4 与
+2026.8.26.1 一模一样),不是这一轮引入的。已写进
+`xim-pkgindex` 的 `sysroot.lua`(#691)。
+
+**② `<pkg>.files.<n>` 是位置编号,而注册是全局的、workspace 是每 subos 的。**
+在一个 subos 里重装 linux-headers 会重写**全局**记录,而别的 subos 的
+workspace 仍然指着同样的成员名 —— 那些名字现在指向别的目的地。表现是
+`self doctor` 冒出 4 条 `xvm-sysroot-drift`。
+`xlings use linux-headers <ver>` 在那个 subos 里跑一次即收敛(4 → 1)。
+剩下的 1 条是 glibc 尚未重新声明(见下)。
+
 ## 12. 本轮没做
 
 - **未声明但可用的 sysroot 链接**(实测 646 条):资产被放进了没有声明它的
@@ -215,3 +243,10 @@ XLINGS_ACTIVE_SUBOS=<name> xlings self doctor --fix
   泄漏换成悬空,影响另一批状态,拆开走。
 - **`xvm::remove_asset` 仍用 `remove_all`**:新代码一律 `fs::remove`;
   Windows junction 在 `remove_all` 下是否跟随**未验证**,不在没测过之前动它。
+- **没有在用户主 subos 上重装 glibc**。`default` 的 `usr/include/scsi` 现在是
+  真目录、带 linux-headers 的 6 个;glibc 那 3 个还差一步
+  (`xlings install glibc && xlings use glibc <ver>`)。
+  **不是回归** —— 修复前那 3 个也是缺的(链接归 linux-headers)。
+  在一台 69 GB、63 个 subos 的主力环境上重装 libc,风险与它能补充的信息
+  不成比例:同一条路径已在隔离 home 里用真实包验过四种情形,
+  真实 home 的 `ftverify` subos 里也走通了 9/9。


### PR DESCRIPTION
承接 #562 / #423。仅文档。

发布后在用户自己的机器上跑过 `self update`,记录实测,以及**两条只有真实 home 才看得见的事**。

```
doctor 报告      5 行,覆盖 112 条泄漏(default 7 / gfxbuild 99 / xkbverify 6)
                 —— 同一台机器,修复前报 0 条
doctor --fix     112 → 0,空目录回收,usr/include 保留
沙箱内编译        zlib / X11 / GL / openssl / glib 头文件全部解析通过
subos info       GL dispatch、mesa EGL/GLX、nvidia GLX 均 ok
GitCode 镜像      16/16;完整下载一份自算 sha256,与索引记录逐字节一致
```

**① 索引迁移在已有 home 上,`install` 不够,还要 `use`。** 新声明的成员只注册不激活,而资产只为 active 版本放置 —— 9 个 `scsi` 头里 5 个仍缺,看起来就像修复没生效。长期行为,2026.8.22.4 上一模一样。已写进 xim-pkgindex#691。

**② `<pkg>.files.<n>` 是位置编号,注册是全局的、workspace 是每 subos 的。** 在一个 subos 重装会重写全局记录,别的 subos 仍指着同样的成员名 —— 那些名字现在指向别的目的地。表现为 4 条 `xvm-sysroot-drift`,在那个 subos 跑一次 `use` 即收敛。

同时记下**故意没做的**:没有在用户主 subos 上重装 glibc。`default` 的 `usr/include/scsi` 已是真目录带 linux-headers 的 6 个,glibc 那 3 个还差 `install + use` 一步 —— **不是回归**(修复前那 3 个也缺),但在一台 69 GB、63 subos 的主力环境上重装 libc,与它能补充的信息不成比例:同一条路径已在隔离 home 用真实包验过四种情形,真实 home 的 `ftverify` subos 里也走通了 9/9。
