### PR TITLE
fix(xim): an installed payload belongs to a package, not to a short name (2026.8.30.2)

### DIFF
--- a/mcpp.toml
+++ b/mcpp.toml
@@ -29,7 +29,7 @@ members = [
 
 [package]
 name = "xlings"
-version = "2026.8.30.1"
+version = "2026.8.30.2"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -10,7 +10,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "2026.8.30.1";
+    static constexpr std::string_view VERSION = "2026.8.30.2";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/xim/installer.cpp
+++ b/src/core/xim/installer.cpp
@@ -2620,7 +2620,7 @@ std::expected<void, std::string> Installer::execute(const InstallPlan& plan, con
         // Trust-but-verify, in two directions, because this lookup crosses a
         // namespace boundary that the rest of the file does not.
         //
-        // ⚠️ THE DB IS KEYED BY xvm TARGET -- A PROGRAM NAME. Everything else
+        // THE DB IS KEYED BY xvm TARGET -- A PROGRAM NAME. Everything else
         // that answers "is this installed" is keyed by PACKAGE identity:
         // `match.installed` (catalog.cpp) stats
         // `<store>/<ns>-x-<name>/<version>`, and `installation_state` below

--- a/src/core/xim/installer.cpp
+++ b/src/core/xim/installer.cpp
@@ -26,6 +26,7 @@ import xlings.core.common;
 import xlings.core.xself;
 import xlings.core.xvm.types;
 import xlings.core.xvm.db;
+import xlings.core.xvm.owner;
 import xlings.core.xvm.bindings;
 import xlings.core.xvm.removal;
 import xlings.core.xvm.registration;
@@ -2616,32 +2617,79 @@ std::expected<void, std::string> Installer::execute(const InstallPlan& plan, con
         }
         // Default: check xvm version database when no installed hook.
         //
-        // Trust-but-verify: a DB entry alone isn't enough. If the
-        // payload directory the entry points to is missing or empty
-        // (broken-payload state — payload manually rm'd, partial
-        // uninstall, FS corruption), fall through and let the install
-        // hook re-create the payload.  Without this fall-through,
-        // `xlings install <pkg>@<ver>` reports success without
-        // actually doing anything — the user can never recover from
-        // a broken payload via the obvious command.
+        // Trust-but-verify, in two directions, because this lookup crosses a
+        // namespace boundary that the rest of the file does not.
+        //
+        // ⚠️ THE DB IS KEYED BY xvm TARGET -- A PROGRAM NAME. Everything else
+        // that answers "is this installed" is keyed by PACKAGE identity:
+        // `match.installed` (catalog.cpp) stats
+        // `<store>/<ns>-x-<name>/<version>`, and `installation_state` below
+        // takes a namespace argument. This lookup takes `node.name` alone, and
+        // a short name is not an identity -- `xim:libdrm` and `compat:libdrm`
+        // are two packages, and a store holding Mesa always has the first.
+        //
+        // What that cost, measured (mcpp#533): a source-build `compat:libdrm`
+        // at the same upstream version as the `xim:libdrm` Mesa pulls in was
+        // reported already-installed on the strength of Mesa's payload, its
+        // `install()` never ran, and the tree it was supposed to build did not
+        // exist. The consumer's build then failed four layers away, in a
+        // linker command line, naming nothing that had anything to do with
+        // package identity. The rule it silently imposed on index authors was
+        // that no package may share a `<short name>@<version>` with any
+        // package in any other namespace -- which is not knowable when the
+        // descriptor is written, and which the ecosystem already violates 20
+        // short names wide.
+        //
+        // ⭐ THE PAYLOAD PATH IS THE ANSWER, and `coordinate_from_payload_path`
+        // is the code that already knows it: the installer WROTE that path, so
+        // `<...>/xpkgs/<ns>-x-<package>/<version>` is not evidence about the
+        // package, it is the package identity recorded at install time. Asking
+        // it here costs one parse of a string we already have in hand.
+        //
+        // Compatibility is why this rejects rather than requires. A record
+        // whose path does not parse as a store coordinate -- a self-managed
+        // tool, a relocated payload, anything installed outside `xpkgs/` --
+        // yields no coordinate and is accepted exactly as before. The
+        // behaviour changes only where a DIFFERENT package's ownership can be
+        // proven, which is the case that was wrong.
+        //
+        // The second direction is the older one: a DB entry alone isn't
+        // enough. If the payload directory the entry points to is missing or
+        // empty (payload manually rm'd, partial uninstall, FS corruption),
+        // fall through and let the install hook re-create the payload.
+        // Without this fall-through, `xlings install <pkg>@<ver>` reports
+        // success without actually doing anything — the user can never recover
+        // from a broken payload via the obvious command.
         else if (!payloadInstalled) {
             auto db = Config::versions();
             auto resolved = xvm::match_version(db, node.name, node.version);
             if (!resolved.empty()) {
                 bool payload_ok = true;
+                bool payload_is_ours = true;
                 if (auto* vdata = xvm::get_vdata(db, node.name, resolved);
                     vdata && !vdata->path.empty()) {
                     auto expanded = xvm::expand_path(
                         vdata->path, Config::paths().homeDir.string());
+                    if (xvm::payload_path_names_another_package(
+                            expanded, node.namespaceName, node.name)) {
+                        payload_is_ours = false;
+                        auto owner =
+                            xvm::coordinate_from_payload_path(expanded);
+                        log::debug("{}: xvm entry {}@{} belongs to {} — "
+                                   "not this package; running install hook",
+                                   node.canonicalName, node.name, resolved,
+                                   owner ? owner->canonical()
+                                         : std::string("another package"));
+                    }
                     std::error_code ec;
                     payload_ok = std::filesystem::is_directory(expanded, ec)
                               && payload_has_content(expanded);
                 }
-                if (payload_ok) {
+                if (payload_is_ours && payload_ok) {
                     log::debug("{} already installed in xvm (version {})",
                               node.name, resolved);
                     payloadInstalled = true;
-                } else {
+                } else if (payload_is_ours) {
                     log::debug("{} registered as {} in xvm but payload "
                               "missing — re-running install hook",
                               node.name, resolved);

--- a/src/core/xvm/owner.cpp
+++ b/src/core/xvm/owner.cpp
@@ -159,4 +159,17 @@ namespace xlings::xvm {
     return std::format("xlings install {}", canonical());
 }
 
+[[nodiscard]] bool
+payload_path_names_another_package(std::string_view payloadPath,
+                                   std::string_view ns,
+                                   std::string_view package) {
+    // The version is deliberately NOT compared. The caller has already
+    // resolved a version through the DB, and a payload path under a different
+    // version of the SAME package is that package's business -- the question
+    // here is only whether the identity matches.
+    auto coord = coordinate_from_payload_path(payloadPath);
+    if (!coord) return false;          // unparseable proves nothing; see header
+    return coord->ns != ns || coord->package != package;
+}
+
 } // namespace xlings::xvm

--- a/src/core/xvm/owner.cppm
+++ b/src/core/xvm/owner.cppm
@@ -84,4 +84,28 @@ owner_candidates(const VersionDB& db,
                  const std::string& target,
                  const std::string& version);
 
+// Does this payload path demonstrably belong to a DIFFERENT package?
+//
+// The versions DB is keyed by xvm TARGET -- a program name -- while every
+// other answer to "is this installed" is keyed by package identity. A caller
+// holding a DB entry and a package therefore has to ask whether the two are
+// even about the same thing, and `coordinate_from_payload_path` is what can
+// tell it: the installer wrote that path, so it carries the identity.
+//
+// ⚠️ POLARITY IS DELIBERATE, and the name says which way. This answers
+// "can I PROVE this is someone else's", not "is this mine". A path that does
+// not parse as a store coordinate -- a self-managed tool, a relocated payload,
+// anything outside `xpkgs/` -- proves nothing and returns false, so a caller
+// written against this predicate keeps its old behaviour everywhere except
+// where ownership is actually contradicted. A `is_mine`-shaped predicate would
+// have had to return false there too, and would have silently reclassified
+// every unparseable path as a mismatch.
+//
+// Refs: mcpp#533, where a `compat:libdrm` install was skipped because
+// `xim:libdrm` at the same upstream version was in the store.
+[[nodiscard]] bool
+payload_path_names_another_package(std::string_view payloadPath,
+                                   std::string_view ns,
+                                   std::string_view package);
+
 }  // namespace xlings::xvm

--- a/src/core/xvm/owner.cppm
+++ b/src/core/xvm/owner.cppm
@@ -92,7 +92,7 @@ owner_candidates(const VersionDB& db,
 // even about the same thing, and `coordinate_from_payload_path` is what can
 // tell it: the installer wrote that path, so it carries the identity.
 //
-// ⚠️ POLARITY IS DELIBERATE, and the name says which way. This answers
+// POLARITY IS DELIBERATE, and the name says which way. This answers
 // "can I PROVE this is someone else's", not "is this mine". A path that does
 // not parse as a store coordinate -- a self-managed tool, a relocated payload,
 // anything outside `xpkgs/` -- proves nothing and returns false, so a caller

--- a/tests/unit/test_xvm_owner.cpp
+++ b/tests/unit/test_xvm_owner.cpp
@@ -1,0 +1,144 @@
+// tests/unit/test_xvm_owner.cpp — a payload path is a package identity, and
+// the predicate that reads it as one.
+//
+// WHAT THESE DEFEND. The versions DB is keyed by xvm TARGET — a program name.
+// Every other answer to "is this package installed" is keyed by package
+// identity. `payload_path_names_another_package` is the bridge, and it is the
+// fix for mcpp#533, where a `compat:libdrm` install was skipped because a
+// `xim:libdrm` payload at the same upstream version was in the store: the
+// install hook never ran, the tree it should have built did not exist, and the
+// consumer's build failed four layers away in a linker command line.
+//
+// ⚠️ MOST OF THESE ASSERT A *false*. The predicate answers "can I PROVE this
+// belongs to someone else", not "is this mine", and the difference is the whole
+// design: a path that does not parse as a store coordinate proves nothing and
+// must be accepted, or every self-managed tool and relocated payload would be
+// reclassified as a mismatch and reinstalled forever. A predicate that only
+// ever said "foreign" would pass the interesting-looking test below and fail
+// every one of the negatives.
+
+#include <gtest/gtest.h>
+
+import std;
+import xlings.core.xvm.owner;
+
+namespace xvm = xlings::xvm;
+
+namespace {
+
+// The layout the installer writes, spelled out rather than composed from a
+// helper: the layout IS the contract with coordinate_from_payload_path, and a
+// shared helper would let the test and the code drift together.
+std::string store_path(std::string_view ns, std::string_view name,
+                       std::string_view version) {
+    if (ns.empty())
+        return std::format("/home/u/.xlings/data/xpkgs/{}/{}", name, version);
+    return std::format("/home/u/.xlings/data/xpkgs/{}-x-{}/{}", ns, name,
+                       version);
+}
+
+}  // namespace
+
+// ─── the case that was wrong ────────────────────────────────────────────────
+
+// mcpp#533 exactly: two packages, same short name, same upstream version, two
+// namespaces. Mesa always pulls in the first, so the second was never built.
+TEST(PayloadOwnership, SameShortNameInAnotherNamespaceIsAnotherPackage) {
+    const auto ximPayload = store_path("xim", "libdrm", "2.4.123");
+
+    EXPECT_TRUE(xvm::payload_path_names_another_package(ximPayload, "compat",
+                                                        "libdrm"));
+    // …and the coordinate recovered from it names the real owner, which is
+    // what the diagnostic prints.
+    auto coord = xvm::coordinate_from_payload_path(ximPayload);
+    ASSERT_TRUE(coord.has_value());
+    EXPECT_EQ(coord->canonical(), "xim:libdrm@2.4.123");
+}
+
+// The whole ecosystem shape, not one instance: these short names each occupy
+// two or more namespaces in a real store today.
+TEST(PayloadOwnership, EveryCrossNamespaceShortNameCollisionIsCaught) {
+    struct Row {
+        const char* owner;
+        const char* asker;
+        const char* name;
+    };
+    const Row rows[] = {
+        {"xim", "compat", "expat"},   {"xim", "fromsource", "zlib"},
+        {"xim", "local", "cairo"},    {"xim", "scode", "linux-headers"},
+        {"compat", "xim", "libffi"},  {"fromsource", "xim", "libpng"},
+    };
+    for (const auto& r : rows) {
+        SCOPED_TRACE(std::format("{} asking about {}:{}", r.owner, r.asker,
+                                 r.name));
+        EXPECT_TRUE(xvm::payload_path_names_another_package(
+            store_path(r.owner, r.name, "1.0.0"), r.asker, r.name));
+    }
+    // Denominator: the loop above must actually have run.
+    EXPECT_EQ(std::size(rows), 6u);
+}
+
+// ─── the cases that must stay accepted ──────────────────────────────────────
+
+TEST(PayloadOwnership, OwnPayloadIsNotForeign) {
+    EXPECT_FALSE(xvm::payload_path_names_another_package(
+        store_path("compat", "libdrm", "2.4.123"), "compat", "libdrm"));
+}
+
+// A different VERSION of the same package is that package's own business. The
+// caller has already resolved a version through the DB; this predicate answers
+// identity only.
+TEST(PayloadOwnership, DifferentVersionOfTheSamePackageIsNotForeign) {
+    EXPECT_FALSE(xvm::payload_path_names_another_package(
+        store_path("compat", "libdrm", "2.4.100"), "compat", "libdrm"));
+}
+
+// The compatibility guarantee. Anything that does not parse as a store
+// coordinate proves nothing, so the caller keeps its previous behaviour.
+TEST(PayloadOwnership, UnparseablePathsProveNothing) {
+    const char* paths[] = {
+        "",
+        "/usr/local/bin/tool",              // installed outside the store
+        "/home/u/.xlings/bin",              // no xpkgs component
+        "relative/path/without/xpkgs",
+    };
+    for (const auto* p : paths) {
+        SCOPED_TRACE(p);
+        EXPECT_FALSE(
+            xvm::payload_path_names_another_package(p, "compat", "libdrm"));
+    }
+    EXPECT_EQ(std::size(paths), 4u);
+}
+
+// An unnamespaced payload (`<store>/xpkgs/<name>/<version>`) is its own
+// identity, and asking about it from a namespace is a genuine mismatch —
+// but asking about it as unnamespaced is not.
+TEST(PayloadOwnership, UnnamespacedPayloadsCompareOnTheEmptyNamespace) {
+    const auto bare = store_path("", "libdrm", "2.4.123");
+    EXPECT_FALSE(xvm::payload_path_names_another_package(bare, "", "libdrm"));
+    EXPECT_TRUE(xvm::payload_path_names_another_package(bare, "compat",
+                                                        "libdrm"));
+}
+
+// Windows-written records reach a Linux reader with backslashes, and that
+// record is exactly the one nothing else can identify — so the predicate must
+// not start guessing there either.
+TEST(PayloadOwnership, SeparatorStyleDoesNotChangeTheAnswer) {
+    const std::string win =
+        R"(C:\Users\u\.xlings\data\xpkgs\xim-x-libdrm\2.4.123)";
+    EXPECT_TRUE(
+        xvm::payload_path_names_another_package(win, "compat", "libdrm"));
+    EXPECT_FALSE(xvm::payload_path_names_another_package(win, "xim", "libdrm"));
+}
+
+// A payload path pointing INTO the package (a bindir) still identifies it:
+// coordinate_from_payload_path keeps the two components after `xpkgs` and
+// discards the rest, and the DB stores bindirs.
+TEST(PayloadOwnership, BindirPathsStillIdentifyTheOwner) {
+    const auto bindir =
+        store_path("xim", "libdrm", "2.4.123") + "/bin";
+    EXPECT_TRUE(
+        xvm::payload_path_names_another_package(bindir, "compat", "libdrm"));
+    EXPECT_FALSE(
+        xvm::payload_path_names_another_package(bindir, "xim", "libdrm"));
+}


### PR DESCRIPTION
## What

The install planner's fallback answer to *"is this already installed"* was keyed on `node.name` — a bare short name — while every other answer in this codebase is keyed on package identity. `match.installed` (`catalog.cpp:302`) stats `<store>/<ns>-x-<name>/<version>`; `installation_state` takes a namespace argument. `installer.cpp`'s xvm fallback did not.

A short name is not an identity.

## The failure, from the consumer side

Reported as [mcpp#533](https://github.com/mcpp-community/mcpp/issues/533). A source-build `compat:libdrm` pinned to the same upstream version as the `xim:libdrm` that Mesa pulls in was reported already-installed on the strength of Mesa's payload. Its `install()` never ran; the tree it was supposed to build did not exist; and the consumer's build then failed four layers away:

```
$ mcpp test
   Compiling compat.libdrm v2.4.123          <- looks resolved
error: build failed
failed: bin/libdrm.so
/bin/sh: 1: -shared: not found
```

The rule this silently imposed on index authors is that no package may share a `<short name>@<version>` with any package in any other namespace — which is not knowable when a descriptor is written, and which a real store already violates 20 short names wide (`libpng`, `expat`, `zlib`, `cairo`, `fontconfig`, `linux-headers`, `nasm`, `ncurses`, …).

## The fix

`coordinate_from_payload_path` already knows the answer, and says so in its own header: the installer *wrote* that path, so `<...>/xpkgs/<ns>-x-<package>/<version>` is not evidence **about** the package, it **is** the package identity recorded at install time. `payload_path_names_another_package` reads it, and the fallback declines a DB entry it can prove belongs elsewhere.

This also removes a surviving answerer to the question `install_state.cppm` was written to consolidate — its own header notes there were four, and this fallback was a fifth.

## Compatibility

The predicate is deliberately **reject-shaped**, not require-shaped. A record whose path does not parse as a store coordinate — a self-managed tool, a relocated payload, anything outside `xpkgs/` — yields no coordinate and is accepted exactly as before. Behaviour changes only where different ownership is *provable*.

## What this does NOT authorise

Publishing a colliding `<name>@<version>` to an index is still unsafe until this version is the floor: a client below it goes on skipping the install, silently. This fix is for the collisions people hit **by accident**, which per the numbers above is the common case.

## Tests

`tests/unit/test_xvm_owner.cpp`, eight cases. Most assert a *false*: the predicate answers "can I prove this is someone else's", not "is this mine", and a version that only ever said yes would reinstall every superseded payload forever.

Verified by reverting the predicate to its previous answer and re-running — `PayloadOwnership.SameShortNameInAnotherNamespaceIsAnotherPackage` fails, so the tests discriminate rather than describe.

Local: `mcpp build` clean, `mcpp test` 50 passed / 0 failed.