### PR TITLE
ci(aarch64): take qemu from the index instead of apt

### DIFF
--- a/.github/workflows/xlings-ci-aarch64.yml
+++ b/.github/workflows/xlings-ci-aarch64.yml
@@ -71,13 +71,12 @@ jobs:
       - name: Checkout xlings
         uses: actions/checkout@v4
 
-      - name: Install system deps + qemu-user-static
+      - name: Install system deps
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft*.list \
                      /etc/apt/sources.list.d/microsoft*.sources
           sudo apt-get update -qq
-          sudo apt-get install -y curl git build-essential qemu-user-static
-          qemu-aarch64-static --version | head -1
+          sudo apt-get install -y curl git build-essential
 
       - name: Install bootstrap xlings
         env:
@@ -88,6 +87,23 @@ jobs:
           echo "XLINGS_HOME=$HOME/.xlings"       >> "$GITHUB_ENV"
           echo "$HOME/.xlings/subos/current/bin" >> "$GITHUB_PATH"
           echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"
+
+      - name: qemu from the ecosystem, not from apt
+        run: |
+          # This job cross-builds a release candidate and then RUNS it, which
+          # needs USER-mode qemu. It used to come from
+          # `apt-get install qemu-user-static`, and on 2026-08-27 that failed
+          # on every run: the runner image ships Microsoft apt sources that
+          # answer 403, so `apt-get update` failed the whole step over a
+          # repository this job installs nothing from. An ecosystem that
+          # supplies its own toolchain should not have a test that cannot run
+          # because a distribution repository is unhappy.
+          #
+          # xim:qemu-user-aarch64 is the same binary from upstream
+          # multiarch/qemu-user-static, statically linked (zero DT_NEEDED), so
+          # it brings no closure of its own.
+          xlings install xim:qemu-user-aarch64 -y
+          qemu-aarch64-static --version | head -1
 
       # NO payload cache here.
       #


### PR DESCRIPTION
The aarch64 job cross-builds a release candidate and then **runs** it, which needs user-mode qemu. It came from `apt-get install qemu-user-static`, and on 2026-08-27 that failed on every run:

```
E: Failed to fetch https://packages.microsoft.com/... 403 Forbidden
```

The runner image ships Microsoft apt sources that 403, and `apt-get update` fails the whole step over a repository **this job installs nothing from**.

An ecosystem that supplies its own toolchain should not have a test that cannot run because a distribution repository is unhappy.

`xim:qemu-user-aarch64` (openxlings/xim-pkgindex#699, merged) is the same upstream binary from `multiarch/qemu-user-static`, **statically linked with zero `DT_NEEDED`** — it brings no closure of its own and needs no elfpatch.

Verified on a real host before wiring it up:

```
ecosystem aarch64-linux-musl-gcc -static  →  aarch64 binary returning 42
ecosystem qemu-aarch64-static             →  exit 42
```

No apt in that chain.

apt still supplies `curl`/`git`/`build-essential`, so the Microsoft-source removal stays — those three still come from there.