### PR TITLE
feat(subos): the default runtime comes from the index, not a constant (2026.8.27.1)

### DIFF
--- a/.agents/docs/2026-08-26-private-glibc-preload-sysconfdir.md
+++ b/.agents/docs/2026-08-26-private-glibc-preload-sysconfdir.md
@@ -1,0 +1,291 @@
+# 私有 glibc 的 preload 应当跟随 sysconfdir(方案 P1)
+
+> 2026-08-26 · 承接 `2026-08-09-ecosystem-closure-design.md`「一个进程只有一个 libc」
+> 触发:`mcpp-community/mcpp#484` / `#485`(评审见 mcpp 侧
+> `.agents/reviews/2026-08-26-pr485-review.md`)
+> 目标:把「宿主凭什么往我们的封闭进程里塞库」这个洞一次堵上,
+> 并顺带给 xlings 补上一个它今天**没有**的能力:用户态 preload
+
+---
+
+## 0. 一句话
+
+私有 glibc 的 rtld 目前**硬编码**读宿主 `/etc/ld.so.preload`,把宿主 `.so`
+注入到每一个受管进程——包括**我们分发给用户的产物**。
+把这个路径改成跟随 `--sysconfdir`(`ld.so.cache` 早就是这么做的),
+并允许运行期用环境变量覆盖以支持重定位。
+
+**这不是给 glibc 加开关,是修正 glibc 自身的不一致。**
+对 `--sysconfdir=/etc` 的普通构建,该补丁是**恒等变换**。
+
+---
+
+## 1. 问题:定级被原始 issue 说小了
+
+`#484` 的标题是「gcc probe fails」。实测(本机,全部可复现,见 §2):
+
+```
+N1. 我们产出的程序,在有 /etc/ld.so.preload 的机器上   → exit=127,起不来
+N2. 同一台机器上,宿主编译的程序                       → exit=0
+```
+
+**真正的性质是:我们产出的二进制在这一类宿主上不可运行。**
+编译器只是第一个撞上的,因为它本身就是一个受管二进制,和用户拿到的产物
+共用同一个私有 loader(产物 `PT_INTERP` = `.../xim-x-glibc/2.44/lib64/ld-linux-x86-64.so.2`)。
+
+### 两种失败模式,第二种更危险
+
+| preload 库的依赖 | 结果 |
+|---|---|
+| 不自足(如 `libonion.so → libdl.so.2`) | **硬挂**,`exit=127`,报错指向一个我们没引用过的库 |
+| 自足(只需 `libc.so.6`) | **静默成功**,宿主 glibc 2.39 编的 `.so` 被绑到私有 2.44 上跑 |
+
+第二种正是前作要防的「一个进程两个 libc」,却从 preload 这个后门进来,零诊断。
+两条今天都无人知晓,因为触发条件(宿主 `/etc/ld.so.preload` 非空)在
+开发机和 CI 上几乎不出现,而在**企业内网机、云上生产机、受合规管控的机器**上常见
+——恰好是用户跑我们产物的地方。
+
+---
+
+## 2. 取证(全部本机实测)
+
+### 2.1 同一个 rtld 里,一个路径可重定位,一个不可
+
+```
+$ strings ~/.mcpp/.../xim-x-glibc/2.44/lib/ld-linux-x86-64.so.2 | grep ld.so
+/etc/ld.so.preload                                     ← 字面量,未被 --prefix 重写
+/home/xlings/.xlings_data/.../2.44/etc/ld.so.cache     ← 被重写成打包机路径
+```
+
+`ld.so.cache` 是 `SYSCONFDIR "/ld.so.cache"`,`/etc/ld.so.preload` 是硬编码字面量。
+**这就是全部病根。**
+
+### 2.2 私有 `ld.so.cache` 从来没有被读到过
+
+```
+$ ls /home/xlings/.xlings_data/.../2.44/etc/ld.so.cache  → No such file or directory
+$ ls ~/.mcpp/.../xim-x-glibc/2.44/etc/ld.so.cache        → 3223 bytes,内容全是打包机路径
+```
+
+loader 找的是打包机绝对路径,用户机器上不存在 ⇒ **私有 cache 恒为空**。
+载荷里那 3223 字节是死重,而且正是它把 issue 报告者引向了「重建 cache」这个
+**不成立**的 workaround(重建出来的落在安装目录,loader 根本不去那里读)。
+
+### 2.3 现成开关不存在
+
+`ld.so --help` 只有 `--inhibit-cache`、`--inhibit-rpath`;`--list-tunables` 里也没有。
+**任何方案都必须改 rtld**,成本相同,应挑语义最好的那个。
+
+### 2.4 受管闭包本来就是自足的
+
+| 二进制 | `PT_INTERP` | `DT_RUNPATH` |
+|---|---|---|
+| `g++` / `cc1plus` / `as` / `ld` / `ar` | 私有 loader | 全部有 |
+
+**不需要任何环境变量。** 所以正确的问题不是「怎么让被注入的宿主库找到依赖」,
+而是「宿主库凭什么在我的封闭进程里」。
+
+### 2.5 两个被否掉的方向,各自的实测理由
+
+| 方向 | `--version` | `-c` | 链接 | 否掉的理由 |
+|---|---|---|---|---|
+| `#485` 的 `loader --library-path` 包住 driver | OK | **FAIL(cc1plus)** | FAIL | `--library-path` **不跨 execve**,而 preload 逐进程重做 |
+| `LD_LIBRARY_PATH`,宿主 binutils | — | FAIL | FAIL | 泄漏进宿主 `as` ⇒ 宿主 loader 装私有 `libc.so.6` ⇒ `__pointer_chk_guard` GLIBC_PRIVATE 崩 |
+| `LD_LIBRARY_PATH`,受管 binutils(`-B`) | — | OK | OK | 端到端可行,但依赖「永不回落宿主 as/ld」这个额外不变量 |
+
+### 2.6 复现手法(无需 root)
+
+⚠️ `LD_PRELOAD`(环境变量)与 `/etc/ld.so.preload`(文件)**是两套机制**,
+只测前者会得出错误结论(补丁 preload 文件路径对 `LD_PRELOAD` 无效)。
+
+```bash
+mkdir etcov && for e in /etc/*; do ln -s "$e" "etcov/$(basename $e)"; done
+echo /path/to/libonion_sim.so > etcov/ld.so.preload
+bwrap --dev-bind / / --ro-bind $PWD/etcov /etc \
+      --unsetenv LD_PRELOAD --unsetenv LD_LIBRARY_PATH  <cmd>
+```
+
+构造件:`gcc -shared -fPIC -o libonion_sim.so x.c -Wl,--no-as-needed -lz`
+(`DT_NEEDED: libz.so.1`,无 `RPATH`/`RUNPATH`)。
+
+---
+
+## 3. 为什么 glibc 把它写死:两层信任模型
+
+`man 8 ld.so` 的 *Secure-execution mode* 一节:`LD_PRELOAD`、`LD_LIBRARY_PATH`、
+`LD_AUDIT`、`LD_DYNAMIC_WEAK`…… 在 setuid 场景下**作废并从环境中抹掉,
+让程序根本看不见**。
+
+`/etc/ld.so.preload` **不在这个列表里**——它不是环境变量,它是那条
+**在 secure-execution 下依然生效**的通道:
+
+| 通道 | 谁能控制 | secure-execution 下 |
+|---|---|---|
+| `LD_PRELOAD` 等 env | 启动进程的任何人 | 作废 + 抹掉 |
+| `/etc/ld.so.preload` | 能写 `/etc` 的人(root) | **照常生效** |
+
+审计探针如果能被 `export X=` 关掉,那就不叫审计。**固定路径不是疏忽,
+是这个机制的全部价值。** 另一个佐证:glibc 给了 cache 和 rpath 的 inhibit 开关
+(且 `--inhibit-rpath` 明确写「secure-execution 下忽略」),**唯独没给 preload 的**。
+
+### 由此得到的判别式
+
+- `ld.so.cache` / `ld.so.conf` / `DT_RPATH` —— 回答「**去哪找**」:可以有多份、
+  无策略含义 → 跟随 sysconfdir、配 inhibit 开关
+- `/etc/ld.so.preload` —— 回答「**什么被强加给你**」:既不 sysconfdir 化,也不给开关
+
+**我们要动的是第二类,所以必须把安全语义一起设计,不能只当成一个路径。**
+
+---
+
+## 4. 方案 P1
+
+### 4.1 语义
+
+rtld 中读 preload 文件的那一处,改为:
+
+```
+1. 若 XLINGS_LD_PRELOAD_FILE 已设置 且 非 AT_SECURE:
+       "" (空)  → 不读任何 preload 文件
+       <path>   → 读该文件
+2. 否则:读 SYSCONFDIR "/ld.so.preload"
+```
+
+三态语义,一个变量。**默认(不设变量)= 读自己 sysconfdir 的那份**,
+而不是宿主 `/etc` 的。
+
+### 4.2 三个关键性质
+
+**① 对普通系统构建是恒等变换。** stock glibc 用 `--sysconfdir=/etc` 构建,
+此时第 2 条即 `/etc/ld.so.preload`,行为与上游逐字一致。
+这既降低风险,也让它有上游化的余地——可以论证当前上游行为是自身的不一致:
+同一个 rtld,cache 被 `--sysconfdir` 重定位了,preload 却没有。
+
+**② 我们的载荷默认封闭。** sysconfdir 是打包机路径,那份文件在用户机器上
+不存在 ⇒ 不 preload ⇒ 编译器、`cc1plus`、`as`、`ld`、`ar`、产出的程序
+**全部自动免疫,不需要任何一处设环境变量**。
+
+**③ env 只为可重定位而存在,不为策略。** sysconfdir 烘死(cache 就是这么坏的),
+所以要开放 payload 级 preload 就必须运行期给路径。**这是新增能力,不是修复的一部分。**
+
+### 4.3 安全规则(承重,不可省)
+
+`XLINGS_LD_PRELOAD_FILE` 必须与 `LD_PRELOAD` **同级对待**:
+`AT_SECURE`(setuid / setgid / file capabilities)时**作废并从环境中抹掉**。
+
+做到这一点,新增权限面 = **0**:`LD_PRELOAD` 本来就给了完全等价的能力
+(任意注入 `.so`),我们没有创造新的攻击面,只是多了一个同权限的入口。
+漏掉这一点,则任何使用私有 glibc 的 setuid 程序都成为提权向量。
+
+### 4.4 这不是 ABI 变更
+
+不涉及符号版本、struct 布局、调用约定;`libc.so.6` 导出符号集不变;
+对该 glibc 编译的程序字节不变;rtld 与程序的接口(auxv、入口协议、符号解析)不变。
+载荷本来就不是 stock(版本横幅已是 `xlings-fromsource`)。
+
+**动的是一条策略语义**,靠 §4.3 化解。
+
+---
+
+## 5. 影响面
+
+### 5.1 受影响 / 不受影响
+
+| 对象 | 是否受影响 | 说明 |
+|---|---|---|
+| 受管编译器与其全部子进程 | ✅ 修好 | 默认封闭 |
+| `mcpp pack --mode self-contained` 产物 | ✅ 修好 | 自带私有 loader |
+| `mcpp pack --mode vendored` 产物 | ➖ 本就不受影响 | `PT_INTERP` 是宿主 loader |
+| `mcpp pack --mode static` 产物 | ➖ 本就不受影响 | 无动态 loader |
+| 宿主上的其他一切程序 | ➖ 完全不受影响 | 补丁只在我们的 rtld 里 |
+
+**不是巧合**:需要自带 loader 的模式才会踩私有 rtld 的坑。
+
+### 5.2 必须明说的策略后果
+
+**我们分发的产物将不再加载用户主机的 preload 探针**(审计 / APM / HIDS)。
+
+支持这个选择的论据:**今天在这类主机上,没有任何「正确行为」值得保留**
+——要么 `exit=127` 起不来,要么静默跨 glibc 混链(§1)。P1 不会破坏任何
+**能工作**的东西。
+
+但这仍是一个策略决定,必须写进 `xim-x-glibc` 的包文档,并在
+release notes 里点名。
+
+### 5.3 旧载荷仍在野
+
+已发布的 glibc 载荷没有这个补丁。过渡期内 mcpp 侧的**诊断**是唯一能把
+`exit=127` 翻译成人话的东西,不可省。
+
+---
+
+## 6. 改动清单
+
+| 仓库 / 文件 | 改动 |
+|---|---|
+| `xim-pkgindex-fromsource` `pkgs/g/glibc.lua`(configure 在 `:102-112`) | ① configure 前加 rtld 源码补丁步骤;② 安装后删除 `etc/ld.so.cache`;③ 版本 bump |
+| 同上 `config()` / `xvm.add("glibc")` 附近 | (可选,新能力)声明 `envs`,机制见 `xlings` `src/core/xvm/types.cppm:44` |
+| 打包机 + 索引 | 重建 artifact、重新发布、索引 bump |
+| `mcpp` | **只加诊断**;撤 `PR#485` 的机制部分 |
+| `mcpp` `src/pack/pack.cppm:686` | (可选,新能力)wrapper 加一行 `export`,紧挨现有 `MCPP_BUNDLE_DIR` |
+
+`glibc.lua:117` 已有的 TODO 正是同一类问题,可一并处理:
+
+```lua
+-- TODO: use make install DESTDIR=$SYSROOT to avoid prefix hardcoding path in some files (libc.so)
+```
+
+### ⚠️ 落地前先确认
+
+本地检出的两个索引里 glibc 都停在 **2.39**
+(`d2learn/xim-pkgindex` 是 `XLINGS_RES` 预编译,`xim-pkgindex-fromsource` 是源码构建),
+而本机装的是 **2.44 预编译产物**(baked path 是打包机的,证明非本机构建)。
+**2.44 的描述符由谁发布,必须先查清**——补丁要打在产出该 artifact 的那条链上。
+
+---
+
+## 7. 验收判据
+
+⚠️ 每一条都要做**撤掉补丁的对照**,否则不知道判据在不在测东西。
+
+1. **端到端,带对照。** 在 §2.6 的 bwrap 环境里,四项全过:
+   `g++ --version` / `-c` 编译 / 完整链接 / **运行产出的程序**;
+   且换回未打补丁的 loader 后**四项全红**。
+   (`#485` 只过第一项——这正是它的测试计划打勾却没发现问题的原因。)
+
+2. **闭包判据,带分母。** `LD_DEBUG=libs` 跑一次受管编译,统计加载对象:
+   **来自宿主路径的数量 = 0 / 总数 N**。这条覆盖 §1 的「静默混链」模式,
+   而它今天没有任何测试。
+
+3. **字面量判据。** `strings <新 loader> | grep -c '^/etc/ld.so.preload$'` == 0。
+
+4. **恒等性判据。** 另用 `--sysconfdir=/etc` 构建一份,在同样 bwrap 环境里
+   preload **照常生效**——证明补丁对普通构建是恒等变换。
+
+5. **安全判据。** 一个 setuid 测试程序在设了 `XLINGS_LD_PRELOAD_FILE` 时,
+   该变量被忽略**且 `/proc/self/environ` 里已被抹掉**。
+
+6. **死重判据。** 新载荷里不存在 `etc/ld.so.cache`。
+
+---
+
+## 8. 风险与回退
+
+| 风险 | 处置 |
+|---|---|
+| glibc 升级需 rebase 补丁 | 一个函数,且我们本就从源码构建;把补丁作为配方的一部分维护 |
+| 用户依赖宿主 preload 探针 | §5.2 已明说;需要时用 `XLINGS_LD_PRELOAD_FILE=/etc/ld.so.preload` 显式恢复 |
+| 补丁写错导致载荷不可用 | 判据 1 的对照 + 判据 4 的恒等性一起构成双向门 |
+| 回退 | 索引层面回退到上一版 glibc 即可;`min` 版本门要写下界不写死 |
+
+---
+
+## 9. 未决
+
+1. **默认值 P1 已定**(读自己的 sysconfdir),但 §5.2 的策略后果需要产品层面确认。
+2. 2.44 描述符的发布位置(§6)。
+3. 变量名:建议 `XLINGS_LD_PRELOAD_FILE`。**归属是 glibc 载荷而非 mcpp**
+   ——吃它的是 xim 装的任何使用私有 glibc 的东西,故用 `XLINGS_*`。
+   勿用 `LD_` 前缀,避免与 glibc 自身命名空间混淆。
+4. `mcpp` `write_topentry_wrapper`(`pack.cppm:727`)服务的 BundleProject 模式
+   是否也用私有 loader,未核实。

