### PR TITLE
docs: post-release verification for 2026.9.5.1

### DIFF
--- a/.agents/docs/2026-09-06-release-2026.9.5.1-notes.md
+++ b/.agents/docs/2026-09-06-release-2026.9.5.1-notes.md
@@ -178,3 +178,35 @@ alias 是命令行、env 值可能是列表,路径不在开头);`fileSrc` / `fil
 | 12 个 doctor / sysroot / switch / install-use e2e | 全过 |
 | `mcpp build --toolchain llvm@20.1.7`(本机复现 macOS clang) | 通过 —— 它先抓到了本 PR 自己引入的两个 libc++ 陷阱 |
 | CI(macOS / Windows / Linux / aarch64+qemu / e2e / verify-root) | 8/8 绿,且 E2E-99 与 `Relocation.*` 在 CI 日志里确实被执行 |
+
+---
+
+## 9. 发布后验证(全部在真机上执行,不是读日志)
+
+### 9.1 发布链
+
+| 检查 | 方法 | 结果 |
+|---|---|---|
+| GitHub 资产 | `gh release view v2026.9.5.1` | **8** 个 |
+| sha256 | **自己算**,再与 sidecar **和**索引配方三方比对 | 4/4 三方一致 |
+| GitCode 镜像 | 本地 `tools/mirror-latest.sh xlings`(GitHub runner 上这一步是**故意**失败的,不能看徽章) | **16/16 OK**(4 归档 + 4 sidecar × 2 镜像,逐个 GET 验证) |
+| 索引 `latest` | 三张平台表逐一读 | 全部 `2026.9.5.1`(#772 已合) |
+| 索引快照传播 | `xlings index list xim` | 发布期快照 `2026.9.5.1` 早于 bump 合入,需 `xlings index use xim latest` + `xlings update` 才拿到 `fe725f4` —— **这是发布顺序造成的既有滞后,不是本次改动引入的**,记在这里免得下次当成 bug 查 |
+
+### 9.2 released 二进制自身
+
+- `verify-release-lifecycle.sh --bin <released>`:**PASS** —— 装包、glibc payload 完整性、进 subos、PATH、绑定唯一性、doctor 零 finding,且真实 store 未被写
+- 用 released 二进制跑 E2E-99(六格)与 E2E-98:**PASS**
+- 真实 home `self update` 2026.9.4.1 → **2026.9.5.1**(版本号是**跑出来**的,不是相信退出码)
+
+### 9.3 生态(`xlings subos <name> --sandbox --cmd ...`,mirror = CN)
+
+| 面 | 检查 | 结果 |
+|---|---|---|
+| 身份 / 路由 | sandbox 里跑的是 released 客户端;PATH 首位是本 subos | ok |
+| 工具链 | `default` 编译并运行;`dev-hello` 自带 gcc;`cortexm-verify`、`eco-musl-060` 农场可读 | ok ×4 |
+| 图形 | GL 农场非空;`xlings-gl-doctor` 可跑;`eco-vk-test` vulkan loader 在位 | ok ×3 |
+| 图形(真实上下文) | `glxinfo -B` 在 `--sandbox` 下失败 —— 沙箱**自己**在进入时就说了「没有 GPU 设备,会走软件渲染,加 `--gpu`」;照它说的加上 `--gpu` 后:direct rendering **Yes**,NVIDIA RTX 4080,OpenGL 4.6 | ok(按工具自己给的办法) |
+| 客户端自检 | `self doctor` 在 `default` 与 220 包的 `gfxbuild` 都出摘要;**`home relocated` 出现 0 次**(没搬过家的 home 不会误报) | ok ×3 |
+
+合计 **14/14**。唯一一次红是我的探针问错了变量(`XLINGS_SUBOS` 在 sandbox 里不导出,导出的是 `XLINGS_SUBOS_LIB`)与问错了 subos —— 改对之后即通过;记在这里因为「探针写错」和「产品坏了」在输出上长得一样。


### PR DESCRIPTION
Records what was actually executed after the release — the four checks that each have a way of passing while nothing happened, the released binary's own behaviour, and the sandbox ecosystem sweep.

Also records two things that cost time and would cost it again:

- the index snapshot the release publishes **predates** the bump PR it triggers, so a client needs `xlings index use xim latest` + `xlings update` before `latest` resolves to the new version. Pre-existing ordering lag, not 2026.9.5.1.
- the single red cell in the sweep was my own probe (`XLINGS_SUBOS` is not exported in the sandbox — `XLINGS_SUBOS_LIB` is), plus a GL check the sandbox had already told me needed `--gpu`. With `--gpu`: direct rendering yes, RTX 4080, OpenGL 4.6.

Docs only.