### PR TITLE
fix(elfcheck,doctor,xim): a guard judges what the loader would do, and a remedy is a command that runs (2026.9.3.2)

### DIFF
--- a/.agents/docs/2026-09-03-diagnostic-truth-impl-plan.md
+++ b/.agents/docs/2026-09-03-diagnostic-truth-impl-plan.md
@@ -141,7 +141,10 @@ A1 失败,在 2026.9.3.2 上 PASS):
 - [x] `mcpp.toml` → `2026.9.3.2`
 - [x] 调研文档状态改「已实现(P0–P7)」,§8b 追加实施中被推翻的判断
 - [x] release notes `.agents/docs/2026-09-03-release-2026.9.3.2-notes.md`
-- [ ] 单 PR(**#581**);CI 全绿;自我 review 一次(已做:一处 note 行花括号、一处前缀提升)
+- [ ] 单 PR(**#581**);CI 全绿;自我 review 一次(已做:一处 note 行花括号、一处前缀提升;
+      CI 首轮 E2E-64 失败:它 grep 的是 `xlings use lostws@`,而新 remedy 拼成 `use lostws 2.0.0`。
+      两种拼法 CLI 都接受(实测同一路径、同一报错),所以是**测试钉住了拼法而不是性质**;
+      测试放宽为 `use lostws(@| )<version>`,remedy 用 `@` 形式与 doctor 其它 remedy 一致)
 - [ ] release;资源一出即本地 `tools/mirror-latest.sh` 补 GitCode
 - [ ] xim-pkgindex `pkgs/x/xlings.lua` bump(bump-index 只开 PR 不合并)
 - [ ] 沙箱真机验证(先 `xlings config --mirror CN`):`self update`;`self doctor --deep --all` 计数;

--- a/.agents/docs/2026-09-03-diagnostic-truth-impl-plan.md
+++ b/.agents/docs/2026-09-03-diagnostic-truth-impl-plan.md
@@ -141,7 +141,7 @@ A1 失败,在 2026.9.3.2 上 PASS):
 - [x] `mcpp.toml` → `2026.9.3.2`
 - [x] 调研文档状态改「已实现(P0–P7)」,§8b 追加实施中被推翻的判断
 - [x] release notes `.agents/docs/2026-09-03-release-2026.9.3.2-notes.md`
