### PR TITLE
ci: a bootstrap that downloaded nothing must not report success

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -646,10 +646,13 @@ jobs:
           # Same failure mode as the POSIX bootstrap, same three fixes: `irm |
           # iex` reports whether iex ran, not whether irm fetched anything,
           # so a reset connection installs nothing and the step goes green.
-          $ErrorActionPreference = 'Stop'
+          # `-ErrorAction Stop` on the call, NOT $ErrorActionPreference: the
+          # preference would stay set for `& $script` below and turn any
+          # non-terminating error the installer writes into an abort -- a
+          # behaviour change well outside what this fixes.
           $script = "$env:TEMP\xlings-quick-install.ps1"
           for ($i = 1; $i -le 3; $i++) {
-            try { Invoke-WebRequest -UseBasicParsing -TimeoutSec 60 `
+            try { Invoke-WebRequest -UseBasicParsing -TimeoutSec 60 -ErrorAction Stop `
                     -Uri https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.ps1 `
                     -OutFile $script; break }
             catch { Write-Host "bootstrap download failed (attempt $i/3); retrying"; Start-Sleep 10 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,29 @@ jobs:
           XLINGS_NON_INTERACTIVE: 1
           XLINGS_VERSION: ${{ env.BOOTSTRAP_XLINGS_VERSION }}
         run: |
-          curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
+          # Retried, piped through a file, and asserted -- three fixes for one
+          # failure mode. `curl … | bash` reports the exit status of BASH, and
+          # bash fed an empty stdin exits 0, so a network reset installs
+          # nothing and the step goes GREEN. Measured on the 2026.9.4.1
+          # release: `curl: (35) Recv failure: Connection reset by peer` here,
+          # step reported success, and the run died two steps later with
+          # `xlings: command not found` (exit 127) pointing at the wrong
+          # thing entirely.
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 3 --retry-delay 5 --connect-timeout 20 \
+              https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh \
+              -o /tmp/xlings-quick-install.sh && break
+            echo "bootstrap download failed (attempt $attempt/3); retrying"
+            sleep 10
+          done
+          test -s /tmp/xlings-quick-install.sh \
+            || { echo "::error::could not download quick_install.sh"; exit 1; }
+          bash /tmp/xlings-quick-install.sh
+          # The assertion that makes a silent no-op impossible: whatever the
+          # installer thought it did, the binary either exists here or it does
+          # not.
+          test -x "$HOME/.xlings/bin/xlings" \
+            || { echo "::error::bootstrap reported success but installed no xlings"; exit 1; }
           echo "XLINGS_HOME=$HOME/.xlings"           >> "$GITHUB_ENV"
           echo "$HOME/.xlings/subos/current/bin"     >> "$GITHUB_PATH"
           echo "$HOME/.xlings/bin"                   >> "$GITHUB_PATH"
@@ -290,7 +312,29 @@ jobs:
           XLINGS_NON_INTERACTIVE: 1
           XLINGS_VERSION: ${{ env.BOOTSTRAP_XLINGS_VERSION }}
         run: |
-          curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
+          # Retried, piped through a file, and asserted -- three fixes for one
+          # failure mode. `curl … | bash` reports the exit status of BASH, and
+          # bash fed an empty stdin exits 0, so a network reset installs
+          # nothing and the step goes GREEN. Measured on the 2026.9.4.1
+          # release: `curl: (35) Recv failure: Connection reset by peer` here,
+          # step reported success, and the run died two steps later with
+          # `xlings: command not found` (exit 127) pointing at the wrong
+          # thing entirely.
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 3 --retry-delay 5 --connect-timeout 20 \
+              https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh \
+              -o /tmp/xlings-quick-install.sh && break
+            echo "bootstrap download failed (attempt $attempt/3); retrying"
+            sleep 10
+          done
+          test -s /tmp/xlings-quick-install.sh \
+            || { echo "::error::could not download quick_install.sh"; exit 1; }
+          bash /tmp/xlings-quick-install.sh
+          # The assertion that makes a silent no-op impossible: whatever the
+          # installer thought it did, the binary either exists here or it does
+          # not.
+          test -x "$HOME/.xlings/bin/xlings" \
+            || { echo "::error::bootstrap reported success but installed no xlings"; exit 1; }
           echo "XLINGS_HOME=$HOME/.xlings"           >> "$GITHUB_ENV"
           echo "$HOME/.xlings/subos/current/bin"     >> "$GITHUB_PATH"
           echo "$HOME/.xlings/bin"                   >> "$GITHUB_PATH"
@@ -373,7 +417,29 @@ jobs:
           XLINGS_NON_INTERACTIVE: 1
           XLINGS_VERSION: ${{ env.BOOTSTRAP_XLINGS_VERSION }}
         run: |
-          curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
+          # Retried, piped through a file, and asserted -- three fixes for one
+          # failure mode. `curl … | bash` reports the exit status of BASH, and
+          # bash fed an empty stdin exits 0, so a network reset installs
+          # nothing and the step goes GREEN. Measured on the 2026.9.4.1
+          # release: `curl: (35) Recv failure: Connection reset by peer` here,
+          # step reported success, and the run died two steps later with
+          # `xlings: command not found` (exit 127) pointing at the wrong
+          # thing entirely.
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 3 --retry-delay 5 --connect-timeout 20 \
+              https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh \
+              -o /tmp/xlings-quick-install.sh && break
+            echo "bootstrap download failed (attempt $attempt/3); retrying"
+            sleep 10
+          done
+          test -s /tmp/xlings-quick-install.sh \
+            || { echo "::error::could not download quick_install.sh"; exit 1; }
+          bash /tmp/xlings-quick-install.sh
+          # The assertion that makes a silent no-op impossible: whatever the
+          # installer thought it did, the binary either exists here or it does
+          # not.
+          test -x "$HOME/.xlings/bin/xlings" \
+            || { echo "::error::bootstrap reported success but installed no xlings"; exit 1; }
           echo "XLINGS_HOME=$HOME/.xlings"           >> "$GITHUB_ENV"
           echo "$HOME/.xlings/subos/current/bin"     >> "$GITHUB_PATH"
           echo "$HOME/.xlings/bin"                   >> "$GITHUB_PATH"
@@ -577,7 +643,26 @@ jobs:
           XLINGS_NON_INTERACTIVE: '1'
           XLINGS_VERSION: ${{ env.BOOTSTRAP_XLINGS_VERSION }}
         run: |
-          irm https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.ps1 | iex
+          # Same failure mode as the POSIX bootstrap, same three fixes: `irm |
+          # iex` reports whether iex ran, not whether irm fetched anything,
+          # so a reset connection installs nothing and the step goes green.
+          $ErrorActionPreference = 'Stop'
+          $script = "$env:TEMP\xlings-quick-install.ps1"
+          for ($i = 1; $i -le 3; $i++) {
+            try { Invoke-WebRequest -UseBasicParsing -TimeoutSec 60 `
+                    -Uri https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.ps1 `
+                    -OutFile $script; break }
+            catch { Write-Host "bootstrap download failed (attempt $i/3); retrying"; Start-Sleep 10 }
+          }
+          if (-not (Test-Path $script) -or (Get-Item $script).Length -eq 0) {
+            Write-Host "::error::could not download quick_install.ps1"; exit 1
+          }
+          & $script
+          # Whatever the installer thought it did, the binary is either here or
+          # it is not.
+          if (-not (Test-Path "$env:USERPROFILE\.xlings\bin\xlings.exe")) {
+            Write-Host "::error::bootstrap reported success but installed no xlings"; exit 1
+          }
           "XLINGS_HOME=$env:USERPROFILE\.xlings"            >> $env:GITHUB_ENV
           "$env:USERPROFILE\.xlings\subos\current\bin"      >> $env:GITHUB_PATH
           "$env:USERPROFILE\.xlings\bin"                    >> $env:GITHUB_PATH

--- a/.github/workflows/xlings-ci-aarch64.yml
+++ b/.github/workflows/xlings-ci-aarch64.yml
@@ -100,7 +100,29 @@ jobs:
           XLINGS_NON_INTERACTIVE: 1
           XLINGS_VERSION: ${{ env.BOOTSTRAP_XLINGS_VERSION }}
         run: |
-          curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
+          # Retried, piped through a file, and asserted -- three fixes for one
+          # failure mode. `curl … | bash` reports the exit status of BASH, and
+          # bash fed an empty stdin exits 0, so a network reset installs
+          # nothing and the step goes GREEN. Measured on the 2026.9.4.1
+          # release: `curl: (35) Recv failure: Connection reset by peer` here,
+          # step reported success, and the run died two steps later with
+          # `xlings: command not found` (exit 127) pointing at the wrong
+          # thing entirely.
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 3 --retry-delay 5 --connect-timeout 20 \
+              https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh \
+              -o /tmp/xlings-quick-install.sh && break
+            echo "bootstrap download failed (attempt $attempt/3); retrying"
+            sleep 10
+          done
+          test -s /tmp/xlings-quick-install.sh \
+            || { echo "::error::could not download quick_install.sh"; exit 1; }
+          bash /tmp/xlings-quick-install.sh
+          # The assertion that makes a silent no-op impossible: whatever the
+          # installer thought it did, the binary either exists here or it does
+          # not.
+          test -x "$HOME/.xlings/bin/xlings" \
+            || { echo "::error::bootstrap reported success but installed no xlings"; exit 1; }
           echo "XLINGS_HOME=$HOME/.xlings"       >> "$GITHUB_ENV"
           echo "$HOME/.xlings/subos/current/bin" >> "$GITHUB_PATH"
           echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"

--- a/.github/workflows/xlings-ci-linux-e2e.yml
+++ b/.github/workflows/xlings-ci-linux-e2e.yml
@@ -54,7 +54,29 @@ jobs:
           XLINGS_NON_INTERACTIVE: 1
           XLINGS_VERSION: ${{ env.BOOTSTRAP_XLINGS_VERSION }}
         run: |
-          curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
+          # Retried, piped through a file, and asserted -- three fixes for one
+          # failure mode. `curl … | bash` reports the exit status of BASH, and
+          # bash fed an empty stdin exits 0, so a network reset installs
+          # nothing and the step goes GREEN. Measured on the 2026.9.4.1
+          # release: `curl: (35) Recv failure: Connection reset by peer` here,
+          # step reported success, and the run died two steps later with
+          # `xlings: command not found` (exit 127) pointing at the wrong
+          # thing entirely.
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 3 --retry-delay 5 --connect-timeout 20 \
+              https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh \
+              -o /tmp/xlings-quick-install.sh && break
+            echo "bootstrap download failed (attempt $attempt/3); retrying"
+            sleep 10
+          done
+          test -s /tmp/xlings-quick-install.sh \
+            || { echo "::error::could not download quick_install.sh"; exit 1; }
+          bash /tmp/xlings-quick-install.sh
+          # The assertion that makes a silent no-op impossible: whatever the
+          # installer thought it did, the binary either exists here or it does
+          # not.
+          test -x "$HOME/.xlings/bin/xlings" \
+            || { echo "::error::bootstrap reported success but installed no xlings"; exit 1; }
           echo "XLINGS_HOME=$HOME/.xlings"           >> "$GITHUB_ENV"
           echo "$HOME/.xlings/subos/current/bin"     >> "$GITHUB_PATH"
           echo "$HOME/.xlings/bin"                   >> "$GITHUB_PATH"

--- a/.github/workflows/xlings-ci-linux-root.yml
+++ b/.github/workflows/xlings-ci-linux-root.yml
@@ -41,7 +41,29 @@ jobs:
           XLINGS_NON_INTERACTIVE: 1
           XLINGS_VERSION: ${{ env.BOOTSTRAP_XLINGS_VERSION }}
         run: |
-          curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
+          # Retried, piped through a file, and asserted -- three fixes for one
+          # failure mode. `curl … | bash` reports the exit status of BASH, and
+          # bash fed an empty stdin exits 0, so a network reset installs
+          # nothing and the step goes GREEN. Measured on the 2026.9.4.1
+          # release: `curl: (35) Recv failure: Connection reset by peer` here,
+          # step reported success, and the run died two steps later with
+          # `xlings: command not found` (exit 127) pointing at the wrong
+          # thing entirely.
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 3 --retry-delay 5 --connect-timeout 20 \
+              https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh \
+              -o /tmp/xlings-quick-install.sh && break
+            echo "bootstrap download failed (attempt $attempt/3); retrying"
+            sleep 10
+          done
+          test -s /tmp/xlings-quick-install.sh \
+            || { echo "::error::could not download quick_install.sh"; exit 1; }
+          bash /tmp/xlings-quick-install.sh
+          # The assertion that makes a silent no-op impossible: whatever the
+          # installer thought it did, the binary either exists here or it does
+          # not.
+          test -x "$HOME/.xlings/bin/xlings" \
+            || { echo "::error::bootstrap reported success but installed no xlings"; exit 1; }
           echo "XLINGS_HOME=$HOME/.xlings"       >> "$GITHUB_ENV"
           echo "$HOME/.xlings/subos/current/bin" >> "$GITHUB_PATH"
           echo "$HOME/.xlings/bin"               >> "$GITHUB_PATH"

--- a/.github/workflows/xlings-ci-linux.yml
+++ b/.github/workflows/xlings-ci-linux.yml
@@ -52,7 +52,29 @@ jobs:
           XLINGS_NON_INTERACTIVE: 1
           XLINGS_VERSION: ${{ env.BOOTSTRAP_XLINGS_VERSION }}
         run: |
-          curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
+          # Retried, piped through a file, and asserted -- three fixes for one
+          # failure mode. `curl … | bash` reports the exit status of BASH, and
+          # bash fed an empty stdin exits 0, so a network reset installs
+          # nothing and the step goes GREEN. Measured on the 2026.9.4.1
+          # release: `curl: (35) Recv failure: Connection reset by peer` here,
+          # step reported success, and the run died two steps later with
+          # `xlings: command not found` (exit 127) pointing at the wrong
+          # thing entirely.
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 3 --retry-delay 5 --connect-timeout 20 \
+              https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh \
+              -o /tmp/xlings-quick-install.sh && break
+            echo "bootstrap download failed (attempt $attempt/3); retrying"
+            sleep 10
+          done
+          test -s /tmp/xlings-quick-install.sh \
+            || { echo "::error::could not download quick_install.sh"; exit 1; }
+          bash /tmp/xlings-quick-install.sh
+          # The assertion that makes a silent no-op impossible: whatever the
+          # installer thought it did, the binary either exists here or it does
+          # not.
+          test -x "$HOME/.xlings/bin/xlings" \
+            || { echo "::error::bootstrap reported success but installed no xlings"; exit 1; }
           echo "XLINGS_HOME=$HOME/.xlings"           >> "$GITHUB_ENV"
           echo "$HOME/.xlings/subos/current/bin"     >> "$GITHUB_PATH"
           echo "$HOME/.xlings/bin"                   >> "$GITHUB_PATH"

--- a/.github/workflows/xlings-ci-macos.yml
+++ b/.github/workflows/xlings-ci-macos.yml
@@ -42,7 +42,29 @@ jobs:
           XLINGS_NON_INTERACTIVE: 1
           XLINGS_VERSION: ${{ env.BOOTSTRAP_XLINGS_VERSION }}
         run: |
-          curl -fsSL https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh | bash
+          # Retried, piped through a file, and asserted -- three fixes for one
+          # failure mode. `curl … | bash` reports the exit status of BASH, and
+          # bash fed an empty stdin exits 0, so a network reset installs
+          # nothing and the step goes GREEN. Measured on the 2026.9.4.1
+          # release: `curl: (35) Recv failure: Connection reset by peer` here,
+          # step reported success, and the run died two steps later with
+          # `xlings: command not found` (exit 127) pointing at the wrong
+          # thing entirely.
+          for attempt in 1 2 3; do
+            curl -fsSL --retry 3 --retry-delay 5 --connect-timeout 20 \
+              https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.sh \
+              -o /tmp/xlings-quick-install.sh && break
+            echo "bootstrap download failed (attempt $attempt/3); retrying"
+            sleep 10
+          done
+          test -s /tmp/xlings-quick-install.sh \
+            || { echo "::error::could not download quick_install.sh"; exit 1; }
+          bash /tmp/xlings-quick-install.sh
+          # The assertion that makes a silent no-op impossible: whatever the
+          # installer thought it did, the binary either exists here or it does
+          # not.
+          test -x "$HOME/.xlings/bin/xlings" \
+            || { echo "::error::bootstrap reported success but installed no xlings"; exit 1; }
           echo "XLINGS_HOME=$HOME/.xlings"           >> "$GITHUB_ENV"
           echo "$HOME/.xlings/subos/current/bin"     >> "$GITHUB_PATH"
           echo "$HOME/.xlings/bin"                   >> "$GITHUB_PATH"

--- a/.github/workflows/xlings-ci-windows.yml
+++ b/.github/workflows/xlings-ci-windows.yml
@@ -42,7 +42,26 @@ jobs:
           XLINGS_NON_INTERACTIVE: '1'
           XLINGS_VERSION: ${{ env.BOOTSTRAP_XLINGS_VERSION }}
         run: |
-          irm https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.ps1 | iex
+          # Same failure mode as the POSIX bootstrap, same three fixes: `irm |
+          # iex` reports whether iex ran, not whether irm fetched anything,
+          # so a reset connection installs nothing and the step goes green.
+          $ErrorActionPreference = 'Stop'
+          $script = "$env:TEMP\xlings-quick-install.ps1"
+          for ($i = 1; $i -le 3; $i++) {
+            try { Invoke-WebRequest -UseBasicParsing -TimeoutSec 60 `
+                    -Uri https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.ps1 `
+                    -OutFile $script; break }
+            catch { Write-Host "bootstrap download failed (attempt $i/3); retrying"; Start-Sleep 10 }
+          }
+          if (-not (Test-Path $script) -or (Get-Item $script).Length -eq 0) {
+            Write-Host "::error::could not download quick_install.ps1"; exit 1
+          }
+          & $script
+          # Whatever the installer thought it did, the binary is either here or
+          # it is not.
+          if (-not (Test-Path "$env:USERPROFILE\.xlings\bin\xlings.exe")) {
+            Write-Host "::error::bootstrap reported success but installed no xlings"; exit 1
+          }
           "XLINGS_HOME=$env:USERPROFILE\.xlings"            >> $env:GITHUB_ENV
           "$env:USERPROFILE\.xlings\subos\current\bin"      >> $env:GITHUB_PATH
           "$env:USERPROFILE\.xlings\bin"                    >> $env:GITHUB_PATH

--- a/.github/workflows/xlings-ci-windows.yml
+++ b/.github/workflows/xlings-ci-windows.yml
@@ -45,10 +45,13 @@ jobs:
           # Same failure mode as the POSIX bootstrap, same three fixes: `irm |
           # iex` reports whether iex ran, not whether irm fetched anything,
           # so a reset connection installs nothing and the step goes green.
-          $ErrorActionPreference = 'Stop'
+          # `-ErrorAction Stop` on the call, NOT $ErrorActionPreference: the
+          # preference would stay set for `& $script` below and turn any
+          # non-terminating error the installer writes into an abort -- a
+          # behaviour change well outside what this fixes.
           $script = "$env:TEMP\xlings-quick-install.ps1"
           for ($i = 1; $i -le 3; $i++) {
-            try { Invoke-WebRequest -UseBasicParsing -TimeoutSec 60 `
+            try { Invoke-WebRequest -UseBasicParsing -TimeoutSec 60 -ErrorAction Stop `
                     -Uri https://raw.githubusercontent.com/openxlings/xlings/main/tools/other/quick_install.ps1 `
                     -OutFile $script; break }
             catch { Write-Host "bootstrap download failed (attempt $i/3); retrying"; Start-Sleep 10 }


### PR DESCRIPTION
The 2026.9.4.1 release died on `xlings: command not found` (exit 127) three steps after the real failure. The real failure was this:

```
curl -fsSL …/quick_install.sh | bash
curl: (35) Recv failure: Connection reset by peer
```

and **the step reported success** — a pipeline's exit status is its last command's, and `bash` fed an empty stdin exits 0. So a reset connection installs nothing, the step goes green, both cache steps go green, and the run dies later pointing at something unrelated. The Windows spelling (`irm … | iex`) has the identical shape.

Ten sites across seven workflows, three changes at each, because no one of them is sufficient:

| change | what it fixes |
|---|---|
| retry (3×, with `--retry`/timeouts) | a transient cross-region fetch is a coin flip on one attempt |
| download to a file, then run the file | the *download's* exit status becomes the step's, instead of the interpreter's |
| **assert `bin/xlings` exists afterwards** | makes a silent no-op impossible regardless of what any installer says about itself |

The third is the point. Whatever the script thought it did, the binary is either there or it is not — and this repo's recurring bug is a thing that never happened producing output identical to it having succeeded. The release workflow was doing it to itself.

Found while releasing #585, which is about that exact bug class in `doctor`.