--- a/.agents/docs/2026-08-27-runtime-binding-default-from-index.md
+++ b/.agents/docs/2026-08-27-runtime-binding-default-from-index.md
@@ -1,0 +1,279 @@
+# 默认 runtime 绑定应当来自索引,而不是常量
+
+> 2026-08-27 · 承接 `2026-08-26-private-glibc-preload-sysconfdir.md`
+> 与 `2026-08-09-ecosystem-closure-design.md` §C1(AD-11 / DEFAULT_RUNTIME)
+> 触发:`xim-pkgindex#692` 合入后,**全新 home 的第一次 `mcpp build` 直接失败**
+
+---
+
+## 0. 一句话
+
+`DEFAULT_RUNTIME = "glibc@2.44"` 和索引里 glibc 的 `latest` 是**同一个决定写在两个仓库**。
+`#692` 把 `latest` 提到 `2.44.2`,这个常量没跟着动,于是每一个**新建** subos
+声明了一个盘上不存在的绑定。
+
+把常量退化成**包名**,版本在**创建时向索引解析**并照旧持久化到 manifest;
+索引不可读时回落到一个钉死的版本,**但把"这次是回落"记下来**。
+
+---
+
+## 1. 已经落地的部分(本设计的前提)
+
+`xim-pkgindex#692`(已合入 main,索引已发布):
+
+| | |
+|---|---|
+| `glibc.lua` | `latest → 2.44.2`;条目 append-only,`2.44`/`2.39` 原样保留 |
+| 产物 | `glibc-2.44.2-linux-x86_64.tar.gz`,GitHub + GitCode 双区,下载回比对逐字节一致 |
+| 补丁 | `elf/rtld.c` 的 preload 路径跟随 `--sysconfdir`;`XLINGS_LD_PRELOAD_FILE` 可运行期覆盖;变量入 `unsecvars.h` |
+| 判据 | `verify-preload-closure.sh`(四态退出码,两侧对照);`TestRevisionOrdering` |
+
+沙箱实测(真实 `/etc/ld.so.preload`,非 overlay):
+
+```
+[已发布的 2.44]  libc.so.6: error while loading shared libraries: libz.so.1
+[2.44.2 走 CN]   GNU C Library (GNU libc) stable release version 2.44.
+```
+
+---
+
+## 2. 问题:一个决定,两个仓库
+
+### 2.1 实测
+
+全新 `MCPP_HOME`,第一次 `mcpp build`:
+
+```
+Downloading xim:glibc@2.44.2                       ← 索引侧正确
+error: default toolchain post-install fixup:
+       selected RuntimeBinding glibc@2.44 requires payload
+       '<home>/registry/data/xpkgs/xim-x-glibc/2.44',
+       but it is not installed; mcpp will not fall back to another directory entry
+```
+
+取证:
+
+```
+gcc payload 的 PT_INTERP   → .../xim-x-glibc/2.44.2/lib64/ld-linux-x86-64.so.2   ✓ elfpatch 对了
+subos/default/.xlings.json → "runtime": "glibc@2.44"                            ✗ 常量
+xim-x-glibc/ 目录          → 2.44.2                                              (只有它)
+```
+
+载荷目录按版本命名,所以盘上没有任何东西答应 `glibc@2.44` 这个绑定。
+
+### 2.2 影响面的形状
+
+**只影响新建 subos,一个老 subos 都不受影响**——因为绑定是创建时属性、持久化在各自
+manifest 里,`preserved_runtime` 会保住已记录的有效值。这正是最容易漏掉的形状:
+开发机上早就建好的 subos 全绿,而任何新用户、新环境、CI 的干净 runner 全红。
+
+### 2.3 为什么这次会漏,而以前不会
+
+`DEFAULT_RUNTIME` 从 2.39 挪到 2.44 是**上游版本**变化——罕见、显眼、有人盯。
+`2.44 → 2.44.2` 是**打包修订**:同一个上游发布,只因为产物要重打而变,
+而且"索引发了个新修订"这件事在 xlings 这边没有任何东西能感知。
+**修订号的引入,才让这两处第一次具备了漂移的条件。**
+
+---
+
+## 3. 方案 A:常量退化成包名,版本向索引解析
+
+### 3.1 为什么这不违反当初写常量的理由
+
+`manifest.cppm` 里那条理由是:
+
+> A constant rather than a lookup: ... inventing a **"pick the newest libc present"**
+> rule would make two homes with the same command produce different subos.
+
+它反对的是**扫描机器上装了什么**。那确实不确定:两台机器装的东西不同,答案就不同。
+
+**读索引的 `latest` 不是那件事。** 同一个索引快照 → 同一个答案,而这正是
+`latest` 的定义,每一个 `xlings install` 已经这么做了。
+
+而且策略本身已经搬走了。`glibc.lua` 现在把它写成明规则:
+
+> `latest` ... **TRACKS the highest glibc of any distribution we support**,
+> as a standing policy rather than a per-version judgement call
+
+常量里那段 `our_glibc >= host_glibc` 的论证,是这条策略的**陈旧副本**。
+删掉副本、留下正本,是这个改动真正在做的事。
+
+### 3.2 形状
+
+```
+manifest.cppm(保持零依赖:不 import Config/xvm/catalog)
+    DEFAULT_RUNTIME_PACKAGE  = "glibc"        ← 名字
+    DEFAULT_RUNTIME_FALLBACK = "glibc@2.44.2" ← 仅在索引答不出时使用
+
+    runtime_for(subosDir, doc, intent, requested = {},
+                defaultRuntime = DEFAULT_RUNTIME_FALLBACK)
+                ^^^^^^^^^^^^^^ 新增参数;第 5 步用它,不再用常量
+
+subos.cpp(可以 import xim,已经在 import xlings.core.xim.commands)
+    resolve_default_runtime() -> { binding, source }
+        auto& catalog = xim::get_catalog(xim::CatalogAccess::LocalOnly);
+        if (!catalog.is_loaded())                    -> { FALLBACK, Fallback }
+        auto m = catalog.resolve_target("glibc", platform);
+        if (!m || m->version.empty())                -> { FALLBACK, Fallback }
+        return { "glibc@" + m->version, Index }
+```
+
+`runtime_for` 仍然是**唯一漏斗**——文件自己的教条("all of them ask the same
+question, and the ONE thing they legitimately disagree about becomes a
+parameter")。这次新增的参数正好是那个"唯一可以合法分歧的东西"。
+
+### 3.2.1 解析器住在 xim 层,不在 subos 层
+
+第一版把 `resolve_default_runtime()` 放在 `subos.cpp`,因为那里已经 import 了
+`xlings.core.xim.commands`。**但这样 `xself/init.cpp` 够不到它**,而
+`init.cpp` 正是 `xlings self init` 写 `subos/default` 的那条路——也就是
+mcpp 沙箱初始化实际走的那条。漏掉它等于这个修复对主路径无效。
+
+`init.cpp` 不能 import `xlings.core.subos`(subos 反过来 import xself,成环)。
+所以「问索引要一个包的版本」下沉到 xim:
+
+```
+xim.commands:   std::optional<std::string> resolve_latest_version(pkg)
+                    // 纯索引查询,LocalOnly,不知道 runtime 是什么
+
+subos / xself:  拿到版本 -> 拼 "glibc@<ver>",或落到 FALLBACK,并记 source
+                    // 策略在这里,查询在下面
+```
+
+分层也更正:xim 回答「索引说这个包是什么版本」,subos/xself 决定
+「拿这个答案做什么」。前者没有 runtime 的概念,后者不需要知道索引长什么样。
+
+### 3.3 只有 Create 传解析值
+
+已核实的五个调用点:
+
+| 位置 | intent | 传什么 |
+|---|---|---|
+| `xself/init.cpp:183` | Create | 解析值(**这条最要紧**:`self init` 写的 `subos/default` 就是 mcpp 首次构建读的那块) |
+| `subos.cpp:479`(new) | Create | 解析值 |
+| `subos.cpp:896`(fork) | Create | 解析值 |
+| `subos.cpp:386`(rebuild) | 变量 | 解析值(Describe 时第 5 步不执行) |
+| `xself/doctor.cpp:2056` | Describe | **不传**,保持返回空 |
+
+Describe 路径一个字都不能改:那里"没有答案"必须继续是空,而不是一个默认值——
+否则就是把猜测记成事实,而这正是这个文件此前修过的缺陷。
+
+### 3.4 回落必须留痕
+
+回落本身是必要的(`subos new` 今天不依赖索引,不能因为这个改动变成硬依赖),
+但**回落的结果和解析的结果长得一模一样**,这是不能接受的:后来的人无法分辨
+一个 subos 钉在旧 glibc 上是"当时索引就这么说"还是"当时索引读不到"。
+
+两件事一起做:
+
+1. **创建时给出可见告警**,点名 `xlings update` 和 `--runtime` 两条出路
+2. **写进 manifest**:`subos_info.runtime_source ∈ {explicit, index, fallback}`
+
+字段是**追加**的,老读者用 `b.value(key, default)` 读,不认识就忽略,
+所以 `SCHEMA_VERSION` 不动(提升它会让今天的读者对明天的 manifest 报"更新的
+schema",而这个字段并不改变任何既有语义)。
+
+---
+
+## 4. 没有采用的方案,以及为什么记下来
+
+### B. 绑定身份 = ABI 身份,而不是打包修订号
+
+`2.44.2` 与 `2.44` 的 **ABI 完全相同**——修订号是我们的打包行为。所以更根本的模型是:
+索引键用 `2.44.2`(为了排序与 sha),而**载荷目录与绑定用 `glibc@2.44`**,
+修订号对所有消费者不可见,`DEFAULT_RUNTIME` 永远不用动。
+
+不采用的原因:要打破"一个版本一个目录"(`xim-x-<name>/<version>`)这个全生态
+不变量,引入 install_as / abi 概念。**它更正确,但它是另一个立项**,
+而本文要修的破口今天就在流血。
+
+记下来是因为:如果 A 落地后仍然出现"某处硬编码了 glibc 版本"的第三例,
+那说明问题不在具体某个常量,而在这个目录身份模型,那时应当直接做 B。
+
+### C. 让绑定解析在找不到载荷时回落到兼容版本
+
+mcpp 明确拒绝("will not fall back to another directory entry"),而且有理由:
+编译侧与产物 interpreter 指向不同 glibc 时,一切看起来都正常,直到加载另一份。
+放宽这里等于把一个响亮的失败换成一个安静的错误。
+
+---
+
+## 5. 验收判据
+
+每条都要有**能证伪的反向对照**——否则不知道它在测什么。
+
+### V1 —— 新建 subos 拿到的是索引的 latest,不是常量
+
+**落地为** `tests/e2e/subos_runtime_binding_test.sh` 的 S4:给测试 home 一个
+**能回答**的本地索引,其 `latest` 指向 `9.9.9` —— 这个字符串在整棵树的常量、
+fixture、载荷里都不存在,所以 manifest 里出现它**只可能**是解析来的。
+断言 `runtime == glibc@9.9.9` 且 `runtime_source == index`。
+
+这就是反证内置进判据本身:一个仍然读常量的实现,S4 必然失败,
+而且失败信息直接说出后果("会在下次 glibc 重新发布时再次漂移")。
+
+### V2 —— 索引读不到时回落,且**留痕**
+
+**落地为**同一个 e2e 的 S1:该 home 用的是**空索引**(原本就是为了避免联网克隆),
+所以它天然是回落路径。断言绑定 == 从源码读出的 `DEFAULT_RUNTIME_FALLBACK`
+(不是写死的字面量),且 `runtime_source == "fallback"`。
+
+S1 与 S4 合起来才是判据:只有一侧的话,"永远回落"和"永远解析成同一个值"
+读数相同——而那正是这次要消灭的形状,不能拿它来验证它自己。
+
+### V3 —— Describe 路径没有被改到
+
+`doctor --fix` 在一个只有 2.39 记录的 subos 上,`runtime` 仍是 `glibc@2.39`,
+且**不等于当前默认值**。
+
+`tests/e2e/subos_runtime_describe_test.sh` 里那条断言必须**从源码推导**当前默认值
+而不是写死字面量——这次已经踩过:它原本写 `!= "glibc@2.44"`,默认值一动
+就变成恒真。
+
+### V4 —— 端到端:全新 home 的第一次 `mcpp build`
+
+沙箱(`xlings subos use <n> --sandbox bwrap`)+ 独立 `MCPP_HOME`:
+
+```
+mcpp config --mirror CN
+mcpp new hello && cd hello && mcpp build
+```
+
+判据:**构建成功**,且 `$MCPP_HOME/registry/data/xpkgs/xim-x-glibc/` 里的目录名
+与 subos 声明的 runtime 版本**相等**。
+
+**反证**:在打补丁前的 xlings 上跑同一条,必须复现
+`selected RuntimeBinding glibc@2.44 requires payload ... but it is not installed`。
+(已实测复现过,见 §2.1。)
+
+⚠️ `mcpp build 2>&1 | tail` 的退出码是 `tail` 的。判据取**输出文本**或分开取 `$?`。
+
+### V5 —— preload 闭包没有被这轮改动破坏
+
+```
+.agents/tools/graphics/verify-preload-closure.sh <payload>   → 0
+```
+对未打补丁的载荷 → 2(inconclusive,**不是** 0)。
+
+---
+
+## 6. 落地顺序
+
+1. **先落常量 bump**(`glibc@2.44` → `glibc@2.44.2`),一行。
+   它把今天所有新建 subos 的破口立刻堵上,且是这个文件文档化的既有动作
+   ("A future default bump updates one line here, knowingly")。
+   同批把 `subos_runtime_describe_test.sh` 的恒真断言改成推导式。
+2. **再落方案 A**,带 V1–V3 的测试。
+3. V4 在 A 落地后于沙箱跑一次,作为跨仓库的合闸判据。
+
+第 1 步不是第 2 步的替代品:没有第 2 步,下一次 glibc 出修订会**一模一样地**再来一次。
+
+---
+
+## 7. 未决
+
+1. `runtime_source` 的取值集合是否还需要第四种(例如 `preserved`,
+   表示 rebuild 保住了已记录的值)。倾向不加:那条路径不经过默认值。
+2. 索引里出现多个 libc 家族(musl)时,`DEFAULT_RUNTIME_PACKAGE` 单值是否够用。
+   `RUNTIME_PACKAGES` 已经是个有序表,届时默认值应当沿用同一个 tie-break,
+   而不是新写一份顺序。

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -29,7 +29,7 @@ members = [
 
 [package]
 name = "xlings"
-version = "2026.8.26.1"
+version = "2026.8.27.1"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -10,7 +10,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "2026.8.26.1";
+    static constexpr std::string_view VERSION = "2026.8.27.1";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/subos.cpp
+++ b/src/core/subos.cpp
@@ -383,7 +383,14 @@ bool ensure_subos_info_(const fs::path& dir, manifest::Intent intent,
     // An unusable block can still carry a valid runtime binding, and that
     // binding — not the caller's request — is what the subos was declared
     // against. runtime_for keeps it through the rebuild.
-    auto runtime = manifest::runtime_for(dir, json, intent, requested);
+    // The default is resolved rather than compiled in, for the same reason
+    // create() resolves it: this constant and the index's `latest` were one
+    // decision in two repositories. Silent here -- a rebuild is not the place
+    // to teach someone about the index -- and the source is left unset,
+    // because a recorded or observed binding outranks the default and this
+    // call cannot see which step answered.
+    auto runtime = manifest::runtime_for(dir, json, intent, requested,
+                                         resolve_default_runtime().binding);
     json[std::string(manifest::BLOCK)] = manifest::make_block({
         .runtime   = std::move(runtime),
         .by        = std::format("xlings {}", Info::VERSION),
@@ -406,6 +413,16 @@ bool ensure_subos_info_(const fs::path& dir, manifest::Intent intent,
     return true;
 }
 
+DefaultRuntime resolve_default_runtime() {
+    const std::string pkg{manifest::DEFAULT_RUNTIME_PACKAGE};
+    if (auto version = xim::index_version_of(pkg))
+        return DefaultRuntime{.binding = pkg + "@" + *version, .resolved = true};
+    return DefaultRuntime{
+        .binding = std::string(manifest::DEFAULT_RUNTIME_FALLBACK),
+        .resolved = false,
+    };
+}
+
 int create(const std::string& name, const fs::path& customDir,
                   sandbox::StorageMode storage, const std::string& imageSize,
                   const std::string& runtime,
@@ -424,8 +441,32 @@ int create(const std::string& name, const fs::path& customDir,
     // Checked before anything is laid down. A malformed runtime that only
     // surfaced at write time would leave a registered subos that cannot
     // satisfy its own invariants.
-    const std::string effectiveRuntime =
-        runtime.empty() ? std::string(manifest::DEFAULT_RUNTIME) : runtime;
+    std::string effectiveRuntime = runtime;
+    std::string runtimeSource{manifest::RUNTIME_SOURCE_EXPLICIT};
+    if (effectiveRuntime.empty()) {
+        const auto def = resolve_default_runtime();
+        effectiveRuntime = def.binding;
+        runtimeSource = std::string(def.resolved ? manifest::RUNTIME_SOURCE_INDEX
+                                                 : manifest::RUNTIME_SOURCE_FALLBACK);
+        if (!def.resolved) {
+            // Said out loud, because the alternative is a subos silently
+            // pinned to whatever this build was compiled with while the index
+            // has moved on -- and the failure that follows names a payload
+            // directory, not a decision anybody remembers making.
+            //
+            // Both remedies, because they answer different situations: the
+            // index has never been synced here, or the caller knew the answer
+            // all along.
+            stream.emit(LogEvent{
+                .level = LogLevel::warn,
+                .message = "index could not answer which "
+                           + std::string(manifest::DEFAULT_RUNTIME_PACKAGE)
+                           + " to bind to; using the built-in " + effectiveRuntime
+                           + ". Run `xlings update` and recreate, or pass "
+                             "`--runtime <package>@<version>`.",
+            });
+        }
+    }
     if (!manifest::is_binding(effectiveRuntime)) {
         stream.emit(ErrorEvent{
             .code = ErrorCode::InvalidInput,
@@ -483,6 +524,14 @@ int create(const std::string& name, const fs::path& customDir,
             .by        = std::format("xlings {}", Info::VERSION),
             .hostGlibc = platform::host_glibc_version(),
             .intent    = manifest::Intent::Create,
+            // Claimed only here. This is the one path that KNOWS: the value
+            // was decided above, before runtime_for was asked, and step 2
+            // returns it verbatim. The other two Create call sites hand
+            // runtime_for a resolved default but cannot tell whether it was
+            // the step that answered -- a recorded or observed binding
+            // outranks it -- so they leave this empty, which reads as
+            // "unknown" rather than as a fourth value.
+            .runtimeSource = runtimeSource,
         });
         write_config_json_(subosConfig, j);
     } else if (!ensure_subos_info_(dir, manifest::Intent::Create,
@@ -894,7 +943,8 @@ int new_from(const std::string& name, const fs::path& customDir,
         subosCfg["workspace"] = nlohmann::json::object();
     if (!manifest::validate_block(subosCfg).empty()) {
         auto forkRuntime = manifest::runtime_for(
-            dstDir, subosCfg, manifest::Intent::Create, runtime);
+            dstDir, subosCfg, manifest::Intent::Create, runtime,
+            resolve_default_runtime().binding);
         subosCfg[std::string(manifest::BLOCK)] = manifest::make_block({
             .runtime   = std::move(forkRuntime),
             .by        = std::format("xlings {}", Info::VERSION),

--- a/src/core/subos.cpp
+++ b/src/core/subos.cpp
@@ -389,8 +389,13 @@ bool ensure_subos_info_(const fs::path& dir, manifest::Intent intent,
     // to teach someone about the index -- and the source is left unset,
     // because a recorded or observed binding outranks the default and this
     // call cannot see which step answered.
-    auto runtime = manifest::runtime_for(dir, json, intent, requested,
-                                         resolve_default_runtime().binding);
+    // Resolved only for Create. Under Describe step 5 does not exist, so the
+    // default is never consulted -- and asking would make every repair and
+    // every rebuild rebuild the catalog for an answer it then discards.
+    auto runtime = intent == manifest::Intent::Create
+        ? manifest::runtime_for(dir, json, intent, requested,
+                                resolve_default_runtime().binding)
+        : manifest::runtime_for(dir, json, intent, requested);
     json[std::string(manifest::BLOCK)] = manifest::make_block({
         .runtime   = std::move(runtime),
         .by        = std::format("xlings {}", Info::VERSION),

--- a/src/core/subos.cppm
+++ b/src/core/subos.cppm
@@ -79,13 +79,32 @@ struct UseNameResolution_ {
 // entry at use-time. The sandbox-private dirs are laid down lazily.
 //
 // `runtime` is the subos's declared runtime binding ("glibc@2.39"): what its
-// binaries are built against. Empty means the built-in default. It is a
-// creation-time property because changing it after the fact would invalidate
-// every payload already installed.
+// binaries are built against. Empty means "resolve it" -- see
+// resolve_default_runtime below. It is a creation-time property because
+// changing it after the fact would invalidate every payload already installed.
 export int create(const std::string& name, const fs::path& customDir,
                   sandbox::StorageMode storage, const std::string& imageSize,
                   const std::string& runtime,
                   EventStream& stream);
+
+// What a subos gets when nobody named a runtime: the index's answer for
+// manifest::DEFAULT_RUNTIME_PACKAGE, or the pinned fallback when the index
+// cannot be read.
+//
+// It lives HERE and not in the manifest module because answering it needs the
+// catalog, and that module is deliberately free of Config/xvm/catalog imports
+// so its invariant checks stay testable without a home on disk. The catalog is
+// read LocalOnly -- index files already on disk, no sync, no network -- which
+// is the same access subos/sandbox.cpp already takes for backend availability.
+//
+// `resolved` distinguishes the two outcomes, and the caller must record it:
+// a fallback binding and a resolved one are byte-identical in the manifest,
+// and only one of them is a decision.
+export struct DefaultRuntime {
+    std::string binding;
+    bool        resolved { false };   // false -> came from the pinned fallback
+};
+export DefaultRuntime resolve_default_runtime();
 
 // Back-compat overloads. Callers that predate the runtime argument get the
 // built-in default, and callers that predate storage get shared as before.

--- a/src/core/subos/manifest.cpp
+++ b/src/core/subos/manifest.cpp
@@ -255,6 +255,7 @@ Info parse(const nlohmann::json& doc) {
     info.described_at   = b.value("described_at", std::string{});
     info.described_by   = b.value("described_by", std::string{});
     info.host_glibc     = b.value("host_glibc", std::string{});
+    info.runtime_source = b.value("runtime_source", std::string{});
 
     if (b.contains("envs") && b["envs"].is_object()) {
         for (auto it = b["envs"].begin(); it != b["envs"].end(); ++it) {
@@ -294,6 +295,13 @@ nlohmann::json make_block(const BlockSpec& spec) {
     // spelling of "no"; an absent key already means that everywhere else in
     // this block.
     if (!spec.runtime.empty()) b["runtime"] = spec.runtime;
+    // Same rule, same reason: absent means "nothing to say", and it is what
+    // every manifest written before this key existed already says. Additive,
+    // so SCHEMA_VERSION does not move -- readers take it with `.value(...)`
+    // and one that has never heard of it is unaffected. Bumping the schema
+    // for a key that changes no existing semantics would make today's readers
+    // announce tomorrow's manifests as newer than they understand.
+    if (!spec.runtimeSource.empty()) b["runtime_source"] = spec.runtimeSource;
     b["envs"] = nlohmann::json::object();
     if (spec.intent == Intent::Create) {
         b["created_at"] = utc_now_iso();
@@ -427,7 +435,8 @@ std::string sysroot_runtime(const fs::path& subosDir, fs::path* fromLink) {
 }
 
 std::string runtime_for(const fs::path& subosDir, const nlohmann::json& doc,
-                        Intent intent, std::string_view requested) {
+                        Intent intent, std::string_view requested,
+                        std::string_view defaultRuntime) {
     // 1 — the subos said what it is.
     if (doc.contains(std::string(BLOCK)) && doc[std::string(BLOCK)].is_object()) {
         const auto r = doc[std::string(BLOCK)].value("runtime", std::string{});
@@ -456,7 +465,7 @@ std::string runtime_for(const fs::path& subosDir, const nlohmann::json& doc,
 
     // 5 — Create only. Under Describe the answer is EMPTY, on purpose: see
     // the header for why a constant here is a fabricated record.
-    return intent == Intent::Create ? std::string(DEFAULT_RUNTIME)
+    return intent == Intent::Create ? std::string(defaultRuntime)
                                     : std::string{};
 }
 

--- a/src/core/subos/manifest.cppm
+++ b/src/core/subos/manifest.cppm
@@ -35,24 +35,59 @@ namespace fs = std::filesystem;
 
 inline constexpr int             SCHEMA_VERSION  = 1;
 inline constexpr std::string_view BLOCK          = "subos_info";
-// The runtime a subos gets when the caller names none. A constant rather than
-// a lookup: slice 1 ships one runtime, and inventing a "pick the newest libc
-// present" rule would make two homes with the same command produce different
-// subos.
+// WHICH RUNTIME A SUBOS GETS WHEN THE CALLER NAMES NONE.
 //
-// 2.44 since 2026.8.9.1 (C1 of the closure contract). The 2.39 floor was a
-// systematic error, not a conservative default: `*-host-link` packages carry
-// host-built libraries into our closure permanently, those need the host
-// glibc's symbol versions, so `our_glibc >= host_glibc` is a standing
-// constraint -- and 2.39 loses it on every distro newer than Ubuntu 24.04
-// (mcpp-community/mcpp#392 is that failure verbatim). Backward compatibility
-// makes the move safe: every 2.39-built payload runs under 2.44.
+// A NAME here, and the version resolved from the index by the caller. The
+// previous shape was a pinned constant, and the reason given for it was:
 //
-// Scope: NEW subos only. The binding is a creation-time property persisted in
-// each subos's own manifest, and rebuild paths preserve a valid recorded
-// binding (see preserved_runtime), so no existing subos changes runtime by
-// this constant moving.
-inline constexpr std::string_view DEFAULT_RUNTIME = "glibc@2.44";
+//     A constant rather than a lookup: ... inventing a "pick the newest libc
+//     PRESENT" rule would make two homes with the same command produce
+//     different subos.
+//
+// That reasoning is sound and it is not what this does. It rejects scanning
+// the MACHINE -- two homes have different things installed, so that answer is
+// per-machine. Reading the index's `latest` is the opposite: two homes on the
+// same index snapshot get the same answer, and it is the answer every
+// `xlings install` already gets. The resolved value is still persisted into
+// the subos's own manifest at creation, so the binding remains a
+// creation-time property; only where the number comes from has moved.
+//
+// WHY IT HAD TO MOVE. The pin and the index's `latest` were one decision
+// written in two repositories, and xim-pkgindex#692 made them disagree:
+//
+//   error: selected RuntimeBinding glibc@2.44 requires payload
+//          '<home>/registry/data/xpkgs/xim-x-glibc/2.44', but it is not
+//          installed; mcpp will not fall back to another directory entry
+//
+// measured on a first `mcpp build` in a fresh home. `latest` resolved to
+// 2.44.2 and installed it; this constant said 2.44; payload directories are
+// named after the version, so nothing on disk answered to the binding. Every
+// NEW subos was affected and no existing one was -- the shape that is easy to
+// miss, because a developer machine full of older subos stays green.
+//
+// It survived until now because 2.39 -> 2.44 is an UPSTREAM version move:
+// rare, visible, and someone is watching. 2.44 -> 2.44.2 is a packaging
+// revision of the same upstream release, which moves whenever an artifact has
+// to be rebuilt. The revision suffix is what first made drift possible.
+//
+// The policy the old comment carried -- `our_glibc >= host_glibc`, because
+// `*-host-link` packages permanently bring host-built libraries into our
+// closure -- now lives in the index, where glibc.lua states that `latest`
+// TRACKS the highest glibc of any distribution we support. Keeping a second
+// copy here is what let the two drift; this is the copy that goes.
+inline constexpr std::string_view DEFAULT_RUNTIME_PACKAGE = "glibc";
+
+// Used ONLY when the index cannot answer -- see resolve_default_runtime() in
+// subos.cpp, which is the single place allowed to decide that. It is a real
+// version because a subos must not be created against a binding nobody can
+// satisfy, and it is deliberately the same value the index's `latest` had
+// when this line was last touched.
+//
+// A subos created from this rather than from the index records
+// `runtime_source: "fallback"`, so a stale pin can never be mistaken for a
+// resolved fact. Nothing else may read it: substituting a constant for an
+// answer under Describe is exactly the defect this file already fixed once.
+inline constexpr std::string_view DEFAULT_RUNTIME_FALLBACK = "glibc@2.44.2";
 
 inline constexpr std::string_view OP_SET     = "set";
 inline constexpr std::string_view OP_PREPEND = "prepend";
@@ -97,6 +132,10 @@ struct Info {
     // unknown: pre-C1 manifests, non-glibc hosts, failed probe. Rule A's
     // right-hand side; a reader must treat unknown as unprovable, not as 0.
     std::string           host_glibc;
+    // See BlockSpec::runtimeSource. Empty = the block predates the field, or
+    // was written by a path that has nothing to say about provenance. A
+    // reader must treat empty as UNKNOWN, never as any of the three values.
+    std::string           runtime_source;
 };
 
 // ── who is asking, and therefore what may be invented ────────────────────
@@ -132,7 +171,22 @@ struct BlockSpec {
     std::string by;         // "xlings <version>"
     std::string hostGlibc;  // empty -> the key is omitted
     Intent      intent = Intent::Create;
+    // Where `runtime` came from. Empty -> the key is omitted, which is what
+    // every pre-existing manifest looks like and is read back as "unknown".
+    //
+    // It exists because the three answers are otherwise INDISTINGUISHABLE on
+    // disk, and they are not equally trustworthy: `index` is what the index
+    // said at creation, `fallback` is a pin used because the index could not
+    // be read, `explicit` is a human. A subos sitting on an old glibc could
+    // be any of the three, and without this nobody -- doctor included -- can
+    // tell a recorded decision from a guess that had nowhere else to go.
+    std::string runtimeSource;  // RUNTIME_SOURCE_* below
 };
+
+// Values for BlockSpec::runtimeSource / Info::runtime_source.
+inline constexpr std::string_view RUNTIME_SOURCE_EXPLICIT = "explicit";
+inline constexpr std::string_view RUNTIME_SOURCE_INDEX    = "index";
+inline constexpr std::string_view RUNTIME_SOURCE_FALLBACK = "fallback";
 
 // The package names that can serve as a subos's C runtime.
 //
@@ -386,10 +440,19 @@ std::string sysroot_runtime(const fs::path& subosDir,
 //      never-recorded side instead of the invalid-block side;
 //   4. the sysroot observation — no record anywhere, but the payload behind
 //      `lib/libc.so.6` is not an opinion;
-//   5. `DEFAULT_RUNTIME`. CREATE ONLY. Under Describe this step does not
-//      exist and the result is EMPTY, which `make_block` writes as an absent
-//      `runtime` key — "we looked and could not tell", which a reader can act
-//      on, rather than a constant it cannot distinguish from a real answer.
+//   5. `defaultRuntime`, the caller's answer to "they didn't say". CREATE
+//      ONLY. Under Describe this step does not exist and the result is EMPTY,
+//      which `make_block` writes as an absent `runtime` key — "we looked and
+//      could not tell", which a reader can act on, rather than a constant it
+//      cannot distinguish from a real answer.
+//
+//      A PARAMETER, not a constant read here, because answering it needs the
+//      index and this module is deliberately free of Config/xvm/catalog
+//      imports (see the header). Callers that can resolve pass the resolved
+//      value; the default keeps the signature usable from a test with no home
+//      on disk. This is the same rule the header already states -- everyone
+//      asks one question, and the ONE thing they legitimately disagree about
+//      becomes a parameter.
 //
 // (3) and (4) are what make the upgrade seamless for every home created
 // before `subos_info` existed. Without them those homes are declared against
@@ -403,7 +466,8 @@ std::string sysroot_runtime(const fs::path& subosDir,
 std::string runtime_for(const fs::path& subosDir,
                         const nlohmann::json& doc,
                         Intent intent,
-                        std::string_view requested = {});
+                        std::string_view requested = {},
+                        std::string_view defaultRuntime = DEFAULT_RUNTIME_FALLBACK);
 
 // ── env declarations ────────────────────────────────────────────────────
 

--- a/src/core/xim/commands.cpp
+++ b/src/core/xim/commands.cpp
@@ -113,6 +113,14 @@ bool confirmed_or_refused_(EventStream& stream, std::string id,
     }, stream.prompt(std::move(req)));
 }
 
+std::optional<std::string> index_version_of(std::string_view package) {
+    auto& catalog = get_catalog(CatalogAccess::LocalOnly);
+    if (!catalog.is_loaded()) return std::nullopt;
+    auto match = catalog.resolve_target(std::string(package), detect_platform());
+    if (!match || match->version.empty()) return std::nullopt;
+    return match->version;
+}
+
 PackageCatalog& get_catalog(CatalogAccess access) {
     static PackageCatalog mgr;
     static bool initialized = false;

--- a/src/core/xim/commands.cppm
+++ b/src/core/xim/commands.cppm
@@ -33,6 +33,26 @@ enum class CatalogAccess { LocalOnly, InstallReady };
 // Shared IndexManager instance (lazy-initialized)
 PackageCatalog& get_catalog(CatalogAccess access = CatalogAccess::LocalOnly);
 
+// What version the index says a package is, without installing anything.
+//
+// Exists so that a decision which must agree with `xlings install <pkg>` can
+// be taken from the same source instead of from a constant kept in step by
+// hand. The first caller is the subos runtime binding, where a pinned
+// `glibc@<ver>` and the index's `latest` were one decision written in two
+// repositories -- and the day they disagreed, every NEW subos declared a
+// payload directory that does not exist (xim-pkgindex#692).
+//
+// LocalOnly on purpose: this answers from index files already on disk. A
+// caller asking "what would install pick" must not turn into a network round
+// trip, and does not need to -- `latest` is a fact about the snapshot this
+// home already has.
+//
+// nullopt = the index cannot answer (never synced, unreadable, no such
+// package, no version for this platform). It is NOT a version, and a caller
+// must not turn it into one silently: absent and "the newest" are different
+// facts, and only one of them is a decision.
+std::optional<std::string> index_version_of(std::string_view package);
+
 std::string detect_platform();
 
 // Forward declaration for deferred install request processing

--- a/src/core/xself/init.cpp
+++ b/src/core/xself/init.cpp
@@ -189,35 +189,39 @@ void ensure_subos_manifest_(const fs::path& subos_dir) {
     // this file cannot import xlings.core.subos: subos imports xself, so that
     // edge would close a cycle. The index query lives one layer down, where
     // both callers can reach it.
-    struct DefaultRuntime { std::string binding; bool resolved; };
-    const DefaultRuntime def = [] -> DefaultRuntime {
-        const std::string pkg{mf::DEFAULT_RUNTIME_PACKAGE};
-        if (auto v = xlings::xim::index_version_of(pkg))
-            return {pkg + "@" + *v, true};
-        return {std::string(mf::DEFAULT_RUNTIME_FALLBACK), false};
-    }();
+    if (creating) {
+        // Only on the creating side. describe_block never consults a default,
+        // and resolving one anyway would rebuild the catalog on every repair
+        // for an answer that is then discarded.
+        struct DefaultRuntime { std::string binding; bool resolved; };
+        const DefaultRuntime def = [] -> DefaultRuntime {
+            const std::string pkg{mf::DEFAULT_RUNTIME_PACKAGE};
+            if (auto v = xlings::xim::index_version_of(pkg))
+                return {pkg + "@" + *v, true};
+            return {std::string(mf::DEFAULT_RUNTIME_FALLBACK), false};
+        }();
 
-    // Provenance is recorded HERE, unlike the two rebuild paths in subos.cpp,
-    // because this call knows the answer: `creating` means the block is being
-    // written from nothing, so step 5 is the step that answers and `def` is
-    // what it answers with. The rebuild paths hand runtime_for a default and
-    // cannot see whether a recorded or observed binding outranked it, so they
-    // record nothing rather than guess.
-    auto runtime = mf::runtime_for(subos_dir, json, mf::Intent::Create,
-                                   {}, def.binding);
-    json[std::string(mf::BLOCK)] = creating
-        ? mf::make_block({
-              .runtime   = runtime,
-              .by        = by,
-              .hostGlibc = platform::host_glibc_version(),
-              .intent    = mf::Intent::Create,
-              .runtimeSource = runtime == def.binding
-                  ? std::string(def.resolved ? mf::RUNTIME_SOURCE_INDEX
-                                             : mf::RUNTIME_SOURCE_FALLBACK)
-                  : std::string{},
-          })
-        : mf::describe_block(subos_dir, json, by,
-                             platform::host_glibc_version());
+        // Provenance is recorded HERE, unlike the rebuild paths in subos.cpp,
+        // because this call can tell: the block is being written from nothing,
+        // so `def` is what step 5 answered with -- and if some earlier step
+        // outranked it, the values differ and nothing is claimed.
+        auto runtime = mf::runtime_for(subos_dir, json, mf::Intent::Create,
+                                       {}, def.binding);
+        json[std::string(mf::BLOCK)] = mf::make_block({
+            .runtime   = runtime,
+            .by        = by,
+            .hostGlibc = platform::host_glibc_version(),
+            .intent    = mf::Intent::Create,
+            .runtimeSource = runtime == def.binding
+                ? std::string(def.resolved ? mf::RUNTIME_SOURCE_INDEX
+                                           : mf::RUNTIME_SOURCE_FALLBACK)
+                : std::string{},
+        });
+    } else {
+        json[std::string(mf::BLOCK)] =
+            mf::describe_block(subos_dir, json, by,
+                               platform::host_glibc_version());
+    }
     ensure_parent_dirs_(path);
     platform::write_string_to_file(path.string(), json.dump(2));
 }

--- a/src/core/xself/init.cpp
+++ b/src/core/xself/init.cpp
@@ -9,6 +9,7 @@ import xlings.platform;
 import xlings.core.xself.compat;
 import xlings.core.xself.profile_resources;
 import xlings.core.subos.manifest;
+import xlings.core.xim.commands;
 
 namespace xlings::xself {
 
@@ -178,12 +179,42 @@ void ensure_subos_manifest_(const fs::path& subos_dir) {
     if (mf::validate_block(json).empty()) return;
 
     const auto by = std::format("xlings {}", Info::VERSION);
+    // The default runtime comes from the index, not from a constant compiled
+    // into this binary. THIS path matters more than it looks: `self init` is
+    // what lays down `subos/default`, and that is the manifest mcpp reads on a
+    // first build in a fresh home -- the exact block that said `glibc@2.44`
+    // while the only payload on disk was 2.44.2 (xim-pkgindex#692).
+    //
+    // Resolved here rather than through subos::resolve_default_runtime because
+    // this file cannot import xlings.core.subos: subos imports xself, so that
+    // edge would close a cycle. The index query lives one layer down, where
+    // both callers can reach it.
+    struct DefaultRuntime { std::string binding; bool resolved; };
+    const DefaultRuntime def = [] -> DefaultRuntime {
+        const std::string pkg{mf::DEFAULT_RUNTIME_PACKAGE};
+        if (auto v = xlings::xim::index_version_of(pkg))
+            return {pkg + "@" + *v, true};
+        return {std::string(mf::DEFAULT_RUNTIME_FALLBACK), false};
+    }();
+
+    // Provenance is recorded HERE, unlike the two rebuild paths in subos.cpp,
+    // because this call knows the answer: `creating` means the block is being
+    // written from nothing, so step 5 is the step that answers and `def` is
+    // what it answers with. The rebuild paths hand runtime_for a default and
+    // cannot see whether a recorded or observed binding outranked it, so they
+    // record nothing rather than guess.
+    auto runtime = mf::runtime_for(subos_dir, json, mf::Intent::Create,
+                                   {}, def.binding);
     json[std::string(mf::BLOCK)] = creating
         ? mf::make_block({
-              .runtime   = mf::runtime_for(subos_dir, json, mf::Intent::Create),
+              .runtime   = runtime,
               .by        = by,
               .hostGlibc = platform::host_glibc_version(),
               .intent    = mf::Intent::Create,
+              .runtimeSource = runtime == def.binding
+                  ? std::string(def.resolved ? mf::RUNTIME_SOURCE_INDEX
+                                             : mf::RUNTIME_SOURCE_FALLBACK)
+                  : std::string{},
           })
         : mf::describe_block(subos_dir, json, by,
                              platform::host_glibc_version());

--- a/tests/e2e/subos_runtime_binding_test.sh
+++ b/tests/e2e/subos_runtime_binding_test.sh
@@ -16,18 +16,27 @@
 #       re-declare every repaired subos against a libc its payloads were
 #       never built for.
 #
-# The expected default IS pinned here ("glibc@2.44"). This is deliberate and
-# is not the "assert only invariants" trap: that lesson is about asserting
-# version PROPAGATION across repos, while this file tests this repo's own
-# contract -- "what runtime does a fresh subos get" is exactly the behavior
-# that changed. A future default bump updates one line here, knowingly.
+# S1's expectation is READ from the source, not written here.
+#
+# It used to be a pinned literal, on the reasoning that "what runtime does a
+# fresh subos get" is this repo's own contract. That was true while the answer
+# was a constant. It no longer is: the version now comes from the index, and
+# the constant below is only what an unanswerable index falls back to. This
+# home is built with an EMPTY index on purpose (see below), so the fallback is
+# the path under test here -- and pinning its value would mean editing this
+# file every time the fallback moves, which is the coupling the change was
+# about removing.
+#
+# S4 covers the other half: an index that CAN answer, answering with something
+# no constant in the tree contains.
 
 set -uo pipefail
 
 # shellcheck source=./project_test_lib.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
 
-EXPECTED_DEFAULT="glibc@2.44"
+EXPECTED_DEFAULT="$(sed -n 's/.*DEFAULT_RUNTIME_FALLBACK = "\(.*\)".*/\1/p' \
+    "$ROOT_DIR/src/core/subos/manifest.cppm" | head -1)"
 
 RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/subos_runtime_binding"
 HOME_DIR="$RUNTIME_DIR/home"
@@ -82,6 +91,16 @@ RUNTIME="$(read_block "$DEFAULT_DIR" 'blk.get("runtime")')"
   || fail "S1: fresh subos runtime is '$RUNTIME', expected '$EXPECTED_DEFAULT'"
 log "  ✓ S1a: fresh subos records runtime $EXPECTED_DEFAULT"
 
+# The index here is empty, so this binding came from the FALLBACK, and the
+# manifest has to say so. Without this the two paths are byte-identical on
+# disk and nobody -- doctor included -- can tell a subos that was pinned
+# because the index said so from one pinned because the index could not be
+# read.
+SRC1="$(read_block "$DEFAULT_DIR" 'blk.get("runtime_source", "")')"
+[ "$SRC1" = "fallback" ] \
+  || fail "S1: empty index, so runtime_source should be 'fallback', got '$SRC1'"
+log "  ✓ S1c: fallback path recorded as runtime_source=fallback"
+
 HOST_GLIBC_EXPECTED="$(/usr/bin/getconf GNU_LIBC_VERSION 2>/dev/null | awk '{print $2}')"
 HOST_GLIBC_RECORDED="$(read_block "$DEFAULT_DIR" 'blk.get("host_glibc", "")')"
 if [ -n "$HOST_GLIBC_EXPECTED" ]; then
@@ -131,5 +150,76 @@ FIXED_SCHEMA="$(read_block "$DEFAULT_DIR" 'blk.get("schema_version")')"
 FIXED_ENVS="$(read_block "$DEFAULT_DIR" 'type(blk.get("envs")).__name__')"
 [ "$FIXED_ENVS" = "dict" ] || fail "S3: envs not repaired (type=$FIXED_ENVS)"
 log "  ✓ S3b: the rest of the block was repaired (schema=1, envs={})"
+
+# ── S4: an index that CAN answer decides, and no constant can fake it ───
+#
+# The claim S1 cannot make: that the version comes from the index at all. With
+# an empty index, "fallback" and "resolved to the same value" are the same
+# reading -- which is exactly the shape this whole change exists to remove, so
+# it cannot be how the change is verified.
+#
+# The index below says 9.9.9. That string appears in no constant, no test
+# fixture and no payload anywhere in the tree, so a manifest carrying it can
+# only have been resolved. Install fails (there is no such tarball); the
+# binding is written before the install step, which is what S2 already relies
+# on.
+# A COPY of the fixture index, with glibc's `latest` rewritten.
+#
+# Hand-rolling a two-file index does not work: the catalog declines to load it
+# and answers "package index not available", which sends S4 down the FALLBACK
+# path -- so a broken harness and a broken feature would read the same, which
+# is the shape this test exists to rule out. The fixture is a real index that
+# the rest of the suite already loads.
+S4_INDEX="$RUNTIME_DIR/answering-index"
+cp -a "$ROOT_DIR/tests/fixtures/xim-pkgindex" "$S4_INDEX"
+python3 "$ROOT_DIR/tests/e2e/support/rewrite_glibc_latest.py" \
+    "$S4_INDEX/pkgs/g/glibc.lua" 9.9.9 \
+  || fail "S4: could not rewrite the fixture glibc recipe"
+
+# A SEPARATE home. S1-S3 ran against the empty index in $HOME_DIR and the
+# catalog cache on disk remembers that answer; pointing the same home at a new
+# index leaves "package not found" behind, which would read as the feature
+# failing rather than the cache being stale.
+S4_HOME="$RUNTIME_DIR/home-s4"
+mkdir -p "$S4_HOME/data/xim-index-repos"
+printf '{}\n' > "$S4_HOME/data/xim-index-repos/xim-indexrepos.json"
+cat > "$S4_HOME/.xlings.json" <<EOF
+{
+  "mirror": "GLOBAL",
+  "index_repos": [
+    { "name": "xim", "url": "$S4_INDEX" }
+  ]
+}
+EOF
+
+x4() { ( cd /tmp && env -i HOME="$HOME" PATH=/usr/bin:/bin \
+         XLINGS_HOME="$S4_HOME" "$BIN" "$@" ) }
+x4 self init >/dev/null 2>&1 || true
+# `update` is what actually syncs an index repo into a home -- without it the
+# catalog answers "package index not available", which S1's empty-index setup
+# also produces, so the two would be indistinguishable.
+x4 update >/dev/null 2>&1 || true
+
+# The index has to actually answer, or S4's real assertion below is measuring
+# the fallback and calling it a pass.
+INFO4="$(x4 info glibc 2>&1)" || true
+printf '%s\n' "$INFO4" | grep -q '9\.9\.9' \
+  || fail "S4: the test index does not answer for glibc at all:
+$INFO4"
+
+OUT4="$(x4 subos new t94 2>&1)" || true
+[ -f "$S4_HOME/subos/t94/.xlings.json" ] \
+  || { echo "$OUT4" >&2; fail "S4: subos new left no manifest at all"; }
+RUNTIME4="$(read_block "$S4_HOME/subos/t94" 'blk.get("runtime")')"
+[ "$RUNTIME4" = "glibc@9.9.9" ] \
+  || fail "S4: index says 9.9.9 but the subos recorded '$RUNTIME4' -- the
+    default is still coming from a constant, so it will drift from the index
+    again the next time glibc is republished"
+log "  ✓ S4a: the index decided the default (glibc@9.9.9)"
+
+SRC4="$(read_block "$S4_HOME/subos/t94" 'blk.get("runtime_source", "")')"
+[ "$SRC4" = "index" ] \
+  || fail "S4: resolved from the index but runtime_source is '$SRC4'"
+log "  ✓ S4b: recorded as runtime_source=index"
 
 log "E2E subos-runtime-binding: PASS"

--- a/tests/e2e/subos_runtime_binding_test.sh
+++ b/tests/e2e/subos_runtime_binding_test.sh
@@ -37,6 +37,12 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
 
 EXPECTED_DEFAULT="$(sed -n 's/.*DEFAULT_RUNTIME_FALLBACK = "\(.*\)".*/\1/p' \
     "$ROOT_DIR/src/core/subos/manifest.cppm" | head -1)"
+# Guarded, because an empty expectation does not fail -- it makes S1a compare
+# "" against a subos that also recorded nothing, and passes. A constant renamed
+# out from under this sed would then be reported as the feature working.
+[ -n "$EXPECTED_DEFAULT" ] \
+  || fail "could not read DEFAULT_RUNTIME_FALLBACK out of manifest.cppm; \
+every assertion below would compare against an empty string"
 
 RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/subos_runtime_binding"
 HOME_DIR="$RUNTIME_DIR/home"

--- a/tests/e2e/subos_runtime_describe_test.sh
+++ b/tests/e2e/subos_runtime_describe_test.sh
@@ -115,8 +115,21 @@ S1_RUNTIME="$(block_field "$H1/subos/default/.xlings.json" runtime)"
   || note_fail "S1: a subos running 2.39 was declared '$S1_RUNTIME'"
 # Stated separately, because it is the specific wrong answer this exists to
 # stop and it must not be satisfiable by "absent".
-[[ "$S1_RUNTIME" != "glibc@2.44" ]] \
-  || note_fail "S1: the subos was re-declared against the current default"
+#
+# The default is READ from the source rather than written here. This line used
+# to say "glibc@2.44", and the day that constant moved to 2.44.2 the assertion
+# would still have passed -- against a value that is no longer the default, so
+# it would no longer have been testing "doctor invented the default". The
+# sibling test subos_runtime_binding_test.sh pins the literal on purpose: it
+# asserts WHAT the default is. This one asserts the default is not used, so it
+# has to follow the default.
+CURRENT_DEFAULT="$(sed -n 's/.*DEFAULT_RUNTIME_FALLBACK = "\(.*\)".*/\1/p' \
+    "$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/src/core/subos/manifest.cppm" \
+    | head -1)"
+[[ -n "$CURRENT_DEFAULT" ]] \
+  || note_fail "S1: could not read DEFAULT_RUNTIME_FALLBACK out of manifest.cppm"
+[[ "$S1_RUNTIME" != "$CURRENT_DEFAULT" ]] \
+  || note_fail "S1: the subos was re-declared against the current default ($CURRENT_DEFAULT)"
 
 # ── S2: nothing to observe -> an ABSENT runtime key, and exit 0 ──────────
 H2="$RUNTIME_DIR/s2"

--- a/tests/e2e/support/rewrite_glibc_latest.py
+++ b/tests/e2e/support/rewrite_glibc_latest.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Point a fixture glibc recipe's `latest` at one version, and remove the rest.
+
+Used by subos_runtime_binding_test.sh S4, which needs an index that answers
+with a version no constant in the tree contains. Leaving the other entries in
+place would leave a second answer to the one question the test asks.
+
+Exits non-zero if the rewrite did not take, because a recipe that silently kept
+its old versions makes S4 assert against the wrong number and report the
+feature broken.
+"""
+import pathlib
+import re
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(f"usage: {sys.argv[0]} <glibc.lua> <version>", file=sys.stderr)
+        return 2
+    path, version = pathlib.Path(sys.argv[1]), sys.argv[2]
+    text = path.read_text()
+
+    block = (
+        "    xpm = {\n"
+        "        linux = {\n"
+        f'            ["latest"] = {{ ref = "{version}" }},\n'
+        f'            ["{version}"] = {{ url = '
+        f'"https://example.invalid/glibc-{version}.tar.gz" }},\n'
+        "        },\n"
+        "    },"
+    )
+    new, count = re.subn(r"    xpm = \{.*?\n    \},", block, text,
+                         count=1, flags=re.S)
+    if count != 1:
+        print(f"{path}: no xpm block matched", file=sys.stderr)
+        return 1
+    path.write_text(new)
+
+    check = path.read_text()
+    if f'"{version}"' not in check:
+        print(f"{path}: rewrite did not take", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_subos_manifest.cpp
+++ b/tests/unit/test_subos_manifest.cpp
@@ -450,7 +450,7 @@ TEST(SubosManifestBlock, NewBlockSatisfiesItsOwnInvariants) {
     nlohmann::json d;
     d["workspace"]  = nlohmann::json::object();
     d["subos_info"] = m::make_block({
-        .runtime = std::string(m::DEFAULT_RUNTIME),
+        .runtime = std::string(m::DEFAULT_RUNTIME_FALLBACK),
         .by      = "xlings test",
         .intent  = m::Intent::Create,
     });
@@ -459,7 +459,7 @@ TEST(SubosManifestBlock, NewBlockSatisfiesItsOwnInvariants) {
 
     auto info = m::parse(d);
     EXPECT_EQ(info.schema_version, m::SCHEMA_VERSION);
-    EXPECT_EQ(info.runtime, m::DEFAULT_RUNTIME);
+    EXPECT_EQ(info.runtime, m::DEFAULT_RUNTIME_FALLBACK);
     EXPECT_TRUE(info.envs.empty());
     EXPECT_FALSE(info.created_at.empty());
 }
@@ -468,7 +468,7 @@ TEST(SubosManifestBlock, NewBlockSatisfiesItsOwnInvariants) {
 // glibc), but it must always be a well-formed binding — a malformed default
 // would make every fresh subos fail its own validation.
 TEST(SubosManifestBlock, DefaultRuntimeIsAWellFormedBinding) {
-    EXPECT_TRUE(m::is_binding(m::DEFAULT_RUNTIME));
+    EXPECT_TRUE(m::is_binding(m::DEFAULT_RUNTIME_FALLBACK));
 }
 
 // host_glibc: written when known, absent when not. Absent and unknown must
@@ -477,7 +477,7 @@ TEST(SubosManifestBlock, HostGlibcIsRecordedWhenKnown) {
     nlohmann::json d;
     d["workspace"]  = nlohmann::json::object();
     d["subos_info"] = m::make_block({
-        .runtime   = std::string(m::DEFAULT_RUNTIME),
+        .runtime   = std::string(m::DEFAULT_RUNTIME_FALLBACK),
         .by        = "xlings test",
         .hostGlibc = "2.39",
         .intent    = m::Intent::Create,
@@ -491,7 +491,7 @@ TEST(SubosManifestBlock, HostGlibcIsOmittedWhenUnknown) {
     nlohmann::json d;
     d["workspace"]  = nlohmann::json::object();
     d["subos_info"] = m::make_block({
-        .runtime = std::string(m::DEFAULT_RUNTIME),
+        .runtime = std::string(m::DEFAULT_RUNTIME_FALLBACK),
         .by      = "xlings test",
         .intent  = m::Intent::Create,
     });
@@ -516,7 +516,7 @@ TEST(SubosManifestPreserve, KeepsAValidRuntimeThroughARebuild) {
         {"envs", 42},                    // invalid on purpose
     };
     EXPECT_FALSE(m::validate_block(d).empty());
-    EXPECT_EQ(m::runtime_for({}, d, m::Intent::Create, m::DEFAULT_RUNTIME),
+    EXPECT_EQ(m::runtime_for({}, d, m::Intent::Create, m::DEFAULT_RUNTIME_FALLBACK),
               "glibc@2.39");
     EXPECT_EQ(m::runtime_for({}, d, m::Intent::Describe), "glibc@2.39");
 }
@@ -535,6 +535,69 @@ TEST(SubosManifestPreserve, CreateFallsBackWhenTheRuntimeItselfIsMalformed) {
     nlohmann::json noBlock = nlohmann::json::object();
     EXPECT_EQ(m::runtime_for({}, noBlock, m::Intent::Create, "glibc@2.44"),
               "glibc@2.44");
+}
+
+// ── the default is a PARAMETER, not a constant read inside ───────────
+//
+// The version a fresh subos gets now comes from the index, resolved by the
+// caller (subos::resolve_default_runtime) and handed in here. These pin the
+// half that lives in this module: that step 5 uses what it was given, that it
+// only exists under Create, and that every earlier step still outranks it.
+//
+// Written with a version no constant in the tree contains, so none of them can
+// pass by coincidence.
+TEST(SubosManifestDefault, Step5UsesTheCallersDefaultNotAConstant) {
+    nlohmann::json empty = nlohmann::json::object();
+    EXPECT_EQ(m::runtime_for({}, empty, m::Intent::Create, {}, "glibc@9.9.9"),
+              "glibc@9.9.9");
+    // And the fallback is what an omitted argument means -- the signature has
+    // to stay usable from a caller with no home and no index on disk.
+    EXPECT_EQ(m::runtime_for({}, empty, m::Intent::Create),
+              std::string(m::DEFAULT_RUNTIME_FALLBACK));
+}
+
+TEST(SubosManifestDefault, DescribeNeverReachesStep5) {
+    nlohmann::json empty = nlohmann::json::object();
+    // Not "returns the fallback": returns NOTHING. A constant here would be a
+    // guess recorded as a fact, which is the defect this file already fixed.
+    EXPECT_EQ(m::runtime_for({}, empty, m::Intent::Describe, {}, "glibc@9.9.9"),
+              "");
+}
+
+TEST(SubosManifestDefault, ARecordedBindingStillOutranksTheResolvedDefault) {
+    nlohmann::json d;
+    d["subos_info"] = { {"runtime", "glibc@2.39"} };
+    EXPECT_EQ(m::runtime_for({}, d, m::Intent::Create, {}, "glibc@9.9.9"),
+              "glibc@2.39");
+}
+
+TEST(SubosManifestDefault, ExplicitRequestStillOutranksTheResolvedDefault) {
+    nlohmann::json empty = nlohmann::json::object();
+    EXPECT_EQ(m::runtime_for({}, empty, m::Intent::Create, "glibc@2.39",
+                             "glibc@9.9.9"),
+              "glibc@2.39");
+}
+
+TEST(SubosManifestDefault, RuntimeSourceRoundTripsAndIsOmittedWhenEmpty) {
+    auto withSource = m::make_block({
+        .runtime = "glibc@9.9.9",
+        .by = "xlings test",
+        .runtimeSource = std::string(m::RUNTIME_SOURCE_INDEX),
+    });
+    EXPECT_EQ(withSource.value("runtime_source", std::string{}), "index");
+
+    // Absent, not empty-string: the same spelling of "nothing to say" the
+    // rest of this block uses, and what every manifest written before the
+    // key existed already looks like.
+    auto without = m::make_block({.runtime = "glibc@9.9.9", .by = "xlings test"});
+    EXPECT_FALSE(without.contains("runtime_source"));
+
+    nlohmann::json doc;
+    doc[std::string(m::BLOCK)] = withSource;
+    EXPECT_EQ(m::parse(doc).runtime_source, "index");
+    nlohmann::json bare;
+    bare[std::string(m::BLOCK)] = without;
+    EXPECT_EQ(m::parse(bare).runtime_source, "");
 }
 
 // ── the subos layer's one live version ───────────────────────────────
@@ -825,7 +888,7 @@ TEST(SubosRuntimeFor, DescribeNeverInventsARuntime) {
 TEST(SubosRuntimeFor, CreateStillTakesTheDefault) {
     nlohmann::json empty = nlohmann::json::parse(R"({"workspace": {}})");
     EXPECT_EQ(m::runtime_for({}, empty, m::Intent::Create),
-              m::DEFAULT_RUNTIME);
+              m::DEFAULT_RUNTIME_FALLBACK);
 }
 
 TEST(SubosRuntimeFor, DescribeIgnoresARequestedRuntime) {


### PR DESCRIPTION
## What broke

`DEFAULT_RUNTIME = "glibc@2.44"` and the index's `latest` for glibc were **one decision written in two repositories**. `xim-pkgindex#692` moved `latest` to `2.44.2`; this constant did not follow. A first `mcpp build` in a fresh home then installs 2.44.2 and refuses to use it:

```
Downloading xim:glibc@2.44.2                       ← index side correct
error: selected RuntimeBinding glibc@2.44 requires payload
       '<home>/registry/data/xpkgs/xim-x-glibc/2.44', but it is not installed
```

Payload directories are named after the version, so nothing on disk answers to the binding.

**Only NEW subos are affected; no existing one is.** A developer machine full of older subos stays green while every new user, new environment and clean CI runner is broken.

It held until now because `2.39 → 2.44` is an *upstream* move — rare, visible, watched. `2.44 → 2.44.2` is a **packaging revision** of the same upstream release, which moves whenever an artifact has to be rebuilt. The revision suffix is what first made drift possible, so this recurs until the second copy is gone.

## What replaces it

| layer | |
|---|---|
| `manifest.cppm` | `DEFAULT_RUNTIME_PACKAGE = "glibc"` (a name) + `DEFAULT_RUNTIME_FALLBACK` (last resort); `runtime_for(..., defaultRuntime)` |
| `xim.commands` | `index_version_of(pkg) -> optional<string>`, `LocalOnly` |
| `subos` / `xself` | resolve, or fall back, and **record which** |

The manifest module stays free of `Config`/`xvm`/`catalog` imports, so its invariant checks still run without a home on disk. The default became a **parameter** — which is the rule that file already states: everyone asks one question, and the one thing they legitimately disagree about becomes a parameter.

The query lives in `xim` rather than `subos` because `xself/init.cpp` needs it and cannot import `xlings.core.subos` (subos imports xself; that edge closes a cycle). `init.cpp` is not an afterthought: **`self init` writes `subos/default`, which is the manifest mcpp reads on a first build.**

### The old argument is untouched

> A constant rather than a lookup: ... inventing a "pick the newest libc **PRESENT**" rule would make two homes with the same command produce different subos.

That rejects scanning the **machine**, and it is still right. Reading the index is the opposite: same snapshot, same answer — and it is the answer `xlings install glibc` already gets. The policy the comment carried (`our_glibc >= host_glibc`) now lives in `glibc.lua` as a standing rule, so keeping a second copy here is what let them drift.

## Provenance, because a fallback and a decision look identical

`subos_info.runtime_source` records `explicit | index | fallback`, and the fallback path warns, naming both remedies. Without it a subos pinned to an old glibc could be any of the three and nobody — doctor included — could tell a recorded decision from a guess with nowhere else to go.

Additive key, read with `.value(...)`, so `SCHEMA_VERSION` does not move: bumping it for a key that changes no existing semantics would make today's readers announce tomorrow's manifests as newer than they understand.

**Describe is untouched.** There the answer stays EMPTY — a constant on that path records a guess as a fact, the defect this file already fixed once.

## Criteria

**S4** (`subos_runtime_binding_test.sh`) is the one that matters: the home gets an index whose glibc `latest` is `9.9.9` — a string in no constant, fixture or payload in the tree — and the subos must record exactly that. An implementation still reading a constant fails it, and the message says what follows: *"will drift from the index again the next time glibc is republished"*.

**S1** keeps the other half from the empty-index home: the fallback binding, read **from the source** rather than pinned in the test, plus `runtime_source=fallback`. One side alone cannot tell "always falls back" from "resolved to the same value" — the exact ambiguity this change removes, so it cannot be how the change is verified.

`subos_runtime_describe_test.sh` now **derives** the current default instead of comparing to a literal. It said `!= "glibc@2.44"`; the day the default moved, that assertion would have passed against a value that is no longer the default — still green, testing nothing.

Local: **48/48 unit**, `subos_runtime_binding` S1–S4 PASS, `subos_runtime_describe` PASS.
`subos_runtime_declaration_upgrade_test` fails here **and fails identically on a pre-change binary** — pre-existing in this environment, not from this change.

## Design

`.agents/docs/2026-08-27-runtime-binding-default-from-index.md`, with the alternative that was **not** taken (bind on ABI identity so a packaging revision is invisible to consumers) and the condition under which it should be: a third hardcoded glibc version anywhere would mean the problem is the directory identity model, not any one constant.