-- [ ] 单 PR;CI 全绿;自我 review 一次
+- [ ] 单 PR(**#581**);CI 全绿;自我 review 一次(已做:一处 note 行花括号、一处前缀提升)
 - [ ] release;资源一出即本地 `tools/mirror-latest.sh` 补 GitCode
 - [ ] xim-pkgindex `pkgs/x/xlings.lua` bump(bump-index 只开 PR 不合并)
 - [ ] 沙箱真机验证(先 `xlings config --mirror CN`):`self update`;`self doctor --deep --all` 计数;

--- a/.agents/docs/2026-09-03-diagnostic-truth-impl-plan.md
+++ b/.agents/docs/2026-09-03-diagnostic-truth-impl-plan.md
@@ -1,0 +1,148 @@
+# 诊断与守卫的「真值」—— 实施计划
+
+> 设计/调研:`.agents/docs/2026-09-03-diagnostic-truth-survey-and-plan.md`
+> 分支 `fix/musl-loader-family-misread`,基线 `ba51901`(2026.9.3.1)。
+> 目标版本 **2026.9.3.2**。单 PR 落地。
+
+> **For agentic workers:** 每个 P 有自己的差分验收:**先让差分在旧二进制(2026.9.3.1)上失败**,
+> 再让它在新二进制上通过。步骤是 `- [ ]` checkbox。
+
+## Global Constraints
+
+- 构建/测试只用 `mcpp build` / `mcpp test`,**不要**裸 xmake,**不要** `mcpp clean`。
+- 单测文件放 `tests/unit/`,自动发现;新增 e2e **必须**注册进 `tests/e2e/run_all.sh`。
+- 本地 e2e 一律 `XLINGS_TEST_MIRROR=CN`;沙箱真机验证前 `xlings config --mirror CN`。
+- commit 一律 `git commit -F -` + 带引号 heredoc。
+- 断言只断言不变量,不断言索引版本号 / 快照条数。
+- 真实 home 上的度量只读(`self doctor --deep --all`),`--fix` 只在 slice 上跑。
+- 不跨仓库:无新 libxpkg 字段、无索引格式变化、无 recipe API 变化。跨仓协作只有发布链:
+  release → `tools/mirror-latest.sh`(本地 gtc 补 GitCode)→ xim-pkgindex `pkgs/x/xlings.lua` bump。
+
+---
+
+## 多角度约束(每条落到一个可验的判据)
+
+| 角度 | 判据 |
+|---|---|
+| 架构 | 报告与拒绝共用同一谓词(`elf_same_source::check`);修谓词,不在两端各打补丁 |
+| 稳定性 | 守卫从「拒一个 plan」回到「拒一个节点」;拒绝写 marker,其余节点继续 |
+| 优雅简洁 | remedy 是 `{command, note}`,渲染层负责分行;不再在字符串里夹散文 |
+| 用户体验 | 每条打印出来的命令都能原样运行;152 条噪声 → 0,真 finding 浮出来 |
+| 兼容性 | 老 home 无迁移动作;老 finding 消失只是不再报,不改任何文件 |
+| 跨平台 | 谓词是纯函数,Windows/macOS 上 scan 本就不产生 INTERP 结果;e2e 用 patchelf,非 Linux SKIP 且说明 |
+| 一致性 | 一处 `owning coordinate` 逻辑(`xvm::owner`)服务 doctor、dispatch、use、update 四处 remedy |
+| 无感升级 | `self update` 不再对 `xim:` 键假报;entry binary 比较前 strip namespace |
+
+---
+
+## 任务依赖图
+
+```
+P1 same-source 顺序语义 ─┐
+P2 守卫契约(逐节点)   ─┼─→ P7 e2e(同一夹具:两包一 plan)─┐
+P4 InterpRuntimeDrift   ─┘                                   │
+P3 remedy 契约(owner 解析 + {command,note})─→ S13 扩门 ──────┼─→ P8 文档/版本 → PR/CI → 自审 → release → gtc → 沙箱验证
+P5 #579 self update 谓词 ────────────────────────────────────┤
+P6 #578 单版本 removal ──────────────────────────────────────┘
+```
+
+**可并行起步:** P1 / P3 / P5 / P6(互不触碰同一函数)。
+**串行:** P2 在 P1 之后(同一处 installer 代码);P4 在 P1 之后(复用 scan 的逐 ELF 信息);P7 依赖 P1+P2。
+
+---
+
+## P1 · 同源检查 = 加载器会做的选择
+
+`src/core/elf_same_source.cppm::check`。
+
+- [x] `CoreSource` 加 `name`(目录条目名 = soname)
+- [x] 沿 RUNPATH **顺序**遍历;每个 core soname 只由**首个**含它的目录回答;后续目录对该 soname 不再计入
+- [x] 注入探针(合成目录)路径:一个合成目录视为回答了全部 core soname
+- [x] 家族守卫、反向规则(`HostLoaderPayloadCore`)、`describe()` 不动
+- [x] 单测:`AnyDifferentCoreRuntimeEntryViolates` 拆成
+      `ACompleteFirstDirectoryAnswersEveryCoreSoname`(pass)与
+      `AnIncompleteFirstDirectoryLeavesLaterEntriesInPlay`(violated);
+      新增真实 home 形状 `OwnGlibcAheadOfADriftedFarmIsNotASplit`(farm 用符号链接)
+
+**差分验收:** 真实 home 只读 `self doctor --deep --all`:`loader/libc split` **152 → 0**;
+`FirstCoreRuntimeEntryDeterminesResult` 与 E2E-62 仍过。
+
+## P2 · 守卫拒一个节点,不拒一个 plan(依赖 P1)
+
+`src/core/xim/installer.cpp:3017` 附近。
+
+- [x] `return std::unexpected` → `write_payload_failure_marker` + `onStatus(Failed)` + `continue`
+- [x] 文案保留「resolution defect … report it with the two paths above」
+- [x] `install_summary` 正常发出;退出码由 `failedCount` 决定(既有逻辑)
+
+**差分验收:** P7 的两包一 plan:被拒包 rc≠0 且有 marker,正常包装上并注册。旧二进制上正常包装不上。
+
+## P3 · remedy 契约:可运行,或空
+
+- [x] `xvm::owner`:新增 `recorded_owner(db, target, version)` —— 只返回**有记录证据**的候选
+      (provider 记录 / payload 路径),不返回「target 自身」这种猜测
+- [x] `xvm/errors.cpp` `not_in_subos`:`NotInSubos` 加 `installCoordinate`;有则
+      `xlings install [-g] <coord>`;无则 `xlings search <name>`(一定能跑)
+- [x] `xvm/shim.cpp:730` `pinned_version_missing`:同上
+- [x] `xim/commands.cpp:2026` `update`:用 `match->canonicalName`
+- [x] `doctor::Finding`:`remedy` 拆为 `remedy`(命令)+ `remedyNote`(散文);渲染层 note 另起一行;
+      迁移 doctor.cpp:462/548/593/617 四处
+- [x] S13 扩门(实际做法):e2e 对每条 `→ run` 取 `xlings <sub>` 的首词,断言 `<sub>` 是真实子命令;
+      命令位不得含 `<one of` / `(adopt` / `(then` / `<version>`;`install … --force` 与 `<ns>-x-<pkg>@`
+      仍被拒。没有加新命令。
+- [x] 单测:`recorded_owner` 三例(provider / path / 无证据→nullopt)
+
+**差分验收:** 真实 home dispatch 一个 group 注册的程序名(如 `slang`)在无主张的 subos:
+输出不含 `xlings install slang`;含 `xlings search slang` 或一条可解析坐标。
+
+## P4 · 把 152 条背后的真信息说出来(依赖 P1)
+
+- [x] `elf_same_source::scan_payload_report(dir)` → `{ findings, interpPayloads: map<payload,count> }`;
+      `scan_payload` 保持签名(返回 `.findings`);`PayloadScanCache` 缓存 report
+- [x] doctor 新 `FindingKind::InterpRuntimeDrift`(**Notice**):按 subos 聚合 ——
+      「subos `<n>` 声明 glibc@2.44;N 个可执行文件(M 个包)的 PT_INTERP 指向 glibc 2.39,
+      它们靠自身 RUNPATH 运行;2.39 若从最后一个 subos 移除,这些二进制将无法启动」
+- [x] `--fix` 不动它;remedy 为空,note 给包清单(最多 8 个 + `+N more`)
+- [x] 只对声明了 runtime 的 subos 报;只统计**注册在该 subos** 的包(workspace installed)
+
+**差分验收:** 真实 home 出现 1 条 Notice,数字 ≈ 18 个包;exit code 不因它非零。
+
+## P5 · #579 `self update` 谓词
+
+- [x] `update_landed_on_index_build`:只有 `local:` 前缀判为「不是索引构建」;其它命名空间都是索引
+- [x] `entry_binary::replace_with`:比较与打印前 strip namespace(本地 lambda,不引入 xvm.db 依赖)
+- [x] `cmd_update`:`use` 之后 `Config::reload_state()` 再读 active
+- [x] 单测更新 `SelfUpdateLanding.*`:`xim:2026.9.2.1` → true;`local:0.4.51` → false
+
+**差分验收:** 单测;真实 home 无法安全复现(需要一次真实升级),在 release 后的 `self update`
+验证中观察不再出现 `nothing was upgraded` / `DOWNGRADED`。
+
+## P6 · #578 单版本 versionless removal
+
+- [x] `xvm/removal.cpp:246` 分支:`versions.size() == 1` → 该唯一键即 exactVersion
+- [x] 单测 `test_xvm_bindings.cpp`:一个存储版本、无 selection、`xvm.remove("fd")` → 成功删除该版本
+
+**差分验收:** 单测在旧实现上得到 `VersionNotFound`。#578 的第 1 点(经目录解析到索引 latest)
+在 e2e 复现失败则记录、不在本 PR 处理。
+
+## P7 · e2e(P1+P2 同一夹具)
+
+`tests/e2e/install_guard_loader_order_test.sh`(已注册为 **E2E-97**;在 2026.9.3.1 二进制上于
+A1 失败,在 2026.9.3.2 上 PASS):
+
+- 两个假 glibc 载荷 `xim-x-glibc/1.0`(interp)与 `2.0`;farm `subos/default/lib` 符号链接指向 2.0
+- 包 A:RUNPATH `[1.0/lib64, farm]` → **必须安装成功**(旧二进制拒绝)
+- 包 B:RUNPATH `[farm]` → 真 split,**拒绝**;与包 C(正常)同一 plan:
+  C 装上并注册,B 有 failure marker,退出码 ≠ 0
+- 非 Linux / 无 patchelf / 无 gcc:SKIP 且打印原因
+
+## P8 · 文档 / 版本 / 发布
+
+- [x] `mcpp.toml` → `2026.9.3.2`
+- [x] 调研文档状态改「已实现(P0–P7)」,§8b 追加实施中被推翻的判断
+- [x] release notes `.agents/docs/2026-09-03-release-2026.9.3.2-notes.md`
+- [ ] 单 PR;CI 全绿;自我 review 一次
+- [ ] release;资源一出即本地 `tools/mirror-latest.sh` 补 GitCode
+- [ ] xim-pkgindex `pkgs/x/xlings.lua` bump(bump-index 只开 PR 不合并)
+- [ ] 沙箱真机验证(先 `xlings config --mirror CN`):`self update`;`self doctor --deep --all` 计数;
+      `xlings subos <n> --sandbox --cmd "gcc --version && cmake --version && node --version"`

--- a/.agents/docs/2026-09-03-diagnostic-truth-survey-and-plan.md
+++ b/.agents/docs/2026-09-03-diagnostic-truth-survey-and-plan.md
@@ -3,8 +3,8 @@
 > 起点:用户贴出的 `self doctor` / `install` 真实输出,三个问题:
 > ① remedy 写成 `xlings install xim-x-xxx@version`;② `--force` 不存在;③ 为什么报错。
 > 分支 `fix/musl-loader-family-misread`,基线 `ba51901`(发布版 2026.9.3.1)。
-> 状态:**调研 + 方案,待 review**。§6 的 P0 已在分支上完成并通过 51 套单测与 3 个受影响 e2e;
-> P1 起未动手。
+> 状态:**已实现 P0–P7**(2026.9.3.2),实施记录见 `2026-09-03-diagnostic-truth-impl-plan.md`,
+> 真机数字见 `2026-09-03-release-2026.9.3.2-notes.md`。§8b 记实施中新增/推翻的判断。
 
 ## 0. 一句话
 
@@ -264,6 +264,19 @@ upgraded」在 `use` 之后**重读状态**再判。已在 issue 里列了三条
 - 「GitCode 索引指针 404,CN 客户端靠跨区回退」 → 今天两端都 200 且一致;撤回。
 - 「`--force` 让 install 以 exit 2 退出」 → rc=1,`Error: unknown option: --force`;注释已改。
 - 「152 条 split 里总有真的」 → 逐二进制运行 + 逐 soname 首命中重算:0。
+
+## 8b. 实施阶段新增的判断与推翻(P1–P7,实施计划见 `2026-09-03-diagnostic-truth-impl-plan.md`)
+
+- **#531 的平台维度早已处理**:`catalog.cpp::resolve_target` 对「存在但无本平台构建」已单独报
+  `has no build for <platform> (available on: …)`;§5 把它列为 open 是我没读到这段。arch 维度由
+  安装期 `check_target_compatibility` 报,`info` 路径未验证 —— 留在 issue 里,不进本 PR。
+- **#578 的第 2 点撞上一条钉死的单测**:`RawEmptyOperationNeverMeansAllVersions`(2026-07-27)断言
+  「单一存储版本 + 空版本操作 → VersionNotFound」。这条规则的名字说的是「空不等于全部」,对 ≥2 个
+  版本仍成立(Ambiguous);对恰好 1 个版本不存在「全部」可指,而 `xvm.remove("fd")` 是每个 uninstall
+  hook 的常规写法。按 #578 的预期改了这半条测试,理由写在测试里。
+- **P3 不做 e2e**:`recorded_owner` 三条单测 + S13 的可运行门;不_in_subos 的 install 动作在夹具索引里
+  没有「程序名≠包名」的现成包,造一个的成本高于收益。记为缺口。
+- **P4 只比声明 runtime 的同名包**:musl 解释的工具在 glibc subos 里是另一个 runtime,不是漂移。
 
 ## 9. 附:本次的度量方法(可复跑)
 

--- a/.agents/docs/2026-09-03-diagnostic-truth-survey-and-plan.md
+++ b/.agents/docs/2026-09-03-diagnostic-truth-survey-and-plan.md
@@ -1,0 +1,278 @@
+# 诊断与守卫的「真值」排查 —— 从三条报错到一类问题
+
+> 起点:用户贴出的 `self doctor` / `install` 真实输出,三个问题:
+> ① remedy 写成 `xlings install xim-x-xxx@version`;② `--force` 不存在;③ 为什么报错。
+> 分支 `fix/musl-loader-family-misread`,基线 `ba51901`(发布版 2026.9.3.1)。
+> 状态:**调研 + 方案,待 review**。§6 的 P0 已在分支上完成并通过 51 套单测与 3 个受影响 e2e;
+> P1 起未动手。
+
+## 0. 一句话
+
+这次排查到的问题都是一个形状:**守卫或诊断回答的是一个比真实问题更弱(或不同)的
+代理问题,然后把答案当作真实问题的答案打印或执行**。
+
+| 真实问题 | 实际回答的代理问题 | 后果 |
+|---|---|---|
+| 这个 core 文件属于哪个 libc 家族 | 解析符号链接之后的**文件名**像什么 | musl 的 loader 是 `libc.so` 的链接 → Unknown → 与 glibc 比较 → 假 split → **拒绝安装** |
+| 加载器实际会从哪个载荷取 libc | RUNPATH 里**有没有任何**目录含别的载荷的 core 文件 | 真实 home 152 条 error,**0 条为真**;同一谓词是安装期硬拒绝 |
+| 用户该敲什么命令 | 拿手头的字符串(store 目录名 / 程序名 / 想象中的 flag)拼一条 | 复制即失败;338 个程序名里 218 个不是包名 |
+| 这次 `self update` 有没有换到索引构建 | 激活键里**有没有冒号** | 2026.9.2.1 起键按身份拼写,index 安装也可带 `xim:` → 假「nothing was upgraded」(#579) |
+
+memory 里早有这个形状的名字:[[proxy predicate, discarded half]]、[[gate the message on behaviour]]。
+本次不同之处在于**同一个代理谓词同时驱动报告与拒绝**:doctor 的噪声与 install 的误拒是一个函数。
+
+## 1. 用户的三个问题,逐条
+
+### ① `xlings install xim-x-bun@1.3.11` —— 拼的是 store 目录名
+
+`doctor.cpp:1779` 用 `root.target`/`root.version` 拼 remedy,而整库扫描时 `root.target` 是
+`data/xpkgs/` 下的**目录名**(`xim-x-bun`),不是包坐标。实测:
+
+```
+$ xlings install xim-x-bun@1.3.11        → "not found in the synced index"
+$ xlings install xim:bun@1.3.11          → 解析成功
+```
+
+修法已在仓里:`xvm::coordinate_from_payload_path` 就是为「从 store 路径反推可安装坐标」写的。
+新 remedy:`xlings remove xim:d2x@0.1.3 -y && xlings install xim:d2x@0.1.3 -y`。
+为什么是 remove+install:`install` 对已注册且载荷在盘的包打印 already installed 什么也不做,
+「重装」在 xlings 里不是一个 flag 而是两步。坐标解析失败时 remedy 留空 ——
+`Finding::remedy` 的契约允许空,不允许错。
+
+### ② `--force` —— `install` 没有这个选项
+
+`cli.cpp:1589-1626`:`install` 只有 `-g/--global`、`-u/--use`,加全局 `-y`。`--force` 是
+`remove` 的(含义是「有依赖者也删」)。实测 `xlings install zz@1.0 --force` →
+`Error: unknown option: --force`,rc=1。
+
+同一字符串在 **两处**:`doctor.cpp:1779`(已修)和 `xvm/commands.cpp:521`
+(`runtime activation refused … hint: reinstall it with xlings install {} --force`,已修为
+`xlings install {}` —— 该分支的前提就是「已注册但载荷缺失」,这正是安装器会重跑 install hook
+的状态,裸 install 就是重装)。`grep 'install .* --force' src` 现为空。
+
+### ③ 为什么报错 —— musl 的 loader 是 libc 的符号链接
+
+```
+xim-x-musl/1.2.5/lib/ld-musl-x86_64.so.1 -> libc.so
+```
+
+`core_runtime_sources_` 只保留 `weakly_canonical` 之后的路径;`core_family_of_path_("libc.so")`
+既不匹配 glibc 模式也不匹配 musl 模式 → `Unknown`;而家族守卫的规则是「任一侧 Unknown 仍比较」
+(为了不放过不认识的载荷)。于是每一个 RUNPATH 触及含 musl 的 subos lib farm 的 glibc 二进制
+都被判 split,`installer.cpp:3017` 的硬守卫**拒绝安装**——用户看到的
+`xlings install xim:bun@1.3.11` 在 node@24.20.0 上失败就是这条。
+
+修:`struct CoreSource { path source; CoreFamily family; }`,家族按**目录条目名**判定,
+解析路径只用作身份与报错。实测真实 home:doctor 178 → 152;`--scope node@24.20.0` 1 → 0。
+单测 `SameSource.AMuslLoaderSymlinkedToLibcIsStillMusl` 用真实形状(符号链接)建 fixture ——
+原来两条 musl 测试 `touch` 的是普通文件,fixture 长得不像它代表的东西,所以从没抓到。
+
+## 2. 顺着查:剩下的 152 条也全是假的
+
+真实 home,分支二进制,`self doctor --deep --all`(4.4 s,470 个载荷):
+
+```
+error 155 = loader/libc split 152 + broken payload 2 + binding state 1
+summary:  broken payloads 152        exit 1
+```
+
+152 条**同一形状**:
+
+```
+interpreter -> xim-x-glibc/2.39/lib64/ld-linux-x86-64.so.2
+RUNPATH     -> …/xim-x-glibc/2.39/lib64 : … : ~/.xlings/subos/default/lib
+core file   -> xim-x-glibc/2.44/lib/ld-linux-x86-64.so.2     ← farm 今天指向 2.44
+```
+
+涉及 18 个包(gcc 71、binutils 29、llvm 17、ncurses 7、cmake 5、bun 5、slang 4、node 3…)。
+直接运行其中 10 个(gcc 11.5.0、d2x、cmake 4.0.2、node ×7)**全部 rc=0**。
+
+按加载器真实语义重算 —— 对每个 core soname(`ld-linux-*`、`libc.so.6`、`libm.so.6`、
+`libpthread.so.0` 等 8 个)沿 RUNPATH **顺序取首个命中目录**,与 interp 载荷比较:
+
+```
+flagged binaries 151   ordered per-soname mismatches 0
+```
+
+### 根因:谓词是「顺序盲」的,而且有单测钉着
+
+`elf_same_source.cppm::check`(2026-08-10,`65002df` 引入)明写:
+
+> Every proven core-runtime entry must agree: a later directory may supply the loader or
+> another core component even when libc.so.6 was found earlier, so one same-source entry
+> cannot wash out another mismatch.
+
+单测 `SameSource.AnyDifferentCoreRuntimeEntryViolates`:RUNPATH `[2.44(同 interp), 2.39]` →
+必须 violated。这个理由只在**首个目录不完整**时成立(首目录有 `libc.so.6` 没 `libm.so.6`,
+`libm` 才会从后面的目录来)。`xim-x-glibc/<v>/lib64` 永远是完整的,所以真实 home 上这条规则
+的全部输出都是假阳性。fixture 每个目录只 `touch` 一个 `libc.so.6`,区分不出「完整首目录」与
+「残缺首目录」,于是把一个更强的策略当成了加载器语义。
+
+### 三重后果
+
+1. **doctor**:这台机器上 98% 的 error 是噪声;真 finding(2 条 broken payload、1 条 binding
+   state)淹在 152 条里;summary 与 exit code 都被假阳性决定。
+2. **install**:同一函数是 `installer.cpp:3017` 的硬拒绝。何时误拒:subos 激活的 glibc ≠
+   farm 实际指向的 glibc(漂移,见 #529),或 recipe 钉了另一版 glibc,或 musl(已修)。
+3. **remedy**:让用户对 18 个包 / 152 个二进制做 remove+install —— 修一个不存在的问题,
+   而重装后 INTERP 变 2.44,行为反而改变。
+
+### 152 条背后的真信息,doctor 没说
+
+`default` 声明并激活 glibc **2.44**(workspace 仅 `['2.44']`),但 152 个二进制的 INTERP 指向
+**2.39**(2026-05 安装时的 runtime;2.39 仍注册在另外 21 个 subos)。它们能跑,是因为自己的
+RUNPATH 先于 farm。这是 #529 的「声明 vs 实际」漂移的逐二进制版本 —— D6 只比 farm 与声明,
+不看每个二进制的 INTERP。如果有一天 2.39 被从最后一个 subos 移除,这 152 个二进制会以
+`ENOENT` 死掉且报错指向二进制本身([[ENOENT names the binary]])。**该报的是这条,而不是 split。**
+
+## 3. 安装守卫的契约漂移
+
+`xim/commands.cpp:865` 的注释是契约:
+
+> installer.execute itself only returns unexpected on cancel or plan-level errors.
+> Per-package failures … accumulate in failedCount.
+
+Rule-B 守卫(`installer.cpp:3017-3027`)对**单包**失败 `return std::unexpected(...)`:
+
+| 契约要求 | 守卫实际 |
+|---|---|
+| 单包失败 → `onStatus(Failed)`,其余节点继续 | 整个 plan 中止(bun 因 node 死) |
+| 失败以 `ErrorEvent{recoverable=true}` 逐包上报 | `ErrorCode::Internal`,`recoverable=false` |
+| `install_summary` 事件 | 不发 |
+| install/config hook 失败写 payload failure marker(#541 ①) | 不写 marker;载荷留在盘上 |
+
+重试行为我先假设是 fail-open(目录非空 → 视为已装 → 跳过守卫),**量过是错的**:
+`payloadInstalled` 由 versions DB 注册决定,被拒节点未注册 → 重试重新走 install hook 与守卫,
+确定性再拒。留在盘上的是一个无 marker 的「有载荷、无账」目录。
+
+## 4. 打印出来的命令:一类,不是两处
+
+盘点 `src/` 里所有拼出 `xlings …` 的字符串(~60 处),不可运行的风险分四型:
+
+| 型 | 例 | 站点 | 状态 |
+|---|---|---|---|
+| A 不存在的 flag | `install … --force` | doctor.cpp:1779、xvm/commands.cpp:521 | **已修** |
+| B store 目录名当坐标 | `install xim-x-bun@1.3.11` | doctor.cpp:1779 | **已修** |
+| C 程序名当包名 | `install g++` / `install -g slang` | errors.cpp:331/342、shim.cpp:730、xvm/commands.cpp:970、xim/commands.cpp:2026 | 未修 |
+| D remedy 字段夹散文 | `xlings self doctor --fix   (adopt …; or migrate with …)` | doctor.cpp:462/548/593/617 | 未修 |
+
+C 型量化:真实 home versions DB 338 个 `program` 条目,**218 个不是索引包名**
+(`g++`、`ar`、`as`、`c++`、`7z`、`aarch64-linux-musl-*` …)。对这些名字,
+`xlings install <name>` 必然 not found。`errors.cpp:320` 的注释已经承认了 `slang` 这一例,
+但只修了「项目提供」那一支,`install -g {target}` 与 `install it here` 两支照旧。
+
+D 型:`diag::Diagnostic` 早已把 `label`(散文)与 `command`(可执行)分开
+(`diag.cppm:63-64`),`doctor::Finding::remedy` 只有一个字符串,散文只能塞进命令里。
+
+## 5. 相邻的同类 open issue(一起排,不重开)
+
+- **#579** `self update` 假报「nothing was upgraded」+ 假 DOWNGRADED:`update_landed_on_index_build`
+  以「键里有冒号」判定 provider;2026.9.2.1 起键按身份拼写。真实 home 8 个 active 值带 `xim:`。
+  另 `entry_binary.cpp:91` 比较前未 strip namespace。
+- **#578** `remove <name>` 经目录解析到索引 latest 而非已装版本;fresh home 里 `remove` 先要索引
+  (实测 `remove zz@1.0 -y` → `package index not available`)。
+- **#529** install 路径不调 `check_runtime_activation`(今天仍只有 `use` 与 doctor 两个调用点);
+  §2 的 152 条正是它的产物。
+- **#531** 「存在但不支持本平台」被报成 not found。
+- **Windows 派发** `shim.cpp:890-897`:非 POSIX 走 `platform::exec` → `cmd.exe /c`
+  (2026.9.3.1 notes §8 已记,未开 issue)。
+- **撤回**:先前记的「GitCode 索引指针 404」今天未复现 —— `xim-index-pointers.json` 两端 200
+  且内容一致;`xim-index-adeba41.tar.gz` 在 `vadeba41`、`latest` 两个 tag 下 GitHub/GitCode 均 200。
+
+## 6. 方案(按收益/风险排序;P0 已完成)
+
+### P0 · 本分支已完成 —— 用户的三个问题
+
+- [x] 家族按条目名分类(`CoreSource`);单测用真实形状(符号链接)
+- [x] remedy 走 `coordinate_from_payload_path`,不可解析则留空
+- [x] 两处 `install --force` 改为可运行命令
+- [x] e2e S13:所有打印的 remedy 不含 `--force`、不含 `<ns>-x-<pkg>@`;零 remedy 时自报 NOT EXERCISED
+- [x] 51 套单测、`self_doctor_test` / `loader_libc_same_source_test` / `shim_table_routing_test` 通过
+
+**验收已量:** 真实 home 178 → 152;node@24.20.0 1 → 0;`xim:d2x` 可解析而 `xim-x-d2x` 不可。
+
+### P1 · 同源检查改为加载器语义(收益最大,改动最小)
+
+`check()` 改为**逐 core soname、按 RUNPATH 顺序首命中**:
+
+```
+for soname in core_set:                   # ld-linux-*/ld-musl-*, libc.so.6, (可扩 libm/libpthread/…)
+    winner = first dir in RUNPATH order that contains soname
+    if winner.payload != interp.payload → violated (names soname, dir, both payloads)
+```
+
+- 保留原理由里**真实**的那一半:首目录残缺时,后续目录才对缺的 soname 计入。
+- `AnyDifferentCoreRuntimeEntryViolates` 拆成两条:完整首目录 + 后续异源 → **pass**;
+  残缺首目录 + 后续异源补齐 → **violated**。`FirstCoreRuntimeEntryDeterminesResult` 不变。
+- `core_set` 是否扩到 libm/libpthread:glibc 2.34+ 已合并进 libc.so.6,但旧 glibc 分开;扩了更严,
+  且不会引入假阳性(仍按首命中)。建议扩。
+- **差分验收**:真实 home slice 上 152 → 0(已用脚本预演,见 §2);E2E-62 仍过;
+  安装守卫在 farm 漂移下不再拒绝(e2e:farm 指 2.44、recipe 钉 2.39 且 RUNPATH 自带 2.39 → 安装成功)。
+- 不影响的:`HostLoaderPayloadCore` 反向规则不动;家族守卫不动。
+
+### P2 · 安装守卫回到契约
+
+- Rule-B 拒绝改为**逐节点失败**:`onStatus(Failed)` + 加入 `refusedNodes` + 写 failure marker;
+  其余节点继续;`install_summary` 照发;退出码由 `failedCount` 决定。
+- 报错文案里的「report it with the two paths above」保留,但补一句「其它包已继续安装」。
+- 差分验收:e2e 造一个被拒节点 + 一个正常节点的 plan,断言正常节点装上、退出码 1、
+  `install_summary.failed == 1`。旧二进制上正常节点装不上。
+
+### P3 · remedy 契约:可执行,或空
+
+- `Finding::remedy` → `{ std::string command; std::string note; }`,与 `diag::Diagnostic` 对齐;
+  渲染层 command 单独一行,note 跟在后面。D 型四处迁移。
+- C 型:程序名 → 包坐标经 `xvm::owner`(已有 `install_command()`)解析后再拼;解析不到则
+  给 `xlings list <name>` / `xlings use <name> --all` 这种**一定能跑**的探查命令,不给 install。
+- 门:S13 扩为「每条 remedy 的 command 经 `spec::validate_manual_argv` 干解析通过」;
+  CI grep 禁止 `install [^"]*--force`。
+
+### P4 · 把 152 条背后的真信息说出来
+
+新 finding `InterpRuntimeDrift`(Notice):「subos `<n>` 声明 glibc 2.44;N 个二进制(M 个包)的
+INTERP 指向 2.39,它们靠自身 RUNPATH 运行;2.39 若从最后一个 subos 移除,这些二进制将无法启动」。
+`--fix` 不动它(改 INTERP 只能重装);remedy 给包清单。与 #529 一并处理 —— 那边是「声明该不该
+随安装变」,这边是「变了之后怎么让人看见」。
+
+### P5 · #579
+
+`update_landed_on_index_build` 改为比较**身份**(strip namespace 后与本次安装记录的版本比),
+或直接读安装刚返回的坐标;`entry_binary.cpp:91` 比较前 strip namespace;最终「nothing was
+upgraded」在 `use` 之后**重读状态**再判。已在 issue 里列了三条,不重复。
+
+### P6 · 已有 issue,按期排
+
+#578、#531、Windows `std::system` 派发(`CreateProcessW` + 空 `SetConsoleCtrlHandler`)。
+
+**版本与打包建议:** P0+P1+P2 一个 PR(2026.9.3.2 或 2026.9.4.1):三者都是「守卫说了假话」,
+且 P1 是当下真实 home 上最大的可见缺陷;P3/P4 第二个 PR;P5/P6 各自随 issue。
+均**不跨仓库**:无新 libxpkg 字段、无索引格式变化、无 recipe API 变化。
+
+## 7. 不变量(测试要锁的,不是版本号)
+
+1. **一个 remedy 要么能原样运行,要么为空。** 门:S13 + 干解析。
+2. **同源判定 = 加载器会做的选择。** 门:完整首目录/残缺首目录两条单测 + 真实 home slice 152→0。
+3. **守卫拒绝一个节点,不拒绝一个 plan。** 门:P2 e2e。
+4. **fixture 长得像它代表的东西。** musl 的 loader 是链接;glibc 的 lib64 是完整的。
+   两次假阳性都是 fixture 失真放过去的。
+5. **报告与拒绝共用一个谓词时,先用报告量,再让它拒绝。** Rule-B 2026-08-10 引入时直接是硬拒绝;
+   `closure_check` 的 rule D/A/E 反而是 WARN-ONLY 先收集(C2.5)。顺序反了。
+
+## 8. 本次被测量推翻的我自己的判断
+
+- 「守卫在重试时 fail-open」 → 错。`payloadInstalled` 由注册决定;重试重新评估。
+- 「GitCode 索引指针 404,CN 客户端靠跨区回退」 → 今天两端都 200 且一致;撤回。
+- 「`--force` 让 install 以 exit 2 退出」 → rc=1,`Error: unknown option: --force`;注释已改。
+- 「152 条 split 里总有真的」 → 逐二进制运行 + 逐 soname 首命中重算:0。
+
+## 9. 附:本次的度量方法(可复跑)
+
+```bash
+# 真实 home,只读
+target/<fp>/bin/xlings self doctor --deep --all > doctor.txt
+grep -c '→ run' doctor.txt                                  # remedy 数
+grep -oE 'xlings remove [^ ]+' doctor.txt | sort | uniq -c   # 涉及的包
+# 对每个被标记的二进制:patchelf --print-interpreter / --print-rpath,
+# 逐 core soname 沿 RUNPATH 首命中 → 与 interp 载荷比较(脚本见会话 scratchpad)
+# 程序名 vs 包名:versions DB 中 type==program 的键 ∩ data/xim-pkgindex/pkgs/*/<name>.lua
+```

--- a/.agents/docs/2026-09-03-release-2026.9.3.2-notes.md
+++ b/.agents/docs/2026-09-03-release-2026.9.3.2-notes.md
@@ -1,0 +1,102 @@
+# 2026.9.3.2 —— 「守卫说的不是加载器会做的事」
+
+> 调研:`2026-09-03-diagnostic-truth-survey-and-plan.md`
+> 计划:`2026-09-03-diagnostic-truth-impl-plan.md`
+> 基线:2026.9.3.1(`ba51901`)
+
+## 1. 一句话
+
+用户贴出的三条 doctor / install 报错(remedy 拼成 store 目录名、`--force` 不存在、一条假的
+loader/libc split 拒绝了安装),查下去是同一个形状:
+
+> **守卫或诊断回答的是一个比真实问题更弱的代理问题,再把答案当真话打印或执行;
+> 而同一个谓词同时驱动 doctor 的报告与 install 的拒绝。**
+
+## 2. 用户看到的
+
+```
+改前                                                改后
+✗ loader/libc split  …/xim-x-gcc/11.5.0/bin/gcc     (不再出现:gcc 自己的 2.39/lib64 在
+  → run  xlings install xim-x-gcc@11.5.0 --force        farm 之前,加载器不会去 farm 取 libc)
+  ×152                                              • runtime drift  subos 'default' declares
+                                                      glibc@2.44, but 42 executable(s) in 2
+                                                      package(s) start on glibc@2.39 …
+                                                      note  packages: xim:binutils@2.42, xim:gcc@16.1.0
+
+$ xlings install xim:bun@1.3.11 -y                  $ xlings install xim:bun@1.3.11 -y
+[error] node@24.20.0: loader/libc payload mismatch   ✓ (musl 的 loader 是 libc.so 的链接;
+[error] install failed …  (整个 plan 中止)              家族按条目名判定,不再误判)
+
+[error] nothing was upgraded: xlings is still        (self update 不再对 xim: 键假报;
+        active at 'xim:2026.8.30.2'                  DOWNGRADED 比较前 strip namespace)
+```
+
+## 3. 做了什么
+
+- **同源检查改为加载器语义**(`elf_same_source::check`):对每个 core soname,沿 RUNPATH 顺序
+  **首个**含它的目录才是回答者;后续目录对该 soname 不再计入。首目录残缺时,缺的 soname 仍由后续
+  目录回答 —— 原规则里真实的那一半保留。
+- **家族按目录条目名判定**(`CoreSource::name/family`):musl 的 `ld-musl-x86_64.so.1 -> libc.so`
+  解析后没有家族标记,原实现把它当 Unknown 与 glibc 比较。
+- **守卫拒一个节点,不拒一个 plan**(`installer.cpp`):Rule-B 拒绝改为写 failure marker +
+  `onStatus(Failed)` + `continue`;其余节点继续;退出码由 `failedCount` 决定,与 install/config
+  hook 失败一致。
+- **remedy 契约**:`Finding::remedy` 只放命令,新字段 `remedyNote` 放散文并单独渲染成 `note` 行;
+  四处夹散文/占位符的 remedy 迁移。dispatch / `use` 的 install 建议经 `xvm::recorded_owner`
+  (只认 provider 记录或 payload 路径)解析成**包坐标**,无记录则给 `xlings search <name>`;
+  `update` 的建议用 `canonicalName`。真实 home 上 338 个程序名中 218 个不是包名。
+- **新 finding `InterpRuntimeDrift`**(Notice):subos 声明 X,却有 N 个已注册可执行文件的
+  PT_INTERP 指向 Y —— 152 条假 split 背后的真信息。不改 exit code,`--fix` 不动。
+- **#579** `self update`:`update_landed_on_index_build` 只把 `local:` 判为非索引构建;
+  `entry_binary::replace_with` 比较前 strip namespace;`use` 之后 `reload_state()` 再判。
+- **#578** 第 2 点:单一存储版本的 versionless removal 解析到该版本(两个仍 Ambiguous)。
+- **P0**(用户的三条):store 目录名 → `coordinate_from_payload_path`;两处 `install --force`
+  改为可运行命令;musl 家族误判。
+
+## 3b. 真机量到的(同一台 83G 真实 home,只读 `self doctor --deep --all`)
+
+```
+                       2026.9.3.1(含 P0)      2026.9.3.2
+error 总数             155                       3
+  loader/libc split    152                       0
+  broken payload       2                         2      ← 真的(codex / xkeyboard-config 路径缺失)
+  binding state        1                         1      ← 真的(local:glibc@2.44.2 根缺失)
+打印的 remedy          162                       10
+runtime drift          —                         1 条 Notice:default 声明 glibc@2.44,
+                                                  42 个可执行文件 / 2 个包(xim:binutils@2.42、
+                                                  xim:gcc@16.1.0)从 glibc@2.39 启动
+```
+
+调研阶段的「151 个二进制 / 18 个包」是**整个 store** 的数;P4 只统计注册在当前 subos 的包,
+所以 `default` 报 42 / 2 —— 其余 16 个包注册在别的 subos,那里的声明另算。
+
+E2E-97 在 2026.9.3.1 二进制上于 A1 失败(`orderok must install … exited 1`),在 2026.9.3.2 上通过。
+
+耗时(同一台机器空闲时,`self doctor --deep --all`):2026.9.3.1 real 4.06 s / user 2.71 s;
+2026.9.3.2 real 4.01 s / user 2.66 s —— P4 多读的 PT_INTERP 字段本来就在 scan 里,没有额外成本。
+(并行跑单测构建时量到过 42–55 s,是机器争用,不是回归。)
+
+## 4. 测试
+
+- 单测:`SameSource.ACompleteFirstDirectoryAnswersEveryCoreSoname` /
+  `AnIncompleteFirstDirectoryLeavesLaterEntriesInPlay` / `OwnGlibcAheadOfADriftedFarmIsNotASplit`
+  (替换了钉住旧规则的 `AnyDifferentCoreRuntimeEntryViolates`);
+  `AMuslLoaderSymlinkedToLibcIsStillMusl`;`RecordedOwner.*` 三例;`SelfUpdateLanding.*` 更新;
+  `XvmExactRemovalTest.VersionlessRemovalWithASingleRecordResolvesToIt` + 双版本仍 Ambiguous。
+- e2e:**E2E-97** `install_guard_loader_order_test.sh`(P1+P2 同一夹具,旧二进制上 A1 与 B2/B3
+  失败);`self_doctor_test.sh` S13 扩为「remedy 首词必须是真实子命令、命令位不含占位符/散文」。
+
+## 5. 兼容性
+
+- 无迁移动作;老 home 上只是 152 条假 error 不再报、多一条 Notice。
+- 不跨仓库:无新 libxpkg 字段、无索引格式变化、无 recipe API 变化。发布链照旧:
+  release → `tools/mirror-latest.sh`(本地 gtc 补 GitCode)→ xim-pkgindex `pkgs/x/xlings.lua` bump。
+- Windows/macOS:谓词是纯函数;那两个平台的 payload 扫描本就不产生 PT_INTERP 结果,E2E-97 在非
+  Linux 上 SKIP 并说明。
+
+## 6. 被实施推翻的判断
+
+- 「守卫在重试时 fail-open」→ 错:`payloadInstalled` 由注册决定,重试重新评估。
+- 「#531 是 open 缺口」→ 平台维度 `resolve_target` 早已单独报;只剩 arch/`info` 路径待验。
+- 「#578 第 2 点是漏写的分支」→ 是一条**钉死的设计**(`RawEmptyOperationNeverMeansAllVersions`);
+  按 #578 的预期只翻了「恰好一个版本」这半条,理由写进了测试。

--- a/.agents/docs/2026-09-03-release-2026.9.3.2-notes.md
+++ b/.agents/docs/2026-09-03-release-2026.9.3.2-notes.md
@@ -3,6 +3,7 @@
 > 调研:`2026-09-03-diagnostic-truth-survey-and-plan.md`
 > 计划:`2026-09-03-diagnostic-truth-impl-plan.md`
 > 基线:2026.9.3.1(`ba51901`)
+> PR: openxlings/xlings#581
 
 ## 1. 一句话
 

--- a/mcpp.toml
+++ b/mcpp.toml
@@ -29,7 +29,7 @@ members = [
 
 [package]
 name = "xlings"
-version = "2026.9.3.1"
+version = "2026.9.3.2"
 description = "Universal package management infrastructure tool with SubOS isolation"
 license = "Apache-2.0"
 repo = "https://github.com/openxlings/xlings"

--- a/src/core/config.cppm
+++ b/src/core/config.cppm
@@ -10,7 +10,7 @@ import xlings.core.xvm.db;
 namespace xlings {
 
 export struct Info {
-    static constexpr std::string_view VERSION = "2026.9.3.1";
+    static constexpr std::string_view VERSION = "2026.9.3.2";
     static constexpr std::string_view REPO = "https://github.com/openxlings/xlings";
 };
 

--- a/src/core/elf_same_source.cppm
+++ b/src/core/elf_same_source.cppm
@@ -140,29 +140,63 @@ inline CoreFamily core_family_of_path_(const fs::path& path) {
     return core_family_of_(path.filename().string());
 }
 
+// A core runtime file, and which family it belongs to.
+//
+// The family comes from the DIRECTORY ENTRY's name, not the resolved target's.
+// On musl the loader and the libc are ONE FILE: a real payload ships
+// `ld-musl-x86_64.so.1` as a symlink to `libc.so`. Resolve it and the name that
+// declared the family is gone -- `libc.so` matches neither the glibc nor the
+// musl pattern, so it classifies as Unknown, and the family guard's deliberate
+// "an unknown family still compares" rule then fires on exactly the case the
+// guard exists to exclude.
+//
+// Measured on a real home: every glibc binary whose RUNPATH reached a subos lib
+// farm containing musl was reported as a loader/libc split, and the
+// install-time guard REFUSED the install.
+//
+// The resolved path is still what identifies the payload and what the error
+// message must name; only the family question is answered by the entry.
+struct CoreSource {
+    fs::path   source;   // resolved -- the payload identity, and what we print
+    CoreFamily family;   // from the entry name, which is what declares it
+};
+
 // Every core runtime file in a directory, resolved through symlinks.
 // Inspecting all of them is essential: a SubOS libdir can itself be split,
 // with its loader link pointing into payload A and libc.so.6 into payload B.
 // directory_iterator order is unspecified, so choosing one entry makes the
 // verdict depend on filesystem history.
-inline std::vector<fs::path> core_runtime_sources_(const fs::path& dir) {
-    std::vector<fs::path> out;
+inline std::vector<CoreSource> core_runtime_sources_(const fs::path& dir) {
+    std::vector<CoreSource> out;
     std::error_code ec;
     if (!fs::is_directory(dir, ec) || ec) return out;
     for (auto it = fs::directory_iterator(
              dir, fs::directory_options::skip_permission_denied, ec);
          !ec && it != fs::directory_iterator(); it.increment(ec)) {
-        if (!is_core_runtime_filename_(it->path().filename().string())) {
-            continue;
-        }
+        const auto entryName = it->path().filename().string();
+        if (!is_core_runtime_filename_(entryName)) continue;
+
         std::error_code rec;
         auto resolved = fs::weakly_canonical(it->path(), rec);
-        out.push_back(rec ? it->path().lexically_normal() : std::move(resolved));
+        auto source = rec ? it->path().lexically_normal() : std::move(resolved);
+
+        // Entry name first. Fall back to the resolved name only when the entry
+        // itself says nothing -- which `is_core_runtime_filename_` makes
+        // impossible today, but the fallback keeps the two functions from
+        // having to agree by accident.
+        auto family = core_family_of_(entryName);
+        if (family == CoreFamily::Unknown) {
+            family = core_family_of_path_(source);
+        }
+        out.push_back({ std::move(source), family });
     }
-    std::ranges::sort(out, {}, [](const fs::path& path) {
-        return path.string();
+    std::ranges::sort(out, {}, [](const CoreSource& e) {
+        return e.source.string();
     });
-    out.erase(std::ranges::unique(out).begin(), out.end());
+    out.erase(std::ranges::unique(out, {}, [](const CoreSource& e) {
+                  return e.source.string();
+              }).begin(),
+              out.end());
     return out;
 }
 
@@ -245,15 +279,21 @@ inline Finding check(std::string_view binary,
             // without building real runtimes. The directory is the identity
             // only in that path; production probes always produce sources.
             const auto payload = payload_of(dir.string());
-            if (!payload.empty()) sources.push_back(dir);
+            // Unknown family on purpose: this is the injected-probe path, and
+            // a synthetic directory declares nothing. Unknown keeps the
+            // fail-loud comparison the guard was written with.
+            if (!payload.empty()) {
+                sources.push_back({ dir, CoreFamily::Unknown });
+            }
         }
 
         const auto interpFamily = core_family_of_path_(fs::path(interp));
-        for (const auto& source : sources) {
+        for (const auto& entry : sources) {
+            const auto& source = entry.source;
             // Only compare within one runtime family. An unknown family on
             // either side still compares, so a payload this does not recognise
             // is never silently excused.
-            const auto sourceFamily = core_family_of_path_(source);
+            const auto sourceFamily = entry.family;
             if (interpFamily != CoreFamily::Unknown
                 && sourceFamily != CoreFamily::Unknown
                 && interpFamily != sourceFamily) {

--- a/src/core/elf_same_source.cppm
+++ b/src/core/elf_same_source.cppm
@@ -157,8 +157,9 @@ inline CoreFamily core_family_of_path_(const fs::path& path) {
 // The resolved path is still what identifies the payload and what the error
 // message must name; only the family question is answered by the entry.
 struct CoreSource {
-    fs::path   source;   // resolved -- the payload identity, and what we print
-    CoreFamily family;   // from the entry name, which is what declares it
+    fs::path    source;  // resolved -- the payload identity, and what we print
+    CoreFamily  family;  // from the entry name, which is what declares it
+    std::string name;    // the entry name -- the SONAME the loader asks for
 };
 
 // Every core runtime file in a directory, resolved through symlinks.
@@ -188,7 +189,7 @@ inline std::vector<CoreSource> core_runtime_sources_(const fs::path& dir) {
         if (family == CoreFamily::Unknown) {
             family = core_family_of_path_(source);
         }
-        out.push_back({ std::move(source), family });
+        out.push_back({ std::move(source), family, entryName });
     }
     std::ranges::sort(out, {}, [](const CoreSource& e) {
         return e.source.string();
@@ -233,11 +234,28 @@ inline fs::path resolve_rpath_entry_(std::string_view binary,
 
 // The invariant, over the two fields as read from one ELF.
 //
-// PASSES when: there is no interpreter (a shared library or a static binary —
+// PASSES when: there is no interpreter (a shared library or a static binary --
 // neither chooses a loader), or no RUNPATH directory is proven to contain a
-// core runtime. Every proven core-runtime entry must agree: a later directory
-// may supply the loader or another core component even when libc.so.6 was
-// found earlier, so one same-source entry cannot wash out another mismatch.
+// core runtime, or every core file the loader WOULD TAKE comes from the
+// interpreter's payload.
+//
+// "Would take" is the loader's rule, not ours: for each SONAME it walks the
+// search path in order and stops at the first directory that has the file.
+// So a core file in a LATER directory is only consulted when no earlier
+// directory supplied that soname -- the first complete glibc lib dir on the
+// path answers every core soname, and whatever sits behind it is never
+// opened.
+//
+// This used to demand that EVERY directory with a core file agree ("a later
+// directory may supply another core component even when libc.so.6 was found
+// earlier"). That is true only when the earlier directory is INCOMPLETE, and
+// it is kept for that case: a soname the first directory lacks is still
+// answered by the next directory that has it. What it is no longer is a
+// verdict on directories the loader never reaches. Measured on a real home,
+// the old rule produced 152 errors, all on binaries whose own glibc lib dir
+// preceded a subos farm that had since moved to another glibc; every one of
+// them ran, and re-evaluated by the loader's rule 0 of 151 were splits. The
+// same predicate is the install-time refusal, so those were refusals too.
 inline Finding check(std::string_view binary,
                      std::string_view interp,
                      std::span<const std::string> rpathEntries,
@@ -266,13 +284,23 @@ inline Finding check(std::string_view binary,
     f.provider = provider_of(f.interpPayload);
     const auto interpIdentity = payload_identity_(f.interpPayload);
 
+    // Core sonames an earlier directory has already answered. The loader
+    // stops at the first hit, so a later directory's copy of the same soname
+    // is never opened and must not be judged.
+    std::set<std::string> answered;
+    // A synthetic directory (injected probe, no real files) declares no
+    // sonames; it stands for "a complete core runtime" and answers all of them.
+    constexpr std::string_view kWholeRuntime = "*";
+
     for (const auto& e : rpathEntries) {
         const auto dir = resolve_rpath_entry_(binary, e);
         if (!coreDirProbe(dir)) continue;
+        if (answered.contains(std::string(kWholeRuntime))) break;
 
         // A SubOS libdir commonly contains several symlinks into shared
-        // payloads. Preserve every resolved source so a loader from A cannot
-        // hide a libc from B merely by being enumerated first.
+        // payloads. Preserve every resolved source: within ONE directory a
+        // loader from A must not hide a libc from B merely by being
+        // enumerated first -- that directory can itself be split.
         auto sources = core_runtime_sources_(dir);
         if (sources.empty()) {
             // Injectable probes let unit tests exercise synthetic store paths
@@ -283,12 +311,18 @@ inline Finding check(std::string_view binary,
             // a synthetic directory declares nothing. Unknown keeps the
             // fail-loud comparison the guard was written with.
             if (!payload.empty()) {
-                sources.push_back({ dir, CoreFamily::Unknown });
+                sources.push_back({ dir, CoreFamily::Unknown,
+                                    std::string(kWholeRuntime) });
             }
         }
 
         const auto interpFamily = core_family_of_path_(fs::path(interp));
         for (const auto& entry : sources) {
+            // First directory to carry a soname is the one the loader takes
+            // it from. Claimed BEFORE the family guard: a same-named file is
+            // the same family by construction, so nothing is lost, and a
+            // later copy must stay unjudged either way.
+            if (!answered.insert(entry.name).second) continue;
             const auto& source = entry.source;
             // Only compare within one runtime family. An unknown family on
             // either side still compares, so a payload this does not recognise
@@ -488,9 +522,23 @@ inline bool is_nested_store_root_(const std::filesystem::path& dir) {
 //
 // Shared with doctor deliberately. Report and repair have drifted three times
 // in this repo; the shape it takes is a finding that fixing does not clear.
-inline std::vector<Finding>
-scan_payload(const std::filesystem::path& dir) {
-    std::vector<Finding> out;
+// Everything one payload scan learned, not only the violations.
+//
+// `interpPayloads` counts, per store payload, the executables whose PT_INTERP
+// points into it. The same-source scan reads that field on every ELF and used
+// to keep it only for the ones it rejected. Doctor uses the rest to say which
+// runtime a package actually STARTS on -- a different question from whether
+// that runtime is the one its subos declares (InterpRuntimeDrift), and the one
+// the 152 false splits on a measured home were standing in for.
+struct PayloadReport {
+    std::vector<Finding> findings;
+    // resolved store payload dir (.../xpkgs/xim-x-glibc/2.39) -> executables
+    std::map<std::string, std::size_t> interpPayloads;
+};
+
+inline PayloadReport
+scan_payload_report(const std::filesystem::path& dir) {
+    PayloadReport out;
     std::error_code ec;
     if (!std::filesystem::is_directory(dir, ec)) return out;
 
@@ -515,11 +563,27 @@ scan_payload(const std::filesystem::path& dir) {
         if (!info) continue;                    // not an ELF we can read
         if (info->interpreter.empty()) continue; // library or static: nothing to pair
 
+        // Which payload this executable starts on. Resolved through the subos
+        // view when PT_INTERP points there, exactly as check() does.
+        auto interpPayload = payload_of(info->interpreter);
+        if (interpPayload.empty()) {
+            std::error_code rec;
+            const auto resolved = std::filesystem::weakly_canonical(
+                std::filesystem::path(info->interpreter), rec);
+            if (!rec) interpPayload = payload_of(resolved.string());
+        }
+        if (!interpPayload.empty()) ++out.interpPayloads[interpPayload];
+
         auto finding = check(it->path().string(), info->interpreter,
                              info->searchPaths);
-        if (finding.violated) out.push_back(std::move(finding));
+        if (finding.violated) out.findings.push_back(std::move(finding));
     }
     return out;
+}
+
+inline std::vector<Finding>
+scan_payload(const std::filesystem::path& dir) {
+    return scan_payload_report(dir).findings;
 }
 
 // One command's worth of scan results, keyed on whether the payload changed.
@@ -570,18 +634,21 @@ public:
         : stampName_(std::move(stampName)) {}
 
     std::vector<Finding> scan(const std::filesystem::path& dir) {
+        return report(dir).findings;
+    }
+    PayloadReport report(const std::filesystem::path& dir) {
         const auto key = key_of_(dir);
         const auto path = dir.string();
         if (auto it = entries_.find(path); it != entries_.end()) {
             if (it->second.key == key) {
                 ++hits_;
-                return it->second.findings;
+                return it->second.report;
             }
         }
         ++misses_;
-        auto findings = scan_payload(dir);
-        entries_.insert_or_assign(path, Entry{key, findings});
-        return findings;
+        auto report = scan_payload_report(dir);
+        entries_.insert_or_assign(path, Entry{key, report});
+        return report;
     }
 
     [[nodiscard]] std::size_t hits() const { return hits_; }
@@ -597,7 +664,7 @@ private:
 
     struct Entry {
         Key key;
-        std::vector<Finding> findings;
+        PayloadReport report;
     };
 
     static std::int64_t write_time_(const std::filesystem::path& p) {

--- a/src/core/entry_binary.cpp
+++ b/src/core/entry_binary.cpp
@@ -84,19 +84,28 @@ bool replace_with(const fs::path& payloadBinary, const fs::path& entry,
                   entry.string(), payloadBinary.string());
         return false;
     }
-    if (before.empty() || before == toVersion) {
-        log::debug("entry binary -> {} ({})", toVersion, coordinate);
+    // `toVersion` arrives as the WORKSPACE KEY, which since 2026.9.2.1 may be
+    // spelled `xim:2026.9.2.1`. The comparator wants a bare version -- given a
+    // key whose first character is not a digit it ranks the key below every
+    // bare version, so an upgrade was reported as DOWNGRADED (#579). The
+    // binary's own report (`before`) is always bare; make the other side match.
+    const auto bare = [](std::string_view v) {
+        const auto colon = v.find(':');
+        return std::string(colon == std::string_view::npos ? v
+                                                            : v.substr(colon + 1));
+    }(toVersion);
+    if (before.empty() || before == bare) {
+        log::debug("entry binary -> {} ({})", bare, coordinate);
         return true;
     }
-    if (version_order::compare(toVersion, before) < 0) {
+    if (version_order::compare(bare, before) < 0) {
         log::warn("entry binary DOWNGRADED {} -> {} ({})",
-                  before, toVersion, coordinate);
+                  before, bare, coordinate);
         log::warn("  every shim in this home dispatches through it; an older "
                   "client may not understand records a newer index wrote");
         return true;
     }
-    log::info("entry binary {} -> {} ({})", before, toVersion,
-              coordinate);
+    log::info("entry binary {} -> {} ({})", before, bare, coordinate);
     return true;
 }
 

--- a/src/core/xim/commands.cpp
+++ b/src/core/xim/commands.cpp
@@ -2023,8 +2023,10 @@ int cmd_update(const std::string& target, bool yes, EventStream& stream) {
     stream.emit(DataEvent{"update_plan", planPayload.dump()});
 
     if (currentActive.empty()) {
+        // The PACKAGE name, which the catalog just resolved; `bareName` is
+        // whatever the user typed, and a printed command has to run as printed.
         log::warn("{} is not installed — run: xlings install {}",
-                  match->canonicalName, bareName);
+                  match->canonicalName, match->canonicalName);
         return 0;
     }
 

--- a/src/core/xim/installer.cpp
+++ b/src/core/xim/installer.cpp
@@ -3021,9 +3021,28 @@ std::expected<void, std::string> Installer::execute(const InstallPlan& plan, con
                 }
                 log::error("  this is a resolution defect, not a bad "
                            "payload -- report it with the two paths above");
-                return std::unexpected(std::format(
+                const auto failure = std::format(
                     "{}@{}: loader/libc payload mismatch in {} binary(ies)",
-                    node.name, node.version, bad.size()));
+                    node.name, node.version, bad.size());
+                // One node's refusal, reported as one node's failure.
+                //
+                // This used to `return std::unexpected(...)`, the shape the
+                // caller documents as "cancel or a plan-level error". One
+                // refused dependency therefore took the whole plan down
+                // (`install bun` died on node), the caller emitted a
+                // non-recoverable Internal error, no install_summary was
+                // sent, and -- unlike every other hook failure -- no marker
+                // was written: the payload sat on disk with nothing saying
+                // why. Same marker, same status event and same `continue` as
+                // the install and config hooks; the exit code follows from
+                // failedCount as it does for them.
+                write_payload_failure_marker(ctx.install_dir, node.version,
+                                             failure);
+                if (onStatus) {
+                    onStatus({ node.name, InstallPhase::Failed, 0.0f,
+                               failure });
+                }
+                continue;
             }
         }
 

--- a/src/core/xself/doctor.cpp
+++ b/src/core/xself/doctor.cpp
@@ -467,7 +467,9 @@ std::vector<Finding> detect_subos_manifest_(const xvm::VersionDB& db,
                     vs.emplace_back(mf::binding_version(b));
                 }
                 version_order::sort_desc(vs);
-                return std::format("xlings use {} {}", dup.name,
+                // `name@version`, the spelling every other doctor remedy
+                // uses for `use`, and the one E2E-64 reads as "a decision".
+                return std::format("xlings use {}@{}", dup.name,
                                    vs.empty() ? std::string{} : vs.front());
             }(),
             .remedyNote = [&] {

--- a/src/core/xself/doctor.cpp
+++ b/src/core/xself/doctor.cpp
@@ -457,16 +457,27 @@ std::vector<Finding> detect_subos_manifest_(const xvm::VersionDB& db,
                 "'{}' is bound {} times in subos '{}' ({}) and has no active "
                 "version, so every one of them contributes",
                 dup.name, dup.bindings.size(), subosName, names),
-            // Naming the versions in the remedy: the user is otherwise left
+            // The command names ONE version -- the highest -- so it runs as
+            // printed; the placeholder `<one of: ...>` it used to carry could
+            // not. The alternatives go in the note: the user is otherwise left
             // choosing between two strings with nothing to tell them apart.
-            .remedy  = std::format("xlings use {}@<one of: {}>", dup.name, [&] {
+            .remedy  = [&] {
+                std::vector<std::string> vs;
+                for (const auto& b : dup.bindings) {
+                    vs.emplace_back(mf::binding_version(b));
+                }
+                version_order::sort_desc(vs);
+                return std::format("xlings use {} {}", dup.name,
+                                   vs.empty() ? std::string{} : vs.front());
+            }(),
+            .remedyNote = [&] {
                 std::string vs;
                 for (const auto& b : dup.bindings) {
                     if (!vs.empty()) vs += ", ";
                     vs += std::string(mf::binding_version(b));
                 }
-                return vs;
-            }()),
+                return "bound versions: " + vs;
+            }(),
         });
     }
 
@@ -546,13 +557,16 @@ std::vector<Finding> detect_subos_manifest_(const xvm::VersionDB& db,
             .version = mismatch->declared,
             .detail  = std::move(detail),
             .remedy  = differentActive
+                ? std::string("xlings self doctor --fix")
+                : std::format("xlings install {}", mismatch->declared),
+            .remedyNote = differentActive
                 ? std::format(
-                    "xlings self doctor --fix   (adopt {}; or migrate with "
-                    "`xlings install {}` then `xlings use {} {}`)",
+                    "adopts {}; to migrate instead: `xlings install {}` then "
+                    "`xlings use {} {}`",
                     mismatch->active, mismatch->declared,
                     mf::binding_name(mismatch->declared),
                     mf::binding_version(mismatch->declared))
-                : std::format("xlings install {}", mismatch->declared),
+                : std::string{},
         });
     }
 
@@ -590,11 +604,12 @@ std::vector<Finding> detect_subos_manifest_(const xvm::VersionDB& db,
                 "binary built here links against {}, not against {}",
                 subosName, info.runtime, shown.string(), served, served,
                 info.runtime),
-            .remedy  = std::format(
-                "xlings use {} {}   (adopt what is serving), or `xlings "
-                "install {}` to make the declaration true",
-                mf::binding_name(served), mf::binding_version(served),
-                info.runtime),
+            .remedy  = std::format("xlings use {} {}",
+                                   mf::binding_name(served),
+                                   mf::binding_version(served)),
+            .remedyNote = std::format(
+                "adopts what is serving; or `xlings install {}` to make the "
+                "declaration true", info.runtime),
         });
     }
 
@@ -614,7 +629,8 @@ std::vector<Finding> detect_subos_manifest_(const xvm::VersionDB& db,
                 "subos '{}' does not record a runtime -- nothing here "
                 "declares, activates or serves one, so tools that need to "
                 "know which libc this is will fall back", subosName),
-            .remedy  = "xlings install glibc   (then it will be recorded)",
+            .remedy  = "xlings install glibc",
+            .remedyNote = "then the runtime will be recorded",
         });
     }
     return out;
@@ -1763,12 +1779,54 @@ Scan detect_(const DoctorState& st, const CoordinateProbe& probe,
         };
         const auto cacheHitsBefore =
             audit.payloadCache ? audit.payloadCache->hits() : 0;
+
+        // Which runtime payload the executables registered in THIS subos start
+        // on (PT_INTERP), per payload. The scan already reads the field for
+        // every ELF; this keeps it. See InterpRuntimeDrift.
+        struct InterpUse {
+            std::size_t executables { 0 };
+            std::set<std::string> packages;
+        };
+        std::map<std::string, InterpUse> interpUse;
+        std::vector<std::string> registeredHere;
+        for (const auto& [target, versions] : Config::workspace_installed()) {
+            for (const auto& v : versions) {
+                const auto* data = xvm::get_vdata(st.db, target, v);
+                if (!data || data->path.empty()) continue;
+                registeredHere.push_back(
+                    fs::path(xvm::expand_path(
+                        data->path, Config::paths().homeDir.string()))
+                        .lexically_normal().string());
+            }
+        }
+        const auto registeredInThisSubos = [&](const fs::path& payloadRoot) {
+            const auto root = payloadRoot.lexically_normal().string();
+            const auto prefix = root + "/";
+            return std::ranges::any_of(registeredHere,
+                [&](const std::string& p) {
+                    return p == root || p.starts_with(prefix);
+                });
+        };
+
         for (const auto& root : payloadAuditRoots) {
             auditTick(root);
             ++auditDone;
-            const auto scanned = audit.payloadCache
-                ? audit.payloadCache->scan(root.path)
-                : elfcheck::scan_payload(root.path);
+            const auto report = audit.payloadCache
+                ? audit.payloadCache->report(root.path)
+                : elfcheck::scan_payload_report(root.path);
+            const auto& scanned = report.findings;
+            if (registeredInThisSubos(root.path)) {
+                const auto coord =
+                    xvm::coordinate_from_payload_path(root.path.string());
+                const auto name = coord
+                    ? coord->canonical()
+                    : std::format("{}@{}", root.storeName, root.version);
+                for (const auto& [payload, count] : report.interpPayloads) {
+                    auto& use = interpUse[payload];
+                    use.executables += count;
+                    use.packages.insert(name);
+                }
+            }
             // The remedy, spelled so it can actually be run.
             //
             // It could not be, in two independent ways. `root.target` is the
@@ -1804,6 +1862,65 @@ Scan detect_(const DoctorState& st, const CoordinateProbe& probe,
                 });
             }
         }
+        // What this subos's executables START on, against what it declares.
+        //
+        // The same-source rule used to report these as splits, 152 of them on
+        // a measured home, none real. The real fact underneath was this one,
+        // and nothing said it: the subos declared 2.44, and 151 executables in
+        // 18 packages carried PT_INTERP into 2.39 and ran on it. Only the
+        // declared runtime's own package is compared -- a musl-interpreted
+        // tool in a glibc subos is a different runtime, not a drifted one.
+        if (audit.deep && !interpUse.empty()) {
+            namespace mf = xlings::subos::manifest;
+            const auto scope = Config::subos_scope();
+            if (const auto doc = mf::read_document(scope.root)) {
+                const auto info = mf::parse(*doc);
+                if (mf::is_binding(info.runtime)) {
+                    const std::string runtimeName(
+                        mf::binding_name(info.runtime));
+                    const std::string declared(
+                        mf::binding_version(info.runtime));
+                    for (const auto& [payload, use] : interpUse) {
+                        const auto coord =
+                            xvm::coordinate_from_payload_path(payload);
+                        if (!coord || coord->package != runtimeName) continue;
+                        if (coord->version == declared) continue;
+                        constexpr std::size_t kNamed = 8;
+                        std::string list;
+                        std::size_t named = 0;
+                        for (const auto& pkg : use.packages) {
+                            if (named++ == kNamed) break;
+                            if (!list.empty()) list += ", ";
+                            list += pkg;
+                        }
+                        if (use.packages.size() > kNamed) {
+                            list += std::format(", +{} more",
+                                                use.packages.size() - kNamed);
+                        }
+                        add({
+                            .kind    = FindingKind::InterpRuntimeDrift,
+                            .level   = FindingLevel::Notice,
+                            .target  = scope.name,
+                            .version = info.runtime,
+                            .detail  = std::format(
+                                "subos '{}' declares {}, but {} executable(s) "
+                                "in {} package(s) start on {}@{}: their "
+                                "PT_INTERP points there and their own RUNPATH "
+                                "lists it ahead of this subos, so they run -- "
+                                "on a runtime this subos does not hold. If "
+                                "{}@{} leaves the store they will fail to "
+                                "start, with an error that names the binary",
+                                scope.name, info.runtime, use.executables,
+                                use.packages.size(), coord->package,
+                                coord->version, coord->package,
+                                coord->version),
+                            .remedyNote = "packages: " + list,
+                        });
+                    }
+                }
+            }
+        }
+
         // Gated on `deep`, not merely on having found roots.
         //
         // A quick run has an empty root list, so without this it reported
@@ -2978,6 +3095,9 @@ Counts count_(const Scan& scan) {
                 if (f.level != FindingLevel::Notice) ++c.binding;
                 break;
             case FindingKind::OtherSubos:      ++c.otherSubos; break;
+            case FindingKind::InterpRuntimeDrift:
+                // A Notice. The binaries work; this changes no exit code.
+                break;
             case FindingKind::LoaderLibcSplit:
                 // Counted as broken, so it reaches the exit code. A finding
                 // that prints and then exits 0 is how a check gets ignored by
@@ -3122,6 +3242,8 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
         add(label, std::move(detail));
         if (!head->remedy.empty()) {
             add("  " + glyph::mark(glyph::remedy, "run"), head->remedy);
+            if (!head->remedyNote.empty())
+                add("  " + glyph::mark(glyph::note, "note"), head->remedyNote);
         } else {
             // No command would help. Saying that is the useful output; a
             // plausible-looking `xlings install <target>` is not.
@@ -3183,6 +3305,8 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
                                     "them", f.conflict));
                 }
                 add("  " + glyph::mark(glyph::remedy, "run"), f.remedy);
+                if (!f.remedyNote.empty())
+                    add("  " + glyph::mark(glyph::note, "note"), f.remedyNote);
                 break;
             case FindingKind::ShimAnchor:
                 add(glyph::mark(glyph::warn, "shim anchor"), f.detail); break;
@@ -3233,6 +3357,8 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
                 // leave it exactly where it is. Name the one that works.
                 if (!f.subos.empty() && !f.remedy.empty()) {
                     add("  " + glyph::mark(glyph::remedy, "run"), f.remedy);
+                    if (!f.remedyNote.empty())
+                        add("  " + glyph::mark(glyph::note, "note"), f.remedyNote);
                 }
                 break;
             }
@@ -3273,8 +3399,11 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
                 add(glyph::mark(glyph::failed, "subos manifest"), f.detail);
                 // The remedy for an unreadable file is not `--fix`, so it has
                 // to be printed rather than left to the generic footer.
-                if (!f.remedy.empty() && f.remedy != "xlings self doctor --fix")
+                if (!f.remedy.empty() && f.remedy != "xlings self doctor --fix") {
                     add("  " + glyph::mark(glyph::remedy, "run"), f.remedy);
+                    if (!f.remedyNote.empty())
+                        add("  " + glyph::mark(glyph::note, "note"), f.remedyNote);
+                }
                 break;
             case FindingKind::SubosEnvOrphan:
                 add(glyph::mark(glyph::failed, "subos env orphan"), f.detail);
@@ -3285,11 +3414,15 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
                 add(glyph::mark(glyph::failed, "subos double binding"), f.detail);
                 if (!f.remedy.empty())
                     add("  " + glyph::mark(glyph::remedy, "run"), f.remedy);
+                if (!f.remedyNote.empty())
+                    add("  " + glyph::mark(glyph::note, "note"), f.remedyNote);
                 break;
             case FindingKind::SubosEnvUnresolved:
                 add(glyph::mark(glyph::failed, "subos env unresolved"), f.detail);
                 if (!f.remedy.empty())
                     add("  " + glyph::mark(glyph::remedy, "run"), f.remedy);
+                if (!f.remedyNote.empty())
+                    add("  " + glyph::mark(glyph::note, "note"), f.remedyNote);
                 break;
             case FindingKind::SubosEnvConflict:
                 // Never collapsed into a count, unlike the notice categories:
@@ -3304,11 +3437,15 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
                     f.detail);
                 if (!f.remedy.empty())
                     add("  " + glyph::mark(glyph::remedy, "run"), f.remedy);
+                if (!f.remedyNote.empty())
+                    add("  " + glyph::mark(glyph::note, "note"), f.remedyNote);
                 break;
             case FindingKind::SubosRuntimeDrift:
                 add(glyph::mark(glyph::warn, "subos runtime drift"), f.detail);
                 if (!f.remedy.empty())
                     add("  " + glyph::mark(glyph::remedy, "run"), f.remedy);
+                if (!f.remedyNote.empty())
+                    add("  " + glyph::mark(glyph::note, "note"), f.remedyNote);
                 break;
             case FindingKind::SubosRuntimeUnknown:
                 // Always printed, though it counts as nothing.
@@ -3322,6 +3459,16 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
                 add(glyph::mark(glyph::note, "subos runtime"), f.detail);
                 if (!f.remedy.empty())
                     add("  " + glyph::mark(glyph::remedy, "run"), f.remedy);
+                if (!f.remedyNote.empty())
+                    add("  " + glyph::mark(glyph::note, "note"), f.remedyNote);
+                break;
+            case FindingKind::InterpRuntimeDrift:
+                // No command. The binaries work, and the only thing that
+                // would change what they start on is a reinstall the user has
+                // to choose. What the reader needs is the list: the note.
+                add(glyph::mark(glyph::note, "runtime drift"), f.detail);
+                if (!f.remedyNote.empty())
+                    add("  " + glyph::mark(glyph::note, "note"), f.remedyNote);
                 break;
             case FindingKind::LoaderLibcSplit:
                 // Not collapsed into a count, and never abbreviated: the two
@@ -3331,6 +3478,8 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
                 add(glyph::mark(glyph::failed, "loader/libc split"), f.detail);
                 if (!f.remedy.empty())
                     add("  " + glyph::mark(glyph::remedy, "run"), f.remedy);
+                if (!f.remedyNote.empty())
+                    add("  " + glyph::mark(glyph::note, "note"), f.remedyNote);
                 break;
             case FindingKind::NssResolution:
                 add(f.level == FindingLevel::Error
@@ -3342,6 +3491,8 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
                 add(glyph::mark(glyph::failed, "incomplete install"), f.detail);
                 if (!f.remedy.empty())
                     add("  " + glyph::mark(glyph::remedy, "run"), f.remedy);
+                if (!f.remedyNote.empty())
+                    add("  " + glyph::mark(glyph::note, "note"), f.remedyNote);
                 break;
             case FindingKind::UnverifiedPayload:
                 // Summarised into one counted line when not verbose -- see
@@ -3353,6 +3504,8 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
                         f.detail);
                     if (!f.remedy.empty())
                         add("  " + glyph::mark(glyph::remedy, "run"), f.remedy);
+                    if (!f.remedyNote.empty())
+                        add("  " + glyph::mark(glyph::note, "note"), f.remedyNote);
                 }
                 break;
             case FindingKind::EntryBinaryDrift:
@@ -3364,6 +3517,8 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
                 add(glyph::mark(glyph::note, "entry binary"), f.detail);
                 if (!f.remedy.empty())
                     add("  " + glyph::mark(glyph::remedy, "run"), f.remedy);
+                if (!f.remedyNote.empty())
+                    add("  " + glyph::mark(glyph::note, "note"), f.remedyNote);
                 break;
             case FindingKind::DuplicateVersionKey: {
                 if (!verbose
@@ -3377,6 +3532,8 @@ void render_(const Scan& scan, const RepairReport& repair, bool fix,
                         : std::format("{}\n    +{} more record(s) of the "
                                       "same release", f.detail, siblings));
                 add("  " + glyph::mark(glyph::remedy, "run"), f.remedy);
+                if (!f.remedyNote.empty())
+                    add("  " + glyph::mark(glyph::note, "note"), f.remedyNote);
                 break;
             }
             default: break;

--- a/src/core/xself/doctor.cpp
+++ b/src/core/xself/doctor.cpp
@@ -1769,6 +1769,30 @@ Scan detect_(const DoctorState& st, const CoordinateProbe& probe,
             const auto scanned = audit.payloadCache
                 ? audit.payloadCache->scan(root.path)
                 : elfcheck::scan_payload(root.path);
+            // The remedy, spelled so it can actually be run.
+            //
+            // It could not be, in two independent ways. `root.target` is the
+            // STORE DIRECTORY name for a whole-store scan (`xim-x-bun`), and
+            // `xlings install xim-x-bun@1.3.11` fails with "not found in the
+            // synced index" -- no package is called that. And `--force` is not
+            // an option `install` has at all (`remove` has one, meaning
+            // something else); the parser rejects it with "unknown option".
+            //
+            // Both answers were already in the repo. `coordinate_from_payload_path`
+            // exists precisely to turn a store path back into the coordinate
+            // that installs it, and `install` on an already-installed package
+            // prints "already installed" and does nothing -- so a reinstall is
+            // remove-then-install, not a flag.
+            //
+            // When the path does not parse as a store coordinate the remedy
+            // stays EMPTY. See Finding::remedy: a command that cannot succeed
+            // is worse than none, because users run them.
+            std::string remedy;
+            if (auto coord = xvm::coordinate_from_payload_path(
+                    root.path.string())) {
+                remedy = std::format("xlings remove {} -y && xlings install {} -y",
+                                     coord->canonical(), coord->canonical());
+            }
             for (const auto& f : scanned) {
                 add({
                     .kind   = FindingKind::LoaderLibcSplit,
@@ -1776,9 +1800,7 @@ Scan detect_(const DoctorState& st, const CoordinateProbe& probe,
                     .target = root.target,
                     .version = root.version,
                     .detail = elfcheck::describe(f),
-                    .remedy = std::format(
-                        "xlings install {}@{} --force",
-                        root.target, root.version),
+                    .remedy = remedy,
                 });
             }
         }

--- a/src/core/xself/doctor.cppm
+++ b/src/core/xself/doctor.cppm
@@ -194,6 +194,17 @@ enum class FindingKind {
     // message naming neither package nor version. Installs cannot produce it
     // any more; this finds the ones already on disk.
     LoaderLibcSplit,
+    // Executables registered in this subos that START on a runtime other than
+    // the one the subos declares: their PT_INTERP points into another glibc
+    // payload, and they run because their own RUNPATH lists that glibc ahead
+    // of the subos farm. Not a split (they are consistent with themselves --
+    // see LoaderLibcSplit) and not an error: they work. A Notice, because what
+    // they work on is a payload this subos does not hold, so the day it leaves
+    // the store they fail with an ENOENT that names the binary. Measured on a
+    // real home: 151 executables in 18 packages started on 2.39 in a subos
+    // declaring 2.44 -- and the old same-source rule reported every one of
+    // them as a split, which they were not.
+    InterpRuntimeDrift,
     // One package bound at two versions in the same subos. The store holds
     // many versions by design; the subos in between is the layer that is
     // supposed to hold exactly one, and until now nothing enforced it. Both
@@ -283,6 +294,11 @@ struct Finding {
     // when no command would help -- which is a fact worth printing, not a
     // reason to print a plausible one. See owning_coordinate().
     std::string  remedy;
+    // Prose that goes WITH the remedy -- what it adopts, what the alternative
+    // is -- rendered on its own line. It used to be appended to `remedy` in
+    // parentheses, which made the printed command fail when pasted: a remedy
+    // is copied and run, so the command field holds nothing but the command.
+    std::string  remedyNote;
     // Why `--fix` must not run the remedy itself.
     //
     // Non-empty means the repair is known IN ADVANCE to be one another repair

--- a/src/core/xself/update.cpp
+++ b/src/core/xself/update.cpp
@@ -15,7 +15,17 @@ bool update_landed_on_index_build(std::string_view activeVersion) {
     // diagnosed. Same rule `version_of` follows -- no observation is not a
     // verdict.
     if (activeVersion.empty()) return true;
-    return activeVersion.find(':') == std::string_view::npos;
+    // The question is the PROVIDER: did `latest` land on a build an index
+    // handed us, or stay on a `local:` one? Until 2026.9.2.1 an index install
+    // always recorded a bare key, so "has a namespace" and "is not an index
+    // build" were the same test. They are not any more: version keys are now
+    // spelled by identity, and `xim:2026.9.2.1` is exactly what a default-index
+    // install may write. Asking "has a colon" of that key reported a
+    // successful upgrade as "nothing was upgraded" (#579). The only provider
+    // that is not an index is `local`.
+    const auto colon = activeVersion.find(':');
+    if (colon == std::string_view::npos) return true;
+    return activeVersion.substr(0, colon) != "local";
 }
 
 int cmd_update() {
@@ -89,6 +99,11 @@ int cmd_update() {
     // this command means by "updated" is "running the build the index just
     // handed us", and a namespaced active version (`local:0.4.51`) is exactly
     // the statement that it is not -- an index install records a bare version.
+    // Re-read the state the `use` above just wrote. Config loaded the
+    // workspace at process start; judging the switch against that snapshot
+    // reported "still active at <the old version>" one line after printing
+    // the switch to the new one (#579).
+    Config::reload_state();
     if (const auto active =
             xvm::get_active_version(Config::effective_workspace(), "xlings");
         !update_landed_on_index_build(active)) {

--- a/src/core/xvm/commands.cpp
+++ b/src/core/xvm/commands.cpp
@@ -20,6 +20,7 @@ import xlings.core.xvm.lock;
 import xlings.core.xvm.bindings;
 import xlings.core.xvm.inspect;
 import xlings.core.xvm.errors;
+import xlings.core.xvm.owner;
 import xlings.core.xvm.switch_plan;
 import xlings.core.xvm.shim;
 import xlings.i18n;
@@ -646,13 +647,23 @@ int cmd_use(const std::string& target, const std::string& version, EventStream& 
     // `install`, which resolves dependencies and materialises them.
     if (filter_to_subos_installed_(target, {resolved}).empty()) {
         const auto origin = Config::version_origin(target);
+        // The package that records `target@resolved`, if a record proves one;
+        // `target` itself is a program name and may not be installable.
+        std::string installCoordinate;
+        {
+            const auto dbNow = Config::versions();
+            if (auto owner = recorded_owner(dbNow, target, resolved)) {
+                installCoordinate = owner->canonical();
+            }
+        }
         diag::emit(not_in_subos({
-            .target           = target,
-            .subos            = Config::subos_scope().name,
-            .suggestedVersion = resolved,
-            .source           = origin.source,
-            .fromProject      = origin.fromProjectManifest,
-            .nothingChanged   = true,
+            .target            = target,
+            .subos             = Config::subos_scope().name,
+            .suggestedVersion  = resolved,
+            .source            = origin.source,
+            .fromProject       = origin.fromProjectManifest,
+            .nothingChanged    = true,
+            .installCoordinate = std::move(installCoordinate),
         }));
         return 1;
     }
@@ -1000,12 +1011,21 @@ collect_version_candidates_(const std::string& target, bool all) {
         // were not errors at all. One block, one marker, and the actions lead
         // with the thing the user almost certainly wants.
         const auto origin = Config::version_origin(target);
+        std::string installCoordinate;
+        if (!global_all.empty()) {
+            auto newest = global_all;
+            version_order::sort_desc(newest);
+            if (auto owner = recorded_owner(db, target, newest.front())) {
+                installCoordinate = owner->canonical();
+            }
+        }
         auto d = not_in_subos({
             .target            = target,
             .subos             = Config::subos_scope().name,
             .versionsElsewhere = global_all,
             .source            = origin.source,
             .fromProject       = origin.fromProjectManifest,
+            .installCoordinate = std::move(installCoordinate),
         });
         if (!global_all.empty()) {
             d.actions.push_back({ "see every subos",

--- a/src/core/xvm/commands.cpp
+++ b/src/core/xvm/commands.cpp
@@ -518,7 +518,10 @@ bool runtime_activation_refused_(const VersionDB& db,
         log::error("[xlings:use] runtime activation refused: {} has no "
                    "payload", mismatch->declared);
         log::error("  nothing was changed");
-        log::error("  hint: reinstall it with `xlings install {} --force`",
+        // `install` has no `--force`; the parser rejects it. A registered
+        // version whose payload is gone is exactly the state the installer
+        // re-runs the install hook for, so the plain install IS the reinstall.
+        log::error("  hint: put the payload back with `xlings install {}`",
                    mismatch->declared);
         return true;
     }

--- a/src/core/xvm/errors.cpp
+++ b/src/core/xvm/errors.cpp
@@ -327,20 +327,31 @@ diag::Diagnostic not_in_subos(const NotInSubos& what) {
         d.facts.push_back({ "declared by project", std::move(list) });
         d.actions.push_back({ "use it there",
             std::format("cd {}", what.providedByProjects.front()) });
-        d.actions.push_back({ "or install here",
-            std::format("xlings install -g {}", what.target) });
+        if (!what.installCoordinate.empty()) {
+            d.actions.push_back({ "or install here",
+                std::format("xlings install -g {}", what.installCoordinate) });
+        } else {
+            d.actions.push_back({ "or find the package",
+                std::format("xlings search {}", what.target) });
+        }
         return d;
     }
 
-    auto pick = what.suggestedVersion;
-    if (pick.empty() && !what.versionsElsewhere.empty()) {
-        auto sorted = what.versionsElsewhere;
-        version_order::sort_desc(sorted);
-        pick = sorted.front();
+    // The install action names a PACKAGE, or is a search.
+    //
+    // `xlings install <target>` used to be printed here, with the newest known
+    // version appended. A target is a program name; that command runs only
+    // when a package happens to share it, and on a measured home 218 of 338
+    // did not (`g++`, `ar`, `as`, `slang`, ...). The caller passes the owner a
+    // record proves when there is one; when there is none, a search is the
+    // command that always runs and always answers the question being asked.
+    if (!what.installCoordinate.empty()) {
+        d.actions.push_back({ "install it here",
+            std::format("xlings install {}", what.installCoordinate) });
+    } else {
+        d.actions.push_back({ "find the package that provides it",
+            std::format("xlings search {}", what.target) });
     }
-    d.actions.push_back({ "install it here",
-        pick.empty() ? std::format("xlings install {}", what.target)
-                     : std::format("xlings install {}@{}", what.target, pick) });
     return d;
 }
 

--- a/src/core/xvm/errors.cppm
+++ b/src/core/xvm/errors.cppm
@@ -106,6 +106,13 @@ struct NotInSubos {
     bool fromProject { false };
     // True when the caller has verified nothing was written.
     bool nothingChanged { false };
+    // The package coordinate a RECORD proves provides `target`
+    // (xvm::recorded_owner), when the caller found one -- `xim:gcc@11.5.0`
+    // for target `g++`. Empty means no record proves an owner, and the
+    // install action becomes `xlings search <target>`. Never `xlings install
+    // <target>`: a target is a PROGRAM name, and on a measured home 218 of 338
+    // program names are not package names, so that command cannot run.
+    std::string installCoordinate;
 };
 
 diag::Diagnostic not_in_subos(const NotInSubos& what);

--- a/src/core/xvm/owner.cpp
+++ b/src/core/xvm/owner.cpp
@@ -141,6 +141,38 @@ owner_candidates(const VersionDB& db,
     return candidates;
 }
 
+std::optional<InstallCoordinate>
+recorded_owner(const VersionDB& db,
+               const std::string& target,
+               const std::string& version) {
+    const auto infoIt = db.find(target);
+    if (infoIt == db.end()) return std::nullopt;
+    const auto dataIt = infoIt->second.versions.find(version);
+    if (dataIt == infoIt->second.versions.end()) return std::nullopt;
+    const VData& data = dataIt->second;
+
+    // 1. the recorded provider -- written by every current client.
+    if (data.bindingGroup) {
+        const auto& group = *data.bindingGroup;
+        const auto colon = group.provider.find(':');
+        InstallCoordinate coord;
+        if (colon == std::string::npos) {
+            coord.package = group.provider;
+        } else {
+            coord.ns      = group.provider.substr(0, colon);
+            coord.package = group.provider.substr(colon + 1);
+        }
+        coord.version = strip_namespace(group.providerVersion);
+        if (!coord.empty() && !coord.version.empty()) return coord;
+    }
+    // 2. the payload path the installer recorded; it carries the identity.
+    if (auto fromPath = coordinate_from_payload_path(data.path);
+        fromPath && !fromPath->empty() && !fromPath->version.empty()) {
+        return fromPath;
+    }
+    return std::nullopt;
+}
+
 }
 
 

--- a/src/core/xvm/owner.cppm
+++ b/src/core/xvm/owner.cppm
@@ -84,6 +84,22 @@ owner_candidates(const VersionDB& db,
                  const std::string& target,
                  const std::string& version);
 
+// The owner a RECORD proves, or nothing.
+//
+// `owner_candidates` ends with guesses -- the target's own name, a binding
+// root -- because its caller confirms each one against the catalog before
+// printing it. A caller that cannot (dispatch, `use`: the error path, no index
+// loaded) must not print a guess as a command. Measured on a real home, 218 of
+// 338 program names are not package names, and `xlings install g++` is what
+// the guess produces for every one of them. This returns only what the
+// installer WROTE -- the recorded provider, or the payload path it recorded --
+// and nullopt otherwise, so the caller can offer `xlings search <name>`, which
+// always runs, instead of a command that cannot.
+std::optional<InstallCoordinate>
+recorded_owner(const VersionDB& db,
+               const std::string& target,
+               const std::string& version);
+
 // Does this payload path demonstrably belong to a DIFFERENT package?
 //
 // The versions DB is keyed by xvm TARGET -- a program name -- while every

--- a/src/core/xvm/removal.cpp
+++ b/src/core/xvm/removal.cpp
@@ -258,6 +258,16 @@ apply_removal_batch(VersionDB& db, Workspace& workspace, WorkspaceInstalled& ins
                 .message =
                     "versionless removal has no unique validated selection",
             });
+        } else if (targetIt != db.end()
+                   && targetIt->second.versions.size() == 1) {
+            // Exactly one stored version and no selection to disagree with
+            // it: that version IS the answer. This branch was missing, so a
+            // versionless `xvm.remove("fd")` -- the ordinary idiom in every
+            // uninstall hook -- fell through to the initial "has no exact
+            // version" error whenever the package had a single record and no
+            // workspace selection (#578). Two versions are refused above as
+            // ambiguous; zero is still not found.
+            exactVersion = targetIt->second.versions.begin()->first;
         }
         if (!exactVersion) {
             return std::unexpected(std::move(exactVersion.error()));

--- a/src/core/xvm/shim.cpp
+++ b/src/core/xvm/shim.cpp
@@ -17,6 +17,7 @@ import xlings.platform;
 import xlings.core.xvm.types;
 import xlings.core.xvm.db;
 import xlings.core.xvm.errors;
+import xlings.core.xvm.owner;
 import xlings.core.version_order;
 // For `project_contributions()` -- the one answer to "which project
 // declares this command". Implementation-unit import only; the xvm
@@ -644,13 +645,27 @@ int shim_dispatch(const std::string& program_name, int argc, char* argv[]) {
             }
 
             const auto origin = Config::version_origin(program_name);
+            // The package to offer, when a record proves one. Dispatch has no
+            // index loaded and must not guess a package name from a program
+            // name; see xvm::recorded_owner.
+            auto elsewhere = get_all_versions(db, program_name);
+            std::string installCoordinate;
+            if (!elsewhere.empty()) {
+                auto newest = elsewhere;
+                version_order::sort_desc(newest);
+                if (auto owner = recorded_owner(db, program_name,
+                                                newest.front())) {
+                    installCoordinate = owner->canonical();
+                }
+            }
             diag::emit(not_in_subos({
                 .target             = program_name,
                 .subos              = Config::subos_scope().name,
-                .versionsElsewhere  = get_all_versions(db, program_name),
+                .versionsElsewhere  = std::move(elsewhere),
                 .providedByProjects = std::move(providers),
                 .source             = origin.source,
                 .fromProject        = origin.fromProjectManifest,
+                .installCoordinate  = std::move(installCoordinate),
             }));
         } else {
             // Genuinely different state: opted into this subos, but nothing is
@@ -726,8 +741,30 @@ int shim_dispatch(const std::string& program_name, int argc, char* argv[]) {
             // declared dependency.
             d.actions.push_back({ "set this project up", "xlings install" });
         } else {
-            d.actions.push_back({ "install the pinned one",
-                std::format("xlings install {}@{}", program_name, version) });
+            // `program_name` is a PROGRAM. When some version of it is
+            // recorded here, the record names the package that provides it,
+            // and the pinned version of THAT package is the install. With no
+            // record at all there is nothing to prove the package's name, so
+            // the search goes first -- it always runs -- and the plain
+            // install is offered for the common case where the two coincide.
+            std::string owned;
+            for (const auto& v : all) {
+                if (auto owner = recorded_owner(db, program_name, v)) {
+                    owned = std::format("{}{}@{}",
+                        owner->ns.empty() ? std::string{} : owner->ns + ":",
+                        owner->package, version);
+                    break;
+                }
+            }
+            if (!owned.empty()) {
+                d.actions.push_back({ "install the pinned one",
+                    std::format("xlings install {}", owned) });
+            } else {
+                d.actions.push_back({ "find the package that provides it",
+                    std::format("xlings search {}", program_name) });
+                d.actions.push_back({ "if the package shares the name",
+                    std::format("xlings install {}@{}", program_name, version) });
+            }
             if (!d.source.empty()) {
                 // Deliberately does NOT repeat the source string: it is
                 // already on the `from` row two lines up, and an action row

--- a/tests/e2e/install_guard_loader_order_test.sh
+++ b/tests/e2e/install_guard_loader_order_test.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# E2E-97: the install-time same-source guard judges what the LOADER would do,
+# and refuses one node rather than one plan.
+#
+# Two defects, one fixture. Both were found on a real home, where the guard's
+# predicate also drives `self doctor`:
+#
+#   P1  The predicate demanded that EVERY RUNPATH directory holding a core
+#       file agree with the interpreter's payload. The loader stops at the
+#       first directory that has a soname, so a complete glibc lib dir ahead
+#       of a subos farm that has since moved to another glibc is not a split:
+#       the farm's libc is never opened. 152 doctor errors on the measured
+#       home, 0 real; the same predicate REFUSED installs.
+#   P2  The refusal `return`ed out of Installer::execute -- the shape the
+#       caller documents as "cancel or plan-level error" -- so one refused
+#       node took every other node down with it, no install_summary was sent,
+#       and no failure marker was written.
+#
+# The rig: fake glibc payloads 1.0 and 2.0 in the store; the default subos lib
+# farm symlinks to 2.0. Three payload-free recipes carry one rigged
+# executable each:
+#
+#   orderok    PT_INTERP -> 1.0; RUNPATH [1.0/lib64, farm]  -> loader takes 1.0's
+#              libc: NOT a split. Must install. (old binary: refused)
+#   splitreal  PT_INTERP -> 1.0; RUNPATH [farm]              -> libc comes from
+#              2.0: a REAL split. Must be refused, WITH a failure marker.
+#   plainok    host-linked, untouched                        -> must install even
+#              when planned together with splitreal.
+#
+# Asserted, in order:
+#   A1 `install orderok`            exits 0, no mismatch in the output
+#   A2 its stamp is not marked incomplete
+#   B1 `install splitreal plainok`  exits non-zero and names splitreal
+#   B2 splitreal's payload carries the failure marker    (old binary: none)
+#   B3 plainok is installed anyway, stamp not incomplete (old binary: plan died)
+#   B4 the message still says this is a resolution defect to report
+#
+# Needs gcc + patchelf to build the rig; Linux only (PT_INTERP into a store
+# payload is the Linux arrangement). Missing tools SKIP loudly.
+
+set -uo pipefail
+
+# shellcheck source=./project_test_lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/project_test_lib.sh"
+
+require_fixture_index
+
+[[ "$(uname -s)" == "Linux" ]] \
+  || { log "SKIP: the same-source guard only has a subject on Linux"; exit 0; }
+for tool in gcc patchelf; do
+  command -v "$tool" >/dev/null 2>&1 \
+    || { log "SKIP: $tool not available (CI installs it; local runs need it on PATH)"; exit 0; }
+done
+
+RUNTIME_DIR="$ROOT_DIR/tests/e2e/runtime/install_guard_loader_order"
+LOCAL_INDEX_DIR="$RUNTIME_DIR/xim-pkgindex"
+HOME_DIR="$RUNTIME_DIR/home"
+RIG_DIR="$RUNTIME_DIR/rig"
+
+cleanup() { rm -rf "$RUNTIME_DIR"; }
+trap cleanup EXIT
+cleanup
+mkdir -p "$RUNTIME_DIR" "$RIG_DIR"
+
+BIN="$(find_xlings_bin)"
+log "client: $("$BIN" --version 2>&1 | head -1)"
+
+cp -r "$FIXTURE_INDEX_DIR" "$LOCAL_INDEX_DIR"
+printf 'xim_indexrepos = {}\n' > "$LOCAL_INDEX_DIR/xim-indexrepos.lua"
+rm -f "$LOCAL_INDEX_DIR/.xlings-index-cache.json"
+mkdir -p "$LOCAL_INDEX_DIR/pkgs/o" "$LOCAL_INDEX_DIR/pkgs/s" "$LOCAL_INDEX_DIR/pkgs/p"
+
+# ── the store: two fake glibc payloads, and a farm that points at the newer ──
+FAKE1="$HOME_DIR/data/xpkgs/xim-x-glibc/1.0"
+FAKE2="$HOME_DIR/data/xpkgs/xim-x-glibc/2.0"
+FARM="$HOME_DIR/subos/default/lib"
+mkdir -p "$FAKE1/lib64" "$FAKE2/lib64" "$FARM"
+for so in ld-linux-x86-64.so.2 libc.so.6; do
+  touch "$FAKE1/lib64/$so" "$FAKE2/lib64/$so"
+  ln -sfn "$FAKE2/lib64/$so" "$FARM/$so"
+done
+
+# ── the rigged executables ─────────────────────────────────────────────
+printf 'int main(void){return 0;}\n' > "$RIG_DIR/main.c"
+gcc -o "$RIG_DIR/plainok" "$RIG_DIR/main.c" || fail "gcc failed on a 1-line program"
+cp "$RIG_DIR/plainok" "$RIG_DIR/orderok"
+cp "$RIG_DIR/plainok" "$RIG_DIR/splitreal"
+
+# Every soname the rig NEEDs has to exist in 1.0 so rule D (closure) stays
+# quiet; content is irrelevant, the scans are name maps.
+while read -r so; do
+  [ -z "$so" ] && continue
+  touch "$FAKE1/lib64/$so" "$FAKE2/lib64/$so"
+done < <(patchelf --print-needed "$RIG_DIR/plainok")
+
+patchelf --set-interpreter "$FAKE1/lib64/ld-linux-x86-64.so.2" "$RIG_DIR/orderok" \
+  || fail "patchelf --set-interpreter failed (orderok)"
+patchelf --force-rpath --set-rpath "$FAKE1/lib64:$FARM" "$RIG_DIR/orderok" \
+  || fail "patchelf --set-rpath failed (orderok)"
+
+patchelf --set-interpreter "$FAKE1/lib64/ld-linux-x86-64.so.2" "$RIG_DIR/splitreal" \
+  || fail "patchelf --set-interpreter failed (splitreal)"
+patchelf --force-rpath --set-rpath "$FARM" "$RIG_DIR/splitreal" \
+  || fail "patchelf --set-rpath failed (splitreal)"
+
+# ── three fixture recipes that carry them into payloads ────────────────
+write_recipe() {
+  local name="$1" letter="$2" rig="$3"
+  cat > "$LOCAL_INDEX_DIR/pkgs/$letter/$name.lua" <<LUA
+package = {
+    spec = "1",
+    name = "$name",
+    description = "Local fixture for tests/e2e/install_guard_loader_order_test.sh",
+    authors = {"xlings-ci"},
+    licenses = {"MIT"},
+    type = "package",
+    archs = {"x86_64"},
+    status = "stable",
+    categories = {"test-fixture"},
+    xpm = {
+        linux   = { ["1.0.0"] = {} },
+        macosx  = { ["1.0.0"] = {} },
+        windows = { ["1.0.0"] = {} },
+    },
+}
+
+import("xim.libxpkg.pkginfo")
+
+function install()
+    local dir = pkginfo.install_dir()
+    os.tryrm(dir)
+    os.mkdir(path.join(dir, "bin"))
+    os.cp("$rig", path.join(dir, "bin", "$name"))
+    return true
+end
+
+function config()
+    return true
+end
+LUA
+}
+write_recipe orderok   o "$RIG_DIR/orderok"
+write_recipe splitreal s "$RIG_DIR/splitreal"
+write_recipe plainok   p "$RIG_DIR/plainok"
+
+# ── isolated home ──────────────────────────────────────────────────────
+mkdir -p "$HOME_DIR/data/xim-index-repos"
+cat > "$HOME_DIR/.xlings.json" <<EOF
+{
+  "mirror": "${XLINGS_TEST_MIRROR:-GLOBAL}",
+  "index_repos": [
+    { "name": "xim", "url": "$LOCAL_INDEX_DIR" }
+  ]
+}
+EOF
+printf '{}\n' > "$HOME_DIR/data/xim-index-repos/xim-indexrepos.json"
+
+x() { ( cd /tmp && env -i HOME="$HOME" PATH=/usr/bin:/bin \
+        XLINGS_HOME="$HOME_DIR" "$BIN" "$@" ) }
+
+x self init >/dev/null 2>&1 || true
+
+# `self init` may have (re)built the farm; the rig needs it pointing at 2.0.
+for so in ld-linux-x86-64.so.2 libc.so.6; do
+  ln -sfn "$FAKE2/lib64/$so" "$FARM/$so"
+done
+
+stamp_of() { find "$HOME_DIR/data/xpkgs" -mindepth 3 -maxdepth 3 -name '.xpkg-install.json' -path "*-x-$1/*" -print -quit; }
+
+# ── A: own glibc ahead of a drifted farm is not a split ─────────────────
+RC=0
+OUT="$(x install orderok@1.0.0 -y 2>&1)" || RC=$?
+printf '%s\n' "$OUT" | sed -n '1,30{s/^/      | /;p}'
+[ "$RC" = "0" ] || fail "A1: orderok must install (its own 1.0 lib dir answers libc.so.6 before the farm); exited $RC"
+echo "$OUT" | strip_ansi | grep -q "loader/libc payload mismatch" \
+  && fail "A1: the guard reported a split on a binary whose loader never reaches the farm"
+log "  ✓ A1: orderok installed; no split reported"
+
+STAMP="$(stamp_of orderok)"
+[ -n "$STAMP" ] || fail "A2: orderok has no install stamp"
+grep -q '"incomplete": true' "$STAMP" && fail "A2: orderok's stamp is marked incomplete"
+log "  ✓ A2: orderok's stamp is clean"
+
+# ── B: a real split is refused as ONE node, and the plan goes on ────────
+RC=0
+OUT="$(x install splitreal@1.0.0 plainok@1.0.0 -y 2>&1)" || RC=$?
+printf '%s\n' "$OUT" | sed -n '1,40{s/^/      | /;p}'
+[ "$RC" != "0" ] || fail "B1: a plan containing a real split must exit non-zero"
+echo "$OUT" | strip_ansi | grep -q "splitreal" \
+  || fail "B1: the failure does not name splitreal:
+$OUT"
+log "  ✓ B1: the plan exits non-zero and names splitreal"
+
+STAMP="$(stamp_of splitreal)"
+[ -n "$STAMP" ] || fail "B2: splitreal left no stamp at all (payload on disk, nothing saying why)"
+grep -q '"incomplete": true' "$STAMP" \
+  || fail "B2: splitreal's refusal wrote no failure marker; the stamp reads as a finished install"
+grep -q 'loader/libc' "$STAMP" \
+  || fail "B2: the marker does not say WHY (expected the mismatch in its reason)"
+log "  ✓ B2: splitreal carries a failure marker naming the mismatch"
+
+STAMP="$(stamp_of plainok)"
+[ -n "$STAMP" ] || fail "B3: plainok was not installed -- one refused node took the plan down"
+grep -q '"incomplete": true' "$STAMP" && fail "B3: plainok's stamp is marked incomplete"
+log "  ✓ B3: plainok installed in the same plan"
+
+echo "$OUT" | strip_ansi | grep -q "resolution defect" \
+  || fail "B4: the refusal no longer says it is a resolution defect to report"
+log "  ✓ B4: the refusal still asks for a report"
+
+log "E2E install-guard-loader-order: PASS"

--- a/tests/e2e/run_all.sh
+++ b/tests/e2e/run_all.sh
@@ -174,6 +174,7 @@ TESTS=(
     # the project. Verified differential against 2026.9.2.1, where it fails at
     # the first assertion.
     "E2E-96 |shim_table_routing_test.sh||"
+    "E2E-97 |install_guard_loader_order_test.sh||"
 )
 
 # ── orphan check: a test that runs NOWHERE looks exactly like one that passes ──

--- a/tests/e2e/self_doctor_test.sh
+++ b/tests/e2e/self_doctor_test.sh
@@ -525,4 +525,21 @@ printf '%s\n' "$out" | grep -qE "xlings install [^ ]+ --force"   && fail "S13: a
 # Anything matching the former in an install/remove command never resolves.
 printf '%s\n' "$out" | grep -qE "xlings (install|remove) [A-Za-z0-9_.]+-x-[A-Za-z0-9_.-]+@"   && fail "S13: a remedy named a store directory instead of a package coordinate; got:\n$out"
 
+# The word after `xlings` has to be a command the CLI has. A placeholder or a
+# parenthetical in the command position fails as surely as a wrong flag does,
+# and three remedies used to carry one (`use X@<one of: ...>`, `... --fix
+# (adopt ...)`, `install glibc (then ...)`). Prose now goes on its own `note`
+# line; the `run` line is the command and nothing else.
+known_cmds=" install remove update search list info why use config subos self index agent profile "
+while read -r cmd; do
+  [ -z "$cmd" ] && continue
+  case "$known_cmds" in
+    *" $cmd "*) ;;
+    *) fail "S13: a remedy starts with \`xlings $cmd\`, which is not a command; got:\n$out" ;;
+  esac
+done < <(printf '%s\n' "$out" | grep -oE "→ run[[:space:]]+xlings [a-z-]+" | awk '{print $NF}')
+
+printf '%s\n' "$out" | grep -E "→ run .*(<one of|\(adopt |\(then |<version>)" \
+  && fail "S13: a remedy carries a placeholder or prose in the command position; got:\n$out"
+
 log "PASS: self doctor scenarios 1-13 (alias repair reported honestly, long report not clamped, remedies runnable)"

--- a/tests/e2e/self_doctor_test.sh
+++ b/tests/e2e/self_doctor_test.sh
@@ -491,4 +491,38 @@ lines=$(printf '%s\n' "$out" | wc -l)
 printf '%s\n' "$out" | grep -q "broken payloads" \
   || fail "S12: the summary line must survive a long report; got $lines lines:\n$out"
 
-log "PASS: self doctor scenarios 1-12 (alias repair reported honestly, long report not clamped)"
+# ── S13: every printed remedy has to be runnable ───────────────────
+#
+# Two ways one was not, both found by a user reading real output:
+#
+#   `xlings install xim-x-bun@1.3.11 --force`
+#
+# `xim-x-bun` is the STORE DIRECTORY name, not a package -- install answers
+# "not found in the synced index". And `--force` is not an option install has
+# at all (remove has one, meaning something else) -- the parser rejects it with
+# "unknown option". A remedy is copied and run; one that cannot succeed is worse than
+# none, which is why Finding::remedy is allowed to be empty.
+#
+# Asserted over whatever this home produces rather than by staging a specific
+# finding: the defect is a CLASS, and staging one instance would only pin the
+# instance. `--deep` so the payload-audit remedies are in the output too.
+log "S13: printed remedies are runnable commands"
+out=$(RUN self doctor --deep --all 2>&1 || true)
+
+# This home may produce no remedies at all, and then the two greps below pass
+# without having looked at anything. "Never exercised" and "passed" must not
+# read the same, so say which one happened.
+remedies=$(printf '%s\n' "$out" | grep -cE "→ run" || true)
+if [[ "$remedies" -eq 0 ]]; then
+  log "  S13: NOT EXERCISED — this home printed no remedies (guard still armed)"
+else
+  log "  S13: inspecting $remedies printed remed(y|ies)"
+fi
+
+printf '%s\n' "$out" | grep -qE "xlings install [^ ]+ --force"   && fail "S13: a remedy passed --force, which \`install\` does not accept; got:\n$out"
+
+# A store directory name is `<ns>-x-<package>`; a coordinate is `[ns:]pkg@ver`.
+# Anything matching the former in an install/remove command never resolves.
+printf '%s\n' "$out" | grep -qE "xlings (install|remove) [A-Za-z0-9_.]+-x-[A-Za-z0-9_.-]+@"   && fail "S13: a remedy named a store directory instead of a package coordinate; got:\n$out"
+
+log "PASS: self doctor scenarios 1-13 (alias repair reported honestly, long report not clamped, remedies runnable)"

--- a/tests/e2e/subos_single_version_test.sh
+++ b/tests/e2e/subos_single_version_test.sh
@@ -214,10 +214,12 @@ echo "$OUT" | strip_ansi | grep -q "double binding" \
   || fail "doctor did not report a package bound at two versions with no active
 version, which is the state that exports every variable twice:
 $OUT"
-echo "$OUT" | strip_ansi | grep -q "xlings use lostws@" \
+# Either spelling `use` accepts -- `lostws@2.0.0` or `lostws 2.0.0` -- is a
+# decision; asserting one of them pinned a spelling, not the property.
+echo "$OUT" | strip_ansi | grep -qE "xlings use lostws(@| )[0-9]" \
   || fail "the remedy does not tell the user how to decide. Nothing here CAN
 decide -- that is why it is reported rather than repaired -- so the remedy has
-to name the choice:
+to name the package AND a version:
 $OUT"
 log "  ✓ contested binding reported, with a remedy that is a decision"
 

--- a/tests/unit/test_elf_same_source.cpp
+++ b/tests/unit/test_elf_same_source.cpp
@@ -173,21 +173,96 @@ TEST(SameSource, FirstCoreRuntimeEntryDeterminesResult) {
                           rpath).violated);
 }
 
-TEST(SameSource, AnyDifferentCoreRuntimeEntryViolates) {
+// The loader stops at the first directory that has a soname. A complete glibc
+// lib dir ahead on the path therefore answers EVERY core soname, and a
+// different payload's copy behind it is never opened -- so it is not a split.
+//
+// This test used to assert the opposite ("any different core-runtime entry
+// violates"). Measured on a real home, that rule produced 152 errors, all on
+// binaries whose own glibc lib dir preceded a subos farm that had since moved
+// to another glibc. Every one of them ran; re-evaluated by the loader's rule,
+// 0 of 151 were splits. The same predicate refused installs.
+TEST(SameSource, ACompleteFirstDirectoryAnswersEveryCoreSoname) {
     TempTree tree;
     const auto loaderDir = tree.payload("2.44") / "lib64";
     const auto laterDir = tree.payload("2.39") / "lib64";
     TempTree::touch(loaderDir / "ld-linux-x86-64.so.2");
     TempTree::touch(loaderDir / "libc.so.6");
+    TempTree::touch(laterDir / "ld-linux-x86-64.so.2");
     TempTree::touch(laterDir / "libc.so.6");
 
     std::vector<std::string> rpath{
         loaderDir.string(),
         laterDir.string(),
     };
-    EXPECT_TRUE(ec::check((tree.payload("2.44") / "bin" / "gcc").string(),
-                          (loaderDir / "ld-linux-x86-64.so.2").string(),
-                          rpath).violated);
+    const auto f = ec::check((tree.payload("2.44") / "bin" / "gcc").string(),
+                             (loaderDir / "ld-linux-x86-64.so.2").string(),
+                             rpath);
+    EXPECT_FALSE(f.violated)
+        << "the later 2.39 copies are behind a complete 2.44 dir and are never "
+           "opened: " << ec::describe(f);
+}
+
+// ...and the half of the old rule that was TRUE stays: when the first
+// directory is incomplete, the soname it lacks IS taken from the next directory
+// that has it, and that one has to come from the interpreter's payload.
+TEST(SameSource, AnIncompleteFirstDirectoryLeavesLaterEntriesInPlay) {
+    TempTree tree;
+    const auto loaderDir = tree.payload("2.44") / "lib64";
+    const auto laterDir = tree.payload("2.39") / "lib64";
+    TempTree::touch(loaderDir / "ld-linux-x86-64.so.2");   // no libc.so.6 here
+    TempTree::touch(laterDir / "libc.so.6");                // so THIS one is loaded
+
+    std::vector<std::string> rpath{
+        loaderDir.string(),
+        laterDir.string(),
+    };
+    const auto f = ec::check((tree.payload("2.44") / "bin" / "gcc").string(),
+                             (loaderDir / "ld-linux-x86-64.so.2").string(),
+                             rpath);
+    EXPECT_TRUE(f.violated);
+    EXPECT_EQ(f.reason, ec::Finding::Reason::PayloadMismatch);
+    EXPECT_NE(f.corePath.find("libc.so.6"), std::string::npos)
+        << "the finding must name the soname actually taken from 2.39";
+}
+
+// The exact shape measured on the real home: interp 2.39, RUNPATH lists the
+// binary's own 2.39 lib dir, then the subos farm -- a symlink farm that now
+// points at 2.44. The farm is a real directory of real symlinks, because a
+// directory of touched files is not the shape this check runs against.
+TEST(SameSource, OwnGlibcAheadOfADriftedFarmIsNotASplit) {
+    namespace fs = std::filesystem;
+    TempTree tree;
+    const auto own = tree.payload("2.39") / "lib64";
+    const auto drifted = tree.payload("2.44") / "lib";
+    const auto farm = tree.root / "subos" / "default" / "lib";
+    TempTree::touch(own / "ld-linux-x86-64.so.2");
+    TempTree::touch(own / "libc.so.6");
+    TempTree::touch(drifted / "ld-linux-x86-64.so.2");
+    TempTree::touch(drifted / "libc.so.6");
+    std::error_code ec2;
+    fs::create_directories(farm, ec2);
+    ASSERT_FALSE(ec2) << ec2.message();
+    fs::create_symlink(drifted / "ld-linux-x86-64.so.2",
+                       farm / "ld-linux-x86-64.so.2", ec2);
+    ASSERT_FALSE(ec2) << ec2.message();
+    fs::create_symlink(drifted / "libc.so.6", farm / "libc.so.6", ec2);
+    ASSERT_FALSE(ec2) << ec2.message();
+
+    std::vector<std::string> rpath{
+        (tree.payload("2.39") / "bin").string(),   // no core files: skipped
+        own.string(),
+        farm.string(),
+    };
+    const auto f = ec::check((tree.payload("2.39") / "bin" / "gcc").string(),
+                             (own / "ld-linux-x86-64.so.2").string(), rpath);
+    EXPECT_FALSE(f.violated) << ec::describe(f);
+
+    // Reversed, the farm answers libc.so.6 first and the split is real.
+    std::vector<std::string> reversed{farm.string(), own.string()};
+    EXPECT_TRUE(ec::check((tree.payload("2.39") / "bin" / "gcc").string(),
+                          (own / "ld-linux-x86-64.so.2").string(),
+                          reversed).violated);
 }
 
 TEST(SameSource, RelativeAndNonStoreEntriesAreIgnored) {

--- a/tests/unit/test_elf_same_source.cpp
+++ b/tests/unit/test_elf_same_source.cpp
@@ -439,6 +439,40 @@ TEST(SameSource, AMuslLoaderIsNotAGlibcBinarysLibc) {
     EXPECT_FALSE(f.violated) << ec::describe(f);
 }
 
+// The shape a real musl payload actually has, which the two tests above do not
+// model: `ld-musl-x86_64.so.1` is a SYMLINK to `libc.so` -- on musl the loader
+// and the libc are one file. Resolving the entry therefore yields a name that
+// carries no family marker at all, and classifying the RESOLVED name reads it
+// as Unknown, which the family guard treats as "compare anyway".
+//
+// Measured on a real home: every glibc binary whose RUNPATH included a subos
+// lib farm containing musl was reported as a loader/libc split, and the
+// install-time guard REFUSED the install -- `xlings install xim:bun@1.3.11`
+// failed on node@24.20.0 with "core file -> .../xim-x-musl/1.2.5/lib/libc.so".
+//
+// `touch`ing a plain file instead of the symlink is what hid this: the fixture
+// was not shaped like the thing it stands for.
+TEST(SameSource, AMuslLoaderSymlinkedToLibcIsStillMusl) {
+    namespace fs = std::filesystem;
+    TempTree tree;
+    const auto glibcLib = tree.payload("2.44") / "lib64";
+    const auto muslLib = tree.root / "data" / "xpkgs" / "xim-x-musl" / "1.2.5" / "lib";
+    TempTree::touch(glibcLib / "ld-linux-x86-64.so.2");
+    TempTree::touch(glibcLib / "libc.so.6");
+
+    // The real layout: the loader IS libc.so, reached through a named link.
+    TempTree::touch(muslLib / "libc.so");
+    std::error_code ec2;
+    fs::create_symlink("libc.so", muslLib / "ld-musl-x86_64.so.1", ec2);
+    ASSERT_FALSE(ec2) << ec2.message();
+
+    std::vector<std::string> rpath{muslLib.string(), glibcLib.string()};
+    const auto f = ec::check((tree.root / "bin" / "node").string(),
+                             (glibcLib / "ld-linux-x86-64.so.2").string(),
+                             rpath);
+    EXPECT_FALSE(f.violated) << ec::describe(f);
+}
+
 // ...and the same across the other direction, so this is a family rule rather
 // than a musl exemption.
 TEST(SameSource, AGlibcLoaderIsNotAMuslBinarysLibc) {

--- a/tests/unit/test_self_repair.cpp
+++ b/tests/unit/test_self_repair.cpp
@@ -361,9 +361,17 @@ TEST(SelfUpdateLanding, ABareVersionIsTheIndexBuild) {
     EXPECT_TRUE(xlings::xself::update_landed_on_index_build("0.4.51"));
 }
 
-TEST(SelfUpdateLanding, ANamespacedVersionIsNot) {
+TEST(SelfUpdateLanding, ALocalBuildIsNot) {
     EXPECT_FALSE(xlings::xself::update_landed_on_index_build("local:0.4.51"));
-    EXPECT_FALSE(xlings::xself::update_landed_on_index_build("scode:1.0"));
+}
+
+// Since 2026.9.2.1 version keys are spelled by identity, so an install from
+// the default index may record `xim:2026.9.2.1` -- and a sub-index records its
+// own namespace. Both ARE index builds. Judging them by "has a colon" reported
+// a successful upgrade as "nothing was upgraded" on a real home (#579).
+TEST(SelfUpdateLanding, ANamespacedIndexBuildStillIs) {
+    EXPECT_TRUE(xlings::xself::update_landed_on_index_build("xim:2026.9.2.1"));
+    EXPECT_TRUE(xlings::xself::update_landed_on_index_build("scode:1.0"));
 }
 
 // The false positive that the obvious implementation ships with: an

--- a/tests/unit/test_xvm_bindings.cpp
+++ b/tests/unit/test_xvm_bindings.cpp
@@ -5064,23 +5064,21 @@ TEST(XvmRemovalBatchTest, RawEmptyOperationNeverMeansAllVersions) {
     EXPECT_EQ(workspace, workspaceBefore);
     EXPECT_EQ(installed, installedBefore);
 
+    // With exactly ONE record there is no "all versions" for the empty
+    // operation to mean, and refusing it made the ordinary uninstall idiom
+    // (`xvm.remove("fd")`) fail on the very state it exists for (#578). The
+    // sole record is the answer; two records above are still ambiguous.
     db["sibling"].versions.erase("repo-b:1.0.0");
     workspace = {{"sibling", "repo-a:1.0.0"}};
     installed = {{"sibling", {"repo-a:1.0.0"}}};
-    const auto oneVersionBefore = xlings::xvm::versions_to_json(db);
 
     result = xlings::xvm::apply_removal_batch(
         db, workspace, installed, operations, {});
 
-    ASSERT_FALSE(result.has_value());
-    EXPECT_EQ(
-        result.error().kind,
-        xlings::xvm::RemovalErrorKind::VersionNotFound);
-    EXPECT_EQ(xlings::xvm::versions_to_json(db), oneVersionBefore);
-    EXPECT_EQ(workspace.at("sibling"), "repo-a:1.0.0");
-    EXPECT_EQ(
-        installed.at("sibling"),
-        (std::vector<std::string>{"repo-a:1.0.0"}));
+    ASSERT_TRUE(result.has_value()) << result.error().message;
+    EXPECT_FALSE(db.contains("sibling")
+                 && db["sibling"].versions.contains("repo-a:1.0.0"))
+        << "the sole record is what a versionless removal removes";
 }
 
 TEST(XvmRemovalBatchTest,
@@ -8316,4 +8314,47 @@ TEST(VersionKeyIdentity, TwinMergePlanNamesTheLoserAndTheRepairConverges) {
     EXPECT_TRUE(db["perldoc"].bindings.empty());
     // Converges: a second plan finds nothing.
     EXPECT_TRUE(fx::plan_twin_merges(db).empty());
+}
+
+// #578: a versionless removal with exactly one stored version and no workspace
+// selection resolved to nothing -- the branch that should have picked the sole
+// record did not exist, so `xvm.remove("fd")` from an uninstall hook failed
+// with "removal operation has no exact version" on the very state it is
+// written for. One record is not ambiguous; it is the answer.
+TEST(XvmExactRemovalTest, VersionlessRemovalWithASingleRecordResolvesToIt) {
+    xlings::xvm::VersionDB db;
+    db["fd"].versions["10.4.2"].path = "/pkg/fd/10.4.2";
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+    const std::vector<xlings::xvm::RemovalOperation> operations{
+        { .op = "remove", .name = "fd", .version = "" },
+    };
+
+    auto result = xlings::xvm::apply_removal_batch(
+        db, workspace, installed, operations, {});
+
+    ASSERT_TRUE(result.has_value())
+        << result.error().message << " (" << result.error().target << ")";
+    EXPECT_FALSE(db.contains("fd") && db["fd"].versions.contains("10.4.2"))
+        << "the sole record must be the one removed";
+}
+
+// ...and two records are still refused as ambiguous, not silently picked.
+TEST(XvmExactRemovalTest, VersionlessRemovalWithTwoRecordsIsStillAmbiguous) {
+    xlings::xvm::VersionDB db;
+    db["fd"].versions["10.4.2"].path = "/pkg/fd/10.4.2";
+    db["fd"].versions["10.5.0"].path = "/pkg/fd/10.5.0";
+    xlings::xvm::Workspace workspace;
+    xlings::xvm::WorkspaceInstalled installed;
+    const std::vector<xlings::xvm::RemovalOperation> operations{
+        { .op = "remove", .name = "fd", .version = "" },
+    };
+
+    auto result = xlings::xvm::apply_removal_batch(
+        db, workspace, installed, operations, {});
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error().kind,
+              xlings::xvm::RemovalErrorKind::AmbiguousVersion);
+    EXPECT_EQ(db["fd"].versions.size(), 2u);
 }

--- a/tests/unit/test_xvm_owner.cpp
+++ b/tests/unit/test_xvm_owner.cpp
@@ -21,6 +21,7 @@
 
 import std;
 import xlings.core.xvm.owner;
+import xlings.core.xvm.types;
 
 namespace xvm = xlings::xvm;
 
@@ -141,4 +142,45 @@ TEST(PayloadOwnership, BindirPathsStillIdentifyTheOwner) {
         xvm::payload_path_names_another_package(bindir, "compat", "libdrm"));
     EXPECT_FALSE(
         xvm::payload_path_names_another_package(bindir, "xim", "libdrm"));
+}
+
+// ── recorded_owner: only what a record proves ────────────────────────────
+//
+// `owner_candidates` ends with guesses that its caller confirms against the
+// catalog. Dispatch and `use` print on the error path with no catalog loaded,
+// and 218 of 338 program names on a measured home are not package names -- so
+// what they print has to come from a record or not be printed at all.
+
+TEST(RecordedOwner, ThePayloadPathNamesThePackageNotTheProgram) {
+    xlings::xvm::VersionDB db;
+    db["g++"].versions["11.5.0"].path =
+        "/home/u/.xlings/data/xpkgs/xim-x-gcc/11.5.0/bin";
+    const auto owner = xlings::xvm::recorded_owner(db, "g++", "11.5.0");
+    ASSERT_TRUE(owner.has_value());
+    EXPECT_EQ(owner->canonical(), "xim:gcc@11.5.0")
+        << "`xlings install g++@11.5.0` cannot run; the path says who can";
+}
+
+TEST(RecordedOwner, TheRecordedProviderWinsOverThePath) {
+    xlings::xvm::VersionDB db;
+    auto& data = db["slang"].versions["0.1.3"];
+    data.path = "/home/u/.xlings/data/xpkgs/xim-x-d2x/0.1.3/bin";
+    data.bindingGroup = xlings::xvm::BindingGroupRef{
+        .provider = "xim:d2x", .providerVersion = "0.1.3",
+        .group = "d2x", .rootTarget = "d2x", .rootVersion = "0.1.3",
+    };
+    const auto owner = xlings::xvm::recorded_owner(db, "slang", "0.1.3");
+    ASSERT_TRUE(owner.has_value());
+    EXPECT_EQ(owner->canonical(), "xim:d2x@0.1.3");
+}
+
+TEST(RecordedOwner, NoRecordIsNoAnswerNotAGuess) {
+    xlings::xvm::VersionDB db;
+    // A self-managed tool: registered, but its path is not a store path.
+    db["tool"].versions["1.0"].path = "/opt/self-managed/tool";
+    EXPECT_FALSE(xlings::xvm::recorded_owner(db, "tool", "1.0").has_value())
+        << "the target's own name is the guess owner_candidates offers; "
+           "recorded_owner must not";
+    EXPECT_FALSE(xlings::xvm::recorded_owner(db, "absent", "1.0").has_value());
+    EXPECT_FALSE(xlings::xvm::recorded_owner(db, "tool", "9.9").has_value());
 }


### PR DESCRIPTION
## What

Three defects a user found by reading real `self doctor` / `install` output turned out to share one shape: a guard or diagnostic answers a weaker question than the one it prints, and the same predicate drives both doctor's report and install's refusal.

Survey: `.agents/docs/2026-09-03-diagnostic-truth-survey-and-plan.md` · Plan: `.agents/docs/2026-09-03-diagnostic-truth-impl-plan.md` · Notes: `.agents/docs/2026-09-03-release-2026.9.3.2-notes.md`

### The user's three (P0)
- `xlings install xim-x-bun@1.3.11 --force` as a remedy: `xim-x-bun` is a store directory, and `install` has no `--force`. Remedy now comes from `coordinate_from_payload_path`; the second `--force` hint (`use`'s runtime refusal) is fixed too.
- The install was refused by a false loader/libc split: musl ships `ld-musl-x86_64.so.1 -> libc.so`, and the family was classified from the RESOLVED name. Now from the entry name. Real home: 178 → 152 findings.

### The 152 that were left (P1) — measured, all false
Every one had the same shape: INTERP → glibc 2.39, RUNPATH `[own 2.39/lib64, …, subos farm → 2.44]`. All run. Re-evaluated with loader semantics (first RUNPATH dir that has each core soname wins): **0 of 151 real**. `elf_same_source::check` demanded every directory agree; it now judges what the loader would take. The half of the old rule that was true (an incomplete first directory) is kept and tested.

### The guard's contract (P2)
Rule-B refusal `return`ed out of `Installer::execute` — one refused node killed the plan, no `install_summary`, no failure marker. Now: marker + `onStatus(Failed)` + `continue`, like every other hook failure.

### Remedies (P3)
`Finding::remedy` is a command; prose moves to the new `remedyNote` line. Dispatch/`use`/`update` install suggestions go through `xvm::recorded_owner` (provider record or payload path only — 218 of 338 program names on a real home are not package names) and fall back to `xlings search <name>`.

### The real fact underneath (P4)
New Notice `InterpRuntimeDrift`: "subos declares glibc@2.44, but N executables in M packages start on glibc@2.39". No exit-code change, no `--fix`.

### Adjacent issues
- #579 `self update`: `xim:`-spelled keys are index builds; DOWNGRADED compares bare versions; state is re-read after the switch.
- #578 (2nd point): a versionless removal with exactly one record resolves to it.

## Tests
- Unit: loader-order trio (replaces `AnyDifferentCoreRuntimeEntryViolates`), musl symlink fixture, `RecordedOwner.*`, `SelfUpdateLanding.*`, single-record removal (+ two records still ambiguous).
- E2E-97 `install_guard_loader_order_test.sh`: P1 + P2 on one fixture; fails on 2026.9.3.1 at A1 and B2/B3.
- S13 extended: every printed remedy starts with a real subcommand and carries no placeholder/prose.

## Real-home measurements (83 GB home, read-only `self doctor --deep --all`)

| | 2026.9.3.1 (+P0) | this PR |
|---|---|---|
| errors | 155 | 3 |
| of which loader/libc split | 152 | 0 |
| broken payload / binding state (real) | 2 / 1 | 2 / 1 |
| printed remedies | 162 | 10 |
| runtime drift (Notice) | — | 1: `default` declares glibc@2.44; 42 executables in 2 packages start on 2.39 |

E2E-97 fails on the 2026.9.3.1 binary at A1 and passes here.

## Compatibility
No migration. No cross-repo change (no libxpkg field, index format, or recipe API). Windows/macOS: the predicate is pure; payload scans produce no PT_INTERP there; E2E-97 skips off-Linux and says so.
