### PR TITLE
fix(subos): the fallback must name a version the index still offers (2026.8.27.3)

### DIFF
--- a/.github/workflows/xlings-ci-aarch64.yml
+++ b/.github/workflows/xlings-ci-aarch64.yml
@@ -27,15 +27,26 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Moved off v2026.8.10.1 because a stale bootstrap is not neutral: the client
-  # that lays down `subos/default` decides the runtime binding, and every
-  # client before 2026.8.27.1 has `glibc@2.44` compiled in. When the index's
-  # `latest` moved past that, this job installed the newer payload and then
-  # refused to use it --
-  #   error: selected RuntimeBinding glibc@2.44 requires payload
-  #          '.../xpkgs/xim-x-glibc/2.44', but it is not installed
-  # -- which is a fact about the pin, not about the commit under test.
-  BOOTSTRAP_XLINGS_VERSION: v2026.8.27.1
+  # A bootstrap pin is not neutral setup: the client that lays down
+  # `subos/default` decides the runtime binding, so this line has to name a
+  # client whose binding the index can satisfy.
+  #
+  # It went v2026.8.10.1 -> v2026.8.27.1 while the index offered glibc 2.44.2,
+  # and back again now that it does not. 2.44.2 was withdrawn
+  # (xim-pkgindex#700: three consumers pin the binding name and none of them
+  # move together), and v2026.8.27.1/.2 fall back to `glibc@2.44.2` -- a
+  # version nothing offers any more:
+  #   error: selected RuntimeBinding glibc@2.44.2 requires payload
+  #          '.../xpkgs/xim-x-glibc/2.44.2', but it is not installed
+  #
+  # v2026.8.10.1 says `glibc@2.44`, which the index does offer and, being
+  # append-only, always will.
+  #
+  # This is still "works because a constant happens to match". The version
+  # that stops being luck is 2026.8.27.3 (this PR): its fallback names a
+  # version the index cannot stop offering, and it resolves from the index
+  # when it can. Move this pin there once .3 is released.
+  BOOTSTRAP_XLINGS_VERSION: v2026.8.10.1
 
 jobs:
   native-contracts:

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -29,7 +29,7 @@ members = [
 
 [package]
 name = "xlings"
-version = "2026.8.27.2"
+version = "2026.8.27.3"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -10,7 +10,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "2026.8.27.2";
+    static constexpr std::string_view VERSION = "2026.8.27.3";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/subos/manifest.cppm
+++ b/src/core/subos/manifest.cppm
@@ -110,16 +110,34 @@ inline constexpr std::string_view DEFAULT_RUNTIME_PACKAGE = "glibc";
 inline constexpr std::string_view DEFAULT_RUNTIME_QUERY = "xim:glibc";
 
 // Used ONLY when the index cannot answer -- see resolve_default_runtime() in
-// subos.cpp, which is the single place allowed to decide that. It is a real
-// version because a subos must not be created against a binding nobody can
-// satisfy, and it is deliberately the same value the index's `latest` had
-// when this line was last touched.
+// subos.cpp, which is the single place allowed to decide that.
+//
+// THIS VALUE MUST NAME A VERSION THE INDEX STILL OFFERS, and that is not
+// obvious enough to leave unwritten. It was `glibc@2.44.2` for a few hours,
+// which was the index's `latest` at the time; when 2.44.2 was withdrawn from
+// the index the fallback kept pointing at it, and every path where the index
+// cannot answer produced an unsatisfiable binding:
+//
+//   error: selected RuntimeBinding glibc@2.44.2 requires payload
+//          '<home>/.../xpkgs/xim-x-glibc/2.44.2', but it is not installed
+//
+// measured on a first `mcpp build` in a fresh MCPP_HOME. mcpp lays out its
+// sandbox -- creating the subos, and therefore the binding -- BEFORE it
+// fetches the index, so that path always takes the fallback. It is not a
+// corner: it is the first thing a new user does.
+//
+// So the rule is not "keep this in step with `latest`" -- that is the very
+// coupling the package name above exists to remove, and it would just live
+// here instead. The rule is: point it at a version the index CANNOT stop
+// offering. Entries in glibc.lua are append-only, so any published version
+// qualifies; 2.44 is the oldest one that satisfies the `our_glibc >=
+// host_glibc` constraint on currently supported distributions.
 //
 // A subos created from this rather than from the index records
 // `runtime_source: "fallback"`, so a stale pin can never be mistaken for a
 // resolved fact. Nothing else may read it: substituting a constant for an
-// answer under Describe is exactly the defect this file already fixed once.
-inline constexpr std::string_view DEFAULT_RUNTIME_FALLBACK = "glibc@2.44.2";
+// answer under Describe is exactly the defect this file already fixed.
+inline constexpr std::string_view DEFAULT_RUNTIME_FALLBACK = "glibc@2.44";
 
 inline constexpr std::string_view OP_SET     = "set";
 inline constexpr std::string_view OP_PREPEND = "prepend";


### PR DESCRIPTION
The fallback was `glibc@2.44.2` — the index's `latest` when it was written. 2.44.2 was then **withdrawn** from the index (openxlings/xim-pkgindex#700), and the fallback kept pointing at it. Every path where the index cannot answer now produces a binding nothing can satisfy:

```
error: selected RuntimeBinding glibc@2.44.2 requires payload
       '<home>/.../xpkgs/xim-x-glibc/2.44.2', but it is not installed
```

Measured on a **first `mcpp build` in a fresh `MCPP_HOME`**, with CN mirror configured. That path is not a corner: mcpp lays out its sandbox — creating the subos, and therefore the binding — **before** it fetches the index, so it *always* takes the fallback. It is the first thing a new user does.

## This one is mine

I withdrew 2.44.2 from the index without moving the client's fallback with it. Which is the same coupling this change set exists to remove, **relocated**: the package name stopped tracking the index, and the fallback quietly started.

So the rule is not *"keep the fallback in step with `latest`"* — that just reinstates the coupling one line down. It is:

> **point the fallback at a version the index cannot stop offering.**

Entries in `glibc.lua` are append-only, so any published version qualifies. `2.44` is the oldest that still satisfies `our_glibc >= host_glibc` on supported distributions. `latest` may now move without this line following.

## What made it visible

`runtime_source: fallback`. The manifest said *which* of the two answers it had used, so a wrong version was legible as "the index could not answer and the pin is stale" instead of a mystery about a missing directory. Same field that caught #568.

Local: 48/48 unit, S1–S5 PASS.